### PR TITLE
Always force at least one entire rebuild when `-f` is provided

### DIFF
--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -72,11 +72,11 @@ if [ ! -f "$PROJECT_PACKAGE_JSON" ]; then
 fi
 
 modified_timestamp () {
-    if [ "$(uname -s)" = "Darwin" ]; then
-        stat -f%m "$@"
-    else
-        stat -c %Z "$@"
-    fi
+    # There's no POSIX-compatible way of getting a file's last modification
+    # date. The best portable shot that works on Mac and Linux platforms is
+    # using Perl, it seems.
+    # Shamelessly stolen from https://unix.stackexchange.com/a/561933
+    perl -MPOSIX -le 'for (@ARGV) { if (@s = lstat$_) {print $s[9]} else {warn "$_: $!\n"} }' -- "$@"
 }
 
 # Returns the modification timestamp for the oldest file found in the given

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -71,6 +71,14 @@ if [ ! -f "$PROJECT_PACKAGE_JSON" ]; then
     exit 2
 fi
 
+modified_timestamp () {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        stat -f%m "$@"
+    else
+        stat -c %Y "$@"
+    fi
+}
+
 # Returns the modification timestamp for the oldest file found in the given
 # files or directories
 oldest_file () {
@@ -146,7 +154,7 @@ liveblocks_pkg_dir () {
 
 rebuild_if_needed () {
     if [ -e "lib/.built-by-link-script" ]; then
-        if [ "$(stat -f%m lib/.built-by-link-script)" -lt "$now" ]; then
+        if [ "$(modified_timestamp lib/.built-by-link-script)" -lt "$now" ]; then
             # If the "built marker" is older than this script invocation date,
             # remove it.
             rm lib/.built-by-link-script

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -161,6 +161,7 @@ rebuild_if_needed () {
         else
             # This was already rebuilt by an earlier invocation of this build
             # script. We don't have to throw away those results!
+            err "Skipping (build still fresh)"
             return
         fi
     fi

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -75,7 +75,7 @@ modified_timestamp () {
     if [ "$(uname -s)" = "Darwin" ]; then
         stat -f%m "$@"
     else
-        stat -c %Y "$@"
+        stat -c %Z "$@"
     fi
 }
 


### PR DESCRIPTION
Small fix for an edge case in the `link-liveblocks.sh` script. It tries to be economic and only rebuild projects that haven't already been rebuilt since this command was invoked. For example, if project X depends on both `@liveblocks/react` and `@liveblocks/client`, then it will only rebuild `@liveblocks/client` once, by leaving a marker file in the `lib/` directory to indicate that.

However, what this means is that in unclean environments (= local dev), you can have those marker files lingering around from a previous build, falsely indicating that those builds are still up to date. In these cases, using `link-liveblocks.sh -f` will falsely skip builds, potentially linking an old version (for example from a previous branch).

This PR fixes this issue, by checking the date modified of those marker files. If they are older than when the script was started, they should be ignored. This way, using `link-liveblocks.sh -f` will guarantee you that you end up with the correctly linked version that matches the local `src/` directories.
