### PR TITLE
Update script to work around Vercel limitations

### DIFF
--- a/scripts/should-example-rebuild-on-vercel.sh
+++ b/scripts/should-example-rebuild-on-vercel.sh
@@ -75,7 +75,9 @@ starts_with () {
 get_all_changed_files () {
     if [ ! -f "changed-files.txt" ]; then
         SHA="$(git rev-parse HEAD)"
-        curl -sH "Accept: application/vnd.github.v3+json" \
+        curl -s \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
             "https://api.github.com/repos/liveblocks/liveblocks/compare/main...$SHA" \
             > diff-since-main.json
 

--- a/scripts/should-example-rebuild-on-vercel.sh
+++ b/scripts/should-example-rebuild-on-vercel.sh
@@ -74,10 +74,15 @@ starts_with () {
 
 get_all_changed_files () {
     if [ ! -f "changed-files.txt" ]; then
+        if [ -z "$GITHUB_ACCESS_TOKEN" ]; then
+            err "Please set the GITHUB_ACCESS_TOKEN env var for this Vercel project for this to work."
+            exit 2
+        fi
+
         SHA="$(git rev-parse HEAD)"
         curl -s \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
+            -H "Authorization: Bearer $GITHUB_ACCESS_TOKEN" \
             "https://api.github.com/repos/liveblocks/liveblocks/compare/main...$SHA" \
             > diff-since-main.json
 


### PR DESCRIPTION
Turns out, you [cannot ask for the diff against `main`](https://github.com/liveblocks/liveblocks/blob/4b67e7448a778c3d089ef19b4f0d6656831bbeaf/scripts/should-example-rebuild-on-vercel.sh#L80-L87) from within Vercel's git context, because they take a shallow clone and strip all the branch information. So instead, try to obtain the list of changes files from the GitHub API instead here.
