### PR TITLE
Allow "for-all" scripts to run shell cmds as well

### DIFF
--- a/scripts/for-all-e2e.sh
+++ b/scripts/for-all-e2e.sh
@@ -15,20 +15,23 @@ err () {
 }
 
 usage () {
-    err "usage: for-all-e2e.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]"
+    err "usage: for-all-e2e.sh [-qfh] [-c <shell-cmd>] <cmd> [<arg1> [<arg2> ...]]"
     err
     err "Runs the given script inside all of our e2e test projects."
     err
     err "Options:"
     err "-q    Don't print the current directory"
     err "-f    Continue, even after an error occurs"
+    err "-c    Run command with \`sh -c\` instead"
     err "-h    Show this help"
 }
 
+cmd=
 quiet=0
 force=0
-while getopts qfh flag; do
+while getopts qc:fh flag; do
     case "$flag" in
+        c) cmd="$OPTARG" ; ;;
         q) quiet=1 ; ;;
         f) force=1 ; ;;
         *) usage; exit 2;;
@@ -48,7 +51,11 @@ for dir in $(find e2e -maxdepth 1 -type d | grep -Ee /); do
         fi
 
         # Run the given command
-        "$@"
+        if [ -n "$cmd" ]; then
+            sh -c "$cmd"
+        else
+            "$@"
+        fi
 
         if [ $force -eq 1 ]; then
             set -e

--- a/scripts/for-all-examples.sh
+++ b/scripts/for-all-examples.sh
@@ -15,20 +15,23 @@ err () {
 }
 
 usage () {
-    err "usage: for-all-examples.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]"
+    err "usage: for-all-examples.sh [-qfh] [-c <shell-cmd>] <cmd> [<arg1> [<arg2> ...]]"
     err
     err "Runs the given script inside all of our examples directories."
     err
     err "Options:"
     err "-q    Don't print the current directory"
     err "-f    Continue, even after an error occurs"
+    err "-c    Run command with \`sh -c\` instead"
     err "-h    Show this help"
 }
 
+cmd=
 quiet=0
 force=0
-while getopts qfh flag; do
+while getopts qc:fh flag; do
     case "$flag" in
+        c) cmd="$OPTARG" ; ;;
         q) quiet=1 ; ;;
         f) force=1 ; ;;
         *) usage; exit 2;;
@@ -48,7 +51,11 @@ for dir in $(find examples -maxdepth 1 -type d | grep -Ee /); do
         fi
 
         # Run the given command
-        "$@"
+        if [ -n "$cmd" ]; then
+            sh -c "$cmd"
+        else
+            "$@"
+        fi
 
         if [ $force -eq 1 ]; then
             set -e

--- a/scripts/for-all-packages.sh
+++ b/scripts/for-all-packages.sh
@@ -15,20 +15,23 @@ err () {
 }
 
 usage () {
-    err "usage: for-all-packages.sh [-qfh] <cmd> [<arg1> [<arg2> ...]]"
+    err "usage: for-all-packages.sh [-qfh] [-c <shell-cmd>] <cmd> [<arg1> [<arg2> ...]]"
     err
     err "Runs the given script inside all of our package directories."
     err
     err "Options:"
     err "-q    Don't print the current directory"
     err "-f    Continue, even after an error occurs"
+    err "-c    Run command with \`sh -c\` instead"
     err "-h    Show this help"
 }
 
+cmd=
 quiet=0
 force=0
-while getopts qfh flag; do
+while getopts qc:fh flag; do
     case "$flag" in
+        c) cmd="$OPTARG" ; ;;
         q) quiet=1 ; ;;
         f) force=1 ; ;;
         *) usage; exit 2;;
@@ -48,7 +51,11 @@ for dir in $(find packages -maxdepth 1 -type d | grep -Ee /); do
         fi
 
         # Run the given command
-        "$@"
+        if [ -n "$cmd" ]; then
+            sh -c "$cmd"
+        else
+            "$@"
+        fi
 
         if [ $force -eq 1 ]; then
             set -e


### PR DESCRIPTION
Previously, you could run, for example:

```
$ for-all-examples.sh npm install
```

But you could not run more than one command in each directory easily. This PR changes that, by supporting a `-c` flag, which allows you to specify a _shell_ command to run (it uses `sh -c 'your command here'`) to run it, instead of directly running `your command here`.

This has the added benefit that you can use `&&` to run multiple commands:

```
$ for-all-examples.sh -c 'npm install && link-liveblocks.sh && npm run build'
```
