### PR TITLE
Improve the `update-examples.sh` script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -290,7 +290,7 @@ commit_to_git () {
      bump_version_in_pkg "$PRIMARY_PKG" "$VERSION"
      build_pkg
      publish_to_npm "$pkgname"
-     commit_to_git "$PRIMARY_PKG" 
+     commit_to_git "$PRIMARY_PKG"
 ) )
 
 # Then, build and publish all the other packages
@@ -327,4 +327,12 @@ if ! git push-current; then
 else
     echo "Done! Please finish it off by writing a nice changelog entry on GitHub."
     open "$URL"
+    read
 fi
+
+echo "==> Upgrade local examples?"
+echo "Now that you're all finished, you may want to also upgrade all our examples"
+echo "to the latest version. To do so, run:"
+echo
+echo "    upgrade-examples.sh $VERSION"
+echo

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -1,4 +1,26 @@
 #!/bin/sh
+set -eu
+
+err () {
+    echo "$@" >&2
+}
+
+usage () {
+    err "usage: upgrade-examples.sh <version>"
+    err
+    err "Upgrades all the example projects by bumping the Liveblocks dependencies"
+    err "to the given version."
+    err
+    err "Options:"
+    err "-h    Show this help"
+}
+
+if [ $# -ne 1 ]; then
+    usage
+    exit 1
+fi
+
+VERSION="$1"
 
 # E2E tests
 

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -eu
 
+# Ensure this script can assume it's run from the repo's
+# root directory, even if the current working directory is
+# different.
+ROOT="$(git rev-parse --show-toplevel)"
+if [ "$(pwd)" != "$ROOT" ]; then
+    ( cd "$ROOT" && exec "$0" "$@" )
+    exit $?
+fi
+
 err () {
     echo "$@" >&2
 }

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -32,7 +32,9 @@ list_all_projects () {
 }
 
 list_liveblocks_deps () {
-    jq -r '(.dependencies // {})|keys[]' package.json | grep -Ee '^@liveblocks'
+    jq -r '(.dependencies // {})|keys[]' package.json \
+        | grep -Ee '^@liveblocks' \
+        | grep -vEe '@liveblocks/node'
 }
 
 list_install_args () {

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -22,115 +22,26 @@ fi
 
 VERSION="$1"
 
-# E2E tests
+list_all_projects () {
+    find examples e2e \
+        -type d '(' -name node_modules -o -name .next ')' -prune \
+        -o \
+        -name package.json \
+        | grep -Ee package.json \
+        | xargs -n1 dirname
+}
 
-echo "Upgrade next-sandbox to $1"
-cd e2e/next-sandbox
-npm install @liveblocks/client@$1 @liveblocks/react@$1 @liveblocks/zustand@$1 @liveblocks/redux@$1
+list_liveblocks_deps () {
+    jq -r '(.dependencies // {})|keys[]' package.json | grep -Ee '^@liveblocks'
+}
 
-cd -
-echo "Upgrade node-sandbox to $1"
-cd e2e/node-sandbox
-npm install @liveblocks/client@$1
+list_install_args () {
+    for dep in $(list_liveblocks_deps); do
+        echo "$dep@$VERSION"
+    done
+}
 
-# Examples
-
-cd -
-echo "Upgrade express-javascript-live-cursors to $1"
-cd examples/express-javascript-live-cursors
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade javascript-live-cursors to $1"
-cd examples/javascript-live-cursors
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade javascript-todo-list to $1"
-cd examples/javascript-todo-list
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade nextjs-live-avatars to $1"
-cd examples/nextjs-live-avatars
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade nextjs-live-cursors to $1"
-cd examples/nextjs-live-cursors
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade nextjs-logo-builder to $1"
-cd examples/nextjs-logo-builder
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade nextjs-threejs-shoe to $1"
-cd examples/nextjs-threejs-shoe
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade nextjs-whiteboard to $1"
-cd examples/nextjs-whiteboard
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade nuxtjs-live-avatars to $1"
-cd examples/nuxtjs-live-avatars
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade react-dashboard to $1"
-cd examples/react-dashboard
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade react-multiplayer-drawing-app to $1"
-cd examples/react-multiplayer-drawing-app
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade react-todo-list to $1"
-cd examples/react-todo-list
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade react-whiteboard to $1"
-cd examples/react-whiteboard
-npm install @liveblocks/client@$1 @liveblocks/react@$1
-
-cd -
-echo "Upgrade redux-todo-list to $1"
-cd examples/redux-todo-list
-npm install @liveblocks/client@$1 @liveblocks/redux@$1
-
-cd -
-echo "Upgrade redux-whiteboard to $1"
-cd examples/redux-whiteboard
-npm install @liveblocks/client@$1 @liveblocks/redux@$1
-
-cd -
-echo "Upgrade sveltekit-live-avatars to $1"
-cd examples/sveltekit-live-avatars
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade sveltekit-live-cursors to $1"
-cd examples/sveltekit-live-cursors
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade vuejs-live-cursors to $1"
-cd examples/vuejs-live-cursors
-npm install @liveblocks/client@$1
-
-cd -
-echo "Upgrade zustand-todo-list to $1"
-cd examples/zustand-todo-list
-npm install @liveblocks/client@$1 @liveblocks/zustand@$1
-
-cd -
-echo "Upgrade zustand-whiteboard to $1"
-cd examples/zustand-whiteboard
-npm install @liveblocks/client@$1 @liveblocks/zustand@$1
+for proj in $(list_all_projects); do
+    echo "==> Upgrade $proj to $VERSION"
+    ( cd "$proj" && npm install $(list_install_args ) )
+done

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -15,21 +15,23 @@ err () {
 }
 
 usage () {
-    err "usage: upgrade-examples.sh <version>"
+    err "usage: upgrade-examples.sh [<version>]"
     err
     err "Upgrades all the example projects by bumping the Liveblocks dependencies"
-    err "to the given version."
+    err "to the given version. If not provided, uses the latest version."
     err
     err "Options:"
     err "-h    Show this help"
 }
 
-if [ $# -ne 1 ]; then
-    usage
-    exit 1
-fi
+while getopts h flag; do
+    case "$flag" in
+        *) usage; exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
 
-VERSION="$1"
+VERSION="${1:-latest}"
 
 list_all_projects () {
     find examples e2e \


### PR DESCRIPTION
This PR does two things. First, it rewrites the `upgrade-examples.sh` script to auto-discover our e2e and example projects, figure out which `@liveblocks/xxx` dependencies each project has, and updates all of them to the provided version. This means we no longer have to maintain a [hardcoded list](https://github.com/liveblocks/liveblocks/blob/2bb895f0cfb843b13b1105c1ba0feb772020494c/scripts/upgrade-examples.sh#L3-L114) of all projects and their dependencies in there.

It also updates our NPM publish script to suggest to run this command at the end (but I'm leaving that to be a manual step deliberately).