### PR TITLE
Support nested `.envrc` files

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+# Automatically put scripts/ in your $PATH, as long as you
+# are inside this repo
 PATH_add ./scripts/

--- a/packages/liveblocks-client/.envrc
+++ b/packages/liveblocks-client/.envrc
@@ -1,1 +1,2 @@
+source_up
 layout node

--- a/packages/liveblocks-client/.envrc
+++ b/packages/liveblocks-client/.envrc
@@ -1,2 +1,5 @@
+# Read the top-level .envrc file as well
 source_up
+
+# Automatically put node_modules/.bin in your $PATH
 layout node

--- a/packages/liveblocks-node/.envrc
+++ b/packages/liveblocks-node/.envrc
@@ -1,1 +1,2 @@
+source_up
 layout node

--- a/packages/liveblocks-node/.envrc
+++ b/packages/liveblocks-node/.envrc
@@ -1,2 +1,5 @@
+# Read the top-level .envrc file as well
 source_up
+
+# Automatically put node_modules/.bin in your $PATH
 layout node

--- a/packages/liveblocks-react/.envrc
+++ b/packages/liveblocks-react/.envrc
@@ -1,1 +1,2 @@
+source_up
 layout node

--- a/packages/liveblocks-react/.envrc
+++ b/packages/liveblocks-react/.envrc
@@ -1,2 +1,5 @@
+# Read the top-level .envrc file as well
 source_up
+
+# Automatically put node_modules/.bin in your $PATH
 layout node

--- a/packages/liveblocks-redux/.envrc
+++ b/packages/liveblocks-redux/.envrc
@@ -1,1 +1,2 @@
+source_up
 layout node

--- a/packages/liveblocks-redux/.envrc
+++ b/packages/liveblocks-redux/.envrc
@@ -1,2 +1,5 @@
+# Read the top-level .envrc file as well
 source_up
+
+# Automatically put node_modules/.bin in your $PATH
 layout node

--- a/packages/liveblocks-zustand/.envrc
+++ b/packages/liveblocks-zustand/.envrc
@@ -1,1 +1,2 @@
+source_up
 layout node

--- a/packages/liveblocks-zustand/.envrc
+++ b/packages/liveblocks-zustand/.envrc
@@ -1,2 +1,5 @@
+# Read the top-level .envrc file as well
 source_up
+
+# Automatically put node_modules/.bin in your $PATH
 layout node


### PR DESCRIPTION
In recent PRs, I've included `.envrc` files in some of the project's directories. For those unfamiliar, these are config files for the amazing [direnv](https://direnv.net/) tool. When you use direnv on your machine, it will automatically load and unload settings when you `cd` into or `cd` out of a directory. I use it for all my projects, and it's amazing.

For example, when you `cd` into `packages/liveblocks-client`, it reads `layout node` which will put `packages/liveblocks-client/node_modules/.bin` on the `$PATH` for you. This means you can easily run locally-installed packages like `eslint`.

Also, when you `cd` out of that directory and into another directory, it will undo those `$PATH` changes automatically.

Can totally recommend it!
