### PR TITLE
Deprecate local initializers (targeted for 0.16.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 - Improve our generated bundles. They are now even more tree-shakable, and smaller!
 
+## `@liveblocks/client`
+
+Some APIs are being **deprecated** and may start showing console warnings when used:
+
+- The `defaultPresence` option to `client.enter()` will get renamed to `initialPresence`
+- The `defaultStorageRoot` option to `client.enter()` will get renamed to `initialStorage`
+
+## `@liveblocks/react`
+
+Some APIs are being **deprecated** and may start showing console warnings when used:
+
+- The RoomProvider's `defaultPresence` will get renamed to `initialPresence`
+- The RoomProvider's `defaultStorageRoot` will get renamed to `initialStorage`
+- The second argument to `useList()`, `useObject()`, and `useMap()` is deprecated
+
+For information, please see https://bit.ly/lak1PlM.
+
 # v0.16.3
 
 Fix bug where internal presence state could not get restored correctly after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Some APIs are being **deprecated** and may start showing console warnings when u
 - The RoomProvider's `defaultStorageRoot` will get renamed to `initialStorage`
 - The second argument to `useList()`, `useObject()`, and `useMap()` is deprecated
 
-For information, please see https://bit.ly/lak1PlM.
+For information, please see https://bit.ly/3Niy5aP.
 
 # v0.16.3
 

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -69,12 +69,12 @@ export function createClient(options: ClientOptions): Client {
 
     deprecateIf(
       options.defaultPresence,
-      "Option `defaultPresence` is scheduled for removal in 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
+      "Argument `defaultPresence` will be removed in @liveblocks/client 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
       "defaultPresence"
     );
     deprecateIf(
       options.defaultStorageRoot,
-      "Option `defaultStorageRoot` is scheduled for removal in 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
+      "Argument `defaultStorageRoot` will be removed in @liveblocks/client 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
       "defaultStorageRoot"
     );
 

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,11 +1,25 @@
 import { createRoom, InternalRoom } from "./room";
 import type {
-  ClientOptions,
-  Room,
-  Client,
-  Presence,
   Authentication,
+  Client,
+  ClientOptions,
+  Presence,
+  Resolve,
+  Room,
+  RoomInitializers,
 } from "./types";
+
+type EnterOptions<TPresence, TStorage> = Resolve<
+  // Enter options are just room initializers, plus an internal option
+  RoomInitializers<TPresence, TStorage> & {
+    /**
+     * INTERNAL OPTION: Only used in a SSR context when you want an empty room
+     * to make sure your react tree is rendered properly without connecting to
+     * websocket
+     */
+    DO_NOT_USE_withoutConnecting?: boolean;
+  }
+>;
 
 /**
  * Create a client that will be responsible to communicate with liveblocks servers.
@@ -45,14 +59,7 @@ export function createClient(options: ClientOptions): Client {
 
   function enter<TStorage>(
     roomId: string,
-    options: {
-      defaultPresence?: Presence;
-      defaultStorageRoot?: TStorage;
-      /**
-       * INTERNAL OPTION: Only used in a SSR context when you want an empty room to make sure your react tree is rendered properly without connecting to websocket
-       */
-      DO_NOT_USE_withoutConnecting?: boolean;
-    } = {}
+    options: EnterOptions<Presence, TStorage> = {}
   ): Room {
     let internalRoom = rooms.get(roomId);
     if (internalRoom) {

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -67,8 +67,10 @@ export function createClient(options: ClientOptions): Client {
     }
     internalRoom = createRoom(
       {
-        defaultPresence: options.defaultPresence,
-        defaultStorageRoot: options.defaultStorageRoot,
+        initialPresence: options.initialPresence,
+        initialStorage: options.initialStorage,
+        defaultPresence: options.defaultPresence, // Will get removed in 0.18
+        defaultStorageRoot: options.defaultStorageRoot, // Will get removed in 0.18
       },
       {
         roomId,

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -69,12 +69,12 @@ export function createClient(options: ClientOptions): Client {
 
     deprecateIf(
       options.defaultPresence,
-      "Argument `defaultPresence` will be removed in @liveblocks/client 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
+      "Argument `defaultPresence` will be removed in @liveblocks/client 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP",
       "defaultPresence"
     );
     deprecateIf(
       options.defaultStorageRoot,
-      "Argument `defaultStorageRoot` will be removed in @liveblocks/client 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
+      "Argument `defaultStorageRoot` will be removed in @liveblocks/client 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP",
       "defaultStorageRoot"
     );
 

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -8,6 +8,7 @@ import type {
   Room,
   RoomInitializers,
 } from "./types";
+import { deprecateIf } from "./utils";
 
 type EnterOptions<TPresence, TStorage> = Resolve<
   // Enter options are just room initializers, plus an internal option
@@ -65,6 +66,18 @@ export function createClient(options: ClientOptions): Client {
     if (internalRoom) {
       return internalRoom.room;
     }
+
+    deprecateIf(
+      options.defaultPresence,
+      "Option `defaultPresence` is scheduled for removal in 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
+      "defaultPresence"
+    );
+    deprecateIf(
+      options.defaultStorageRoot,
+      "Option `defaultStorageRoot` is scheduled for removal in 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
+      "defaultStorageRoot"
+    );
+
     internalRoom = createRoom(
       {
         initialPresence: options.initialPresence,

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -12,7 +12,7 @@
  */
 
 export type { SerializedCrdtWithId, ServerMessage } from "./live";
-export type { Resolve } from "./types";
+export type { Resolve, RoomInitializers } from "./types";
 
 export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";
 export { deprecate, deprecateIf } from "./utils";

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1434,8 +1434,8 @@ See v0.13 release notes for more information.
 }
 
 export function defaultState(
-  me?: Presence,
-  defaultStorageRoot?: JsonObject
+  initialPresence?: Presence,
+  initialStorage?: JsonObject
 ): State {
   return {
     connection: { state: "closed" },
@@ -1458,17 +1458,17 @@ export function defaultState(
       pongTimeout: 0,
     },
     buffer: {
-      presence: me == null ? {} : me,
+      presence: initialPresence == null ? {} : initialPresence,
       messages: [],
       storageOperations: [],
     },
     intervalHandles: {
       heartbeat: 0,
     },
-    me: me == null ? {} : me,
+    me: initialPresence == null ? {} : initialPresence,
     users: {},
     others: makeOthers({}),
-    defaultStorageRoot,
+    defaultStorageRoot: initialStorage,
     idFactory: null,
 
     // Storage

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1511,8 +1511,12 @@ export function createRoom(
   const initialStorage = options.initialStorage ?? options.defaultStorageRoot;
 
   const state = defaultState(
-    typeof initialPresence === "function" ? initialPresence() : initialPresence,
-    typeof initialStorage === "function" ? initialStorage() : initialStorage
+    typeof initialPresence === "function"
+      ? initialPresence(context.roomId)
+      : initialPresence,
+    typeof initialStorage === "function"
+      ? initialStorage(context.roomId)
+      : initialStorage
   );
 
   const machine = makeStateMachine(state, context);

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -18,6 +18,7 @@ import type {
   BroadcastOptions,
   AuthorizeResponse,
   Authentication,
+  RoomInitializers,
 } from "./types";
 import type { Json, JsonObject } from "./json";
 import { isJsonObject, isJsonArray, parseJson } from "./json";
@@ -1503,10 +1504,7 @@ export type InternalRoom = {
 };
 
 export function createRoom(
-  options: {
-    defaultPresence?: Presence;
-    defaultStorageRoot?: Record<string, any>;
-  },
+  options: RoomInitializers<Presence, Record<string, any>>,
   context: Context
 ): InternalRoom {
   const state = defaultState(

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1507,8 +1507,8 @@ export function createRoom(
   options: RoomInitializers<Presence, Record<string, any>>,
   context: Context
 ): InternalRoom {
-  const initialPresence = options.defaultPresence;
-  const initialStorage = options.defaultStorageRoot;
+  const initialPresence = options.initialPresence ?? options.defaultPresence;
+  const initialStorage = options.initialStorage ?? options.defaultStorageRoot;
 
   const state = defaultState(
     typeof initialPresence === "function" ? initialPresence() : initialPresence,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1507,9 +1507,12 @@ export function createRoom(
   options: RoomInitializers<Presence, Record<string, any>>,
   context: Context
 ): InternalRoom {
+  const initialPresence = options.defaultPresence;
+  const initialStorage = options.defaultStorageRoot;
+
   const state = defaultState(
-    options.defaultPresence,
-    options.defaultStorageRoot
+    typeof initialPresence === "function" ? initialPresence() : initialPresence,
+    typeof initialStorage === "function" ? initialStorage() : initialStorage
   );
 
   const machine = makeStateMachine(state, context);

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -148,8 +148,8 @@ export type StorageUpdate =
 export type StorageCallback = (updates: StorageUpdate[]) => void;
 
 export type RoomInitializers<TPresence, TStorage> = Resolve<{
-  defaultPresence?: TPresence;
-  defaultStorageRoot?: TStorage;
+  defaultPresence?: TPresence | (() => TPresence);
+  defaultStorageRoot?: TStorage | (() => TStorage);
 }>;
 
 export type Client = {

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -163,7 +163,7 @@ export type Client = {
   /**
    * Enters a room and returns it.
    * @param roomId The id of the room
-   * @param defaultPresence Optional. Should be serializable to JSON. If omitted, an empty object will be used.
+   * @param options Optional. You can provide initializers for the Presence or Storage when entering the Room.
    */
   enter<TStorage extends Record<string, any> = Record<string, any>>(
     roomId: string,

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -147,6 +147,11 @@ export type StorageUpdate =
 
 export type StorageCallback = (updates: StorageUpdate[]) => void;
 
+export type RoomInitializers<TPresence, TStorage> = Resolve<{
+  defaultPresence?: TPresence;
+  defaultStorageRoot?: TStorage;
+}>;
+
 export type Client = {
   /**
    * Gets a room. Returns null if {@link Client.enter} has not been called previously.
@@ -162,10 +167,7 @@ export type Client = {
    */
   enter<TStorage extends Record<string, any> = Record<string, any>>(
     roomId: string,
-    options?: {
-      defaultPresence?: Presence;
-      defaultStorageRoot?: TStorage;
-    }
+    options?: RoomInitializers<Presence, TStorage>
   ): Room;
 
   /**

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -152,11 +152,11 @@ export type RoomInitializers<TPresence, TStorage> = Resolve<{
    * The initial Presence to use and announce when you enter the Room. The
    * Presence is available on all users in the Room (me & others).
    */
-  initialPresence?: TPresence | (() => TPresence);
+  initialPresence?: TPresence | ((roomId: string) => TPresence);
   /**
    * The initial Storage to use when entering a new Room.
    */
-  initialStorage?: TStorage | (() => TStorage);
+  initialStorage?: TStorage | ((roomId: string) => TStorage);
   /**
    * @deprecated Please use `initialPresence` instead. This property is
    * scheduled for removal in 0.18.

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -161,12 +161,12 @@ export type RoomInitializers<TPresence, TStorage> = Resolve<{
    * @deprecated Please use `initialPresence` instead. This property is
    * scheduled for removal in 0.18.
    */
-  defaultPresence?: TPresence | (() => TPresence);
+  defaultPresence?: () => TPresence;
   /**
    * @deprecated Please use `initialStorage` instead. This property is
    * scheduled for removal in 0.18.
    */
-  defaultStorageRoot?: TStorage | (() => TStorage);
+  defaultStorageRoot?: TStorage;
 }>;
 
 export type Client = {

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -148,7 +148,24 @@ export type StorageUpdate =
 export type StorageCallback = (updates: StorageUpdate[]) => void;
 
 export type RoomInitializers<TPresence, TStorage> = Resolve<{
+  /**
+   * The initial Presence to use and announce when you enter the Room. The
+   * Presence is available on all users in the Room (me & others).
+   */
+  initialPresence?: TPresence | (() => TPresence);
+  /**
+   * The initial Storage to use when entering a new Room.
+   */
+  initialStorage?: TStorage | (() => TStorage);
+  /**
+   * @deprecated Please use `initialPresence` instead. This property is
+   * scheduled for removal in 0.18.
+   */
   defaultPresence?: TPresence | (() => TPresence);
+  /**
+   * @deprecated Please use `initialStorage` instead. This property is
+   * scheduled for removal in 0.18.
+   */
   defaultStorageRoot?: TStorage | (() => TStorage);
 }>;
 

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -36,7 +36,7 @@ export function deprecate(message: string, key = message) {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
       _emittedDeprecationWarnings.add(key);
-      console.warn(`DEPRECATION WARNING: ${message}`);
+      console.error(`DEPRECATION WARNING: ${message}`);
     }
   }
 }

--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -1,4 +1,5 @@
 export { LiveblocksProvider, useClient } from "./client";
+
 export {
   RoomProvider,
   useRoom,

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -55,12 +55,12 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
 
   deprecateIf(
     defaultPresence,
-    "RoomProvider's `defaultPresence` prop will be removed in @liveblocks/react 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
+    "RoomProvider's `defaultPresence` prop will be removed in @liveblocks/react 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP",
     "defaultPresence"
   );
   deprecateIf(
     defaultStorageRoot,
-    "RoomProvider's `defaultStorageRoot` prop will be removed in @liveblocks/react 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
+    "RoomProvider's `defaultStorageRoot` prop will be removed in @liveblocks/react 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP",
     "defaultStorageRoot"
   );
 
@@ -370,7 +370,7 @@ export function useMap<TKey extends string, TValue extends Lson>(
 ): LiveMap<TKey, TValue> | null;
 /**
  * @deprecated We no longer recommend initializing the
- * entries from the useMap() hook. For details, see https://bit.ly/lak1PlM.
+ * entries from the useMap() hook. For details, see https://bit.ly/3Niy5aP.
  */
 export function useMap<TKey extends string, TValue extends Lson>(
   key: string,
@@ -395,7 +395,7 @@ Instead, please initialize this data where you set up your RoomProvider:
       ...
     </RoomProvider>
 
-Please see https://bit.ly/lak1PlM for details.`
+Please see https://bit.ly/3Niy5aP for details.`
   );
   const value = useCrdt(key, new LiveMap(entries));
   //                         ^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +422,7 @@ Instead, please initialize your storage where you set up your RoomProvider:
       ...
     </RoomProvider>
 
-Please see https://bit.ly/lak1PlM for details.`
+Please see https://bit.ly/3Niy5aP for details.`
     );
     return null;
   }
@@ -443,7 +443,7 @@ export function useList<TValue extends Lson>(
 ): LiveList<TValue> | null;
 /**
  * @deprecated We no longer recommend initializing the
- * items from the useList() hook. For details, see https://bit.ly/lak1PlM.
+ * items from the useList() hook. For details, see https://bit.ly/3Niy5aP.
  */
 export function useList<TValue extends Lson>(
   key: string,
@@ -470,7 +470,7 @@ Instead, please initialize this data where you set up your RoomProvider:
       ...
     </RoomProvider>
 
-Please see https://bit.ly/lak1PlM for details.`
+Please see https://bit.ly/3Niy5aP for details.`
   );
   const value = useCrdt<LiveList<TValue>>(key, new LiveList(items));
   //                                           ^^^^^^^^^^^^^^^^^^^
@@ -497,7 +497,7 @@ Instead, please initialize your storage where you set up your RoomProvider:
       ...
     </RoomProvider>
 
-Please see https://bit.ly/lak1PlM for details.`
+Please see https://bit.ly/3Niy5aP for details.`
     );
     return null;
   }
@@ -518,7 +518,7 @@ export function useObject<TData extends LsonObject>(
 ): LiveObject<TData> | null;
 /**
  * @deprecated We no longer recommend initializing the fields from the
- * useObject() hook. For details, see https://bit.ly/lak1PlM.
+ * useObject() hook. For details, see https://bit.ly/3Niy5aP.
  */
 export function useObject<TData extends LsonObject>(
   key: string,
@@ -545,7 +545,7 @@ Instead, please initialize this data where you set up your RoomProvider:
       ...
     </RoomProvider>
 
-Please see https://bit.ly/lak1PlM for details.`
+Please see https://bit.ly/3Niy5aP for details.`
   );
   const value = useCrdt(key, new LiveObject(initialData));
   //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -572,7 +572,7 @@ Instead, please initialize your storage where you set up your RoomProvider:
       ...
     </RoomProvider>
 
-Please see https://bit.ly/lak1PlM for details.`
+Please see https://bit.ly/3Niy5aP for details.`
     );
     return null;
   }

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -12,6 +12,7 @@ import type {
   User,
 } from "@liveblocks/client";
 import { LiveMap, LiveList, LiveObject } from "@liveblocks/client";
+import { deprecateIf } from "@liveblocks/client/internal";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
 import useRerender from "./useRerender";
 
@@ -51,6 +52,17 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
       throw new Error("RoomProvider id property should be a string.");
     }
   }
+
+  deprecateIf(
+    defaultPresence,
+    "RoomProvider's `defaultPresence` prop is scheduled for removal in 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
+    "defaultPresence"
+  );
+  deprecateIf(
+    defaultStorageRoot,
+    "RoomProvider's `defaultStorageRoot` prop is scheduled for removal in 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
+    "defaultStorageRoot"
+  );
 
   const client = useClient();
 

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -348,58 +348,105 @@ export function useStorage<TStorage extends Record<string, any>>(): [
  * The hook triggers a re-render if the LiveMap is updated, however it does not triggers a re-render if a nested CRDT is updated.
  *
  * @param key The storage key associated with the LiveMap
- * @param entries Optional entries that are used to create the LiveMap for the first time
  * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
  *
  * @example
- * const emptyMap = useMap("mapA");
- * const mapWithItems = useMap("mapB", [["keyA", "valueA"], ["keyB", "valueB"]]);
+ * const shapesById = useMap<string, Shape>("shapes");
  */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string
+): LiveMap<TKey, TValue> | null;
+/**
+ * @deprecated We no longer recommend initializing the
+ * entries from the useMap() hook. For details, see https://bit.ly/lak1PlM.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string,
+  entries: readonly (readonly [TKey, TValue])[] | null
+): LiveMap<TKey, TValue> | null;
 export function useMap<TKey extends string, TValue extends Lson>(
   key: string,
   entries?: readonly (readonly [TKey, TValue])[] | null | undefined
 ): LiveMap<TKey, TValue> | null {
+  if (entries && process.env.NODE_ENV === "development") {
+    console.warn(
+      "We no longer recommend initializing the items from the useMap() hook. Please see https://bit.ly/lak1PlM for details."
+    );
+  }
   return useCrdt(key, new LiveMap(entries));
+  //                  ^^^^^^^^^^^^^^^^^^^^
+  //                  NOTE: This param is scheduled for removal in 0.18
 }
 
 /**
- * Returns the LiveList associated with the provided key. If the LiveList does not exist, a new LiveList will be created.
+ * Returns the LiveList associated with the provided key.
  * The hook triggers a re-render if the LiveList is updated, however it does not triggers a re-render if a nested CRDT is updated.
  *
  * @param key The storage key associated with the LiveList
- * @param items Optional items that are used to create the LiveList for the first time
  * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
  *
  * @example
- * const emptyList = useList("listA");
- * const listWithItems = useList("listB", ["a", "b", "c"]);
+ * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
  */
+export function useList<TValue extends Lson>(
+  key: string
+): LiveList<TValue> | null;
+/**
+ * @deprecated We no longer recommend initializing the
+ * items from the useList() hook. For details, see https://bit.ly/lak1PlM.
+ */
+export function useList<TValue extends Lson>(
+  key: string,
+  items: TValue[]
+): LiveList<TValue> | null;
 export function useList<TValue extends Lson>(
   key: string,
   items?: TValue[] | undefined
 ): LiveList<TValue> | null {
+  if (items && process.env.NODE_ENV === "development") {
+    console.warn(
+      "We no longer recommend initializing the items from the useList() hook. Please see https://bit.ly/lak1PlM for details."
+    );
+  }
+
   return useCrdt<LiveList<TValue>>(key, new LiveList(items));
+  //                                    ^^^^^^^^^^^^^^^^^^^
+  //                                    NOTE: This param is scheduled for removal in 0.18
 }
 
 /**
- * Returns the LiveObject associated with the provided key. If the LiveObject does not exist, it will be created with the initialData parameter.
+ * Returns the LiveObject associated with the provided key.
  * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
  *
  * @param key The storage key associated with the LiveObject
- * @param initialData Optional data that is used to create the LiveObject for the first time
  * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
  *
  * @example
- * const object = useObject("obj", {
- *   company: "Liveblocks",
- *   website: "https://liveblocks.io"
- * });
+ * const object = useObject("obj");
  */
+export function useObject<TData extends LsonObject>(
+  key: string
+): LiveObject<TData> | null;
+/**
+ * @deprecated We no longer recommend initializing the fields from the
+ * useObject() hook. For details, see https://bit.ly/lak1PlM.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string,
+  initialData: TData
+): LiveObject<TData> | null;
 export function useObject<TData extends LsonObject>(
   key: string,
   initialData?: TData
 ): LiveObject<TData> | null {
+  if (initialData && process.env.NODE_ENV === "development") {
+    console.warn(
+      "We no longer recommend initializing the items from the useObject() hook. Please see https://bit.ly/lak1PlM for details."
+    );
+  }
   return useCrdt(key, new LiveObject(initialData));
+  //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //                  NOTE: This param is scheduled for removal in 0.18
 }
 
 /**

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -33,7 +33,14 @@ type RoomProviderProps<TStorage> = Resolve<
  * That means that you can't have 2 RoomProvider with the same room id in your react tree.
  */
 export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
-  const { id: roomId, defaultPresence, defaultStorageRoot } = props;
+  const {
+    id: roomId,
+    initialPresence,
+    initialStorage,
+    defaultPresence, // Will get removed in 0.18
+    defaultStorageRoot, // Will get removed in 0.18
+  } = props;
+
   if (process.env.NODE_ENV !== "production") {
     if (roomId == null) {
       throw new Error(
@@ -49,8 +56,10 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
 
   const [room, setRoom] = React.useState(() =>
     client.enter(roomId, {
-      defaultPresence,
-      defaultStorageRoot,
+      initialPresence,
+      initialStorage,
+      defaultPresence, // Will get removed in 0.18
+      defaultStorageRoot, // Will get removed in 0.18
       DO_NOT_USE_withoutConnecting: typeof window === "undefined",
     } as any)
   );
@@ -58,8 +67,10 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
   React.useEffect(() => {
     setRoom(
       client.enter(roomId, {
-        defaultPresence,
-        defaultStorageRoot,
+        initialPresence,
+        initialStorage,
+        defaultPresence, // Will get removed in 0.18
+        defaultStorageRoot, // Will get removed in 0.18
         DO_NOT_USE_withoutConnecting: typeof window === "undefined",
       } as any)
     );

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -55,12 +55,12 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
 
   deprecateIf(
     defaultPresence,
-    "RoomProvider's `defaultPresence` prop is scheduled for removal in 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
+    "RoomProvider's `defaultPresence` prop will be removed in @liveblocks/react 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/lak1PlM",
     "defaultPresence"
   );
   deprecateIf(
     defaultStorageRoot,
-    "RoomProvider's `defaultStorageRoot` prop is scheduled for removal in 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
+    "RoomProvider's `defaultStorageRoot` prop will be removed in @liveblocks/react 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/lak1PlM",
     "defaultStorageRoot"
   );
 

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -382,7 +382,7 @@ export function useMap<TKey extends string, TValue extends Lson>(
 ): LiveMap<TKey, TValue> | null {
   deprecateIf(
     entries,
-    "We no longer recommend initializing the items from the useMap() hook. Please see https://bit.ly/lak1PlM for details."
+    "Support for initializing entries in useMap() directly will be removed in @liveblocks/react 0.18. Please see https://bit.ly/lak1PlM for details."
   );
   return useCrdt(key, new LiveMap(entries));
   //                  ^^^^^^^^^^^^^^^^^^^^
@@ -416,7 +416,7 @@ export function useList<TValue extends Lson>(
 ): LiveList<TValue> | null {
   deprecateIf(
     items,
-    "We no longer recommend initializing the items from the useList() hook. Please see https://bit.ly/lak1PlM for details."
+    "Support for initializing items in useList() directly will be removed in @liveblocks/react 0.18. Please see https://bit.ly/lak1PlM for details."
   );
   return useCrdt<LiveList<TValue>>(key, new LiveList(items));
   //                                    ^^^^^^^^^^^^^^^^^^^
@@ -450,7 +450,7 @@ export function useObject<TData extends LsonObject>(
 ): LiveObject<TData> | null {
   deprecateIf(
     initialData,
-    "We no longer recommend initializing the items from the useObject() hook. Please see https://bit.ly/lak1PlM for details."
+    "Support for initializing data in useObject() directly will be removed in @liveblocks/react 0.18. Please see https://bit.ly/lak1PlM for details."
   );
   return useCrdt(key, new LiveObject(initialData));
   //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -12,25 +12,20 @@ import type {
   User,
 } from "@liveblocks/client";
 import { LiveMap, LiveList, LiveObject } from "@liveblocks/client";
+import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
 import useRerender from "./useRerender";
 
 const RoomContext = React.createContext<Room | null>(null);
 
-type RoomProviderProps<TStorage> = {
-  /**
-   * The id of the room you want to connect to
-   */
-  id: string;
-  /**
-   * A callback that let you initialize the default presence when entering the room.
-   * If ommited, the default presence will be an empty object
-   */
-  defaultPresence?: () => Presence;
-
-  defaultStorageRoot?: TStorage;
-
-  children: React.ReactNode;
-};
+type RoomProviderProps<TStorage> = Resolve<
+  {
+    /**
+     * The id of the room you want to connect to
+     */
+    id: string;
+    children: React.ReactNode;
+  } & RoomInitializers<Presence, TStorage>
+>;
 
 /**
  * Makes a Room available in the component hierarchy below.

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -382,7 +382,20 @@ export function useMap<TKey extends string, TValue extends Lson>(
 ): LiveMap<TKey, TValue> | null {
   deprecateIf(
     entries,
-    "Support for initializing entries in useMap() directly will be removed in @liveblocks/react 0.18. Please see https://bit.ly/lak1PlM for details."
+    `Support for initializing entries in useMap() directly will be removed in @liveblocks/react 0.18.
+
+Instead, please initialize this data where you set up your RoomProvider:
+
+    const initialStorage = () => {
+      ${JSON.stringify(key)}: new LiveMap(...),
+      ...
+    };
+
+    <RoomProvider initialStorage={initialStorage}>
+      ...
+    </RoomProvider>
+
+Please see https://bit.ly/lak1PlM for details.`
   );
   return useCrdt(key, new LiveMap(entries));
   //                  ^^^^^^^^^^^^^^^^^^^^
@@ -416,7 +429,22 @@ export function useList<TValue extends Lson>(
 ): LiveList<TValue> | null {
   deprecateIf(
     items,
-    "Support for initializing items in useList() directly will be removed in @liveblocks/react 0.18. Please see https://bit.ly/lak1PlM for details."
+    `Support for initializing items in useList() directly will be removed in @liveblocks/react 0.18.
+
+Instead, please initialize this data where you set up your RoomProvider:
+
+    import { LiveList } from "@liveblocks/client";
+
+    const initialStorage = () => {
+      ${JSON.stringify(key)}: new LiveList(...),
+      ...
+    };
+
+    <RoomProvider initialStorage={initialStorage}>
+      ...
+    </RoomProvider>
+
+Please see https://bit.ly/lak1PlM for details.`
   );
   return useCrdt<LiveList<TValue>>(key, new LiveList(items));
   //                                    ^^^^^^^^^^^^^^^^^^^
@@ -450,7 +478,22 @@ export function useObject<TData extends LsonObject>(
 ): LiveObject<TData> | null {
   deprecateIf(
     initialData,
-    "Support for initializing data in useObject() directly will be removed in @liveblocks/react 0.18. Please see https://bit.ly/lak1PlM for details."
+    `Support for initializing data in useObject() directly will be removed in @liveblocks/react 0.18.
+
+Instead, please initialize this data where you set up your RoomProvider:
+
+    import { LiveObject } from "@liveblocks/client";
+
+    const initialStorage = () => {
+      ${JSON.stringify(key)}: new LiveObject(...),
+      ...
+    };
+
+    <RoomProvider initialStorage={initialStorage}>
+      ...
+    </RoomProvider>
+
+Please see https://bit.ly/lak1PlM for details.`
   );
   return useCrdt(key, new LiveObject(initialData));
   //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -380,11 +380,10 @@ export function useMap<TKey extends string, TValue extends Lson>(
   key: string,
   entries?: readonly (readonly [TKey, TValue])[] | null | undefined
 ): LiveMap<TKey, TValue> | null {
-  if (entries && process.env.NODE_ENV === "development") {
-    console.warn(
-      "We no longer recommend initializing the items from the useMap() hook. Please see https://bit.ly/lak1PlM for details."
-    );
-  }
+  deprecateIf(
+    entries,
+    "We no longer recommend initializing the items from the useMap() hook. Please see https://bit.ly/lak1PlM for details."
+  );
   return useCrdt(key, new LiveMap(entries));
   //                  ^^^^^^^^^^^^^^^^^^^^
   //                  NOTE: This param is scheduled for removal in 0.18
@@ -415,12 +414,10 @@ export function useList<TValue extends Lson>(
   key: string,
   items?: TValue[] | undefined
 ): LiveList<TValue> | null {
-  if (items && process.env.NODE_ENV === "development") {
-    console.warn(
-      "We no longer recommend initializing the items from the useList() hook. Please see https://bit.ly/lak1PlM for details."
-    );
-  }
-
+  deprecateIf(
+    items,
+    "We no longer recommend initializing the items from the useList() hook. Please see https://bit.ly/lak1PlM for details."
+  );
   return useCrdt<LiveList<TValue>>(key, new LiveList(items));
   //                                    ^^^^^^^^^^^^^^^^^^^
   //                                    NOTE: This param is scheduled for removal in 0.18
@@ -451,11 +448,10 @@ export function useObject<TData extends LsonObject>(
   key: string,
   initialData?: TData
 ): LiveObject<TData> | null {
-  if (initialData && process.env.NODE_ENV === "development") {
-    console.warn(
-      "We no longer recommend initializing the items from the useObject() hook. Please see https://bit.ly/lak1PlM for details."
-    );
-  }
+  deprecateIf(
+    initialData,
+    "We no longer recommend initializing the items from the useObject() hook. Please see https://bit.ly/lak1PlM for details."
+  );
   return useCrdt(key, new LiveObject(initialData));
   //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //                  NOTE: This param is scheduled for removal in 0.18

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -49,7 +49,7 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
 
   const [room, setRoom] = React.useState(() =>
     client.enter(roomId, {
-      defaultPresence: defaultPresence ? defaultPresence() : undefined,
+      defaultPresence,
       defaultStorageRoot,
       DO_NOT_USE_withoutConnecting: typeof window === "undefined",
     } as any)
@@ -58,7 +58,7 @@ export function RoomProvider<TStorage>(props: RoomProviderProps<TStorage>) {
   React.useEffect(() => {
     setRoom(
       client.enter(roomId, {
-        defaultPresence: defaultPresence ? defaultPresence() : undefined,
+        defaultPresence,
         defaultStorageRoot,
         DO_NOT_USE_withoutConnecting: typeof window === "undefined",
       } as any)


### PR DESCRIPTION
This PR deprecates the "local state initializers" APIs for our React package in favor of adoption "global state initializers". The rationale for this release is documented here:

https://bit.ly/lak1PlM

### 🏁 Checklist

- [x] Go over an example one more time, say the spreadsheet app
- [x] Throw deprecation warning when calling useList() with argument
- [x] Throw deprecation warning when calling useList() in the preferred way, but the key does not exist - ie warn when its created on the fly!
- [x] Verify that incrementally adding keys to the `initialStorage` value will indeed incrementally create those keys
- [x] Update all examples on liveblocks.io to match the recommended pattern (see https://github.com/liveblocks/liveblocks.io/pull/197)
- [x] ~Update all examples in this repo so none of them show these deprecation warnings~ (can't do this in this PR, examples currently don't use the local linked version)
- [x] Double-check the documentation for all of these APIs
- [x] Update CHANGELOG
- [x] Put link to Discord channel in gist
- [x] Move gist to GitHub discussion (will do after merge + publish)
- [x] Replace bit.ly link with link to final location
- [x] ~Publish to NPM~ (will do post-merge)
