### PR TITLE
Upgrade all examples to latest TypeScript

### DIFF
--- a/examples/nextjs-live-avatars/package-lock.json
+++ b/examples/nextjs-live-avatars/package-lock.json
@@ -21,7 +21,7 @@
         "postcss": "^8.2.13",
         "prettier": "^2.6.2",
         "tailwindcss": "^2.1.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1878,9 +1878,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3221,9 +3221,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "universalify": {

--- a/examples/nextjs-live-avatars/package.json
+++ b/examples/nextjs-live-avatars/package.json
@@ -22,6 +22,6 @@
     "postcss": "^8.2.13",
     "prettier": "^2.6.2",
     "tailwindcss": "^2.1.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.4"
   }
 }

--- a/examples/nextjs-live-cursors-chat/package-lock.json
+++ b/examples/nextjs-live-cursors-chat/package-lock.json
@@ -20,7 +20,7 @@
         "postcss": "^8.2.13",
         "prettier": "^2.6.2",
         "tailwindcss": "^2.1.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3682,9 +3682,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6759,9 +6759,9 @@
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "uniq": {

--- a/examples/nextjs-live-cursors-chat/package.json
+++ b/examples/nextjs-live-cursors-chat/package.json
@@ -21,6 +21,6 @@
     "postcss": "^8.2.13",
     "prettier": "^2.6.2",
     "tailwindcss": "^2.1.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.4"
   }
 }

--- a/examples/nextjs-live-cursors-scroll/package-lock.json
+++ b/examples/nextjs-live-cursors-scroll/package-lock.json
@@ -20,7 +20,7 @@
         "postcss": "^8.2.13",
         "prettier": "^2.6.2",
         "tailwindcss": "^2.1.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3682,9 +3682,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6759,9 +6759,9 @@
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "uniq": {

--- a/examples/nextjs-live-cursors-scroll/package.json
+++ b/examples/nextjs-live-cursors-scroll/package.json
@@ -21,6 +21,6 @@
     "postcss": "^8.2.13",
     "prettier": "^2.6.2",
     "tailwindcss": "^2.1.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.4"
   }
 }

--- a/examples/nextjs-live-selection/package-lock.json
+++ b/examples/nextjs-live-selection/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "^16.10.1",
         "@types/react": "^17.0.2",
         "prettier": "^2.6.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2761,9 +2761,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5139,9 +5139,9 @@
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "unpipe": {

--- a/examples/nextjs-live-selection/package.json
+++ b/examples/nextjs-live-selection/package.json
@@ -18,6 +18,6 @@
     "@types/node": "^16.10.1",
     "@types/react": "^17.0.2",
     "prettier": "^2.6.2",
-    "typescript": "^4.2.2"
+    "typescript": "^4.6.4"
   }
 }

--- a/examples/nextjs-logo-builder/package-lock.json
+++ b/examples/nextjs-logo-builder/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/react": "17.0.33",
         "prettier": "^2.6.2",
-        "typescript": "4.4.4"
+        "typescript": "^4.4.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/examples/nextjs-logo-builder/package.json
+++ b/examples/nextjs-logo-builder/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/react": "17.0.33",
     "prettier": "^2.6.2",
-    "typescript": "4.4.4"
+    "typescript": "^4.4.4"
   }
 }

--- a/examples/nextjs-whiteboard-advanced/package-lock.json
+++ b/examples/nextjs-whiteboard-advanced/package-lock.json
@@ -23,7 +23,7 @@
         "postcss": "^8.2.13",
         "prettier": "^2.6.2",
         "tailwindcss": "^2.1.2",
-        "typescript": "^4.6.3"
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3410,9 +3410,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "universalify": {

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -24,6 +24,6 @@
     "postcss": "^8.2.13",
     "prettier": "^2.6.2",
     "tailwindcss": "^2.1.2",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.4"
   }
 }


### PR DESCRIPTION
This prevents this line from showing up in the console logs in Next projects:

    warn  - Minimum recommended TypeScript version is v4.3.2, older versions can potentially be incompatible with Next.js. Detected: 4.2.2
