### PR TITLE
Add `Resolve<T>` helper type

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -4,7 +4,6 @@ export { LiveList } from "./LiveList";
 export type {
   Others,
   Presence,
-  Resolve,
   Room,
   Client,
   User,

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -4,6 +4,7 @@ export { LiveList } from "./LiveList";
 export type {
   Others,
   Presence,
+  Resolve,
   Room,
   Client,
   User,

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -1,2 +1,4 @@
 export * from "./live";
 export * from "./position";
+
+export type { Resolve } from "./types";

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -4,6 +4,30 @@ import type { LiveObject } from "./LiveObject";
 import { Json, JsonObject } from "./json";
 import { Lson, LsonObject } from "./lson";
 
+/**
+ * This helper type is effectively a no-op, but will force TypeScript to
+ * "evaluate" any named helper types in its definition. This can sometimes make
+ * API signatures clearer in IDEs.
+ *
+ * For example, in:
+ *
+ *   type Payload<T> = { data: T };
+ *
+ *   let r1: Payload<string>;
+ *   let r2: Resolve<Payload<string>>;
+ *
+ * The inferred type of `r1` is going to be `Payload<string>` which shows up in
+ * editor hints, and it may be unclear what's inside if you don't know the
+ * definition of `Payload`.
+ *
+ * The inferred type of `r2` is going to be `{ data: string }`, which may be
+ * more helpful.
+ *
+ * This trick comes from:
+ * https://effectivetypescript.com/2022/02/25/gentips-4-display/
+ */
+export type Resolve<T> = T extends Function ? T : { [K in keyof T]: T[K] };
+
 export type MyPresenceCallback<T extends Presence = Presence> = (me: T) => void;
 
 export type OthersEventCallback<T extends Presence = Presence> = (


### PR DESCRIPTION
This type is a useful helper when building libraries with type definitions. Trick comes from https://effectivetypescript.com/2022/02/25/gentips-4-display/, and when used strategically it can really improve the developer experience in IDEs, see [this playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAShDOB7ANgNwgHgCoD4oF4osoIAPYCAOwBN4oAxAV0oGNgBLRSqAfiKgBcUAN4BtANJR23ANYQQiAGZEAukKwSVAXwDcAKD2hIsBI2TBsefHqhQAPiKiIZQ4ACdGEADRQwAQxBkRD9qdSgtG3tHZyFFP2R4aB8INzcAW3gAcyF4d2lM8P09ZAhgKDcARiE4eDMLXLd80RUcfQB6NtsAPR4DErK3ACZqhBR0DBq6jAamlta9Du7eoA):

![Screen Shot 2022-05-03 at 12 09 53@2x](https://user-images.githubusercontent.com/83844/166436432-57a4868e-3b56-42aa-872e-5744a2d8eda3.png)

(Not all types have to be resolved. There is a place for both of these type display variants. This utility lets us control it a bit though!)

I'm going to be using this in the next PR.