### PR TITLE
Make running mass commands on all packages/examples easier to run

### DIFF
--- a/scripts/for-all-e2e.sh
+++ b/scripts/for-all-e2e.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+# Ensure this script can assume it's run from the repo's
+# root directory, even if the current working directory is
+# different.
+ROOT="$(git rev-parse --show-toplevel)"
+if [ "$(pwd)" != "$ROOT" ]; then
+    ( cd "$ROOT" && exec "$0" "$@" )
+    exit $?
+fi
+
+err () {
+    echo "$@" >&2
+}
+
+usage () {
+    err "usage: for-all-e2e.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]"
+    err
+    err "Runs the given script inside all of our e2e test projects."
+    err
+    err "Options:"
+    err "-q    Don't print the current directory"
+    err "-f    Continue, even after an error occurs"
+    err "-h    Show this help"
+}
+
+quiet=0
+force=0
+while getopts qfh flag; do
+    case "$flag" in
+        q) quiet=1 ; ;;
+        f) force=1 ; ;;
+        *) usage; exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+for dir in $(find e2e -maxdepth 1 -type d | grep -Ee /); do
+    if [ $quiet -eq 0 ]; then
+        err
+        err "==> In $dir"
+    fi
+
+    ( cd "$dir" && (
+        if [ $force -eq 1 ]; then
+            set +e
+        fi
+
+        # Run the given command
+        "$@"
+
+        if [ $force -eq 1 ]; then
+            set -e
+        fi
+    ) )
+done

--- a/scripts/for-all-examples.sh
+++ b/scripts/for-all-examples.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+# Ensure this script can assume it's run from the repo's
+# root directory, even if the current working directory is
+# different.
+ROOT="$(git rev-parse --show-toplevel)"
+if [ "$(pwd)" != "$ROOT" ]; then
+    ( cd "$ROOT" && exec "$0" "$@" )
+    exit $?
+fi
+
+err () {
+    echo "$@" >&2
+}
+
+usage () {
+    err "usage: for-all-examples.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]"
+    err
+    err "Runs the given script inside all of our examples directories."
+    err
+    err "Options:"
+    err "-q    Don't print the current directory"
+    err "-f    Continue, even after an error occurs"
+    err "-h    Show this help"
+}
+
+quiet=0
+force=0
+while getopts qfh flag; do
+    case "$flag" in
+        q) quiet=1 ; ;;
+        f) force=1 ; ;;
+        *) usage; exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+for dir in $(find examples -maxdepth 1 -type d | grep -Ee /); do
+    if [ $quiet -eq 0 ]; then
+        err
+        err "==> In $dir"
+    fi
+
+    ( cd "$dir" && (
+        if [ $force -eq 1 ]; then
+            set +e
+        fi
+
+        # Run the given command
+        "$@"
+
+        if [ $force -eq 1 ]; then
+            set -e
+        fi
+    ) )
+done

--- a/scripts/for-all-packages.sh
+++ b/scripts/for-all-packages.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+# Ensure this script can assume it's run from the repo's
+# root directory, even if the current working directory is
+# different.
+ROOT="$(git rev-parse --show-toplevel)"
+if [ "$(pwd)" != "$ROOT" ]; then
+    ( cd "$ROOT" && exec "$0" "$@" )
+    exit $?
+fi
+
+err () {
+    echo "$@" >&2
+}
+
+usage () {
+    err "usage: for-all-packages.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]"
+    err
+    err "Runs the given script inside all of our package directories."
+    err
+    err "Options:"
+    err "-q    Don't print the current directory"
+    err "-f    Continue, even after an error occurs"
+    err "-h    Show this help"
+}
+
+quiet=0
+force=0
+while getopts qfh flag; do
+    case "$flag" in
+        q) quiet=1 ; ;;
+        f) force=1 ; ;;
+        *) usage; exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+for dir in $(find packages -maxdepth 1 -type d | grep -Ee /); do
+    if [ $quiet -eq 0 ]; then
+        err
+        err "==> In $dir"
+    fi
+
+    ( cd "$dir" && (
+        if [ $force -eq 1 ]; then
+            set +e
+        fi
+
+        # Run the given command
+        "$@"
+
+        if [ $force -eq 1 ]; then
+            set -e
+        fi
+    ) )
+done


### PR DESCRIPTION
This PR adds three helper scripts:

- `for-all-examples.sh <your cmd>`
- `for-all-packages.sh <your cmd>`
- `for-all-e2e.sh <your cmd>`

Which you can use as follows:

```sh
$ for-all-examples.sh npm install
```

Or to run prettier en-masse:

```sh
$ for-all-examples.sh prettier --write src
```

You can provide any command and this script will first `cd` into each directory and then run your command. The current working directory from where you invoke this script isn't relevant, it will run fine from anywhere in the repo.

By default, if one command fails, it immediately aborts the script. If you want to allow and ignore failures and just continue with the remainder of the directories, you can provide the `-f` (force) argument. Full usage:

```
$ for-all-examples.sh -h
usage: for-all-examples.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]

Runs the given script inside all of our examples directories.

Options:
-q    Don't print the current directory
-f    Continue, even after an error occurs
-h    Show this help
```
