### PR TITLE
Make `getOthers()` API return an array directly

### DIFF
--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -79,20 +79,22 @@ function makeOthers<T extends Presence>(userMap: {
     return publicKeys;
   });
 
-  return {
-    get count() {
-      return users.length;
-    },
-    [Symbol.iterator]() {
-      return users[Symbol.iterator]();
-    },
-    map(callback) {
-      return users.map(callback);
-    },
-    toArray() {
-      return users;
-    },
-  };
+  // NOTE: We extend the array instance with custom `count` and `toArray()`
+  // methods here. This is done for backward-compatible reasons. These APIs
+  // will be deprecated in a future version.
+  Object.defineProperty(users, "count", {
+    value: users.length,
+    enumerable: false,
+  });
+  Object.defineProperty(users, "toArray", {
+    value: () => users,
+    enumerable: false,
+  });
+
+  return Object.freeze(users) as Others<T>;
+  //                          ^^^^^^^^^^^^
+  //                          Necessary only while the backward-compatible APIs
+  //                          are getting attached in the lines above.
 }
 
 function log(...params: any[]) {

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -123,27 +123,35 @@ export type AuthenticationToken = {
   info?: any;
 };
 
+//
+// NOTE: The `count` and `toArray()` methods are here for backward-compatible
+// reasons only. We want to eventually deprecate these APIs in favor of
+// `length` and just accessing the array directly here.
+//
+// prettier-ignore
+type ReadonlyArrayWithLegacyMethods<T> =
+  // Base type
+  readonly T[]
+  &
+  // Legacy methods
+  // (These will be removed in a future release.)
+  {
+    /**
+     * @deprecated Prefer the normal .length property on arrays.
+     */
+    readonly count: number;
+    /**
+     * @deprecated Calling .toArray() is no longer needed
+     */
+    toArray(): T[];
+  };
+
 /**
- * Represents all the other users connected in the room. Treated as immutable.
+ * A read-only array containing all other users connected to the room.
  */
-export interface Others<TPresence extends Presence = Presence> {
-  /**
-   * Number of other users in the room.
-   */
-  readonly count: number;
-  /**
-   * Returns a new Iterator object that contains the users.
-   */
-  [Symbol.iterator](): IterableIterator<User<TPresence>>;
-  /**
-   * Returns the array of connected users in room.
-   */
-  toArray(): User<TPresence>[];
-  /**
-   * This function let you map over the connected users in the room.
-   */
-  map<U>(callback: (user: User<TPresence>) => U): U[];
-}
+export type Others<P extends Presence = Presence> =
+  // NOTE: This will become a normal `ReadonlyArray<User<P>>` later
+  ReadonlyArrayWithLegacyMethods<User<P>>;
 
 /**
  * Represents a user connected in a room. Treated as immutable.


### PR DESCRIPTION
This simplifies the API for the `getOthers()` call to not return a custom array proxy, but a real array. This was attempted to be merged in #109 and #122, but led to some debate about potentially closing off a future optimization path, see https://github.com/liveblocks/liveblocks/pull/122#issuecomment-1092444391.

I'm now reopening this PR as it stood to continue that discussion, because I think the API simpliciation would still be a better DX.