### PR TITLE
Avoid trusting unverified inputs

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -65,6 +65,12 @@ module.exports = {
         message:
           "In library code, never write `LiveRegister` without explicit type params! Type parameter defaults are only meant for end users.",
       },
+      {
+        selector:
+          "CallExpression[callee.object.name='JSON'][callee.property.name='parse']",
+        message:
+          "Using `JSON.parse()` is type-unsafe. Prefer using the `parseJson()` utility method (from `src/json`).",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-client/src/json.ts
+++ b/packages/liveblocks-client/src/json.ts
@@ -25,3 +25,15 @@ export function parseJson(rawMessage: string): Json | undefined {
     return undefined;
   }
 }
+
+export function isJsonArray(data: Json): data is JsonArray {
+  return Array.isArray(data);
+}
+
+export function isJsonObject(data: Json): data is JsonObject {
+  return data !== null && typeof data === "object" && !isJsonArray(data);
+}
+
+export function isJsonScalar(data: Json): data is JsonScalar {
+  return typeof data !== "object";
+}

--- a/packages/liveblocks-client/src/json.ts
+++ b/packages/liveblocks-client/src/json.ts
@@ -33,7 +33,3 @@ export function isJsonArray(data: Json): data is JsonArray {
 export function isJsonObject(data: Json): data is JsonObject {
   return data !== null && typeof data === "object" && !isJsonArray(data);
 }
-
-export function isJsonScalar(data: Json): data is JsonScalar {
-  return typeof data !== "object";
-}

--- a/packages/liveblocks-client/src/json.ts
+++ b/packages/liveblocks-client/src/json.ts
@@ -19,6 +19,7 @@ export type JsonObject = { [key: string]: Json };
  */
 export function parseJson(rawMessage: string): Json | undefined {
   try {
+    // eslint-disable-next-line no-restricted-syntax
     return JSON.parse(rawMessage);
   } catch (e) {
     return undefined;

--- a/packages/liveblocks-client/src/json.ts
+++ b/packages/liveblocks-client/src/json.ts
@@ -12,3 +12,15 @@ export type Json = JsonScalar | JsonArray | JsonObject;
 export type JsonScalar = string | number | boolean | null;
 export type JsonArray = Json[];
 export type JsonObject = { [key: string]: Json };
+
+/**
+ * Alternative to JSON.parse() that will not throw in production. If the passed
+ * string cannot be parsed, this will return `undefined`.
+ */
+export function parseJson(rawMessage: string): Json | undefined {
+  try {
+    return JSON.parse(rawMessage);
+  } catch (e) {
+    return undefined;
+  }
+}

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -853,7 +853,7 @@ See v0.13 release notes for more information.
   }
 
   function parseServerMessages(text: string): ServerMessage[] | null {
-    let data: Json | undefined = parseJson(text);
+    const data: Json | undefined = parseJson(text);
     if (data === undefined) {
       return null;
     } else if (isJsonArray(data)) {
@@ -880,52 +880,45 @@ See v0.13 release notes for more information.
       others: [] as OthersEvent[],
     };
 
-    for (const subMessage of subMessages) {
-      switch (subMessage.type) {
+    for (const message of messages) {
+      switch (message.type) {
         case ServerMessageType.UserJoined: {
-          updates.others.push(onUserJoinedMessage(message as UserJoinMessage));
+          updates.others.push(onUserJoinedMessage(message));
           break;
         }
         case ServerMessageType.UpdatePresence: {
-          const othersPresenceUpdate = onUpdatePresenceMessage(
-            subMessage as UpdatePresenceMessage
-          );
+          const othersPresenceUpdate = onUpdatePresenceMessage(message);
           if (othersPresenceUpdate) {
             updates.others.push(othersPresenceUpdate);
           }
           break;
         }
         case ServerMessageType.Event: {
-          onEvent(subMessage);
+          onEvent(message);
           break;
         }
         case ServerMessageType.UserLeft: {
-          const event = onUserLeftMessage(subMessage as UserLeftMessage);
+          const event = onUserLeftMessage(message);
           if (event) {
             updates.others.push(event);
           }
           break;
         }
         case ServerMessageType.RoomState: {
-          updates.others.push(
-            onRoomStateMessage(subMessage as RoomStateMessage)
-          );
+          updates.others.push(onRoomStateMessage(message));
           break;
         }
         case ServerMessageType.InitialStorageState: {
           // createOrUpdateRootFromMessage function could add ops to offlineOperations.
           // Client shouldn't resend these ops as part of the offline ops sending after reconnect.
           const offlineOps = new Map(state.offlineOperations);
-          createOrUpdateRootFromMessage(subMessage);
+          createOrUpdateRootFromMessage(message);
           applyAndSendOfflineOps(offlineOps);
           _getInitialStateResolver?.();
           break;
         }
         case ServerMessageType.UpdateStorage: {
-          const applyResult = apply(
-            (subMessage as UpdateStorageMessage).ops,
-            false
-          );
+          const applyResult = apply(message.ops, false);
           applyResult.updates.storageUpdates.forEach((value, key) => {
             updates.storageUpdates.set(
               key,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -196,9 +196,10 @@ export function makeStateMachine(
       auth: (room: string) => Promise<AuthorizeResponse>,
       createWebSocket: (token: string) => WebSocket
     ) {
-      if (isTokenValid(state.token)) {
-        const parsedToken = parseToken(state.token!);
-        const socket = createWebSocket(state.token!);
+      const token = state.token;
+      if (token && isTokenValid(token)) {
+        const parsedToken = parseToken(token);
+        const socket = createWebSocket(token);
         authenticationSuccess(parsedToken, socket);
       } else {
         return auth(context.roomId)

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1561,14 +1561,23 @@ function parseToken(token: string): AuthenticationToken {
     );
   }
 
-  const data = JSON.parse(atob(tokenParts[1]));
-  if (typeof data.actor !== "number") {
-    throw new Error(
-      `Authentication error. Liveblocks could not parse the response of your authentication endpoint`
-    );
+  const data = parseJson(atob(tokenParts[1]));
+  if (
+    data !== undefined &&
+    isJsonObject(data) &&
+    typeof data.actor === "number" &&
+    (data.id === undefined || typeof data.id === "string")
+  ) {
+    return {
+      actor: data.actor,
+      id: data.id,
+      info: data.info as Json | undefined,
+    };
   }
 
-  return data;
+  throw new Error(
+    `Authentication error. Liveblocks could not parse the response of your authentication endpoint`
+  );
 }
 
 function prepareCreateWebSocket(

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -148,7 +148,7 @@ export type Client = {
 export type AuthenticationToken = {
   actor: number;
   id?: string;
-  info?: any;
+  info?: Json;
 };
 
 /**

--- a/packages/liveblocks-client/src/utils.test.ts
+++ b/packages/liveblocks-client/src/utils.test.ts
@@ -6,7 +6,24 @@ import {
   getTreesDiffOperations,
   findNonSerializableValue,
   isTokenValid,
+  compact,
 } from "./utils";
+
+describe("compact", () => {
+  it("compact w/ empty list", () => {
+    expect(compact([])).toEqual([]);
+  });
+
+  it("icompact removes nulls and undefined values", () => {
+    expect(compact(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+    expect(compact(["x", undefined])).toEqual(["x"]);
+    expect(compact([0, null, undefined, NaN, Infinity])).toEqual([
+      0,
+      NaN,
+      Infinity,
+    ]);
+  });
+});
 
 describe("getTreesDiffOperations", () => {
   test("new liveList Register item", () => {

--- a/packages/liveblocks-client/src/utils.test.ts
+++ b/packages/liveblocks-client/src/utils.test.ts
@@ -283,11 +283,6 @@ describe("isTokenValid", () => {
   const token =
     "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb29tSWQiOiJvcG5NVEpZVTYtZDlxYXliSGRJcmciLCJhcHBJZCI6IjYwOWRiZjA2ZWEzZTUxZDQxM2NkM2UxZCIsImFjdG9yIjoxMDQsInNjb3BlcyI6WyJyb29tOnJlYWQiLCJyb29tOndyaXRlIiwid2Vic29ja2V0OnByZXNlbmNlIiwid2Vic29ja2V0OnN0b3JhZ2UiXSwibWF4Q29ubmVjdGlvbnNQZXJSb29tIjoyMCwibWF4Q29ubmVjdGlvbnMiOjIwMDAsImlhdCI6MTY0OTE4NjUwNiwiZXhwIjoxNjQ5MTkwMTA2fQ.WU3EPGN31ApmBh295ANMc42OlpQ2jqQyKoqN7hyxwgquN6IS6p3T_BUVtuu453e8FLwOTmC5OtLqdNb-YhmMZBnjonPjCkCZcgb7JwlexjIK70rELtm74JMYIZZ2hb3syY0Ib5lUtGZ4kYrKk11QK_FPnQzHfh_Es14V82xMLWB0Xi31Bi4bRWgMbi7oNsmEW43xBHdjosvWDiZ5db0jX8H24PscaGyR3Ce-ZUZXb3Ozm--XBc3HNpM9AAf8J5-WRIBJgzMzqCSuUybSUQvd8rEWu49o64PDQvMLdKieRxu2f-FYvI0Y59hS__p0EiSfQDdjfvHA-yKu56K9tbLLug";
 
-  test("token is null", () => {
-    const isValid = isTokenValid(null);
-    expect(isValid).toBeFalsy();
-  });
-
   test("token is valid", () => {
     // 5 minutes and 1 second before the expiration date.
     const now = (tokenExpiredDate - 301) * 1000;

--- a/packages/liveblocks-client/src/utils.test.ts
+++ b/packages/liveblocks-client/src/utils.test.ts
@@ -14,7 +14,7 @@ describe("compact", () => {
     expect(compact([])).toEqual([]);
   });
 
-  it("icompact removes nulls and undefined values", () => {
+  it("compact removes nulls and undefined values", () => {
     expect(compact(["a", "b", "c"])).toEqual(["a", "b", "c"]);
     expect(compact(["x", undefined])).toEqual(["x"]);
     expect(compact([0, null, undefined, NaN, Infinity])).toEqual([

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -368,11 +368,7 @@ export function findNonSerializableValue(
   return false;
 }
 
-export function isTokenValid(token: string | null) {
-  if (token === null) {
-    return false;
-  }
-
+export function isTokenValid(token: string) {
   const tokenParts = token.split(".");
   if (tokenParts.length !== 3) {
     return false;

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -14,7 +14,7 @@ import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
-import { Json } from "./json";
+import { Json, isJsonObject, parseJson } from "./json";
 import { Lson, LsonObject } from "./lson";
 import {
   LiveListUpdates,
@@ -374,8 +374,12 @@ export function isTokenValid(token: string) {
     return false;
   }
 
-  const data = JSON.parse(atob(tokenParts[1]));
-  if (typeof data.exp !== "number") {
+  const data = parseJson(atob(tokenParts[1]));
+  if (
+    data === undefined ||
+    !isJsonObject(data) ||
+    typeof data.exp !== "number"
+  ) {
     return false;
   }
 

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -32,6 +32,14 @@ export function remove<T>(array: T[], item: T) {
   }
 }
 
+/**
+ * Removes null and undefined values from the array, and reflects this in the
+ * output type.
+ */
+export function compact<T>(items: readonly T[]): NonNullable<T>[] {
+  return items.filter((item: T): item is NonNullable<T> => item != null);
+}
+
 export function creationOpToLiveStructure(op: CreateOp): AbstractCrdt {
   switch (op.type) {
     case OpType.CreateRegister:

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -22,6 +22,16 @@ import { remove } from "../src/utils";
 // TODO: Further improve this type
 type fixme = unknown;
 
+/**
+ * Deep-clones a JSON-serializable value.
+ */
+function deepClone<T extends Json>(items: T): T {
+  // NOTE: In this case, the combination of JSON.parse() and JSON.stringify
+  // won't lead to type unsafety, so this use case is okay.
+  // eslint-disable-next-line no-restricted-syntax
+  return JSON.parse(JSON.stringify(items));
+}
+
 export class MockWebSocket implements WebSocket {
   CONNECTING = 0;
   OPEN = 1;
@@ -183,7 +193,7 @@ async function prepareRoomWithStorage<T extends LsonObject>(
 
   const getStoragePromise = machine.getStorage<T>();
 
-  const clonedItems = JSON.parse(JSON.stringify(items));
+  const clonedItems = deepClone(items);
   machine.onMessage(
     serverMessage({
       type: ServerMessageType.InitialStorageState,


### PR DESCRIPTION
This PR plugs a potential security risk where untrusted inputs (via the result of `JSON.parse()`) are used (partially) unverified, allowing arbitrary data to trickle into our system which won't match the TypeScript types at runtime. There is no concrete risk, but in general you want to avoid this pattern, because it's a potential attack vector that malicious users could exploit.

This PR adds explicit validation of these inputs. How? By first [disallowing the use of `JSON.parse()`](https://github.com/liveblocks/liveblocks/blob/a8e8bc5eea5a0db30b216ad23b519b63bb54d52d/packages/liveblocks-client/.eslintrc.js#L68-L73), because in TypeScript its result is `any` (and it can throw!). Instead, we use the type-safe `parseJson()` helper that I added here, which will return `Json`. This way, TypeScript forces us to handle all the assumptions we're making explicitly first. You can see this reflected in the extended conditional checks.

## Future Work
A similar issue [exists here still](https://github.com/liveblocks/liveblocks/blob/a8e8bc5eea5a0db30b216ad23b519b63bb54d52d/packages/liveblocks-client/src/room.ts#L852-L853), where the assumed shape of the TypeScript object should be verified at runtime instead of assumed using an `as` statement. This issue isn't addressed yet. For big object structures like this, using `if`-statements becomes unwieldy. Of course, there [exists a library to help express this more elegantly 😉](https://github.com/nvie/decoders), but I didn't want to introduce a dependency here yet.
