### PR TITLE
@liveblocks/client: Expose roomId on Crdt to simplify consumptions on multi-rooms scenarios

### DIFF
--- a/packages/liveblocks/src/AbstractCrdt.ts
+++ b/packages/liveblocks/src/AbstractCrdt.ts
@@ -5,6 +5,7 @@ export type ApplyResult =
   | { modified: false };
 
 export interface Doc {
+  roomId: string;
   generateId: () => string;
   generateOpId: () => string;
   getItem: (id: string) => AbstractCrdt | undefined;
@@ -24,6 +25,10 @@ export abstract class AbstractCrdt {
    */
   protected get _doc() {
     return this.#doc;
+  }
+
+  get roomId() {
+    return this.#doc ? this.#doc.roomId : null;
   }
 
   /**

--- a/packages/liveblocks/src/LiveObject.test.ts
+++ b/packages/liveblocks/src/LiveObject.test.ts
@@ -15,6 +15,41 @@ import {
 import { LiveList } from ".";
 
 describe("LiveObject", () => {
+  describe("roomId", () => {
+    it("should be null for orphan", () => {
+      expect(new LiveObject().roomId).toBeNull();
+    });
+
+    it("should be the associated room id if attached", async () => {
+      const { root, assert } = await prepareIsolatedStorageTest(
+        [createSerializedObject("root", {})],
+        1
+      );
+
+      expect(root.roomId).toBe("room-id");
+    });
+
+    it("should be null after being detached", async () => {
+      const { root } = await prepareIsolatedStorageTest<{
+        child: LiveObject<{ a: number }>;
+      }>(
+        [
+          createSerializedObject("root", {}),
+          createSerializedObject("0:0", { a: 0 }, "root", "child"),
+        ],
+        1
+      );
+
+      const child = root.get("child");
+
+      expect(child.roomId).toBe("room-id");
+
+      root.set("child", new LiveObject({ a: 1 }));
+
+      expect(child.roomId).toBe(null);
+    });
+  });
+
   it("update non existing property", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest([
       createSerializedObject("0:0", {}),

--- a/packages/liveblocks/src/room.ts
+++ b/packages/liveblocks/src/room.ts
@@ -316,6 +316,7 @@ export function makeStateMachine(
       generateId,
       generateOpId,
       dispatch: storageDispatch,
+      roomId: context.room,
     }) as LiveObject<T>;
   }
 


### PR DESCRIPTION
Exposing `roomId` on AbstractCrdt simplifies consumption for multi rooms application without impacting the API surface too much. Even if not ideal, it allows subscription to CRDT updates without having a direct link between the room and the CRDT. 

```typescript
// This code assumes that the room exists and the LiveObject is attached to the storage root
const room = client.getRoom(liveObject.roomId);
room.subscribe(room, () => { });
```