### PR TITLE
Make `link-liveblocks.sh -f` a bit faster on CI builds

### DIFF
--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -135,6 +135,12 @@ liveblocks_pkg_dir () {
 }
 
 rebuild_if_needed () {
+    if [ -e "lib/.built-by-link-script" ]; then
+        # This was already rebuilt by an earlier invocation of this build
+        # script. We don't have to throw away those results!
+        return
+    fi
+
     if [ $force -eq 0 -a -d "lib" ]; then
         # SRC_TIMESTAMP="$(oldest_file src node_modules)"
         SRC_TIMESTAMP="$(oldest_file src)"
@@ -149,6 +155,7 @@ rebuild_if_needed () {
     echo "==> Rebuilding (in $(pwd))"
     rm -rf lib
     npm run build
+    touch "lib/.built-by-link-script"
 }
 
 prep_liveblocks_deps () {


### PR DESCRIPTION
Our e2e test has recursive liveblocks deps. For example, the e2e project needs `@liveblocks/react`, which in turn needs `@liveblocks/client`. When run with the `-f` flag—like we do in CI builds—this will throw away the results of an earlier forced build. We'll only need to enforce a rebuild once, not all the time.
