### PR TITLE
fix: duplicate list items in client B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ...
 
+## `@liveblocks/zustand` & `@liveblocks/redux`
+
+Fixes an issue when initializing an array with items would result in having duplicated items in other clients.
+Examples:
+
+- Client A updates state : `{ list: [0]}`
+- Client B states is updated to : `{ list: [0, 0]}`
+
 # v0.16.2
 
 ## `@liveblocks/client`

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -132,7 +132,7 @@ describe("2 ways tests with two clients", () => {
       assert({ syncObj: { a: { subA: "ok" } } }, 3, 1);
     });
 
-    test("update object, add nested LiveList with one element", async () => {
+    test("create LiveList with one LiveRegister item in same batch", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<{
         doc: any;
       }>(
@@ -146,12 +146,56 @@ describe("2 ways tests with two clients", () => {
       expect(state).toEqual({ doc: {} });
 
       const { oldState, newState } = applyStateChanges(state, () => {
-        state.doc = { pos: [0] };
+        state.doc = { sub: [0] };
       });
 
       patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
 
-      assert({ doc: { pos: [0] } }, 4, 1);
+      assert({ doc: { sub: [0] } }, 4, 2);
+    });
+
+    test("create nested LiveList with one LiveObject item in same batch", async () => {
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        doc: any;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedObject("0:1", {}, "0:0", "doc"),
+        ],
+        1
+      );
+
+      expect(state).toEqual({ doc: {} });
+
+      const { oldState, newState } = applyStateChanges(state, () => {
+        state.doc = { sub: { subSub: [{ a: 1 }] } };
+      });
+
+      patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
+
+      assert({ doc: { sub: { subSub: [{ a: 1 }] } } }, 5, 3);
+    });
+
+    test("Add nested objects in same batch", async () => {
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        doc: any;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedObject("0:1", {}, "0:0", "doc"),
+        ],
+        1
+      );
+
+      expect(state).toEqual({ doc: {} });
+
+      const { oldState, newState } = applyStateChanges(state, () => {
+        state.doc = { pos: { a: { b: 1 } } };
+      });
+
+      patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
+
+      assert({ doc: { pos: { a: { b: 1 } } } }, 4, 2);
     });
 
     test("delete object key", async () => {

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -132,6 +132,28 @@ describe("2 ways tests with two clients", () => {
       assert({ syncObj: { a: { subA: "ok" } } }, 3, 1);
     });
 
+    test("update object, add nested LiveList with one element", async () => {
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        doc: any;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedObject("0:1", {}, "0:0", "doc"),
+        ],
+        1
+      );
+
+      expect(state).toEqual({ doc: {} });
+
+      const { oldState, newState } = applyStateChanges(state, () => {
+        state.doc = { pos: [0] };
+      });
+
+      patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
+
+      assert({ doc: { pos: [0] } }, 4, 1);
+    });
+
     test("delete object key", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<{
         syncObj: { a?: number };

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -463,7 +463,7 @@ export function makeStateMachine(
       },
     };
 
-    const updatedNodeIds = new Set<string>();
+    const createdNodeIds = new Set<string>();
     for (const op of item) {
       if (op.type === "presence") {
         const reverse = {
@@ -496,9 +496,9 @@ export function makeStateMachine(
         if (applyOpResult.modified) {
           const parentId = applyOpResult.modified.node._parent?._id!;
 
-          // If the parent was updated in the same batch, we don't want to notify
+          // If the parent was created in the same batch, we don't want to notify
           // storage updates for the children.
-          if (!updatedNodeIds.has(parentId)) {
+          if (!createdNodeIds.has(parentId)) {
             result.updates.storageUpdates.set(
               applyOpResult.modified.node._id!,
               mergeStorageUpdates(
@@ -511,7 +511,13 @@ export function makeStateMachine(
             result.reverse.unshift(...applyOpResult.reverse);
           }
 
-          updatedNodeIds.add(applyOpResult.modified.node._id!);
+          if (
+            op.type === OpType.CreateList ||
+            op.type === OpType.CreateMap ||
+            op.type === OpType.CreateObject
+          ) {
+            createdNodeIds.add(applyOpResult.modified.node._id!);
+          }
         }
       }
     }


### PR DESCRIPTION
## Zustand and Redux packages
Fixes an issue when initializing an array with items would result in having duplicated items in other clients. 
Examples:
- Client A updates state :  `{ list: [0]}`
- Client B states is updated to : `{ list: [0, 0]}`