### PR TITLE
Ignore tests in `lib/` directory

### DIFF
--- a/packages/liveblocks-client/jest.config.js
+++ b/packages/liveblocks-client/jest.config.js
@@ -1,4 +1,5 @@
 // jest.config.js
 module.exports = {
+  modulePathIgnorePatterns: ["<rootDir>/lib/"],
   setupFiles: ["./jest.setup.js"],
 };

--- a/packages/liveblocks-react/jest.config.js
+++ b/packages/liveblocks-react/jest.config.js
@@ -1,4 +1,5 @@
 // jest.config.js
 module.exports = {
+  modulePathIgnorePatterns: ["<rootDir>/lib/"],
   setupFiles: ["./jest.setup.js"],
 };

--- a/packages/liveblocks-redux/jest.config.js
+++ b/packages/liveblocks-redux/jest.config.js
@@ -1,5 +1,6 @@
 // jest.config.js
 module.exports = {
   testEnvironment: "jsdom",
+  modulePathIgnorePatterns: ["<rootDir>/lib/"],
   setupFiles: ["./jest.setup.js"],
 };

--- a/packages/liveblocks-zustand/jest.config.js
+++ b/packages/liveblocks-zustand/jest.config.js
@@ -1,5 +1,6 @@
 // jest.config.js
 module.exports = {
   testEnvironment: "jsdom",
+  modulePathIgnorePatterns: ["<rootDir>/lib/"],
   setupFiles: ["./jest.setup.js"],
 };


### PR DESCRIPTION
This ignores the `lib/` directory when running `jest`. This could break and be confusing in situations where old/buggy code lives in `lib/` from a previous compilation, and thus may suggest bugs even if the files in `src/` are already passing again (but TypeScript recompilation hasn't happened yet).