### PR TITLE
feat: @liveblocks/client works in non-dom environments

### DIFF
--- a/packages/liveblocks/src/client.ts
+++ b/packages/liveblocks/src/client.ts
@@ -49,7 +49,8 @@ export function createClient(options: ClientOptions): Client {
     options: {
       defaultPresence?: Presence;
       defaultStorageRoot?: TStorageRoot;
-    } = {}
+      WebSocketPolyfill: typeof WebSocket
+    } = {WebSocketPolyfill: WebSocket}
   ): Room {
     let internalRoom = rooms.get(roomId);
     if (internalRoom) {

--- a/packages/liveblocks/src/room.test.ts
+++ b/packages/liveblocks/src/room.test.ts
@@ -30,7 +30,8 @@ const defaultContext = {
   throttleDelay: 100,
   liveblocksServer: "wss://live.liveblocks.io",
   onError: () => {},
-};
+  WebSocketPolyfill: WebSocket
+}
 
 function withDateNow(now: number, callback: () => void) {
   const realDateNow = Date.now.bind(global.Date);

--- a/packages/liveblocks/src/room.ts
+++ b/packages/liveblocks/src/room.ts
@@ -171,6 +171,7 @@ type Context = {
   liveblocksServer: string;
   throttleDelay: number;
   publicApiKey?: string;
+  WebSocketPolyfill: typeof WebSocket
 };
 
 export function makeStateMachine(
@@ -187,7 +188,7 @@ export function makeStateMachine(
           context.publicApiKey
         );
         const parsedToken = parseToken(token);
-        const socket = new WebSocket(
+        const socket = new context.WebSocketPolyfill!(
           `${context.liveblocksServer}/?token=${token}`
         );
         socket.addEventListener("message", onMessage);
@@ -685,10 +686,6 @@ See v0.13 release notes for more information.
   }
 
   function connect() {
-    if (typeof window === "undefined") {
-      return;
-    }
-
     if (
       state.connection.state !== "closed" &&
       state.connection.state !== "unavailable"
@@ -1013,7 +1010,7 @@ See v0.13 release notes for more information.
     clearTimeout(state.timeoutHandles.pongTimeout);
     state.timeoutHandles.pongTimeout = effects.schedulePongTimeout();
 
-    if (state.socket.readyState === WebSocket.OPEN) {
+    if (state.socket.readyState === state.socket.OPEN) {
       state.socket.send("ping");
     }
   }
@@ -1073,7 +1070,7 @@ See v0.13 release notes for more information.
       });
     }
 
-    if (state.socket == null || state.socket.readyState !== WebSocket.OPEN) {
+    if (state.socket == null || state.socket.readyState !== state.socket.OPEN) {
       state.buffer.storageOperations = [];
       return;
     }
@@ -1439,6 +1436,7 @@ export function createRoom(
   options: ClientOptions & {
     defaultPresence?: Presence;
     defaultStorageRoot?: Record<string, any>;
+    WebSocketPolyfill: typeof WebSocket;
   }
 ): InternalRoom {
   const throttleDelay = options.throttle || 100;
@@ -1467,6 +1465,7 @@ export function createRoom(
     authEndpoint,
     room: name,
     publicApiKey: options.publicApiKey,
+    WebSocketPolyfill: options.WebSocketPolyfill
   });
 
   const room: Room = {

--- a/packages/liveblocks/test/utils.ts
+++ b/packages/liveblocks/test/utils.ts
@@ -68,6 +68,7 @@ const defaultContext = {
   throttleDelay: -1, // No throttle for standard storage test
   liveblocksServer: "wss://live.liveblocks.io",
   onError: () => {},
+  WebSocketPolyfill: WebSocket
 };
 
 async function prepareRoomWithStorage<T>(


### PR DESCRIPTION
Inspired by `yjs` and `hocuspocus`, one should be able to interact with the same storage interface from a node environment. This allows for a `WebSocket` polyfill to be passed in when entering a room.

`yarn add @liveblocks/client ws`

```ts
import { createClient } from '@liveblocks/client';

const client = createClient({ publicApiKey: 'your-key' });
const room = client.enter('room-id', { WebSocketPolyfill: require('ws') })

const storage = await room.getStorage();
const map = storage.getMap('mymap');
map.set('a', 1);
```