### PR TITLE
Set all package targets to ES2015

### DIFF
--- a/packages/liveblocks-react/tsconfig.json
+++ b/packages/liveblocks-react/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "esnext",
     "outDir": "lib",
     "rootDir": "src",

--- a/packages/liveblocks-react/tsconfig.json
+++ b/packages/liveblocks-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "module": "esnext",
+    "module": "es2020",
     "outDir": "lib",
     "rootDir": "src",
     "lib": ["es6", "dom", "es2016", "es2017"],

--- a/packages/liveblocks-redux/tsconfig.json
+++ b/packages/liveblocks-redux/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2015",
     "strict": true,
     "jsx": "react-jsx",
     "esModuleInterop": true,

--- a/packages/liveblocks-zustand/tsconfig.json
+++ b/packages/liveblocks-zustand/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2015",
     "strict": true,
     "jsx": "react-jsx",
     "esModuleInterop": true,


### PR DESCRIPTION
This explicitly sets all TypeScript compile targets to `es2015` (= alias of `es6`). In the case of `@liveblocks/react`, this means an upgrade from `es5` to `es2015`. This upgrade is necessary to avoid TypeScript errors like the one below:

![Screen Shot 2022-04-06 at 09 39 37@2x](https://user-images.githubusercontent.com/83844/161921663-61896132-c123-422a-b1e9-84826dc973a9.png)

To avoid errors like above, the targeted version of `@liveblocks/react` (and other secondary packages) should never be higher than the targeted ES version of `@liveblocks/client`.

In most other packages, the targeted version wasn't specified explicitly, i.e. `esnext`, which may make the compiled code not useable for developers that cannot use the latest ES version yet. This PR effectively “downgrades” the targeted ES version in those packages.

Whether we pick `es2015`, or perhaps want to target a higher runtime is a trade-off between compiled bundle size and support in more code bases.

I therefore think `es2015` is a good pick for now, but lmk if you think we should aim higher here!
