### PR TITLE
Allow skipping Vercel builds by using specific tags in commit messages

### DIFF
--- a/scripts/should-example-rebuild-on-vercel.sh
+++ b/scripts/should-example-rebuild-on-vercel.sh
@@ -90,6 +90,14 @@ get_all_changed_files () {
         # on Vercel environments
         echo '
         const data = require("./diff-since-main.json");
+
+        // If some commits on this branch have the phrase "[no vercel]" or
+        // "[skip examples]" or some combination like that in their message, skip
+        // this build
+        if (data?.commits?.some(commit => /\[(no|skip).*(vercel|examples|deploy).*\]/i.test(commit.message))) {
+            process.exit(0);
+        }
+
         const files = data?.files ?? [];
         for (const file of files) {
             console.log(file.filename);


### PR DESCRIPTION
Examples of tags you can put in commit messages that will cause example builds to be skipped for those PRs/branches:

- `[no deploy]`
- `[skip Vercel]`
- `[skip examples]`

Basically any combination of: `[{no,skip} {deploy,examples,vercel}]` is recognized (case-insensitive).

Once such a commit lands on a PR or branch, there is no way to "undo" that, unless you rewrite the Git history by removing the commit or changing the commit message.
