### PR TITLE
Use type-only imports where possible

### DIFF
--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -1,5 +1,6 @@
-import { CreateOp, Op, OpType, SerializedCrdt } from "./live";
-import { StorageUpdate } from "./types";
+import { OpType } from "./live";
+import type { CreateOp, Op, SerializedCrdt } from "./live";
+import type { StorageUpdate } from "./types";
 
 export type ApplyResult =
   | { reverse: Op[]; modified: StorageUpdate }

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -1,4 +1,5 @@
-import { AbstractCrdt, Doc, ApplyResult } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
+import type { Doc, ApplyResult } from "./AbstractCrdt";
 import {
   deserialize,
   selfOrRegister,
@@ -16,9 +17,9 @@ import {
   CreateOp,
 } from "./live";
 import { makePosition, compare } from "./position";
-import { LiveListUpdateDelta, LiveListUpdates } from "./types";
+import type { LiveListUpdateDelta, LiveListUpdates } from "./types";
 import { LiveRegister } from "./LiveRegister";
-import { Lson } from "./lson";
+import type { Lson } from "./lson";
 
 type LiveListItem = [crdt: AbstractCrdt, position: string];
 

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -15,8 +15,8 @@ import {
   SerializedCrdt,
   CreateOp,
 } from "./live";
-import { LiveMapUpdates } from "./types";
-import { Lson } from "./lson";
+import type { LiveMapUpdates } from "./types";
+import type { Lson } from "./lson";
 
 /**
  * The LiveMap class is similar to a JavaScript Map that is synchronized on all clients.

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -1,4 +1,5 @@
-import { AbstractCrdt, Doc, ApplyResult } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
+import type { Doc, ApplyResult } from "./AbstractCrdt";
 import { creationOpToLiveStructure, deserialize, isCrdt } from "./utils";
 import {
   CrdtType,
@@ -11,9 +12,13 @@ import {
   SerializedCrdtWithId,
   UpdateObjectOp,
 } from "./live";
-import { LiveObjectUpdates, UpdateDelta, LiveObjectUpdateDelta } from "./types";
-import { JsonObject } from "./json";
-import { LsonObject, ToJson } from "./lson";
+import type {
+  LiveObjectUpdates,
+  UpdateDelta,
+  LiveObjectUpdateDelta,
+} from "./types";
+import type { JsonObject } from "./json";
+import type { LsonObject, ToJson } from "./lson";
 
 /**
  * The LiveObject class is similar to a JavaScript object that is synchronized on all clients.

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -1,4 +1,5 @@
-import { AbstractCrdt, Doc, ApplyResult } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
+import type { Doc, ApplyResult } from "./AbstractCrdt";
 import {
   SerializedCrdtWithId,
   CrdtType,
@@ -7,7 +8,7 @@ import {
   SerializedCrdt,
   CreateOp,
 } from "./live";
-import { Json } from "./json";
+import type { Json } from "./json";
 
 /**
  * @internal

--- a/packages/liveblocks-client/src/client.node.test.ts
+++ b/packages/liveblocks-client/src/client.node.test.ts
@@ -5,7 +5,7 @@
 import { createClient } from ".";
 // We're using node-fetch 2.X because 3+ only support ESM and jest is a pain to use with ESM
 import { Response } from "node-fetch";
-import { ClientOptions } from "./types";
+import type { ClientOptions } from "./types";
 import { MockWebSocket } from "../test/utils";
 
 (global as any).atob = (data: string) => Buffer.from(data, "base64");

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,5 +1,11 @@
 import { createRoom, InternalRoom } from "./room";
-import { ClientOptions, Room, Client, Presence, Authentication } from "./types";
+import type {
+  ClientOptions,
+  Room,
+  Client,
+  Presence,
+  Authentication,
+} from "./types";
 
 /**
  * Create a client that will be responsible to communicate with liveblocks servers.

--- a/packages/liveblocks-client/src/doc.test.ts
+++ b/packages/liveblocks-client/src/doc.test.ts
@@ -1,7 +1,7 @@
 import { OpType } from "./live";
-import { LiveList } from "./LiveList";
-import { LiveMap } from "./LiveMap";
-import { LiveObject } from "./LiveObject";
+import type { LiveList } from "./LiveList";
+import type { LiveMap } from "./LiveMap";
+import type { LiveObject } from "./LiveObject";
 import {
   prepareStorageTest,
   createSerializedObject,

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -15,7 +15,7 @@ import {
   patchLiveObject,
 } from "./immutable";
 import { LiveObject } from "./LiveObject";
-import { StorageUpdate } from "./types";
+import type { StorageUpdate } from "./types";
 
 // TODO: Further improve this type
 type fixme = unknown;

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -3,9 +3,9 @@ import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
-import { Lson, LsonObject } from "./lson";
-import { Json } from "./json";
-import { StorageUpdate } from "./types";
+import type { Lson, LsonObject } from "./lson";
+import type { Json } from "./json";
+import type { StorageUpdate } from "./types";
 import { findNonSerializableValue } from "./utils";
 
 function lsonObjectToJson<O extends LsonObject>(

--- a/packages/liveblocks-client/src/live.ts
+++ b/packages/liveblocks-client/src/live.ts
@@ -1,5 +1,5 @@
-import { Json, JsonObject } from "./json";
-import { Presence } from "./types";
+import type { Json, JsonObject } from "./json";
+import type { Presence } from "./types";
 
 /**
  * Messages that can be sent from the server to the client.

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -22,7 +22,7 @@ import {
 } from "./live";
 import { LiveList } from "./LiveList";
 import { makeStateMachine, defaultState, createRoom } from "./room";
-import { Authentication, Others } from "./types";
+import type { Authentication, Others } from "./types";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Others,
   Presence,
   Room,
@@ -19,8 +19,9 @@ import {
   AuthorizeResponse,
   Authentication,
 } from "./types";
-import { Json, JsonObject, isJsonObject, isJsonArray, parseJson } from "./json";
-import { Lson, LsonObject } from "./lson";
+import type { Json, JsonObject } from "./json";
+import { isJsonObject, isJsonArray, parseJson } from "./json";
+import type { Lson, LsonObject } from "./lson";
 import {
   compact,
   getTreesDiffOperations,
@@ -46,7 +47,7 @@ import {
   SerializedCrdt,
   WebsocketCloseCodes,
 } from "./live";
-import { LiveMap } from "./LiveMap";
+import type { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import { LiveList } from "./LiveList";
 import { AbstractCrdt, ApplyResult } from "./AbstractCrdt";

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -1,8 +1,8 @@
 import type { LiveList } from "./LiveList";
 import type { LiveMap } from "./LiveMap";
 import type { LiveObject } from "./LiveObject";
-import { Json, JsonObject } from "./json";
-import { Lson, LsonObject } from "./lson";
+import type { Json, JsonObject } from "./json";
+import type { Lson, LsonObject } from "./lson";
 
 /**
  * This helper type is effectively a no-op, but will force TypeScript to

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -1,4 +1,4 @@
-import { AbstractCrdt, Doc } from "./AbstractCrdt";
+import type { AbstractCrdt, Doc } from "./AbstractCrdt";
 import {
   SerializedCrdtWithId,
   CrdtType,
@@ -15,8 +15,8 @@ import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
 import { Json, isJsonObject, parseJson } from "./json";
-import { Lson, LsonObject } from "./lson";
-import {
+import type { Lson, LsonObject } from "./lson";
+import type {
   LiveListUpdates,
   LiveMapUpdates,
   LiveObjectUpdates,

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -1,4 +1,4 @@
-import { AbstractCrdt } from "../src/AbstractCrdt";
+import type { AbstractCrdt } from "../src/AbstractCrdt";
 import { liveObjectToJson, patchImmutableObject } from "../src/immutable";
 import {
   ClientMessage,
@@ -9,14 +9,14 @@ import {
   ServerMessage,
   ServerMessageType,
 } from "../src/live";
-import { Json } from "../src/json";
-import { Lson, LsonObject, ToJson } from "../src/lson";
+import type { Json } from "../src/json";
+import type { Lson, LsonObject, ToJson } from "../src/lson";
 import { LiveList } from "../src/LiveList";
 import { LiveMap } from "../src/LiveMap";
 import { LiveObject } from "../src/LiveObject";
 import { makePosition } from "../src/position";
 import { defaultState, Effects, makeStateMachine } from "../src/room";
-import { Authentication } from "../src/types";
+import type { Authentication } from "../src/types";
 import { remove } from "../src/utils";
 
 // TODO: Further improve this type

--- a/packages/liveblocks-client/tsconfig.json
+++ b/packages/liveblocks-client/tsconfig.json
@@ -11,7 +11,9 @@
     "declaration": true,
     "moduleResolution": "node",
     "lib": ["dom", "esnext"],
-    "stripInternal": true
+    "stripInternal": true,
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true
   },
   "include": ["./src/**/*.ts", "./test/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/liveblocks-node/tsconfig.json
+++ b/packages/liveblocks-node/tsconfig.json
@@ -9,7 +9,9 @@
     "strictFunctionTypes": true,
     "declaration": true,
     "moduleResolution": "node",
-    "outDir": "./lib/esm"
+    "outDir": "./lib/esm",
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "src/**/*.spec.ts"]

