### PR TITLE
Forbid use of private identifiers in library code

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -36,11 +36,11 @@ module.exports = {
     // -------------------------------
     "no-restricted-syntax": [
       "error",
-      // {
-      //   selector: "PrivateIdentifier",
-      //   message:
-      //     "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
-      // },
+      {
+        selector: "PrivateIdentifier",
+        message:
+          "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -26,11 +26,11 @@ module.exports = {
     // -------------------------------
     "no-restricted-syntax": [
       "error",
-      // {
-      //   selector: "PrivateIdentifier",
-      //   message:
-      //     "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
-      // },
+      {
+        selector: "PrivateIdentifier",
+        message:
+          "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -34,11 +34,11 @@ module.exports = {
     // -------------------------------
     "no-restricted-syntax": [
       "error",
-      // {
-      //   selector: "PrivateIdentifier",
-      //   message:
-      //     "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
-      // },
+      {
+        selector: "PrivateIdentifier",
+        message:
+          "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -34,11 +34,11 @@ module.exports = {
     // -------------------------------
     "no-restricted-syntax": [
       "error",
-      // {
-      //   selector: "PrivateIdentifier",
-      //   message:
-      //     "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
-      // },
+      {
+        selector: "PrivateIdentifier",
+        message:
+          "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -36,11 +36,11 @@ module.exports = {
     // -------------------------------
     "no-restricted-syntax": [
       "error",
-      // {
-      //   selector: "PrivateIdentifier",
-      //   message:
-      //     "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
-      // },
+      {
+        selector: "PrivateIdentifier",
+        message:
+          "Avoid private identifiers to reduce bundle size. Instead of using `#foo`, prefer using `private _foo`.",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:


### PR DESCRIPTION
This PR suggests to replace private identifiers in library code with TypeScript's `private` keyword instead (which is better for bundle size).

This is a follow-up on https://github.com/liveblocks/liveblocks/pull/110#discussion_r840563287.