### PR TITLE
Fix flacky zustand and redux unit tests

### DIFF
--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -601,6 +601,9 @@ describe("middleware", () => {
 
         store.dispatch({ type: "SET_VALUE", value: 2 });
 
+        // Waiting for last update to be sent because of room internal throttling
+        await waitFor(() => socket.sentMessages[1] != null);
+
         expect(socket.sentMessages[1]).toEqual(
           JSON.stringify([
             {
@@ -628,6 +631,9 @@ describe("middleware", () => {
           type: "SET_ITEMS",
           items: [{ text: "A" }, { text: "B" }],
         });
+
+        // Waiting for last update to be sent because of room internal throttling
+        await waitFor(() => socket.sentMessages[1] != null);
 
         expect(socket.sentMessages[1]).toEqual(
           JSON.stringify([

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -524,6 +524,9 @@ describe("middleware", () => {
 
         store.getState().setValue(2);
 
+        // Waiting for last update to be sent because of room internal throttling
+        await waitFor(() => socket.sentMessages[1] != null);
+
         expect(socket.sentMessages[1]).toEqual(
           JSON.stringify([
             {
@@ -548,6 +551,9 @@ describe("middleware", () => {
         ]);
 
         store.getState().setItems([{ text: "A" }, { text: "B" }]);
+
+        // Waiting for last update to be sent because of room internal throttling
+        await waitFor(() => socket.sentMessages[1] != null);
 
         expect(socket.sentMessages[1]).toEqual(
           JSON.stringify([


### PR DESCRIPTION
Making sure we're waiting for socket messages to be flushed on some unit test just in case tests are running too fast on the CI.

Fixes https://github.com/liveblocks/liveblocks/issues/203