### PR TITLE
Add general purpose `deprecate()` helper

### DIFF
--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -7,6 +7,8 @@
  * time and without announcement. This module purely exists to share code
  * between the several Liveblocks packages.
  *
+ * But since you're so deep inside Liveblocks code... we're hiring!
+ * https://join.team/liveblocks ;)
  */
 
 export * from "./live";

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -7,8 +7,6 @@
  * time and without announcement. This module purely exists to share code
  * between the several Liveblocks packages.
  *
- * But since you're so deep inside Liveblocks code... we're hiring!
- * https://join.team/liveblocks ;)
  */
 
 export * from "./live";

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -1,4 +1,19 @@
+/**
+ * PRIVATE / INTERNAL APIS
+ * -----------------------
+ *
+ * This module is intended for internal use only, PLEASE DO NOT RELY ON ANY OF
+ * THE EXPORTS IN HERE. These are implementation details that can change at any
+ * time and without announcement. This module purely exists to share code
+ * between the several Liveblocks packages.
+ *
+ * But since you're so deep inside Liveblocks code... we're hiring!
+ * https://join.team/liveblocks ;)
+ */
+
 export * from "./live";
 export * from "./position";
+
+export { deprecate, deprecateIf } from "./utils";
 
 export type { Resolve } from "./types";

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -36,8 +36,8 @@ export function deprecate(message: string, key = message) {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
       _emittedDeprecationWarnings.add(key);
+      console.warn(`⚠️  [DEPRECATED] ${message}`);
     }
-    console.warn(`⚠️  [DEPRECATED] ${message}`);
   }
 }
 

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -29,20 +29,20 @@ import {
 const _emittedDeprecationWarnings: Set<string> = new Set();
 
 /**
- * Displays a [DEPRECATED] warning in the dev console. Only in dev mode, and
+ * Displays a deprecation warning in the dev console. Only in dev mode, and
  * only once per message/key. In production, this is a no-op.
  */
 export function deprecate(message: string, key = message) {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
       _emittedDeprecationWarnings.add(key);
-      console.warn(`⚠️  [DEPRECATED] ${message}`);
+      console.warn(`DEPRECATION WARNING: ${message}`);
     }
   }
 }
 
 /**
- * Conditionally displays a [DEPRECATED] warning in the dev
+ * Conditionally displays a deprecation warning in the dev
  * console if the first argument is truthy. Only in dev mode, and
  * only once per message/key. In production, this is a no-op.
  */

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -23,6 +23,41 @@ import {
   StorageUpdate,
 } from "./types";
 
+// Keeps a set of deprecation messages in memory that it has warned about
+// already. There will be only one deprecation message in the console, no
+// matter how often it gets called.
+const _emittedDeprecationWarnings: Set<string> = new Set();
+
+/**
+ * Displays a [DEPRECATED] warning in the dev console. Only in dev mode, and
+ * only once per message/key. In production, this is a no-op.
+ */
+export function deprecate(message: string, key = message) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!_emittedDeprecationWarnings.has(key)) {
+      _emittedDeprecationWarnings.add(key);
+    }
+    console.warn(`⚠️  [DEPRECATED] ${message}`);
+  }
+}
+
+/**
+ * Conditionally displays a [DEPRECATED] warning in the dev
+ * console if the first argument is truthy. Only in dev mode, and
+ * only once per message/key. In production, this is a no-op.
+ */
+export function deprecateIf(
+  condition: unknown,
+  message: string,
+  key = message
+) {
+  if (process.env.NODE_ENV !== "production") {
+    if (condition) {
+      deprecate(message, key);
+    }
+  }
+}
+
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {
     if (array[i] === item) {


### PR DESCRIPTION
This adds a `deprecate()` and `deprecateIf()` helper utilities, and exports them as internals, so we can use them from all libraries. These runtime functions will throw a console warning at runtime. Use these whenever you also use a `@deprecated` comment annotation.

Only has an effect in dev/test envs. In production, this function will be a no-op.

Every unique deprecation message will be thrown only once, even if deprecated APIs are called multiple times, or from multiple places. Only the first warning will get printed, the rest of them will be no-ops.

## Uniqueness key
Normally you won't need the optional `key` param, and it defaults to the message content itself. But you can use it to control uniqueness, which is useful for the deprecation I want to use in the in upcoming 0.17 release.

For example, we want to deprecate the `defaultXxx` arguments here:

- `createRoom(defaultPresence, defaultStorageRoot)` (lowest-level, internal API)
  - called by `client.enter(defaultPresence, defaultStorageRoot)` (public API)
    - called by `<RoomProvider defaultPresence={...} defaultStorageRoot={...} />` (public API)

But where to point the developer towards? If we throw the error at the deepest level (from `createRoom()`), then the developer will have no idea. They're never manually calling that after all! They call `client.enter()` or use the `RoomProvider` APIs. To be maximally helpful to developers, we'll want to speak the language in the error message that the developer is familiar with.

That's where the `key` arg comes in. We can put a deprecation message in _all_ public APIs. So we show the deprecation warning in `client.enter()` _and_ inside `RoomProvider`, but use the same message key. That way, if they are using the `RoomProvider`, they'll see a message indicating they should rename the `RoomProvider` props. Then, when the RoomProvider internally invokes `client.enter()`, it tries to display an error, but sees that an error for this key has already been emitted, and it will not nag about those internals that don't make sense to the developer.

And otherwise, if they use `client.enter()` directly, we'll display a warning specific to that API.
