### PR TITLE
Add custom script to smartly skip Vercel builds

### DIFF
--- a/scripts/should-example-rebuild-on-vercel.sh
+++ b/scripts/should-example-rebuild-on-vercel.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+set -eu
+
+# Ensure this script can assume it's run from the repo's
+# root directory, even if the current working directory is
+# different.
+ROOT="$(git rev-parse --show-toplevel)"
+if [ "$(pwd)" != "$ROOT" ]; then
+    ( cd "$ROOT" && exec "$0" "$@" )
+    exit $?
+fi
+
+err () {
+    echo "$@" >&2
+}
+
+usage () {
+    err "usage: should-example-rebuild-on-vercel.sh [-h] <example-name>"
+    err
+    err "Returns a 0 or 1 exit code, indicating whether the given example should be redeployed."
+    err
+    err "Options:"
+    err "-v    Be verbose"
+    err "-h    Show this help"
+}
+
+verbose=0
+while getopts vh flag; do
+    case "$flag" in
+        v) verbose=1 ;;
+        h) usage; exit 0;;
+        *) usage; exit 2;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+if [ "$#" -lt 1 ]; then
+    usage
+    exit 2
+elif [ "$#" -gt 1 ]; then
+    shift 1
+    err "Superfluous arguments: $@"
+    usage
+    exit 2
+fi
+
+EXAMPLE="${1%/}"
+
+if [ ! -d "examples/$EXAMPLE" ]; then
+    err "Unknown example: $EXAMPLE"
+    err "Valid examples are:"
+    ls examples/ | cat >&2
+    exit 2
+fi
+
+list_dependencies () {
+    echo '
+      const config = require("./package.json");
+      const deps = new Set([
+          ...(Object.keys(config?.dependencies ?? {})),
+      ]);
+      for (const dep of deps) {
+          console.log(dep);
+      }
+    ' | node -
+}
+
+make_relative () {
+    root="$(git root)"
+    while read f; do
+        echo "$(realpath --relative-to=. "$root/$f")"
+    done
+}
+
+starts_with () {
+    test "${1#$2}" != "$1"
+}
+
+get_all_changed_files () {
+    git diff --stat --name-only origin/main... -- | make_relative
+}
+
+#
+# We're only interested in checking the examples and packages folders, ignore
+# any other changed files.
+#
+get_interesting_changed_files () {
+    get_all_changed_files \
+      | grep -Ee '^(examples|packages)/' \
+      | grep -vEe "/[.]" \
+      | grep -vEe "(\.md)\$" \
+      | grep -vEe "\b(test|jest)\b"
+}
+
+make_filter_pattern () {
+    PAT="(examples/$EXAMPLE"
+
+    for dep in $( cd "examples/$EXAMPLE" && list_dependencies ); do
+        if starts_with "$dep" "@liveblocks/"; then
+            PAT="$PAT|packages/liveblocks-${dep#@liveblocks/}"
+        fi
+    done
+
+    PAT="$PAT)"
+    echo $PAT
+}
+
+files_that_should_trigger_rebuild () {
+    get_interesting_changed_files \
+        | grep -Ee "$(make_filter_pattern)"
+}
+
+if [ "$(files_that_should_trigger_rebuild | wc -l)" -eq 0 ]; then
+    if [ $verbose -eq 1 ]; then
+        err "Example \"$EXAMPLE\" unaffected by change."
+    fi
+    exit 0
+else
+    if [ $verbose -eq 1 ]; then
+        err "⚠️  Example \"$EXAMPLE\" needs rebuild."
+        files_that_should_trigger_rebuild >&2
+        err
+    fi
+    exit 1
+fi


### PR DESCRIPTION
This morning, @marcbouchenoire and I paired on our Vercel setup, and wanted the best of these both worlds:

1. Rebuild/redeploy the examples if they changed, or if any of the Liveblocks packages changed.
2. Reduce the number of (concurrent) builds we issue on every commit, to save precious time and $$$$$.

This PR adds a script we can run for each example to decide smartly whether to trigger a Vercel deployment or not, based on the contents of the Git diff.

It works as follows.

```
$ should-example-rebuild-on-vercel.sh -v nextjs-live-cursors
Example "nextjs-live-cursors" unaffected by change.
```

You give it the name of an example, and it returns exit code 0 (no rebuild needed) or 1 (please rebuild). It determines that value in a smart way: if any of the files in the example itself have changed (compared to `origin/main`, that is), it requests a rebuild. But it will also read the dependencies from `package.json` and figure out which Liveblocks packages this relies on dynamically. When so, it will also check if any of the files in that package have changed.

Some files, like `*.md` files, hidden dotfiles, or `*.test.*` files will be ignored and won't trigger a build.

This command is intended to be suitable to run on Vercel, specifically for this config: https://vercel.com/docs/concepts/projects/overview#ignored-build-step
