### PR TITLE
Fix: Vercel comments for Nuxt.js example

### DIFF
--- a/examples/nuxtjs-live-avatars/vercel.json
+++ b/examples/nuxtjs-live-avatars/vercel.json
@@ -1,5 +1,7 @@
 {
-  "version": 2,
+  "github": {
+    "silent": true
+  },
   "builds": [
     {
       "src": "nuxt.config.js",


### PR DESCRIPTION
This PR fixes the Vercel comment setting being overridden within the `nuxtjs-live-avatars` example, because of its own `vercel.json` file.