### PR TITLE
Make type params of LiveStructure type mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.17.0 (not yet released)
+
+## TypeScript improvements
+
+Various Live structures now take mandatory type params:
+
+- `LiveMap<K, V>` (just like `Map<K, V>`)
+- `LiveObject<{ a: number, b: string }>` (just like, for example, `{ a: number, b: string }`)
+- `LiveList<T>` (just like `Array<T>`)
+
 # v0.16.5 (not yet released)
 
 - Various internal refactorings

--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -49,30 +49,6 @@ module.exports = {
       },
       {
         selector:
-          'TSTypeReference[typeName.name="LiveObject"][typeParameters.params.length != 1]',
-        message:
-          "In library code, never write `LiveObject` without explicit type params! Type parameter defaults are only meant for end users.",
-      },
-      {
-        selector:
-          'TSTypeReference[typeName.name="LiveMap"][typeParameters.params.length != 2]',
-        message:
-          "In library code, never write `LiveMap` without explicit type params! Type parameter defaults are only meant for end users.",
-      },
-      {
-        selector:
-          'TSTypeReference[typeName.name="LiveList"][typeParameters.params.length != 1]',
-        message:
-          "In library code, never write `LiveList` without explicit type params! Type parameter defaults are only meant for end users.",
-      },
-      {
-        selector:
-          'TSTypeReference[typeName.name="LiveRegister"][typeParameters.params.length != 1]',
-        message:
-          "In library code, never write `LiveRegister` without explicit type params! Type parameter defaults are only meant for end users.",
-      },
-      {
-        selector:
           "CallExpression[callee.object.name='JSON'][callee.property.name='parse']",
         message:
           "Using `JSON.parse()` is type-unsafe. Prefer using the `parseJson()` utility method (from `src/json`).",

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -25,10 +25,7 @@ type LiveListItem = [crdt: AbstractCrdt, position: string];
 /**
  * The LiveList class represents an ordered collection of items that is synchronized across clients.
  */
-export class LiveList<TItem extends Lson = Lson> extends AbstractCrdt {
-  //                                     ^^^^^^
-  //                                     NOTE: Default arg will be removed in next major version
-
+export class LiveList<TItem extends Lson> extends AbstractCrdt {
   // TODO: Naive array at first, find a better data structure. Maybe an Order statistics tree?
   private _items: Array<LiveListItem>;
 

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -25,12 +25,8 @@ import {
  * If multiple clients update the same property simultaneously, the last modification received by the Liveblocks servers is the winner.
  */
 export class LiveMap<
-  TKey extends string = string,
-  //                  ^^^^^^^^
-  //                  NOTE: Default arg will be removed in next major version
-  TValue extends Lson = Lson
-  //                  ^^^^^^
-  //                  NOTE: Default arg will be removed in next major version
+  TKey extends string,
+  TValue extends Lson
 > extends AbstractCrdt {
   private _map: Map<TKey, AbstractCrdt>;
 

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -29,11 +29,7 @@ import {
  * Keys should be a string, and values should be serializable to JSON.
  * If multiple clients update the same property simultaneously, the last modification received by the Liveblocks servers is the winner.
  */
-export class LiveObject<
-  O extends LsonObject = LsonObject
-  //                   ^^^^^^^^^^^^
-  //                   NOTE: Default arg will be removed in next major version
-> extends AbstractCrdt {
+export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   private _map: Map<string, any>;
   private _propToLastUpdate: Map<string, string>;
 


### PR DESCRIPTION
This makes the type params of the various Live structures mandatory, instead of defaulting them to an opaque default.

No longer valid types:

- `LiveList` (without type params)
- `LiveMap` (without type params)
- `LiveObject` (without type params)

Valid:

- `LiveMap<K, V>` (just like `Map<K, V>`)
- `LiveObject<{ a: number, b: string }>` (just like, for example, `{ a: number, b: string }`)
- `LiveList<T>` (just like `Array<T>`)
