### PR TITLE
Make packages subpath exports compatible with typescript

### DIFF
--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -2,24 +2,24 @@
   "name": "@liveblocks/client",
   "version": "0.16.0",
   "description": "A client that lets you interact with Liveblocks servers.",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "files": [
-    "lib/**"
+    "**"
   ],
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./lib/index.d.ts",
-      "module": "./lib/esm/index.js",
-      "import": "./lib/esm/index.mjs",
-      "default": "./lib/index.js"
+      "types": "./index.d.ts",
+      "module": "./esm/index.js",
+      "import": "./esm/index.mjs",
+      "default": "./index.js"
     },
     "./internal": {
-      "types": "./lib/internal.d.ts",
-      "module": "./lib/esm/internal.js",
-      "import": "./lib/esm/internal.mjs",
-      "default": "./lib/internal.js"
+      "types": "./internal.d.ts",
+      "module": "./esm/internal.js",
+      "import": "./esm/internal.mjs",
+      "default": "./internal.js"
     }
   },
   "keywords": [
@@ -32,7 +32,7 @@
     "url": "https://github.com/liveblocks/liveblocks/issues"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "test": "jest --watch",
     "test-ci": "jest"
   },

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -2,18 +2,18 @@
   "name": "@liveblocks/react",
   "version": "0.16.0",
   "description": "A set of React hooks and providers to use Liveblocks declaratively.",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "files": [
-    "lib/**"
+    "**"
   ],
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./lib/index.d.ts",
-      "module": "./lib/esm/index.js",
-      "import": "./lib/esm/index.mjs",
-      "default": "./lib/index.js"
+      "types": "./index.d.ts",
+      "module": "./esm/index.js",
+      "import": "./esm/index.mjs",
+      "default": "./index.js"
     }
   },
   "keywords": [
@@ -27,7 +27,7 @@
     "url": "https://github.com/liveblocks/liveblocks/issues"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "start": "rollup -c -w",
     "test": "jest --watch"
   },

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -17,12 +17,11 @@ import {
   useOthers,
 } from ".";
 
-// TODO: find out why typescript is complaining when using @liveblocks/client/internal even if properly defined in package.json
 import {
   ClientMessageType,
   CrdtType,
   ServerMessageType,
-} from "@liveblocks/client/lib/internal";
+} from "@liveblocks/client/internal";
 
 /**
  * https://github.com/Luka967/websocket-close-codes

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -3,17 +3,17 @@
   "version": "0.16.0",
   "sideEffects": false,
   "description": "A store enhancer to integrate Liveblocks into Redux stores.",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "files": [
-    "lib/"
+    "**"
   ],
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "module": "./lib/esm/index.js",
-      "import": "./lib/esm/index.mjs",
-      "default": "./lib/index.js"
+      "types": "./index.d.ts",
+      "module": "./esm/index.js",
+      "import": "./esm/index.mjs",
+      "default": "./index.js"
     }
   },
   "keywords": [
@@ -25,7 +25,7 @@
     "collaborative"
   ],
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "test": "jest --watch",
     "dtslint": "dtslint --localTs node_modules/typescript/lib --expectOnly types"
   },

--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -10,7 +10,7 @@ import {
   SerializedCrdtWithId,
   ServerMessage,
   ServerMessageType,
-} from "@liveblocks/client/lib/internal";
+} from "@liveblocks/client/internal";
 import {
   missingClient,
   mappingShouldBeAnObject,

--- a/packages/liveblocks-redux/test/utils.ts
+++ b/packages/liveblocks-redux/test/utils.ts
@@ -1,7 +1,4 @@
-import {
-  CrdtType,
-  SerializedCrdtWithId,
-} from "@liveblocks/client/lib/internal";
+import { CrdtType, SerializedCrdtWithId } from "@liveblocks/client/internal";
 
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -3,17 +3,17 @@
   "version": "0.16.0",
   "sideEffects": false,
   "description": "A middleware to integrate Liveblocks into Zustand stores.",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "files": [
-    "lib/"
+    "**"
   ],
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "module": "./lib/esm/index.js",
-      "import": "./lib/esm/index.mjs",
-      "default": "./lib/index.js"
+      "types": "./index.d.ts",
+      "module": "./esm/index.js",
+      "import": "./esm/index.mjs",
+      "default": "./index.js"
     }
   },
   "keywords": [
@@ -25,7 +25,7 @@
     "collaborative"
   ],
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "test": "jest --watch",
     "dtslint": "dtslint --localTs node_modules/typescript/lib --expectOnly types"
   },

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -10,7 +10,7 @@ import {
   SerializedCrdtWithId,
   ServerMessage,
   ServerMessageType,
-} from "@liveblocks/client/lib/internal";
+} from "@liveblocks/client/internal";
 import { list, MockWebSocket, obj, waitFor } from "../test/utils";
 import {
   mappingShouldBeAnObject,

--- a/packages/liveblocks-zustand/test/utils.ts
+++ b/packages/liveblocks-zustand/test/utils.ts
@@ -1,7 +1,4 @@
-import {
-  CrdtType,
-  SerializedCrdtWithId,
-} from "@liveblocks/client/lib/internal";
+import { CrdtType, SerializedCrdtWithId } from "@liveblocks/client/internal";
 
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -180,8 +180,11 @@ prep_liveblocks_deps () {
 
             rebuild_if_needed
 
-            # Built package is located in the lib folder, including the package.json
-            cd "./lib"
+            # If a `package.json` exists in the dist folder, consider it the
+            # root of the package.
+            if [ -f "./lib/package.json" ]; then
+                cd "./lib"
+            fi
 
             # Register this link
             npm_link

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -180,6 +180,9 @@ prep_liveblocks_deps () {
 
             rebuild_if_needed
 
+            # Built package is located in the lib folder, including the package.json
+            cd "./lib"
+
             # Register this link
             npm_link
         ) )

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -270,7 +270,11 @@ publish_to_npm () {
         read -p "OTP token? " OTP
     done
 
-    npm publish ./lib --tag "${TAG:-latest}" --otp "$OTP"
+    if [ -f "./lib/package.json" ]; then
+        cd "./lib"
+    fi
+
+    npm publish --tag "${TAG:-latest}" --otp "$OTP"
 }
 
 commit_to_git () {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -270,7 +270,7 @@ publish_to_npm () {
         read -p "OTP token? " OTP
     done
 
-    npm publish --tag "${TAG:-latest}" --otp "$OTP"
+    npm publish ./lib --tag "${TAG:-latest}" --otp "$OTP"
 }
 
 commit_to_git () {


### PR DESCRIPTION
Update our packages subpath exports to be compatible with typescript.

[Subpath exports](https://nodejs.org/api/packages.html#subpath-exports) are supported by node.js but typescript (and tsc) only support it with the latest beta version (and `moduleResolutions: "node12"`).

To work around this limitation, we update the subpath exports to have the exact same name as the js file they map to. That way typescript can understand the imports while more modern tools like `esbuild` will use them if necessary.

We copy the package.json and README file to the `lib` folder after a build and assume that link and publish will be done from this subfolder.  (Technique shamelessly stolen from zustand : https://github.com/pmndrs/zustand/blob/main/package.json#L68)