### PR TITLE
Add broadcast option to queue events if websocket is not ready

### DIFF
--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -7,6 +7,7 @@ import {
   Room,
   User,
   LiveList,
+  BroadcastOptions,
 } from "@liveblocks/client";
 import * as React from "react";
 
@@ -221,8 +222,11 @@ export function useBroadcastEvent() {
   const room = useRoom();
 
   return React.useCallback(
-    (event: any) => {
-      room.broadcastEvent(event);
+    (
+      event: any,
+      options: BroadcastOptions = { shouldQueueEventIfNotReady: false }
+    ) => {
+      room.broadcastEvent(event, options);
     },
     [room]
   );

--- a/packages/liveblocks/src/index.ts
+++ b/packages/liveblocks/src/index.ts
@@ -1,6 +1,13 @@
 export { LiveObject } from "./LiveObject";
 export { LiveMap } from "./LiveMap";
 export { LiveList } from "./LiveList";
-export type { Others, Presence, Room, Client, User } from "./types";
+export type {
+  Others,
+  Presence,
+  Room,
+  Client,
+  User,
+  BroadcastOptions,
+} from "./types";
 
 export { createClient } from "./client";

--- a/packages/liveblocks/src/room.ts
+++ b/packages/liveblocks/src/room.ts
@@ -19,6 +19,7 @@ import {
   LiveObjectUpdates,
   LiveListUpdates,
   LiveMapUpdates,
+  BroadcastOptions,
 } from "./types";
 import { isSameNodeOrChildOf, remove } from "./utils";
 import auth, { parseToken } from "./authentication";
@@ -1055,8 +1056,13 @@ See v0.13 release notes for more information.
     return state.others as Others<T>;
   }
 
-  function broadcastEvent(event: any) {
-    if (state.socket == null) {
+  function broadcastEvent(
+    event: any,
+    options: BroadcastOptions = {
+      shouldQueueEventIfNotReady: false,
+    }
+  ) {
+    if (state.socket == null && options.shouldQueueEventIfNotReady == false) {
       return;
     }
 

--- a/packages/liveblocks/src/types.ts
+++ b/packages/liveblocks/src/types.ts
@@ -40,6 +40,13 @@ export type LiveListUpdates<TItem = any> = {
   node: LiveList<TItem>;
 };
 
+export type BroadcastOptions = {
+  /**
+   * Whether or not event is queued if the connection is currently closed.
+   */
+  shouldQueueEventIfNotReady: boolean;
+};
+
 export type StorageUpdate =
   | LiveMapUpdates
   | LiveObjectUpdates
@@ -504,7 +511,7 @@ export type Room = {
    *   }
    * });
    */
-  broadcastEvent: (event: any) => void;
+  broadcastEvent: (event: any, options?: BroadcastOptions) => void;
 
   /**
    * Get the room's storage asynchronously.

--- a/packages/liveblocks/src/types.ts
+++ b/packages/liveblocks/src/types.ts
@@ -43,6 +43,8 @@ export type LiveListUpdates<TItem = any> = {
 export type BroadcastOptions = {
   /**
    * Whether or not event is queued if the connection is currently closed.
+   *
+   * ❗ We are not sure if we want to support this option in the future so it might be deprecated to be replaced by something else
    */
   shouldQueueEventIfNotReady: boolean;
 };


### PR DESCRIPTION
```typescript
// Event will be queued and sent once the connection is open
room.broadcast({ type: "EVENT" }, { shouldQueueEventsIfNotReady: true });
```