### PR TITLE
Automate publishing to NPM

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+PATH_add ./scripts/

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -15,6 +15,10 @@ err () {
     echo "$@" >&2
 }
 
+is_valid_version () {
+    echo "$1" | grep -qEe "^[0-9]+[.][0-9]+[.][0-9]+(-[[:alnum:].]+)?$"
+}
+
 usage () {
     err "usage: publish.sh [-V <version> [-t <tag>] [-h]"
     # err "usage: publish.sh [-Vtnh]"
@@ -155,6 +159,12 @@ check_npm_stuff_is_stable () {
 }
 
 check_all_the_things () {
+    if [ -n "$VERSION" ] && ! is_valid_version "$VERSION"; then
+        # Check for typos early on
+        err "Invalid version: $VERSION"
+        exit 2
+    fi
+
     check_git_toolbelt_installed
     check_jq_installed
     check_moreutils_installed
@@ -169,7 +179,7 @@ check_all_the_things
 
 echo "The current version is: $(jq -r .version "${PACKAGE_DIRS[0]}/package.json")"
 
-while ! echo "$VERSION" | grep -Ee "^[0-9]+[.][0-9]+[.][0-9]+(-[[:alnum:].]+)?$"; do
+while ! is_valid_version "$VERSION"; do
     if [ -n "$VERSION" ]; then
         err "Invalid version number: $VERSION"
         err "Please try again."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -231,7 +231,6 @@ bump_version_in_pkg () {
 }
 
 build_pkg () {
-    rm -rf lib
     npm run build
 }
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+set -eu
+
+# The output directory for the package build
+ROOT="$(git rev-parse --show-toplevel)"
+GITHUB_URL="https://github.com/liveblocks/liveblocks"
+PACKAGE_DIRS=(
+    "packages/liveblocks-client"
+    "packages/liveblocks-react"
+    "packages/liveblocks-redux"
+    "packages/liveblocks-zustand"
+)
+
+err () {
+    echo "$@" >&2
+}
+
+check_git_toolbelt_installed () {
+    # Test existence of a random toolbelt command
+    if ! which -s git-root; then
+        err ""
+        err "Oops!"
+        err "git-toolbelt is not installed. The git-toolbelt is"
+        err "a collection of useful small scripts that make writing"
+        err "shell scripts easier. This script relies on it!"
+        err ""
+        err "You can find it at:"
+        err "  https://github.com/nvie/git-toolbelt"
+        err ""
+        err "Please run:"
+        err "  brew install fzf"
+        err "  brew tap nvie/tap"
+        err "  brew install nvie/tap/git-toolbelt"
+        err ""
+        exit 2
+    fi
+}
+
+check_moreutils_installed () {
+    if ! which -s sponge; then
+        err ""
+        err "Moreutils is not installed. It's a fantastic toolkit of UNIX"
+        err "tools that make writing scripts like this much easier."
+        err ""
+        err "You can find more info at:"
+        err "  https://joeyh.name/code/moreutils"
+        err ""
+        err "Please run:"
+        err "  brew install moreutils"
+        err ""
+        exit 2
+    fi
+}
+
+check_jq_installed () {
+    if ! which -s jq; then
+        err ""
+        err "jq is not installed."
+        err ""
+        err "You can find it at:"
+        err "  https://stedolan.github.io/jq/"
+        err ""
+        err "Please run:"
+        err "  brew install jq"
+        err ""
+        exit 2
+    fi
+}
+
+check_current_branch () {
+    # Check we're on the main branch
+    if [ "$(git current-branch)" != "main" ]; then
+        err "To publish this package, you must be on \"main\" branch."
+        exit 2
+    fi
+}
+
+check_up_to_date_with_upstream () {
+    # Update to latest version
+    git fetch
+
+    if [ "$(git sha main)" != "$(git sha origin/main)" ]; then
+        err "Not up to date with upstream. Please pull/push latest changes before publishing."
+        exit 2
+    fi
+}
+
+check_cwd () {
+    if [ "$(pwd)" != "$ROOT" ]; then
+        err "This script must be run from the project's root directory."
+        exit 2
+    fi
+}
+
+check_no_local_changes () {
+    if git is-dirty; then
+        err "There are local changes. Please commit those before publishing."
+        exit 3
+    fi
+}
+
+check_npm_stuff_is_stable () {
+    for pkg in ${PACKAGE_DIRS[@]}; do
+        ( cd "$pkg" && (
+            # Before bumping anything, first make sure that all projects have
+            # a clean and stable node_modules directory and lock files!
+            rm -rf node_modules lib
+            npm install
+
+            if git is-dirty; then
+                err "I just removed node_modules and reinstalled all package dependencies"
+                err "inside $pkg, and found unexpected changes in the following files:"
+                err ""
+                git modified
+                err ""
+                err "Please fix those issues first."
+                exit 2
+            fi
+        ) )
+    done
+}
+
+check_all_the_things () {
+    check_git_toolbelt_installed
+    check_jq_installed
+    check_moreutils_installed
+    # check_current_branch   # TODO: Put back
+    check_up_to_date_with_upstream
+    check_cwd
+    check_no_local_changes
+    check_npm_stuff_is_stable
+}
+
+check_all_the_things 
+
+echo "The current version is: $(jq -r .version "${PACKAGE_DIRS[0]}/package.json")"
+
+VERSION=""
+while true; do
+    read -p "Enter a new version: " answer
+    if ! echo "$answer" | grep -Ee "^[0-9]+[.][0-9]+[.][0-9]+(-[[:alnum:].]+)?$"; then
+        err "Invalid version number: $answer"
+        err "Please try again."
+        err ""
+    else
+        VERSION="$answer"
+        break
+    fi
+done
+
+# Write the same new version to all package.json files
+for pkg in ${PACKAGE_DIRS[@]}; do
+    ( cd "$pkg" && (
+        jq ". + { version: \"$VERSION\" }" package.json | sponge package.json
+        prettier --write package.json
+        npm install
+
+        if ! git modified | grep -qEe package-lock.json; then
+            err "Hmm. package-lock.json wasn\'t affected by the version bump. This is fishy. Please manually inspect!"
+            exit 5
+        fi
+
+        rm -rf node_modules lib
+        npm run build
+        # TODO: commit changes here?
+    ) )
+done
+
+echo "Done"
+exit 33
+
+DIST="${ROOT}/dist"
+
+# Work from the root folder, build the dist/ folder
+cd "$ROOT"
+
+yarn run test
+./bin/build.sh
+
+if git is-dirty; then
+    git commit -m "Bump package `@liveblocks/client` to $VERSION" package.json
+    git push-current
+fi
+
+read -p "OTP token? " OTP
+if [ -z "$OTP" ]; then
+    exit 2
+fi
+
+cd "$DIST" && yarn publish --new-version "$VERSION" --otp "$OTP" "$@"
+
+# Open browser tab to create new release
+open "${GITHUB_URL}/blob/v${VERSION}/CHANGELOG.md"
+open "${GITHUB_URL}/releases/new?tag=${VERSION}&title=${VERSION}&body=%23%23%20%60%40liveblocks%2Fclient%60%0A%0A-%20%2A%2ATODO%3A%20Describe%20relevant%20changes%20for%20this%20package%2A%2A%0A%0A%0A%23%23%20%60%40liveblocks%2Freact%60%0A%0A-%20%2A%2ATODO%3A%20Describe%20relevant%20changes%20for%20this%20package%2A%2A%0A%0A%0A%23%23%20%60%40liveblocks%2Fredux%60%0A%0A-%20%2A%2ATODO%3A%20Describe%20relevant%20changes%20for%20this%20package%2A%2A%0A%0A%0A%23%23%20%60%40liveblocks%2Fzustand%60%0A%0A-%20%2A%2ATODO%3A%20Describe%20relevant%20changes%20for%20this%20package%2A%2A%0A%0A"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -311,10 +311,10 @@ echo ""
 echo "All published!"
 echo ""
 echo "You can double-check the NPM releases here:"
-echo "  - https://www.npmjs.com/package/@liveblocks/client"
-echo "  - https://www.npmjs.com/package/@liveblocks/react"
-echo "  - https://www.npmjs.com/package/@liveblocks/redux"
-echo "  - https://www.npmjs.com/package/@liveblocks/zustand"
+for pkgdir in ${PACKAGE_DIRS[@]}; do
+    pkgname="$(npm_pkgname "$pkgdir")"
+    echo "  - https://www.npmjs.com/package/$pkgname"
+done
 echo ""
 
 echo "==> Pushing changes to GitHub"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -192,8 +192,9 @@ check_all_the_things () {
 
 check_all_the_things
 
+CURRENT_VERSION="$(jq -r .version "$PRIMARY_PKG/package.json")"
 if [ -z "$VERSION" ]; then
-    echo "The current version is: $(jq -r .version "$PRIMARY_PKG/package.json")"
+    echo "The current version is: $CURRENT_VERSION"
 fi
 
 while ! is_valid_version "$VERSION"; do
@@ -226,9 +227,11 @@ bump_version_in_pkg () {
         exit 4
     fi
 
-    if ! git modified | grep -qEe package-lock.json; then
-        err "Hmm. package-lock.json wasn\'t affected by the version bump. This is fishy. Please manually inspect!"
-        exit 5
+    if [ "$CURRENT_VERSION" != "$VERSION"; then
+        if ! git modified | grep -qEe package-lock.json; then
+            err "Hmm. package-lock.json wasn\'t affected by the version bump. This is fishy. Please manually inspect!"
+            exit 5
+        fi
     fi
 }
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -236,9 +236,29 @@ build_pkg () {
     npm run build
 }
 
+# Turns "packages/liveblocks-client" => "@liveblocks/client"
+npm_pkgname () {
+    echo "@liveblocks/${1#"packages/liveblocks-"}"
+}
+
+npm_pkg_exists () {
+    PKGNAME="$1"
+    test "$(npm view "$PKGNAME@$VERSION" version)" = "$VERSION"
+}
+
 publish_to_npm () {
-    PKG="$1"
-    echo "I'm ready to publish $PKG to NPM, under $VERSION!"
+    PKGDIR="$1"
+    PKGNAME="$(npm_pkgname "$1")"
+
+    if npm_pkg_exists "$PKGNAME"; then
+        err ""
+        err "WARNING: Package $PKGNAME @ $VERSION already exists on NPM!"
+        err "Will skip this for now and continue with the rest of the script..."
+        err ""
+        return
+    fi
+
+    echo "I'm ready to publish $PKGNAME to NPM, under $VERSION!"
     echo "For this, I'll need the One-Time Password (OTP) token."
 
     OTP=""

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -149,7 +149,7 @@ check_npm_stuff_is_stable () {
                 err "I just removed node_modules and reinstalled all package dependencies"
                 err "inside $pkg, and found unexpected changes in the following files:"
                 err ""
-                git modified
+                ( cd "$ROOT" && git modified )
                 err ""
                 err "Please fix those issues first."
                 exit 2
@@ -177,7 +177,9 @@ check_all_the_things () {
 
 check_all_the_things
 
-echo "The current version is: $(jq -r .version "${PACKAGE_DIRS[0]}/package.json")"
+if [ -z "$VERSION" ]; then
+    echo "The current version is: $(jq -r .version "${PACKAGE_DIRS[0]}/package.json")"
+fi
 
 while ! is_valid_version "$VERSION"; do
     if [ -n "$VERSION" ]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,7 +27,6 @@ is_valid_otp_token () {
 
 usage () {
     err "usage: publish.sh [-V <version>] [-t <tag>] [-h]"
-    # err "usage: publish.sh [-Vtnh]"
     err
     err ""
     err "Publish a new version of the Liveblocks packages to NPM."
@@ -35,19 +34,15 @@ usage () {
     err "Options:"
     err "-V <version>  Set version to publish (default: prompt)"
     err "-t <tag>      Sets the tag to use on NPM (default: latest)"
-    # err "-n            Dry run"
     err "-h            Show this help"
 }
 
 VERSION=
 TAG=
-# dryrun=0
-# while getopts V:t:nh flag; do
 while getopts V:t:h flag; do
     case "$flag" in
         V) VERSION=$OPTARG;;
         t) TAG=$OPTARG;;
-        # n) dryrun=1;;
         *) usage; exit 2;;
     esac
 done

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -187,7 +187,7 @@ check_all_the_things () {
     check_up_to_date_with_upstream
     check_cwd
     check_no_local_changes
-    # check_npm_stuff_is_stable # TODO: Put back, this is disabled for speed/testing only
+    check_npm_stuff_is_stable
 }
 
 check_all_the_things

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,11 +22,11 @@ is_valid_version () {
 }
 
 is_valid_otp_token () {
-    echo "$1" | grep -qEe "^[0-9]{6}?$"
+    echo "$1" | grep -qEe "^[0-9]{6}$"
 }
 
 usage () {
-    err "usage: publish.sh [-V <version> [-t <tag>] [-h]"
+    err "usage: publish.sh [-V <version>] [-t <tag>] [-h]"
     # err "usage: publish.sh [-Vtnh]"
     err
     err ""

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -256,8 +256,10 @@ publish_to_npm () {
 
     if npm_pkg_exists "$PKGNAME"; then
         err ""
+        err "===================================================================="
         err "WARNING: Package $PKGNAME @ $VERSION already exists on NPM!"
         err "Will skip this for now and continue with the rest of the script..."
+        err "===================================================================="
         err ""
         return
     fi


### PR DESCRIPTION
Fixes #118.

This adds a script that performs all the steps from [these instructions](https://www.notion.so/liveblocks/How-to-074d3dfa5b944adb986fe176572d6887#9a10b3d58f014982a513f667ca5d67bd).

This needs to be tested against more edge cases, but it's built in a way where failures of certain steps will not cause harm. The script will end and you can try running it again without issues.

The script is written in a self-checking way, so it will verify its own assumptions before taking action, and fail with a friendly error message otherwise. For example, it won't continue if you have local changes in your worktree, or if you're not up-to-date with the latest upstream version, or if you enter an incorrect version number, etc.

Once I have push access to NPM, I can give this script a spin!
