### PR TITLE
Fix to make `JsonObject` type partial

### DIFF
--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -13,7 +13,10 @@ function lsonObjectToJson<O extends LsonObject>(
 ): { [K in keyof O]: Json } {
   const result: { [K in keyof O]: Json } = {} as any;
   for (const key in obj) {
-    result[key] = lsonToJson(obj[key]);
+    const val = obj[key];
+    if (val !== undefined) {
+      result[key] = lsonToJson(val);
+    }
   }
   return result;
 }
@@ -294,7 +297,10 @@ function patchImmutableNode(
 
         for (const key in update.updates) {
           if (update.updates[key]?.type === "update") {
-            newState[key] = lsonToJson(update.node.get(key));
+            const val = update.node.get(key);
+            if (val !== undefined) {
+              newState[key] = lsonToJson(val);
+            }
           } else if (update.updates[key]?.type === "delete") {
             delete newState[key];
           }

--- a/packages/liveblocks-client/src/json.ts
+++ b/packages/liveblocks-client/src/json.ts
@@ -11,7 +11,7 @@
 export type Json = JsonScalar | JsonArray | JsonObject;
 export type JsonScalar = string | number | boolean | null;
 export type JsonArray = Json[];
-export type JsonObject = { [key: string]: Json };
+export type JsonObject = Partial<{ [key: string]: Json }>;
 
 /**
  * Alternative to JSON.parse() that will not throw in production. If the passed

--- a/packages/liveblocks-client/src/json.ts
+++ b/packages/liveblocks-client/src/json.ts
@@ -11,7 +11,7 @@
 export type Json = JsonScalar | JsonArray | JsonObject;
 export type JsonScalar = string | number | boolean | null;
 export type JsonArray = Json[];
-export type JsonObject = Partial<{ [key: string]: Json }>;
+export type JsonObject = { [key: string]: Json | undefined };
 
 /**
  * Alternative to JSON.parse() that will not throw in production. If the passed

--- a/packages/liveblocks-client/src/lson.ts
+++ b/packages/liveblocks-client/src/lson.ts
@@ -49,7 +49,7 @@ export type ToJson<T extends Lson | LsonObject> =
   T extends LiveList<infer I> ? ToJson<I>[] :
 
   // A LiveObject serializes to an equivalent JSON object
-  T extends LiveObject<infer O> ? { [K in keyof O]: ToJson<Exclude<O[K], undefined>> } :
+  T extends LiveObject<infer O> ? ToJson<O> :
 
   // A LiveMap serializes to a JSON object with string-V pairs
   T extends LiveMap<infer KS, infer V> ? { [K in KS]: ToJson<V> } :

--- a/packages/liveblocks-client/src/lson.ts
+++ b/packages/liveblocks-client/src/lson.ts
@@ -19,7 +19,7 @@ export type Lson =
  * A mapping of keys to Lson values. A Lson value is any valid JSON
  * value or a Live storage data structure (LiveMap, LiveList, etc.)
  */
-export type LsonObject = { [key: string]: Lson };
+export type LsonObject = Partial<{ [key: string]: Lson }>;
 
 /**
  * Helper type to convert any valid Lson type to the equivalent Json type.
@@ -43,13 +43,13 @@ export type ToJson<T extends Lson | LsonObject> =
   T extends Json ? T :
 
   // Any LsonObject recursively becomes a JsonObject
-  T extends LsonObject ? { [K in keyof T]: ToJson<T[K]> } :
+  T extends LsonObject ? { [K in keyof T]: ToJson<Exclude<T[K], undefined>> } :
 
   // A LiveList serializes to an equivalent JSON array
   T extends LiveList<infer I> ? ToJson<I>[] :
 
   // A LiveObject serializes to an equivalent JSON object
-  T extends LiveObject<infer O> ? { [K in keyof O]: ToJson<O[K]> } :
+  T extends LiveObject<infer O> ? { [K in keyof O]: ToJson<Exclude<O[K], undefined>> } :
 
   // A LiveMap serializes to a JSON object with string-V pairs
   T extends LiveMap<infer KS, infer V> ? { [K in KS]: ToJson<V> } :

--- a/packages/liveblocks-client/src/lson.ts
+++ b/packages/liveblocks-client/src/lson.ts
@@ -19,7 +19,7 @@ export type Lson =
  * A mapping of keys to Lson values. A Lson value is any valid JSON
  * value or a Live storage data structure (LiveMap, LiveList, etc.)
  */
-export type LsonObject = Partial<{ [key: string]: Lson }>;
+export type LsonObject = { [key: string]: Lson | undefined };
 
 /**
  * Helper type to convert any valid Lson type to the equivalent Json type.

--- a/packages/liveblocks-client/src/lson.ts
+++ b/packages/liveblocks-client/src/lson.ts
@@ -43,7 +43,9 @@ export type ToJson<T extends Lson | LsonObject> =
   T extends Json ? T :
 
   // Any LsonObject recursively becomes a JsonObject
-  T extends LsonObject ? { [K in keyof T]: ToJson<Exclude<T[K], undefined>> } :
+  T extends LsonObject ?
+    { [K in keyof T]: ToJson<Exclude<T[K], undefined>>
+                        | (undefined extends T[K] ? undefined : never) } :
 
   // A LiveList serializes to an equivalent JSON array
   T extends LiveList<infer I> ? ToJson<I>[] :

--- a/packages/liveblocks-client/src/lson.ts
+++ b/packages/liveblocks-client/src/lson.ts
@@ -33,8 +33,8 @@ export type LsonObject = Partial<{ [key: string]: Lson }>;
  *   ToJson<string | LiveList<number>>  // string | number[]
  *   ToJson<LiveMap<string, LiveList<number>>>
  *                                      // { [key: string]: number[] }
- *   ToJson<LiveObject<{ a: number, b: LiveList<string> }>>
- *                                      // { a: null, b: string[] }
+ *   ToJson<LiveObject<{ a: number, b: LiveList<string>, c?: number }>>
+ *                                      // { a: null, b: string[], c?: number }
  *
  */
 // prettier-ignore

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1572,7 +1572,7 @@ function parseToken(token: string): AuthenticationToken {
     return {
       actor: data.actor,
       id: data.id,
-      info: data.info as Json | undefined,
+      info: data.info,
     };
   }
 


### PR DESCRIPTION
This fixes the `JsonObject` type to recognize that keys could be validly `undefined`.

Wrong behavior:

```tsx
const obj: JsonObject = ...;
obj.whatever;   // => Json ❌
```

New/correct behavior:

```tsx
const obj: JsonObject = ...;
obj.whatever;   // => Json | undefined ✅
```
