### PR TITLE
Let Rollup builds fail if there are TypeScript errors

### DIFF
--- a/packages/liveblocks-client/rollup.config.js
+++ b/packages/liveblocks-client/rollup.config.js
@@ -49,6 +49,7 @@ function createDeclarationConfig(input, output) {
           declaration: true,
           outDir: `./lib/tmp`, // We need to put it in "lib" because of typescript can't @rollup/plugin-typescript ouput outside tsconfig outDir option
           tsconfig: "./tsconfig.build.json",
+          noEmitOnError: true, // Let rollup build fail if there are TypeScript errors
         }),
       ],
     },

--- a/packages/liveblocks-react/rollup.config.js
+++ b/packages/liveblocks-react/rollup.config.js
@@ -49,6 +49,7 @@ function createDeclarationConfig(input, output) {
           declaration: true,
           outDir: `./lib/tmp`, // We need to put it in "lib" because of typescript can't @rollup/plugin-typescript ouput outside tsconfig outDir option
           tsconfig: "./tsconfig.build.json",
+          noEmitOnError: true, // Let rollup build fail if there are TypeScript errors
         }),
       ],
     },

--- a/packages/liveblocks-redux/rollup.config.js
+++ b/packages/liveblocks-redux/rollup.config.js
@@ -47,6 +47,7 @@ function createDeclarationConfig(input, output) {
         declaration: true,
         outDir: output,
         tsconfig: "./tsconfig.build.json",
+        noEmitOnError: true, // Let rollup build fail if there are TypeScript errors
       }),
       {
         closeBundle: async () => {

--- a/packages/liveblocks-zustand/rollup.config.js
+++ b/packages/liveblocks-zustand/rollup.config.js
@@ -47,6 +47,7 @@ function createDeclarationConfig(input, output) {
         declaration: true,
         outDir: output,
         tsconfig: "./tsconfig.build.json",
+        noEmitOnError: true, // Let rollup build fail if there are TypeScript errors
       }),
       {
         closeBundle: async () => {


### PR DESCRIPTION
I noticed that sometimes the Rollup could throw TypeScript errors, but would happily continue. This adds a setting that will let those builds fail if such TypeScript errors are found, so we can fix them.
