### PR TITLE
Use `useRerender()` hook

### DIFF
--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -10,6 +10,7 @@ import {
   BroadcastOptions,
 } from "@liveblocks/client";
 import * as React from "react";
+import useRerender from "./useRerender";
 
 type LiveblocksProviderProps = {
   children: React.ReactNode;
@@ -325,15 +326,11 @@ export function useSelf<
   TPresence extends Presence = Presence
 >(): User<TPresence> | null {
   const room = useRoom();
-  const [, update] = React.useState(0);
+  const rerender = useRerender();
 
   React.useEffect(() => {
-    function onChange() {
-      update((x) => x + 1);
-    }
-
-    const unsubscribePresence = room.subscribe("my-presence", onChange);
-    const unsubscribeConnection = room.subscribe("connection", onChange);
+    const unsubscribePresence = room.subscribe("my-presence", rerender);
+    const unsubscribeConnection = room.subscribe("connection", rerender);
 
     return () => {
       unsubscribePresence();
@@ -465,7 +462,7 @@ export function useHistory() {
 function useCrdt<T>(key: string, initialCrdt: T): T | null {
   const room = useRoom();
   const [root] = useStorage();
-  const [, setCount] = React.useState(0);
+  const rerender = useRerender();
 
   React.useEffect(() => {
     if (root == null) {
@@ -479,10 +476,6 @@ function useCrdt<T>(key: string, initialCrdt: T): T | null {
       root.set(key, crdt);
     }
 
-    function onChange() {
-      setCount((x) => x + 1);
-    }
-
     function onRootChange() {
       const newCrdt = root!.get(key);
       if (newCrdt !== crdt) {
@@ -490,22 +483,22 @@ function useCrdt<T>(key: string, initialCrdt: T): T | null {
         crdt = newCrdt;
         unsubscribeCrdt = room.subscribe(
           crdt as any /* AbstractCrdt */,
-          onChange
+          rerender
         );
-        setCount((x) => x + 1);
+        rerender();
       }
     }
 
     let unsubscribeCrdt = room.subscribe(
       crdt as any /* AbstractCrdt */,
-      onChange
+      rerender
     );
     const unsubscribeRoot = room.subscribe(
       root as any /* AbstractCrdt */,
       onRootChange
     );
 
-    setCount((x) => x + 1);
+    rerender();
 
     return () => {
       unsubscribeRoot();

--- a/packages/liveblocks-react/src/useRerender.ts
+++ b/packages/liveblocks-react/src/useRerender.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useReducer } from 'react';
 
 /**
  * Trigger a re-render programmatically, without changing the component's
@@ -15,11 +15,12 @@ import { useCallback, useState } from 'react';
  *
  */
 export default function useRerender(): () => void {
-  const [, update] = useState<unknown>(null);
-  return useCallback(() => {
+  const [, update] = useReducer(
     // NOTE: This assigns a new, empty, object on every call, which forces
     // a state update, and thus a re-render of the calling component.
-    update({});
-  }, []);
+    () => ({}),
+    {}
+  );
+  return update;
 }
 

--- a/packages/liveblocks-react/src/useRerender.ts
+++ b/packages/liveblocks-react/src/useRerender.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Trigger a re-render programmatically, without changing the component's
+ * state.
+ *
+ * Usage:
+ *
+ *   const rerender = useRerender();
+ *   return (
+ *     <button onClick={rerender}>
+ *       {Math.random()}
+ *     </button>
+ *   )
+ *
+ */
+export default function useRerender(): () => void {
+  const [, update] = useState<unknown>(null);
+  return useCallback(() => {
+    // NOTE: This assigns a new, empty, object on every call, which forces
+    // a state update, and thus a re-render of the calling component.
+    update({});
+  }, []);
+}
+


### PR DESCRIPTION
Changes the "increment hidden state var" trick into a new hook called `useRerender()`, which makes the intent behind this trick clearer, and call sites more minimal.

At first, I kept the `x => x + 1` logic in there, but then worried about potentially hitting the `MAX_SAFE_INTEGER` limit for long running apps, after which increments will no longer functionally work as intended:

<img width="251" alt="Screen Shot 2022-03-31 at 09 24 32@2x" src="https://user-images.githubusercontent.com/83844/161000682-b2318f1e-ba6e-4677-94c4-f68b7c387687.png">

Instead, in this new implementation, I'm simply assigning a new empty object instance every time, which won't run into a max limit (and [isn't at all slower](https://jsben.ch/0fT7s)).
