### PR TITLE
Disallow use of `async` functions

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -71,6 +71,16 @@ module.exports = {
         message:
           "Using `JSON.parse()` is type-unsafe. Prefer using the `parseJson()` utility method (from `src/json`).",
       },
+      {
+        selector: "FunctionDeclaration[async=true]",
+        message:
+          "Using `async` functions will emit extra support code in our CommonJS bundle, increasing its size. Using the Promise API instead will lead to a smaller bundle.",
+      },
+      {
+        selector: "ArrowFunctionExpression[async=true]",
+        message:
+          "Using `async` functions will emit extra support code in our CommonJS bundle, increasing its size. Using the Promise API instead will lead to a smaller bundle.",
+      },
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-client/tsconfig.json
+++ b/packages/liveblocks-client/tsconfig.json
@@ -10,7 +10,7 @@
     "strictFunctionTypes": true,
     "declaration": true,
     "moduleResolution": "node",
-    "lib": ["es2019", "dom", "esnext"],
+    "lib": ["dom", "esnext"],
     "stripInternal": true
   },
   "include": ["./src/**/*.ts", "./test/**/*.ts"],


### PR DESCRIPTION
Following up on https://github.com/liveblocks/liveblocks/pull/178#discussion_r864522989, this now formally disallows the use of `async` inside `liveblocks-client`, because it will inflate the bundle size (only the CommonJS output).
