### PR TITLE
Make `getOthers` return a standard array interface

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,9 +15,15 @@ jobs:
         with:
           repository: liveblocks/liveblocks
           ref: refs/heads/${{ github.head_ref }}
-      - run: npm install
-      - run: npm run build
-      - run: npm run test-ci
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Ensure TypeScript compiles
+        run: npm run build
+
+      - name: Run unit tests
+        run: npm run test-ci
 
   e2e-tests:
     timeout-minutes: 60

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -78,20 +78,19 @@ function makeOthers<T extends Presence>(presenceMap: {
     return publicKeys;
   });
 
-  return {
-    get count() {
-      return array.length;
-    },
-    [Symbol.iterator]() {
-      return array[Symbol.iterator]();
-    },
-    map(callback) {
-      return array.map(callback);
-    },
-    toArray() {
-      return array;
-    },
-  };
+  const arrayish: Others<T> = Object.assign(
+    array,
+
+    // NOTE: We extend the array instance with custom `count` and `toArray()`
+    // methods here. This is done for backward-compatible reasons. These APIs
+    // will be deprecated in a future version.
+    {
+      count: array.length,
+      toArray: () => array,
+    }
+  );
+
+  return Object.freeze(arrayish);
 }
 
 function log(...params: any[]) {

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -78,19 +78,22 @@ function makeOthers<T extends Presence>(presenceMap: {
     return publicKeys;
   });
 
-  const arrayish: Others<T> = Object.assign(
-    array,
+  // NOTE: We extend the array instance with custom `count` and `toArray()`
+  // methods here. This is done for backward-compatible reasons. These APIs
+  // will be deprecated in a future version.
+  Object.defineProperty(array, "count", {
+    value: array.length,
+    enumerable: false,
+  });
+  Object.defineProperty(array, "toArray", {
+    value: () => array,
+    enumerable: false,
+  });
 
-    // NOTE: We extend the array instance with custom `count` and `toArray()`
-    // methods here. This is done for backward-compatible reasons. These APIs
-    // will be deprecated in a future version.
-    {
-      count: array.length,
-      toArray: () => array,
-    }
-  );
-
-  return Object.freeze(arrayish);
+  return Object.freeze(array) as Others<T>;
+  //                          ^^^^^^^^^^^^
+  //                          Necessary only while the backward-compatible APIs
+  //                          are getting attached in the lines above.
 }
 
 function log(...params: any[]) {

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -70,27 +70,27 @@ function makeIdFactory(connectionId: number): IdFactory {
   return () => `${connectionId}:${count++}`;
 }
 
-function makeOthers<T extends Presence>(presenceMap: {
+function makeOthers<T extends Presence>(userMap: {
   [key: number]: User<T>;
 }): Others<T> {
-  const array = Object.values(presenceMap).map((presence) => {
-    const { _hasReceivedInitialPresence, ...publicKeys } = presence;
+  const users = Object.values(userMap).map((user) => {
+    const { _hasReceivedInitialPresence, ...publicKeys } = user;
     return publicKeys;
   });
 
   // NOTE: We extend the array instance with custom `count` and `toArray()`
   // methods here. This is done for backward-compatible reasons. These APIs
   // will be deprecated in a future version.
-  Object.defineProperty(array, "count", {
-    value: array.length,
+  Object.defineProperty(users, "count", {
+    value: users.length,
     enumerable: false,
   });
-  Object.defineProperty(array, "toArray", {
-    value: () => array,
+  Object.defineProperty(users, "toArray", {
+    value: () => users,
     enumerable: false,
   });
 
-  return Object.freeze(array) as Others<T>;
+  return Object.freeze(users) as Others<T>;
   //                          ^^^^^^^^^^^^
   //                          Necessary only while the backward-compatible APIs
   //                          are getting attached in the lines above.

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -123,27 +123,35 @@ export type AuthenticationToken = {
   info?: any;
 };
 
+//
+// NOTE: The `count` and `toArray()` methods are here for backward-compatible
+// reasons only. We want to eventually deprecate these APIs in favor of
+// `length` and just accessing the array directly here.
+//
+// prettier-ignore
+type ReadonlyArrayWithLegacyMethods<T> =
+  // Base type
+  readonly T[]
+  &
+  // Legacy methods
+  // (These will be removed in a future release.)
+  {
+    /**
+     * @deprecated Prefer the normal .length property on arrays.
+     */
+    readonly count: number;
+    /**
+     * @deprecated Calling .toArray() is no longer needed
+     */
+    toArray(): T[];
+  };
+
 /**
- * Represents all the other users connected in the room. Treated as immutable.
+ * A read-only array containing all other users connected to the room.
  */
-export interface Others<TPresence extends Presence = Presence> {
-  /**
-   * Number of other users in the room.
-   */
-  readonly count: number;
-  /**
-   * Returns a new Iterator object that contains the users.
-   */
-  [Symbol.iterator](): IterableIterator<User<TPresence>>;
-  /**
-   * Returns the array of connected users in room.
-   */
-  toArray(): User<TPresence>[];
-  /**
-   * This function let you map over the connected users in the room.
-   */
-  map<U>(callback: (user: User<TPresence>) => U): U[];
-}
+export type Others<P extends Presence = Presence> =
+  // NOTE: This will become a normal `ReadonlyArray<User<P>>` later
+  ReadonlyArrayWithLegacyMethods<User<P>>;
 
 /**
  * Represents a user connected in a room. Treated as immutable.


### PR DESCRIPTION
Take two for getting #109 merged.

See ad1413decb726b6775b417459d38ec88ef58939a for the necessary fix!