### PR TITLE
Simplify internal imports

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -16,24 +16,3 @@ export type { Json, JsonObject } from "./json";
 export type { Lson, LsonObject } from "./lson";
 
 export { createClient } from "./client";
-
-import {
-  liveObjectToJson,
-  lsonToJson,
-  patchLiveList,
-  patchImmutableObject,
-  patchLiveObject,
-  patchLiveObjectKey,
-} from "./immutable";
-
-/**
- * @internal
- */
-export const internals = {
-  liveObjectToJson,
-  lsonToJson,
-  patchLiveList,
-  patchImmutableObject,
-  patchLiveObject,
-  patchLiveObjectKey,
-};

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -16,4 +16,13 @@ export * from "./position";
 
 export { deprecate, deprecateIf } from "./utils";
 
+export {
+  liveObjectToJson,
+  lsonToJson,
+  patchLiveList,
+  patchImmutableObject,
+  patchLiveObject,
+  patchLiveObjectKey,
+} from "./immutable";
+
 export type { Resolve } from "./types";

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -5,11 +5,12 @@ import {
   LiveObject,
   LsonObject,
   Presence,
-  internals,
-  StorageUpdate,
-  Json,
-  Lson,
 } from "@liveblocks/client";
+import {
+  patchImmutableObject,
+  patchLiveObjectKey,
+  lsonToJson,
+} from "@liveblocks/client/internal";
 import { StoreEnhancer } from "redux";
 import {
   mappingShouldBeAnObject,
@@ -18,29 +19,6 @@ import {
   mappingValueShouldBeABoolean,
   missingClient,
 } from "./errors";
-
-// @liveblocks/client export internals API to be used only by our packages.
-// Internals APIs are removed from public d.ts so we patch them manually here to consume them.
-// They are patched inline because @rollup/plugin-typescript does not respect tsconfig typeRoots
-// @internal is necessary to remove it from public d.ts
-/**
- * @internal
- */
-declare module "@liveblocks/client" {
-  const internals: {
-    patchImmutableObject<T>(state: T, updates: StorageUpdate[]): T;
-    patchLiveObjectKey<O extends LsonObject>(
-      liveObject: LiveObject<O>,
-      key: keyof O,
-      prev: unknown,
-      next: unknown
-    ): void;
-    lsonToJson(value: Lson): Json;
-    liveObjectToJson(liveObject: LiveObject<LsonObject>): Json;
-  };
-}
-
-const { patchImmutableObject, patchLiveObjectKey, lsonToJson } = internals;
 
 export type Mapping<T> = Partial<{
   [Property in keyof T]: boolean;

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -1,16 +1,17 @@
 import { StateCreator, SetState, GetState, StoreApi } from "zustand";
 import {
   Client,
-  internals,
-  Json,
   LiveObject,
-  Lson,
   LsonObject,
   Presence,
   Room,
-  StorageUpdate,
   User,
 } from "@liveblocks/client";
+import {
+  lsonToJson,
+  patchImmutableObject,
+  patchLiveObjectKey,
+} from "@liveblocks/client/internal";
 import {
   mappingShouldBeAnObject,
   mappingShouldNotHaveTheSameKeys,
@@ -19,29 +20,6 @@ import {
   missingClient,
   missingMapping,
 } from "./errors";
-
-// @liveblocks/client export internals API to be used only by our packages.
-// Internals APIs are removed from public d.ts so we patch them manually here to consume them.
-// They are patched inline because @rollup/plugin-typescript does not respect tsconfig typeRoots
-// @internal is necessary to remove it from public d.ts
-/**
- * @internal
- */
-declare module "@liveblocks/client" {
-  const internals: {
-    patchImmutableObject<T>(state: T, updates: StorageUpdate[]): T;
-    patchLiveObjectKey<O extends LsonObject>(
-      liveObject: LiveObject<O>,
-      key: keyof O,
-      prev: unknown,
-      next: unknown
-    ): void;
-    lsonToJson(value: Lson): Json;
-    liveObjectToJson(liveObject: LiveObject<LsonObject>): Json;
-  };
-}
-
-const { patchLiveObjectKey, patchImmutableObject, lsonToJson } = internals;
 
 export type LiveblocksState<
   TState,


### PR DESCRIPTION
Following #189, we can now import these in a non-hacky way, too.