--- a/packages/liveblocks-react/src/client.tsx
+++ b/packages/liveblocks-react/src/client.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Client } from "@liveblocks/client";
+import type { Client } from "@liveblocks/client";
 
 type LiveblocksProviderProps = {
   children: React.ReactNode;

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -10,18 +10,17 @@ import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { createClient } from "@liveblocks/client";
 import {
+  ClientMessageType,
+  CrdtType,
+  ServerMessageType,
+} from "@liveblocks/client/internal";
+import {
   LiveblocksProvider,
   RoomProvider,
   useMyPresence,
   useObject,
   useOthers,
 } from ".";
-
-import {
-  ClientMessageType,
-  CrdtType,
-  ServerMessageType,
-} from "@liveblocks/client/internal";
 
 /**
  * https://github.com/Luka967/websocket-close-codes

--- a/packages/liveblocks-react/src/rooms.tsx
+++ b/packages/liveblocks-react/src/rooms.tsx
@@ -1,12 +1,9 @@
 import * as React from "react";
 import { useClient } from "./client";
-import {
+import type {
   BroadcastOptions,
   History,
   Json,
-  LiveList,
-  LiveMap,
-  LiveObject,
   Lson,
   LsonObject,
   Others,
@@ -14,6 +11,7 @@ import {
   Room,
   User,
 } from "@liveblocks/client";
+import { LiveMap, LiveList, LiveObject } from "@liveblocks/client";
 import useRerender from "./useRerender";
 
 const RoomContext = React.createContext<Room | null>(null);

--- a/packages/liveblocks-react/tsconfig.json
+++ b/packages/liveblocks-react/tsconfig.json
@@ -17,7 +17,9 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true
   },
   "include": [
     "./src/**/*.ts",

--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -1,15 +1,19 @@
 import { createClient } from "@liveblocks/client";
-import { LiveblocksState, Mapping, enhancer, actions } from ".";
+import type { LiveblocksState, Mapping } from ".";
+import { enhancer, actions } from ".";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { configureStore, Reducer } from "@reduxjs/toolkit";
+import type { Reducer } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
 import { list, MockWebSocket, obj, waitFor } from "../test/utils";
 import {
   ClientMessageType,
   OpType,
+  ServerMessageType,
+} from "@liveblocks/client/internal";
+import type {
   SerializedCrdtWithId,
   ServerMessage,
-  ServerMessageType,
 } from "@liveblocks/client/internal";
 import {
   missingClient,

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Client,
   User,
   Room,
@@ -11,7 +11,7 @@ import {
   patchLiveObjectKey,
   lsonToJson,
 } from "@liveblocks/client/internal";
-import { StoreEnhancer } from "redux";
+import type { StoreEnhancer } from "redux";
 import {
   mappingShouldBeAnObject,
   mappingShouldNotHaveTheSameKeys,

--- a/packages/liveblocks-redux/tsconfig.json
+++ b/packages/liveblocks-redux/tsconfig.json
@@ -8,7 +8,9 @@
     "moduleResolution": "node",
     "noUncheckedIndexedAccess": true,
     "lib": ["es2019", "dom", "esnext"],
-    "stripInternal": true
+    "stripInternal": true,
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true
   },
   "file": ["src/index.ts", "src/index.test.ts"],
   "exclude": ["node_modules"]

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -1,14 +1,18 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { createClient, Presence } from "@liveblocks/client";
-import { Mapping, middleware } from ".";
+import { createClient } from "@liveblocks/client";
+import type { Presence } from "@liveblocks/client";
+import type { Mapping } from ".";
+import { middleware } from ".";
 import create from "zustand";
-import { StateCreator } from "zustand";
+import type { StateCreator } from "zustand";
+import type {
+  SerializedCrdtWithId,
+  ServerMessage,
+} from "@liveblocks/client/internal";
 import {
   ClientMessageType,
   OpType,
-  SerializedCrdtWithId,
-  ServerMessage,
   ServerMessageType,
 } from "@liveblocks/client/internal";
 import { list, MockWebSocket, obj, waitFor } from "../test/utils";

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -1,5 +1,5 @@
-import { StateCreator, SetState, GetState, StoreApi } from "zustand";
-import {
+import type { StateCreator, SetState, GetState, StoreApi } from "zustand";
+import type {
   Client,
   LiveObject,
   LsonObject,

--- a/packages/liveblocks-zustand/tsconfig.json
+++ b/packages/liveblocks-zustand/tsconfig.json
@@ -8,7 +8,9 @@
     "moduleResolution": "node",
     "noUncheckedIndexedAccess": true,
     "lib": ["es2019", "dom", "esnext"],
-    "stripInternal": true
+    "stripInternal": true,
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true
   },
   "file": ["src/index.ts", "src/index.test.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This is a small clean-up pass that utilizes TypeScript's ["type-only imports" and exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export). By enabling this flag in `tsconfig.json`, TypeScript will throw errors if you're only importing types from a specific module, and remind you to declare the imports as `import type` instead. By doing so, you statically declare that all of those imports will all be types. This is useful to tools like Babel as they can know for sure that those imports are intended to strictly be types. I also find it makes code more readable to me as a developer. Reading `import { Json } from './json'`, you instantly know that it's just a type, and not a class, for example.

This can also help reduce chances of import cycles in some cases. If an import cycles is only needed at the type level, then using `import type` instead removes the import cycle at runtime, so tools like Node, Babel, or bundlers have an easier time.
