### PR TITLE
Make `getOthers` return a standard array interface

### DIFF
--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -78,20 +78,19 @@ function makeOthers<T extends Presence>(presenceMap: {
     return publicKeys;
   });
 
-  return {
-    get count() {
-      return array.length;
-    },
-    [Symbol.iterator]() {
-      return array[Symbol.iterator]();
-    },
-    map(callback) {
-      return array.map(callback);
-    },
-    toArray() {
-      return array;
-    },
-  };
+  const arrayish: Others<T> = Object.assign(
+    array,
+
+    // NOTE: We extend the array instance with custom `count` and `toArray()`
+    // methods here. This is done for backward-compatible reasons. These APIs
+    // will be deprecated in a future version.
+    {
+      count: array.length,
+      toArray: () => array,
+    }
+  );
+
+  return Object.freeze(arrayish);
 }
 
 function log(...params: any[]) {

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -128,7 +128,7 @@ export type AuthenticationToken = {
 // reasons only. We want to eventually deprecate these APIs in favor of
 // `length` and just accessing the array directly here.
 //
-type ReadonlyArrayish<T> = readonly T[] & {
+type ReadonlyArrayWithLegacyMethods<T> = readonly T[] & {
   // @deprecated
   readonly count: number;
   // @deprecated
@@ -140,7 +140,7 @@ type ReadonlyArrayish<T> = readonly T[] & {
  */
 export type Others<P extends Presence = Presence> =
   // NOTE: This will become a normal `ReadonlyArray<User<P>>` later
-  ReadonlyArrayish<User<P>>;
+  ReadonlyArrayWithLegacyMethods<User<P>>;
 
 /**
  * Represents a user connected in a room. Treated as immutable.

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -124,7 +124,7 @@ export type AuthenticationToken = {
 };
 
 //
-// TODO: The `count` and `toArray()` methods are here for backward-compatible
+// NOTE: The `count` and `toArray()` methods are here for backward-compatible
 // reasons only. We want to eventually deprecate these APIs in favor of
 // `length` and just accessing the array directly here.
 //
@@ -139,7 +139,7 @@ type ReadonlyArrayish<T> = readonly T[] & {
  * A read-only array containing all other users connected to the room.
  */
 export type Others<P extends Presence = Presence> =
-  // TODO: Make this a normal `ReadonlyArray<User<P>>` later
+  // NOTE: This will become a normal `ReadonlyArray<User<P>>` later
   ReadonlyArrayish<User<P>>;
 
 /**

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -128,12 +128,23 @@ export type AuthenticationToken = {
 // reasons only. We want to eventually deprecate these APIs in favor of
 // `length` and just accessing the array directly here.
 //
-type ReadonlyArrayWithLegacyMethods<T> = readonly T[] & {
-  // @deprecated
-  readonly count: number;
-  // @deprecated
-  toArray(): T[];
-};
+// prettier-ignore
+type ReadonlyArrayWithLegacyMethods<T> =
+  // Base type
+  readonly T[]
+  &
+  // Legacy methods
+  // (These will be removed in a future release.)
+  {
+    /**
+     * @deprecated Prefer the normal .length property on arrays.
+     */
+    readonly count: number;
+    /**
+     * @deprecated Calling .toArray() is no longer needed
+     */
+    toArray(): T[];
+  };
 
 /**
  * A read-only array containing all other users connected to the room.

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -123,27 +123,24 @@ export type AuthenticationToken = {
   info?: any;
 };
 
-/**
- * Represents all the other users connected in the room. Treated as immutable.
- */
-export interface Others<TPresence extends Presence = Presence> {
-  /**
-   * Number of other users in the room.
-   */
+//
+// TODO: The `count` and `toArray()` methods are here for backward-compatible
+// reasons only. We want to eventually deprecate these APIs in favor of
+// `length` and just accessing the array directly here.
+//
+type ReadonlyArrayish<T> = readonly T[] & {
+  // @deprecated
   readonly count: number;
-  /**
-   * Returns a new Iterator object that contains the users.
-   */
-  [Symbol.iterator](): IterableIterator<User<TPresence>>;
-  /**
-   * Returns the array of connected users in room.
-   */
-  toArray(): User<TPresence>[];
-  /**
-   * This function let you map over the connected users in the room.
-   */
-  map<U>(callback: (user: User<TPresence>) => U): U[];
-}
+  // @deprecated
+  toArray(): T[];
+};
+
+/**
+ * A read-only array containing all other users connected to the room.
+ */
+export type Others<P extends Presence = Presence> =
+  // TODO: Make this a normal `ReadonlyArray<User<P>>` later
+  ReadonlyArrayish<User<P>>;
 
 /**
  * Represents a user connected in a room. Treated as immutable.


### PR DESCRIPTION
This changes the API of `getOthers()` to return a standardized (but readonly) array directly, rather than the custom array proxy object.

This means that:

```tsx
const others = useOthers();

others.toArray().some(u => u.presence?.isVIP);
//    ^^^^^^^^^^ No longer needed

others.some(u => u.presence?.isVIP);  // All array methods are directly available
```

Also, `others.count` can just become `others.length`.

The non-standard APIs `count` and `toArray()` are still retained by this change, but could be marked as `@deprecated` going forward, and be removed in a future release.
