### PR TITLE
Ignore getStorage promise in useStorage if hook is unmounted

### DIFF
--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -333,14 +333,20 @@ export function useStorage<TRoot extends Record<string, any>>(): [
   const [root, setState] = React.useState<LiveObject<TRoot> | null>(null);
 
   React.useEffect(() => {
+    let didCancel = false;
+
     async function fetchStorage() {
       const storage = await room.getStorage<TRoot>();
-      setState(storage.root);
+      if (!didCancel) {
+        setState(storage.root);
+      }
     }
 
     fetchStorage();
 
-    return () => {};
+    return () => {
+      didCancel = true;
+    };
   }, [room]);
 
   return [root];


### PR DESCRIPTION
`useStorage` hook is calling an asynchronous function to initialize the storage. We need to ignore the promise callback to make sure that a state change is not triggered once a components is unmounted.

For more information:

https://overreacted.io/a-complete-guide-to-useeffect/