### PR TITLE
Only export internals that are needed/used

### DIFF
--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -11,8 +11,44 @@
  * https://join.team/liveblocks ;)
  */
 
-export * from "./live";
-export * from "./position";
+export type {
+  ClientEventMessage,
+  ClientMessage,
+  ClientMessageType,
+  CrdtType,
+  CreateListOp,
+  CreateMapOp,
+  CreateObjectOp,
+  CreateOp,
+  CreateRegisterOp,
+  DeleteCrdtOp,
+  DeleteObjectKeyOp,
+  EventMessage,
+  FetchStorageClientMessage,
+  InitialDocumentStateMessage,
+  Op,
+  OpType,
+  RoomStateMessage,
+  SerializedCrdt,
+  SerializedCrdtWithId,
+  SerializedList,
+  SerializedMap,
+  SerializedObject,
+  SerializedRegister,
+  ServerMessage,
+  ServerMessageType,
+  SetParentKeyOp,
+  UpdateObjectOp,
+  UpdatePresenceClientMessage,
+  UpdatePresenceMessage,
+  UpdateStorageClientMessage,
+  UpdateStorageMessage,
+  UserJoinMessage,
+  UserLeftMessage,
+  WebsocketCloseCodes,
+} from "./live";
+
+export { min, max, makePosition, posCodes, pos, compare } from "./position";
 
 export { deprecate, deprecateIf } from "./utils";
 

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -11,54 +11,14 @@
  * https://join.team/liveblocks ;)
  */
 
-export type {
-  ClientEventMessage,
-  ClientMessage,
-  ClientMessageType,
-  CrdtType,
-  CreateListOp,
-  CreateMapOp,
-  CreateObjectOp,
-  CreateOp,
-  CreateRegisterOp,
-  DeleteCrdtOp,
-  DeleteObjectKeyOp,
-  EventMessage,
-  FetchStorageClientMessage,
-  InitialDocumentStateMessage,
-  Op,
-  OpType,
-  RoomStateMessage,
-  SerializedCrdt,
-  SerializedCrdtWithId,
-  SerializedList,
-  SerializedMap,
-  SerializedObject,
-  SerializedRegister,
-  ServerMessage,
-  ServerMessageType,
-  SetParentKeyOp,
-  UpdateObjectOp,
-  UpdatePresenceClientMessage,
-  UpdatePresenceMessage,
-  UpdateStorageClientMessage,
-  UpdateStorageMessage,
-  UserJoinMessage,
-  UserLeftMessage,
-  WebsocketCloseCodes,
-} from "./live";
+export type { SerializedCrdtWithId, ServerMessage } from "./live";
+export type { Resolve } from "./types";
 
-export { min, max, makePosition, posCodes, pos, compare } from "./position";
-
+export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";
 export { deprecate, deprecateIf } from "./utils";
 
 export {
-  liveObjectToJson,
   lsonToJson,
-  patchLiveList,
   patchImmutableObject,
-  patchLiveObject,
   patchLiveObjectKey,
 } from "./immutable";
-
-export type { Resolve } from "./types";


### PR DESCRIPTION
This PR changes the export declarations inside `internals.ts` to only export what's actually used by secondary packages. The use of `*` will default to exporting too much in the bundle, and thus potentially makes the bundle larger than strictly needed.

By only exporting what's actually used, rollup will automatically tree-shake off any dead code, if we have any. If we ever find ourselves in need of exposing more internal APIs, we can simply add those to the list of exports, and the bundle will adjust.