### PR TITLE
Upkeep: Add descriptions to packages

### DIFF
--- a/packages/liveblocks-client/README.md
+++ b/packages/liveblocks-client/README.md
@@ -18,6 +18,8 @@
   </a>
 </p>
 
+A client that lets you interact with [Liveblocks](https://liveblocks.io) servers.
+
 ## Installation
 
 ```

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liveblocks/client",
   "version": "0.15.11",
-  "description": "",
+  "description": "A client that lets you interact with Liveblocks servers.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [

--- a/packages/liveblocks-node/README.md
+++ b/packages/liveblocks-node/README.md
@@ -18,6 +18,8 @@
   </a>
 </p>
 
+A server-side utility that lets you set up a [Liveblocks](https://liveblocks.io) authentication endpoint.
+
 ## Installation
 
 ```

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liveblocks/node",
   "version": "0.3.0",
-  "description": "",
+  "description": "A server-side utility that lets you set up a Liveblocks authentication endpoint.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "files": [

--- a/packages/liveblocks-react/README.md
+++ b/packages/liveblocks-react/README.md
@@ -18,6 +18,8 @@
   </a>
 </p>
 
+A set of [React](https://reactjs.org/) hooks and providers to use [Liveblocks](https://liveblocks.io) declaratively.
+
 ## Installation
 
 ```

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liveblocks/react",
   "version": "0.15.11",
-  "description": "",
+  "description": "A set of React hooks and providers to use Liveblocks declaratively.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [

--- a/packages/liveblocks-redux/README.md
+++ b/packages/liveblocks-redux/README.md
@@ -18,6 +18,8 @@
   </a>
 </p>
 
+A [store enhancer](https://redux.js.org/understanding/thinking-in-redux/glossary#store-enhancer) to integrate [Liveblocks](https://liveblocks.io) into [Redux](https://redux-toolkit.js.org/) stores.
+
 ## Installation
 
 ```

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -2,7 +2,7 @@
   "name": "@liveblocks/redux",
   "version": "0.15.11",
   "sideEffects": false,
-  "description": "",
+  "description": "A store enhancer to integrate Liveblocks into Redux stores.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [

--- a/packages/liveblocks-zustand/README.md
+++ b/packages/liveblocks-zustand/README.md
@@ -18,6 +18,8 @@
   </a>
 </p>
 
+A [middleware](https://github.com/pmndrs/zustand#middleware) to integrate [Liveblocks](https://liveblocks.io) into [Zustand](https://github.com/pmndrs/zustand) stores.
+
 ## Installation
 
 ```

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -2,7 +2,7 @@
   "name": "@liveblocks/zustand",
   "version": "0.15.11",
   "sideEffects": false,
-  "description": "",
+  "description": "A middleware to integrate Liveblocks into Zustand stores.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [


### PR DESCRIPTION
This tiny PR adds descriptions to all packages (in their `package.json` empty description field and their `README.md`), both to improve situations like NPM and Bundlephobia (e.g. image below) and also to provide a one-sentence summary of what a package provides before needing to read the docs.

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/6959425/163584059-d7e3fe42-9ac1-47e1-92af-f3950652b1bb.png">
