### PR TITLE
Restore `exports` setting

### DIFF
--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -5,6 +5,16 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
+  "exports": {
+    "./internal": {
+      "require": "./internal.js",
+      "import": "./internal.mjs"
+    },
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs"
+    }
+  },
   "files": [
     "**"
   ],


### PR DESCRIPTION
Restores the exports setting. I found a case where this export is still needed.

If you have a (modern) project depending on Redux, and you're importing from `@liveblocks/redux` somewhere using ES modules, then that will resolve to the file `liveblocks-redux/lib/index.mjs`, which contains this line of code:

```jsx
import { patchLiveObjectKey, lsonToJson, patchImmutableObject } from '@liveblocks/client/internal';
```

However, in `.mjs` files, it's crucial to import using file extensions. We can fix this in two ways:

- Either this compiled module should import from `@liveblocks/client/internal.mjs` instead; or
- We set up this subexport, so this `.mjs` file can find the source

This PR does the latter, to avoid having to add hacks to rewrite those imports in generated `.mjs` files.