### PR TITLE
Fix: batching without ops should not add item to the undo/redo stack

### DIFF
--- a/packages/liveblocks/src/room.test.ts
+++ b/packages/liveblocks/src/room.test.ts
@@ -470,6 +470,24 @@ describe("room", () => {
       expect(storageRootSubscriber).toHaveBeenCalledWith(storage.root);
     });
 
+    test("batch without operations should not add an item to the undo stack", async () => {
+      const { storage, assert, undo, redo, batch, subscribe, refSubscribe } =
+        await prepareStorageTest<{
+          a: number;
+        }>([createSerializedObject("0:0", { a: 1 })], 1);
+
+      storage.root.set("a", 2);
+
+      // Batch without operations on storage or presence
+      batch(() => {});
+
+      assert({ a: 2 });
+
+      undo();
+
+      assert({ a: 1 });
+    });
+
     test("batch storage with changes from server", async () => {
       const { storage, assert, undo, redo, batch, subscribe, refSubscribe } =
         await prepareStorageTest<{

--- a/packages/liveblocks/src/room.ts
+++ b/packages/liveblocks/src/room.ts
@@ -1153,12 +1153,18 @@ See v0.13 release notes for more information.
       callback();
     } finally {
       state.isBatching = false;
-      addToUndoStack(state.batch.reverseOps);
+
+      if (state.batch.reverseOps.length > 0) {
+        addToUndoStack(state.batch.reverseOps);
+      }
 
       // Clear the redo stack because batch is always called from a local operation
       state.redoStack = [];
 
-      dispatch(state.batch.ops);
+      if (state.batch.ops.length > 0) {
+        dispatch(state.batch.ops);
+      }
+
       notify(state.batch.updates);
       state.batch = {
         ops: [],


### PR DESCRIPTION
Related issue #39 