### PR TITLE
@liveblocks/react: Throw an error if RoomProvider id is invalid

### DIFF
--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -69,6 +69,17 @@ export function RoomProvider<TStorageRoot>({
   defaultPresence,
   defaultStorageRoot,
 }: RoomProviderProps<TStorageRoot>) {
+  if (process.env.NODE_ENV !== "production") {
+    if (id == null) {
+      throw new Error(
+        "RoomProvider id property is required. For more information: https://liveblocks.io/docs/errors/liveblocks-react/RoomProvider-id-property-is-required"
+      );
+    }
+    if (typeof id !== "string") {
+      throw new Error("RoomProvider id property should be a string.");
+    }
+  }
+
   const client = useClient();
 
   React.useEffect(() => {


### PR DESCRIPTION
Throw an error when `RoomProvider` `id` property  is null / undefined. It seems that it's a common error even if typescript does not allows it.