### PR TITLE
Link script improvements

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
 
       - name: Install dependencies (and link to local Liveblocks source)
-        run: ../../scripts/link-liveblocks.sh -f
+        run: ../../scripts/link-liveblocks.sh
 
       - name: Build
         run: npm run build
@@ -75,7 +75,7 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
 
       - name: Install dependencies (and link to local Liveblocks source)
-        run: ../../scripts/link-liveblocks.sh -f
+        run: ../../scripts/link-liveblocks.sh
 
       - name: Install Playwright
         run: npx playwright install --with-deps

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -22,8 +22,9 @@ usage () {
 }
 
 now="$(date +%s)"
-while getopts h flag; do
+while getopts hf flag; do
     case "$flag" in
+        f) err "Flag -f is no longer needed or supported" ;;
         *) usage; exit 2;;
     esac
 done

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -116,7 +116,7 @@ npm_install () {
 npm_link () {
     logfile="$(mktemp)"
     if [ $# -gt 0 ]; then
-        err "Linking in $(pwd):"
+        err "Linking:"
         for item in "$@"; do
             err "- $item"
         done
@@ -148,7 +148,7 @@ rebuild_if_needed () {
         if [ "$(sha_stamp)" = "$(cat lib/.built-by-link-script)" ]; then
             # This was already rebuilt by an earlier invocation of this build
             # script. We don't have to throw away those results!
-            err "Skipping (build still fresh)"
+            err "Skipping build of $(basename $(pwd)) (still fresh)"
             return
         fi
     fi
@@ -193,7 +193,8 @@ link_liveblocks_deps () {
         return
     fi
 
-    echo "==> Linking Liveblocks dependencies"
+    echo
+    echo "==> Linking Liveblocks dependencies of $(basename $(pwd))"
     npm_link $(list_liveblocks_dependencies)
 }
 
@@ -205,7 +206,8 @@ link_liveblocks_and_peer_deps () {
         return
     fi
 
-    echo "==> Linking Liveblocks & peer dependencies"
+    echo
+    echo "==> Linking Liveblocks & peer dependencies of $(basename $(pwd))"
     npm_link $(list_liveblocks_and_peer_dependencies)
 }
 

--- a/scripts/link-liveblocks.sh
+++ b/scripts/link-liveblocks.sh
@@ -136,11 +136,11 @@ liveblocks_pkg_dir () {
     echo "$LIVEBLOCKS_ROOT/packages/liveblocks-${1#@liveblocks/}"
 }
 
-# Returns a single MD5 string representing the "input state" for this project.
-# It works by taking the MD5 hash of all files in the current worktree known to
+# Returns a single SHA1 string representing the "input state" for this project.
+# It works by taking the SHA1 hash of all files in the current worktree known to
 # Git, then hashing that entire list again.
 sha_stamp () {
-    git ls-files --cached --modified --exclude-standard --deduplicate | xargs md5 -r | md5 -q
+    git ls-files --cached --modified --exclude-standard --deduplicate | xargs sha1sum | sha1sum | cut -d' ' -f1
 }
 
 rebuild_if_needed () {


### PR DESCRIPTION
Tweaks the link script a bit to make it simpler and more reliable. Previously, the check to see if the build is still fresh was relying on comparing source vs build file timestamps, which is unreliable. In this PR, I'm switching that check to verify that using SHA1 hashes on the input files.

Also, this level of robustness completely removes the need for the `-f` flag, which I've made optional now. You can now safely change any invocation of `link-liveblocks.sh -f` to just `link-liveblocks.sh`.

While I was at it, I've made the logs it emits a bit more readable too.
