### PR TITLE
Hotfix: Fix README visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://liveblocks.io#gh-light-mode-only">
-    <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/upkeep/readme/.github/assets/header-wordmark-light.svg" alt="Liveblocks"   />
+    <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/header-wordmark-light.svg" alt="Liveblocks"   />
   </a>
   <a href="https://liveblocks.io#gh-dark-mode-only">
-    <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/upkeep/readme/.github/assets/header-wordmark-dark.svg" alt="Liveblocks"   />
+    <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/header-wordmark-dark.svg" alt="Liveblocks"   />
   </a>
 </p>
 <p align="center">


### PR DESCRIPTION
This PR fixes a README visual referencing the `upkeep/readme` branch (which slipped through when testing) instead of `main`. 