### PR TITLE
Run unit tests and lints for *all* packages

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,6 +25,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
+      - name: Link E2E test app to use local Liveblocks build
+        run: ../../scripts/link-liveblocks.sh -f
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,13 +33,13 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
-      - name: Link E2E test app to use local Liveblocks build
-        run: ../../scripts/link-liveblocks.sh -f
-
       - name: Install dependencies
         run: npm install
 
-      - name: Ensure TypeScript compiles
+      - name: Link E2E test app to use local Liveblocks build
+        run: ../../scripts/link-liveblocks.sh -f
+
+      - name: Build
         run: npm run build
 
       - name: Run unit tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: packages/liveblocks-client
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: npm install
@@ -41,10 +41,10 @@ jobs:
         working-directory: e2e/next-sandbox
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,10 +33,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
-      - name: Install dependencies
-        run: npm install
-
-      - name: Link E2E test app to use local Liveblocks build
+      - name: Install dependencies (and link to local Liveblocks source)
         run: ../../scripts/link-liveblocks.sh -f
 
       - name: Build
@@ -77,7 +74,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
-      - name: Link E2E test app to use local Liveblocks build
+      - name: Install dependencies (and link to local Liveblocks source)
         run: ../../scripts/link-liveblocks.sh -f
 
       - name: Install Playwright

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
 
       - name: Install dependencies
         run: npm install
@@ -58,6 +60,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
 
       - name: Link E2E test app to use local Liveblocks build
         run: ../../scripts/link-liveblocks.sh -f

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,12 +26,15 @@ jobs:
         run: npm run test-ci
 
   e2e-tests:
+    runs-on: ubuntu-latest
+
     timeout-minutes: 60
+
     env:
       LIVEBLOCKS_SECRET_KEY: ${{ secrets.E2E_TEST_LIVEBLOCKS_SECRET_KEY }}
       LIVEBLOCKS_SERVER: ${{ secrets.E2E_TEST_LIVEBLOCKS_SERVER }}
       LIVEBLOCKS_AUTHORIZE_ENDPOINT: ${{ secrets.E2E_TEST_LIVEBLOCKS_AUTHORIZE_ENDPOINT }}
-    runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: e2e/next-sandbox

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,9 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-        with:
-          repository: liveblocks/liveblocks
-          ref: refs/heads/${{ github.head_ref }}
 
       - name: Install dependencies
         run: npm install
@@ -45,9 +42,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-        with:
-          repository: liveblocks/liveblocks
-          ref: refs/heads/${{ github.head_ref }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,7 +11,8 @@ jobs:
         working-directory: packages/liveblocks-client
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: npm install
@@ -41,7 +42,8 @@ jobs:
         working-directory: e2e/next-sandbox
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on: [pull_request]
 
 jobs:
-  unit-tests:
+  test:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run unit tests
         run: npm run test-ci
 
+      - name: Run lint checks
+        run: npm run lint
+
   e2e-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,10 +9,18 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
+        pkg:
+          [
+            "liveblocks-client",
+            "liveblocks-react",
+            "liveblocks-redux",
+            "liveblocks-zustand",
+            "liveblocks-node",
+          ]
 
     defaults:
       run:
-        working-directory: packages/liveblocks-client
+        working-directory: packages/${{ matrix.pkg }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,6 +28,10 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [16.x]
+
     timeout-minutes: 60
 
     env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,10 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [16.x]
+
     defaults:
       run:
         working-directory: packages/liveblocks-client
@@ -13,6 +17,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm install

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "lint": "eslint src/ test/",
     "test": "jest --watch",
     "test-ci": "jest"
   },

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -24,7 +24,7 @@
     "build:cjs": "tsc -p tsconfig-cjs.json",
     "lint": "eslint src/",
     "test": "jest --watch",
-    "test-ci": "jest"
+    "test-ci": "jest --passWithNoTests"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -22,7 +22,9 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.json",
     "build:cjs": "tsc -p tsconfig-cjs.json",
-    "test": "jest --watch"
+    "lint": "eslint src/",
+    "test": "jest --watch",
+    "test-ci": "jest"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -29,7 +29,9 @@
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "start": "rollup -c -w",
-    "test": "jest --watch"
+    "lint": "eslint src/",
+    "test": "jest --watch",
+    "test-ci": "jest"
   },
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -26,7 +26,9 @@
   ],
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "lint": "eslint src/ test/",
     "test": "jest --watch",
+    "test-ci": "jest",
     "dtslint": "dtslint --localTs node_modules/typescript/lib --expectOnly types"
   },
   "license": "Apache-2.0",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -26,7 +26,9 @@
   ],
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "lint": "eslint src/ test/",
     "test": "jest --watch",
+    "test-ci": "jest",
     "dtslint": "dtslint --localTs node_modules/typescript/lib --expectOnly types"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR sets up our CI builds to run unit tests, build scripts, and ESLint for _all_ of our packages, not just `liveblocks-client`:

<img src="https://user-images.githubusercontent.com/83844/166658239-0fdd7279-9c02-49f9-abbb-a90edb315cba.png" width="300" />

This also sets up caching using GitHub Action's optimized NPM caching, so there isn't much of a performance downside to running more of these in parallel.

With this matrix build setup, we may be able to add more CI checks. For example, I would love to include all of our examples projects in these builds (or did you have another idea for this already, @marcbouchenoire?). I'd love to get a CI failure if I make a breaking change somewhere in `liveblocks-client` for example, we can see exactly if (and why) it breaks one of our examples projects, and catch that as early on as possible. This would save a ton of manual checking that I'm doing now.

Other areas of extending this matrix is to test against more Node versions or more TypeScript versions.
