### PR TITLE
Prefactor: carry Presence type deeper in internal types

### DIFF
--- a/packages/liveblocks-client/src/LiveList.test.ts
+++ b/packages/liveblocks-client/src/LiveList.test.ts
@@ -20,6 +20,7 @@ import {
   SerializedCrdtWithId,
   WebsocketCloseCodes,
 } from "./live";
+import type { JsonObject as FixmePresence } from "./json";
 
 describe("LiveList", () => {
   describe("not attached", () => {
@@ -62,9 +63,10 @@ describe("LiveList", () => {
   });
 
   it("create document with list in root", async () => {
-    const { assert } = await prepareStorageTest<{
-      items: LiveList<any>;
-    }>([
+    const { assert } = await prepareStorageTest<
+      { items: LiveList<any> },
+      FixmePresence
+    >([
       createSerializedObject("0:0", {}),
       createSerializedList("0:1", "0:0", "items"),
     ]);
@@ -75,9 +77,10 @@ describe("LiveList", () => {
   });
 
   it("init list with items", async () => {
-    const { assert } = await prepareStorageTest<{
-      items: LiveList<LiveObject<{ a: number }>>;
-    }>([
+    const { assert } = await prepareStorageTest<
+      { items: LiveList<LiveObject<{ a: number }>> },
+      FixmePresence
+    >([
       createSerializedObject("0:0", {}),
       createSerializedList("0:1", "0:0", "items"),
       createSerializedObject("0:2", { a: 0 }, "0:1", FIRST_POSITION),
@@ -92,9 +95,12 @@ describe("LiveList", () => {
 
   describe("push", () => {
     it("push LiveObject", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -128,9 +134,12 @@ describe("LiveList", () => {
     });
 
     it("push existing LiveObject should throw", async () => {
-      const { storage, assert } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, assert } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -153,9 +162,12 @@ describe("LiveList", () => {
     });
 
     it("push number", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<number>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<number>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -184,9 +196,12 @@ describe("LiveList", () => {
     });
 
     it("push LiveMap", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveMap<string, number>>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<LiveMap<string, number>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -211,9 +226,12 @@ describe("LiveList", () => {
 
   describe("insert", () => {
     it("insert LiveObject at position 0", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -223,11 +241,7 @@ describe("LiveList", () => {
       );
 
       assert({
-        items: [
-          {
-            a: 1,
-          },
-        ],
+        items: [{ a: 1 }],
       });
 
       const root = storage.root;
@@ -236,14 +250,7 @@ describe("LiveList", () => {
       items.insert(new LiveObject({ a: 0 }), 0);
 
       assert({
-        items: [
-          {
-            a: 0,
-          },
-          {
-            a: 1,
-          },
-        ],
+        items: [{ a: 0 }, { a: 1 }],
       });
 
       assertUndoRedo();
@@ -256,9 +263,12 @@ describe("LiveList", () => {
         storage: doc,
         assert,
         assertUndoRedo,
-      } = await prepareStorageTest<{
-        items: LiveList<number>;
-      }>([
+      } = await prepareStorageTest<
+        {
+          items: LiveList<number>;
+        },
+        FixmePresence
+      >([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
         createSerializedRegister("0:2", "0:1", FIRST_POSITION, 0),
@@ -283,9 +293,12 @@ describe("LiveList", () => {
 
     it("delete child LiveObject should remove descendants", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
-        await prepareStorageTest<{
-          items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>>;
-        }>([
+        await prepareStorageTest<
+          {
+            items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>>;
+          },
+          FixmePresence
+        >([
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
           createSerializedObject("0:2", {}, "0:1", "!"),
@@ -293,13 +306,7 @@ describe("LiveList", () => {
         ]);
 
       assert({
-        items: [
-          {
-            child: {
-              a: 0,
-            },
-          },
-        ],
+        items: [{ child: { a: 0 } }],
       });
 
       storage.root.toObject().items.delete(0);
@@ -316,9 +323,12 @@ describe("LiveList", () => {
 
   describe("move", () => {
     it("list.move after current position", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>([
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
         createSerializedObject("0:2", { a: 0 }, "0:1", FIRST_POSITION),
@@ -327,17 +337,7 @@ describe("LiveList", () => {
       ]);
 
       assert({
-        items: [
-          {
-            a: 0,
-          },
-          {
-            a: 1,
-          },
-          {
-            a: 2,
-          },
-        ],
+        items: [{ a: 0 }, { a: 1 }, { a: 2 }],
       });
 
       const root = storage.root;
@@ -345,17 +345,7 @@ describe("LiveList", () => {
       items.move(0, 1);
 
       assert({
-        items: [
-          {
-            a: 1,
-          },
-          {
-            a: 0,
-          },
-          {
-            a: 2,
-          },
-        ],
+        items: [{ a: 1 }, { a: 0 }, { a: 2 }],
       });
 
       assertUndoRedo();
@@ -364,9 +354,12 @@ describe("LiveList", () => {
 
   describe("clear", () => {
     it("should delete all items", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -423,9 +416,12 @@ describe("LiveList", () => {
     });
 
     it("set register", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -451,9 +447,12 @@ describe("LiveList", () => {
     });
 
     it("set nested object", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -477,7 +476,10 @@ describe("LiveList", () => {
   describe("apply CreateRegister", () => {
     it(`with intent "set" should replace existing item`, async () => {
       const { assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -508,7 +510,10 @@ describe("LiveList", () => {
 
     it(`with intent "set" should notify with a "set" update`, async () => {
       const { root, applyRemoteOperations, subscribe } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -545,7 +550,10 @@ describe("LiveList", () => {
 
     it(`with intent "set" should insert item if conflict with a delete operation`, async () => {
       const { root, assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -584,7 +592,10 @@ describe("LiveList", () => {
 
     it(`with intent "set" should notify with a "insert" update if no item exists at this position`, async () => {
       const { root, applyRemoteOperations, subscribe } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -622,7 +633,10 @@ describe("LiveList", () => {
 
     it("on existing position should give the right update", async () => {
       const { root, assert, applyRemoteOperations, subscribe } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -670,7 +684,10 @@ describe("LiveList", () => {
   describe("conflict", () => {
     it("list conflicts", async () => {
       const { root, assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -713,7 +730,10 @@ describe("LiveList", () => {
 
     it("list conflicts 2", async () => {
       const { root, applyRemoteOperations, assert } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -783,7 +803,10 @@ describe("LiveList", () => {
 
     it("list conflicts with offline", async () => {
       const { root, assert, applyRemoteOperations, machine } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -833,7 +856,10 @@ describe("LiveList", () => {
 
     it("list conflicts with undo redo and remote change", async () => {
       const { root, assert, applyRemoteOperations, machine } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -881,7 +907,10 @@ describe("LiveList", () => {
 
     it("list conflicts - move", async () => {
       const { root, assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<
+          { items: LiveList<string> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -939,9 +968,12 @@ describe("LiveList", () => {
       storage: doc,
       assert,
       assertUndoRedo,
-    } = await prepareStorageTest<{
-      items: LiveList<LiveObject<{ b: number }>>;
-    }>(
+    } = await prepareStorageTest<
+      {
+        items: LiveList<LiveObject<{ b: number }>>;
+      },
+      FixmePresence
+    >(
       [
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
@@ -971,9 +1003,12 @@ describe("LiveList", () => {
 
   describe("subscriptions", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -996,9 +1031,12 @@ describe("LiveList", () => {
     });
 
     test("deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1034,9 +1072,12 @@ describe("LiveList", () => {
 
     test("remote move operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareStorageTest<
+          {
+            items: LiveList<string>;
+          },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1073,9 +1114,12 @@ describe("LiveList", () => {
 
     test("remote delete item operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareStorageTest<
+          {
+            items: LiveList<string>;
+          },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1106,9 +1150,12 @@ describe("LiveList", () => {
     });
 
     test("batch multiple actions", async () => {
-      const { storage, subscribe, batch, assert } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, subscribe, batch, assert } = await prepareStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1146,9 +1193,12 @@ describe("LiveList", () => {
     });
 
     test("batch multiple inserts", async () => {
-      const { storage, subscribe, batch, assert } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, subscribe, batch, assert } = await prepareStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1176,9 +1226,12 @@ describe("LiveList", () => {
     });
 
     test("clear with deep subscribe ", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1214,9 +1267,12 @@ describe("LiveList", () => {
     });
 
     test("move with deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1258,9 +1314,12 @@ describe("LiveList", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1345,9 +1404,12 @@ describe("LiveList", () => {
     });
 
     test("Register moved in list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1421,9 +1483,12 @@ describe("LiveList", () => {
     });
 
     test("Register deleted from list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<
+        {
+          items: LiveList<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1490,9 +1555,12 @@ describe("LiveList", () => {
 
   describe("internal methods", () => {
     test("_detachChild", async () => {
-      const { root } = await prepareIsolatedStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { root } = await prepareIsolatedStorageTest<
+        {
+          items: LiveList<LiveObject<{ a: number }>>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),

--- a/packages/liveblocks-client/src/LiveList.test.ts
+++ b/packages/liveblocks-client/src/LiveList.test.ts
@@ -64,8 +64,8 @@ describe("LiveList", () => {
 
   it("create document with list in root", async () => {
     const { assert } = await prepareStorageTest<
-      { items: LiveList<any> },
-      FixmePresence
+      FixmePresence,
+      { items: LiveList<any> }
     >([
       createSerializedObject("0:0", {}),
       createSerializedList("0:1", "0:0", "items"),
@@ -78,8 +78,8 @@ describe("LiveList", () => {
 
   it("init list with items", async () => {
     const { assert } = await prepareStorageTest<
-      { items: LiveList<LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { items: LiveList<LiveObject<{ a: number }>> }
     >([
       createSerializedObject("0:0", {}),
       createSerializedList("0:1", "0:0", "items"),
@@ -96,10 +96,8 @@ describe("LiveList", () => {
   describe("push", () => {
     it("push LiveObject", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -135,10 +133,8 @@ describe("LiveList", () => {
 
     it("push existing LiveObject should throw", async () => {
       const { storage, assert } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -163,10 +159,8 @@ describe("LiveList", () => {
 
     it("push number", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<number>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<number> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -197,10 +191,8 @@ describe("LiveList", () => {
 
     it("push LiveMap", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<LiveMap<string, number>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveMap<string, number>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -227,10 +219,8 @@ describe("LiveList", () => {
   describe("insert", () => {
     it("insert LiveObject at position 0", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -263,12 +253,7 @@ describe("LiveList", () => {
         storage: doc,
         assert,
         assertUndoRedo,
-      } = await prepareStorageTest<
-        {
-          items: LiveList<number>;
-        },
-        FixmePresence
-      >([
+      } = await prepareStorageTest<FixmePresence, { items: LiveList<number> }>([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
         createSerializedRegister("0:2", "0:1", FIRST_POSITION, 0),
@@ -294,10 +279,8 @@ describe("LiveList", () => {
     it("delete child LiveObject should remove descendants", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
         await prepareStorageTest<
-          {
-            items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>>;
-          },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>> }
         >([
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -324,10 +307,8 @@ describe("LiveList", () => {
   describe("move", () => {
     it("list.move after current position", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
@@ -355,10 +336,8 @@ describe("LiveList", () => {
   describe("clear", () => {
     it("should delete all items", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -417,10 +396,8 @@ describe("LiveList", () => {
 
     it("set register", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -448,10 +425,8 @@ describe("LiveList", () => {
 
     it("set nested object", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -477,8 +452,8 @@ describe("LiveList", () => {
     it(`with intent "set" should replace existing item`, async () => {
       const { assert, applyRemoteOperations } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("root", {}),
@@ -511,8 +486,8 @@ describe("LiveList", () => {
     it(`with intent "set" should notify with a "set" update`, async () => {
       const { root, applyRemoteOperations, subscribe } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("root", {}),
@@ -551,8 +526,8 @@ describe("LiveList", () => {
     it(`with intent "set" should insert item if conflict with a delete operation`, async () => {
       const { root, assert, applyRemoteOperations } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("root", {}),
@@ -593,8 +568,8 @@ describe("LiveList", () => {
     it(`with intent "set" should notify with a "insert" update if no item exists at this position`, async () => {
       const { root, applyRemoteOperations, subscribe } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("root", {}),
@@ -634,8 +609,8 @@ describe("LiveList", () => {
     it("on existing position should give the right update", async () => {
       const { root, assert, applyRemoteOperations, subscribe } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -685,8 +660,8 @@ describe("LiveList", () => {
     it("list conflicts", async () => {
       const { root, assert, applyRemoteOperations } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -731,8 +706,8 @@ describe("LiveList", () => {
     it("list conflicts 2", async () => {
       const { root, applyRemoteOperations, assert } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -804,8 +779,8 @@ describe("LiveList", () => {
     it("list conflicts with offline", async () => {
       const { root, assert, applyRemoteOperations, machine } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -857,8 +832,8 @@ describe("LiveList", () => {
     it("list conflicts with undo redo and remote change", async () => {
       const { root, assert, applyRemoteOperations, machine } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -908,8 +883,8 @@ describe("LiveList", () => {
     it("list conflicts - move", async () => {
       const { root, assert, applyRemoteOperations } =
         await prepareIsolatedStorageTest<
-          { items: LiveList<string> },
-          FixmePresence
+          FixmePresence,
+          { items: LiveList<string> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -969,10 +944,8 @@ describe("LiveList", () => {
       assert,
       assertUndoRedo,
     } = await prepareStorageTest<
-      {
-        items: LiveList<LiveObject<{ b: number }>>;
-      },
-      FixmePresence
+      FixmePresence,
+      { items: LiveList<LiveObject<{ b: number }>> }
     >(
       [
         createSerializedObject("0:0", {}),
@@ -1004,10 +977,8 @@ describe("LiveList", () => {
   describe("subscriptions", () => {
     test("simple action", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1032,10 +1003,8 @@ describe("LiveList", () => {
 
     test("deep subscribe", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1072,12 +1041,7 @@ describe("LiveList", () => {
 
     test("remote move operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<
-          {
-            items: LiveList<string>;
-          },
-          FixmePresence
-        >(
+        await prepareStorageTest<FixmePresence, { items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1114,12 +1078,7 @@ describe("LiveList", () => {
 
     test("remote delete item operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<
-          {
-            items: LiveList<string>;
-          },
-          FixmePresence
-        >(
+        await prepareStorageTest<FixmePresence, { items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1151,10 +1110,8 @@ describe("LiveList", () => {
 
     test("batch multiple actions", async () => {
       const { storage, subscribe, batch, assert } = await prepareStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1194,10 +1151,8 @@ describe("LiveList", () => {
 
     test("batch multiple inserts", async () => {
       const { storage, subscribe, batch, assert } = await prepareStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1227,10 +1182,8 @@ describe("LiveList", () => {
 
     test("clear with deep subscribe ", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1268,10 +1221,8 @@ describe("LiveList", () => {
 
     test("move with deep subscribe", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1315,10 +1266,8 @@ describe("LiveList", () => {
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to list", async () => {
       const { assert, machine, root } = await prepareIsolatedStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1405,10 +1354,8 @@ describe("LiveList", () => {
 
     test("Register moved in list", async () => {
       const { assert, machine, root } = await prepareIsolatedStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1484,10 +1431,8 @@ describe("LiveList", () => {
 
     test("Register deleted from list", async () => {
       const { assert, machine, root } = await prepareIsolatedStorageTest<
-        {
-          items: LiveList<string>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1556,10 +1501,8 @@ describe("LiveList", () => {
   describe("internal methods", () => {
     test("_detachChild", async () => {
       const { root } = await prepareIsolatedStorageTest<
-        {
-          items: LiveList<LiveObject<{ a: number }>>;
-        },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),

--- a/packages/liveblocks-client/src/LiveMap.test.ts
+++ b/packages/liveblocks-client/src/LiveMap.test.ts
@@ -16,6 +16,7 @@ import {
   SerializedCrdtWithId,
   WebsocketCloseCodes,
 } from "./live";
+import type { JsonObject as FixmePresence } from "./json";
 
 describe("LiveMap", () => {
   describe("not attached", () => {
@@ -97,9 +98,10 @@ describe("LiveMap", () => {
   });
 
   it("create document with map in root", async () => {
-    const { storage, assert } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>([
+    const { storage, assert } = await prepareStorageTest<
+      { map: LiveMap<string, LiveObject<{ a: number }>> },
+      FixmePresence
+    >([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
     ]);
@@ -114,9 +116,10 @@ describe("LiveMap", () => {
   });
 
   it("init map with items", async () => {
-    const { storage, assert } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>([
+    const { storage, assert } = await prepareStorageTest<
+      { map: LiveMap<string, LiveObject<{ a: number }>> },
+      FixmePresence
+    >([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
       createSerializedObject("0:2", { a: 0 }, "0:1", "first"),
@@ -145,9 +148,10 @@ describe("LiveMap", () => {
   });
 
   it("map.set object", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, number>;
-    }>(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, number> },
+      FixmePresence
+    >(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -187,9 +191,10 @@ describe("LiveMap", () => {
 
   describe("delete", () => {
     it("should delete LiveObject", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        map: LiveMap<string, LiveObject<{ a: number }>>;
-      }>([
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        { map: LiveMap<string, LiveObject<{ a: number }>> },
+        FixmePresence
+      >([
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
         createSerializedRegister("0:2", "0:1", "first", 0),
@@ -231,9 +236,10 @@ describe("LiveMap", () => {
 
     it("should remove nested data structure from cache", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
-        await prepareStorageTest<{
-          map: LiveMap<string, LiveObject<{ a: number }>>;
-        }>(
+        await prepareStorageTest<
+          { map: LiveMap<string, LiveObject<{ a: number }>> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedMap("0:1", "0:0", "map"),
@@ -262,9 +268,10 @@ describe("LiveMap", () => {
 
     it("should delete live list", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
-        await prepareStorageTest<{
-          map: LiveMap<string, LiveList<number>>;
-        }>(
+        await prepareStorageTest<
+          { map: LiveMap<string, LiveList<number>> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedMap("0:1", "0:0", "map"),
@@ -294,9 +301,10 @@ describe("LiveMap", () => {
 
     // https://github.com/liveblocks/liveblocks/issues/95
     it("should have deleted key when subscriber is called", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<{
-        map: LiveMap<string, string>;
-      }>(
+      const { root, subscribe } = await prepareIsolatedStorageTest<
+        { map: LiveMap<string, string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -318,9 +326,10 @@ describe("LiveMap", () => {
     });
 
     it("should call subscribe when key is deleted", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<{
-        map: LiveMap<string, string>;
-      }>(
+      const { root, subscribe } = await prepareIsolatedStorageTest<
+        { map: LiveMap<string, string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -343,9 +352,10 @@ describe("LiveMap", () => {
     });
 
     it("should not call subscribe when key is not deleted", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<{
-        map: LiveMap<string, string>;
-      }>(
+      const { root, subscribe } = await prepareIsolatedStorageTest<
+        { map: LiveMap<string, string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -368,9 +378,10 @@ describe("LiveMap", () => {
   });
 
   it("map.set live object", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, LiveObject<{ a: number }>> },
+      FixmePresence
+    >(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -394,9 +405,10 @@ describe("LiveMap", () => {
   });
 
   it("map.set already attached live object should throw", async () => {
-    const { storage } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>([
+    const { storage } = await prepareStorageTest<
+      { map: LiveMap<string, LiveObject<{ a: number }>> },
+      FixmePresence
+    >([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
     ]);
@@ -411,10 +423,13 @@ describe("LiveMap", () => {
   });
 
   it("new Map with already attached live object should throw", async () => {
-    const { storage } = await prepareStorageTest<{
-      child: LiveObject | null;
-      map: LiveMap<string, LiveObject<{ a: number }>> | null;
-    }>([createSerializedObject("0:0", { child: null, map: null })], 1);
+    const { storage } = await prepareStorageTest<
+      {
+        child: LiveObject | null;
+        map: LiveMap<string, LiveObject<{ a: number }>> | null;
+      },
+      FixmePresence
+    >([createSerializedObject("0:0", { child: null, map: null })], 1);
 
     const root = storage.root;
     const child = new LiveObject({ a: 0 });
@@ -424,9 +439,10 @@ describe("LiveMap", () => {
   });
 
   it("map.set live object on existing key", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, LiveObject<{ a: number }>> },
+      FixmePresence
+    >(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -452,78 +468,61 @@ describe("LiveMap", () => {
   });
 
   it("attach map with items to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, { a: number }>;
-    }>([createSerializedObject("0:0", {})], 1);
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, { a: number }> },
+      FixmePresence
+    >([createSerializedObject("0:0", {})], 1);
 
     assert({});
 
     storage.root.set("map", new LiveMap([["first", { a: 0 }]]));
 
     assert({
-      map: [
-        [
-          "first",
-          {
-            a: 0,
-          },
-        ],
-      ],
+      map: [["first", { a: 0 }]],
     });
 
     assertUndoRedo();
   });
 
   it("attach map with live objects to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>([createSerializedObject("0:0", {})], 1);
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, LiveObject<{ a: number }>> },
+      FixmePresence
+    >([createSerializedObject("0:0", {})], 1);
 
     assert({});
 
     storage.root.set("map", new LiveMap([["first", new LiveObject({ a: 0 })]]));
 
     assert({
-      map: [
-        [
-          "first",
-          {
-            a: 0,
-          },
-        ],
-      ],
+      map: [["first", { a: 0 }]],
     });
 
     assertUndoRedo();
   });
 
   it("attach map with objects to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, { a: number }>;
-    }>([createSerializedObject("0:0", {})], 1);
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, { a: number }> },
+      FixmePresence
+    >([createSerializedObject("0:0", {})], 1);
 
     assert({});
 
     storage.root.set("map", new LiveMap([["first", { a: 0 }]]));
 
     assert({
-      map: [
-        [
-          "first",
-          {
-            a: 0,
-          },
-        ],
-      ],
+      map: [["first", { a: 0 }]],
     });
 
     assertUndoRedo();
   });
 
   it("add list in map", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveList<string>>;
-    }>(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, LiveList<string>> },
+      FixmePresence
+    >(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -544,9 +543,10 @@ describe("LiveMap", () => {
   });
 
   it("add map in map", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveMap<string, string>>;
-    }>(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { map: LiveMap<string, LiveMap<string, string>> },
+      FixmePresence
+    >(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -568,9 +568,10 @@ describe("LiveMap", () => {
 
   describe("subscriptions", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        map: LiveMap<string, string>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        { map: LiveMap<string, string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -593,9 +594,10 @@ describe("LiveMap", () => {
     });
 
     test("deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        map: LiveMap<string, LiveObject<{ a: number }>>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        { map: LiveMap<string, LiveObject<{ a: number }>> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -632,9 +634,10 @@ describe("LiveMap", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to map", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        map: LiveMap<string, string>;
-      }>(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<
+        { map: LiveMap<string, string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -710,9 +713,10 @@ describe("LiveMap", () => {
 
   describe("internal methods", () => {
     test("_detachChild", async () => {
-      const { root } = await prepareIsolatedStorageTest<{
-        map: LiveMap<string, LiveObject<{ a: number }>>;
-      }>(
+      const { root } = await prepareIsolatedStorageTest<
+        { map: LiveMap<string, LiveObject<{ a: number }>> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),

--- a/packages/liveblocks-client/src/LiveMap.test.ts
+++ b/packages/liveblocks-client/src/LiveMap.test.ts
@@ -99,8 +99,8 @@ describe("LiveMap", () => {
 
   it("create document with map in root", async () => {
     const { storage, assert } = await prepareStorageTest<
-      { map: LiveMap<string, LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveObject<{ a: number }>> }
     >([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
@@ -117,8 +117,8 @@ describe("LiveMap", () => {
 
   it("init map with items", async () => {
     const { storage, assert } = await prepareStorageTest<
-      { map: LiveMap<string, LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveObject<{ a: number }>> }
     >([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
@@ -149,8 +149,8 @@ describe("LiveMap", () => {
 
   it("map.set object", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, number> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, number> }
     >(
       [
         createSerializedObject("0:0", {}),
@@ -192,8 +192,8 @@ describe("LiveMap", () => {
   describe("delete", () => {
     it("should delete LiveObject", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        { map: LiveMap<string, LiveObject<{ a: number }>> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, LiveObject<{ a: number }>> }
       >([
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -237,8 +237,8 @@ describe("LiveMap", () => {
     it("should remove nested data structure from cache", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
         await prepareStorageTest<
-          { map: LiveMap<string, LiveObject<{ a: number }>> },
-          FixmePresence
+          FixmePresence,
+          { map: LiveMap<string, LiveObject<{ a: number }>> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -269,8 +269,8 @@ describe("LiveMap", () => {
     it("should delete live list", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
         await prepareStorageTest<
-          { map: LiveMap<string, LiveList<number>> },
-          FixmePresence
+          FixmePresence,
+          { map: LiveMap<string, LiveList<number>> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -302,8 +302,8 @@ describe("LiveMap", () => {
     // https://github.com/liveblocks/liveblocks/issues/95
     it("should have deleted key when subscriber is called", async () => {
       const { root, subscribe } = await prepareIsolatedStorageTest<
-        { map: LiveMap<string, string> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -327,8 +327,8 @@ describe("LiveMap", () => {
 
     it("should call subscribe when key is deleted", async () => {
       const { root, subscribe } = await prepareIsolatedStorageTest<
-        { map: LiveMap<string, string> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -353,8 +353,8 @@ describe("LiveMap", () => {
 
     it("should not call subscribe when key is not deleted", async () => {
       const { root, subscribe } = await prepareIsolatedStorageTest<
-        { map: LiveMap<string, string> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -379,8 +379,8 @@ describe("LiveMap", () => {
 
   it("map.set live object", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveObject<{ a: number }>> }
     >(
       [
         createSerializedObject("0:0", {}),
@@ -406,8 +406,8 @@ describe("LiveMap", () => {
 
   it("map.set already attached live object should throw", async () => {
     const { storage } = await prepareStorageTest<
-      { map: LiveMap<string, LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveObject<{ a: number }>> }
     >([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
@@ -424,11 +424,11 @@ describe("LiveMap", () => {
 
   it("new Map with already attached live object should throw", async () => {
     const { storage } = await prepareStorageTest<
+      FixmePresence,
       {
         child: LiveObject | null;
         map: LiveMap<string, LiveObject<{ a: number }>> | null;
-      },
-      FixmePresence
+      }
     >([createSerializedObject("0:0", { child: null, map: null })], 1);
 
     const root = storage.root;
@@ -440,8 +440,8 @@ describe("LiveMap", () => {
 
   it("map.set live object on existing key", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveObject<{ a: number }>> }
     >(
       [
         createSerializedObject("0:0", {}),
@@ -469,8 +469,8 @@ describe("LiveMap", () => {
 
   it("attach map with items to root", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, { a: number }> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, { a: number }> }
     >([createSerializedObject("0:0", {})], 1);
 
     assert({});
@@ -486,8 +486,8 @@ describe("LiveMap", () => {
 
   it("attach map with live objects to root", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, LiveObject<{ a: number }>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveObject<{ a: number }>> }
     >([createSerializedObject("0:0", {})], 1);
 
     assert({});
@@ -503,8 +503,8 @@ describe("LiveMap", () => {
 
   it("attach map with objects to root", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, { a: number }> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, { a: number }> }
     >([createSerializedObject("0:0", {})], 1);
 
     assert({});
@@ -520,8 +520,8 @@ describe("LiveMap", () => {
 
   it("add list in map", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, LiveList<string>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveList<string>> }
     >(
       [
         createSerializedObject("0:0", {}),
@@ -544,8 +544,8 @@ describe("LiveMap", () => {
 
   it("add map in map", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { map: LiveMap<string, LiveMap<string, string>> },
-      FixmePresence
+      FixmePresence,
+      { map: LiveMap<string, LiveMap<string, string>> }
     >(
       [
         createSerializedObject("0:0", {}),
@@ -569,8 +569,8 @@ describe("LiveMap", () => {
   describe("subscriptions", () => {
     test("simple action", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        { map: LiveMap<string, string> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -595,8 +595,8 @@ describe("LiveMap", () => {
 
     test("deep subscribe", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        { map: LiveMap<string, LiveObject<{ a: number }>> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -635,8 +635,8 @@ describe("LiveMap", () => {
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to map", async () => {
       const { assert, machine, root } = await prepareIsolatedStorageTest<
-        { map: LiveMap<string, string> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -714,8 +714,8 @@ describe("LiveMap", () => {
   describe("internal methods", () => {
     test("_detachChild", async () => {
       const { root } = await prepareIsolatedStorageTest<
-        { map: LiveMap<string, LiveObject<{ a: number }>> },
-        FixmePresence
+        FixmePresence,
+        { map: LiveMap<string, LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),

--- a/packages/liveblocks-client/src/LiveObject.test.ts
+++ b/packages/liveblocks-client/src/LiveObject.test.ts
@@ -32,8 +32,8 @@ describe("LiveObject", () => {
 
     it("should be null after being detached", async () => {
       const { root } = await prepareIsolatedStorageTest<
-        { child: LiveObject<{ a: number }> },
-        FixmePresence
+        FixmePresence,
+        { child: LiveObject<{ a: number }> }
       >(
         [
           createSerializedObject("root", {}),
@@ -138,8 +138,8 @@ describe("LiveObject", () => {
   it("update with LiveObject", async () => {
     const { storage, assert, operations, assertUndoRedo, getUndoStack } =
       await prepareStorageTest<
-        { child: LiveObject<{ a: number }> | null },
-        FixmePresence
+        FixmePresence,
+        { child: LiveObject<{ a: number }> | null }
       >([createSerializedObject("0:0", { child: null })], 1);
 
     const root = storage.root;
@@ -198,14 +198,14 @@ describe("LiveObject", () => {
   it("remove nested grand child record with update", async () => {
     const { storage, assert, assertUndoRedo, getItemsCount } =
       await prepareStorageTest<
+        FixmePresence,
         {
           a: number;
           child: LiveObject<{
             b: number;
             grandChild: LiveObject<{ c: number }>;
           }> | null;
-        },
-        FixmePresence
+        }
       >([
         createSerializedObject("0:0", { a: 0 }),
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
@@ -236,13 +236,8 @@ describe("LiveObject", () => {
   it("remove nested child record with update", async () => {
     const { storage, assert, assertUndoRedo, getItemsCount } =
       await prepareStorageTest<
-        {
-          a: number;
-          child: LiveObject<{
-            b: number;
-          }> | null;
-        },
-        FixmePresence
+        FixmePresence,
+        { a: number; child: LiveObject<{ b: number }> | null }
       >([
         createSerializedObject("0:0", { a: 0 }),
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
@@ -320,8 +315,8 @@ describe("LiveObject", () => {
 
   it("update nested record", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      { a: number; child: LiveObject<{ b: number }> },
-      FixmePresence
+      FixmePresence,
+      { a: number; child: LiveObject<{ b: number }> }
     >([
       createSerializedObject("0:0", { a: 0 }),
       createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
@@ -350,11 +345,11 @@ describe("LiveObject", () => {
 
   it("update deeply nested record", async () => {
     const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      FixmePresence,
       {
         a: number;
         child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
-      },
-      FixmePresence
+      }
     >([
       createSerializedObject("0:0", { a: 0 }),
       createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
@@ -398,7 +393,7 @@ describe("LiveObject", () => {
     describe("should ignore incoming updates if current op has not been acknowledged", () => {
       test("when value is not a crdt", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<{ a: number }, FixmePresence>(
+          await prepareIsolatedStorageTest<FixmePresence, { a: number }>(
             [createSerializedObject("0:0", { a: 0 })],
             1
           );
@@ -424,8 +419,8 @@ describe("LiveObject", () => {
       it("when value is a LiveObject", async () => {
         const { root, assert, applyRemoteOperations } =
           await prepareIsolatedStorageTest<
-            { a: LiveObject<{ subA: number }> },
-            FixmePresence
+            FixmePresence,
+            { a: LiveObject<{ subA: number }> }
           >(
             [
               createSerializedObject("0:0", {}),
@@ -457,8 +452,8 @@ describe("LiveObject", () => {
       it("when value is a LiveList with LiveObjects", async () => {
         const { root, assert, applyRemoteOperations } =
           await prepareIsolatedStorageTest<
-            { a: LiveList<LiveObject<{ b: number }>> },
-            FixmePresence
+            FixmePresence,
+            { a: LiveList<LiveObject<{ b: number }>> }
           >(
             [
               createSerializedObject("0:0", {}),
@@ -499,8 +494,8 @@ describe("LiveObject", () => {
 
     it("should delete property from the object", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        { a?: number },
-        FixmePresence
+        FixmePresence,
+        { a?: number }
       >([createSerializedObject("0:0", { a: 0 })]);
       assert({ a: 0 });
 
@@ -512,8 +507,8 @@ describe("LiveObject", () => {
 
     it("should delete nested crdt", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        { child?: LiveObject<{ a: number }> },
-        FixmePresence
+        FixmePresence,
+        { child?: LiveObject<{ a: number }> }
       >([
         createSerializedObject("0:0", {}),
         createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -529,8 +524,8 @@ describe("LiveObject", () => {
 
     it("should not notify if property does not exist", async () => {
       const { root, subscribe } = await prepareIsolatedStorageTest<
-        { a?: number },
-        FixmePresence
+        FixmePresence,
+        { a?: number }
       >([createSerializedObject("0:0", {})]);
 
       const callback = jest.fn();
@@ -543,8 +538,8 @@ describe("LiveObject", () => {
 
     it("should notify if property has been deleted", async () => {
       const { root, subscribe } = await prepareIsolatedStorageTest<
-        { a?: number },
-        FixmePresence
+        FixmePresence,
+        { a?: number }
       >([createSerializedObject("0:0", { a: 1 })]);
 
       const callback = jest.fn();
@@ -559,7 +554,7 @@ describe("LiveObject", () => {
   describe("applyDeleteObjectKey", () => {
     it("should not notify if property does not exist", async () => {
       const { root, subscribe, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{ a?: number }, FixmePresence>([
+        await prepareIsolatedStorageTest<FixmePresence, { a?: number }>([
           createSerializedObject("0:0", {}),
         ]);
 
@@ -575,7 +570,7 @@ describe("LiveObject", () => {
 
     it("should notify if property has been deleted", async () => {
       const { root, subscribe, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{ a?: number }, FixmePresence>([
+        await prepareIsolatedStorageTest<FixmePresence, { a?: number }>([
           createSerializedObject("0:0", { a: 1 }),
         ]);
 
@@ -593,8 +588,8 @@ describe("LiveObject", () => {
   describe("subscriptions", () => {
     test("simple action", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 0 })], 1);
 
       const callback = jest.fn();
@@ -611,8 +606,8 @@ describe("LiveObject", () => {
 
     test("subscribe multiple actions", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        { child: LiveObject<{ a: number }>; child2: LiveObject<{ a: number }> },
-        FixmePresence
+        FixmePresence,
+        { child: LiveObject<{ a: number }>; child2: LiveObject<{ a: number }> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -642,10 +637,13 @@ describe("LiveObject", () => {
 
     test("deep subscribe", async () => {
       const { storage, subscribe } = await prepareStorageTest<
+        FixmePresence,
         {
-          child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
-        },
-        FixmePresence
+          child: LiveObject<{
+            a: number;
+            subchild: LiveObject<{ b: number }>;
+          }>;
+        }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -688,13 +686,13 @@ describe("LiveObject", () => {
     test("deep subscribe remote operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
         await prepareStorageTest<
+          FixmePresence,
           {
             child: LiveObject<{
               a: number;
               subchild: LiveObject<{ b: number }>;
             }>;
-          },
-          FixmePresence
+          }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -745,13 +743,13 @@ describe("LiveObject", () => {
     test("subscribe subchild remote operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
         await prepareStorageTest<
+          FixmePresence,
           {
             child: LiveObject<{
               a: number;
               subchild: LiveObject<{ b: number }>;
             }>;
-          },
-          FixmePresence
+          }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -795,8 +793,8 @@ describe("LiveObject", () => {
     test("deep subscribe remote and local operation - delete object key", async () => {
       const { storage, subscribe, applyRemoteOperations } =
         await prepareStorageTest<
-          { child: LiveObject<{ a?: number; b?: number }> },
-          FixmePresence
+          FixmePresence,
+          { child: LiveObject<{ a?: number; b?: number }> }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -840,8 +838,8 @@ describe("LiveObject", () => {
   describe("reconnect with remote changes and subscribe", () => {
     test("LiveObject updated", async () => {
       const { assert, machine, root } = await prepareIsolatedStorageTest<
-        { obj: LiveObject<{ a: number }> },
-        FixmePresence
+        FixmePresence,
+        { obj: LiveObject<{ a: number }> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -899,8 +897,8 @@ describe("LiveObject", () => {
 
     test("LiveObject updated nested", async () => {
       const { assert, machine, root } = await prepareIsolatedStorageTest<
-        { obj: LiveObject<{ a: number }> },
-        FixmePresence
+        FixmePresence,
+        { obj: LiveObject<{ a: number }> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -971,7 +969,7 @@ describe("LiveObject", () => {
   describe("undo apply update", () => {
     test("subscription should gives the right update", async () => {
       const { root, assert, subscribe, undo } =
-        await prepareIsolatedStorageTest<{ a: number }, FixmePresence>(
+        await prepareIsolatedStorageTest<FixmePresence, { a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -995,13 +993,13 @@ describe("LiveObject", () => {
   describe("internal methods", () => {
     test("_detachChild", async () => {
       const { root } = await prepareIsolatedStorageTest<
+        FixmePresence,
         {
           obj: LiveObject<{
             a: LiveObject<{ subA: number }>;
             b: LiveObject<{ subA: number }>;
           }>;
-        },
-        FixmePresence
+        }
       >(
         [
           createSerializedObject("0:0", {}),

--- a/packages/liveblocks-client/src/LiveObject.test.ts
+++ b/packages/liveblocks-client/src/LiveObject.test.ts
@@ -13,6 +13,7 @@ import {
   WebsocketCloseCodes,
 } from "./live";
 import { LiveList } from ".";
+import type { JsonObject as FixmePresence } from "./json";
 
 describe("LiveObject", () => {
   describe("roomId", () => {
@@ -30,9 +31,10 @@ describe("LiveObject", () => {
     });
 
     it("should be null after being detached", async () => {
-      const { root } = await prepareIsolatedStorageTest<{
-        child: LiveObject<{ a: number }>;
-      }>(
+      const { root } = await prepareIsolatedStorageTest<
+        { child: LiveObject<{ a: number }> },
+        FixmePresence
+      >(
         [
           createSerializedObject("root", {}),
           createSerializedObject("0:0", { a: 0 }, "root", "child"),
@@ -135,9 +137,10 @@ describe("LiveObject", () => {
 
   it("update with LiveObject", async () => {
     const { storage, assert, operations, assertUndoRedo, getUndoStack } =
-      await prepareStorageTest<{
-        child: LiveObject<{ a: number }> | null;
-      }>([createSerializedObject("0:0", { child: null })], 1);
+      await prepareStorageTest<
+        { child: LiveObject<{ a: number }> | null },
+        FixmePresence
+      >([createSerializedObject("0:0", { child: null })], 1);
 
     const root = storage.root;
 
@@ -194,13 +197,16 @@ describe("LiveObject", () => {
 
   it("remove nested grand child record with update", async () => {
     const { storage, assert, assertUndoRedo, getItemsCount } =
-      await prepareStorageTest<{
-        a: number;
-        child: LiveObject<{
-          b: number;
-          grandChild: LiveObject<{ c: number }>;
-        }> | null;
-      }>([
+      await prepareStorageTest<
+        {
+          a: number;
+          child: LiveObject<{
+            b: number;
+            grandChild: LiveObject<{ c: number }>;
+          }> | null;
+        },
+        FixmePresence
+      >([
         createSerializedObject("0:0", { a: 0 }),
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
         createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
@@ -229,12 +235,15 @@ describe("LiveObject", () => {
 
   it("remove nested child record with update", async () => {
     const { storage, assert, assertUndoRedo, getItemsCount } =
-      await prepareStorageTest<{
-        a: number;
-        child: LiveObject<{
-          b: number;
-        }> | null;
-      }>([
+      await prepareStorageTest<
+        {
+          a: number;
+          child: LiveObject<{
+            b: number;
+          }> | null;
+        },
+        FixmePresence
+      >([
         createSerializedObject("0:0", { a: 0 }),
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
       ]);
@@ -310,10 +319,10 @@ describe("LiveObject", () => {
   });
 
   it("update nested record", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      a: number;
-      child: LiveObject<{ b: number }>;
-    }>([
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      { a: number; child: LiveObject<{ b: number }> },
+      FixmePresence
+    >([
       createSerializedObject("0:0", { a: 0 }),
       createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
     ]);
@@ -340,10 +349,13 @@ describe("LiveObject", () => {
   });
 
   it("update deeply nested record", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      a: number;
-      child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
-    }>([
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+      {
+        a: number;
+        child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
+      },
+      FixmePresence
+    >([
       createSerializedObject("0:0", { a: 0 }),
       createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
       createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
@@ -386,7 +398,7 @@ describe("LiveObject", () => {
     describe("should ignore incoming updates if current op has not been acknowledged", () => {
       test("when value is not a crdt", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<{ a: number }>(
+          await prepareIsolatedStorageTest<{ a: number }, FixmePresence>(
             [createSerializedObject("0:0", { a: 0 })],
             1
           );
@@ -411,7 +423,10 @@ describe("LiveObject", () => {
 
       it("when value is a LiveObject", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<{ a: LiveObject<{ subA: number }> }>(
+          await prepareIsolatedStorageTest<
+            { a: LiveObject<{ subA: number }> },
+            FixmePresence
+          >(
             [
               createSerializedObject("0:0", {}),
               createSerializedObject("0:1", { subA: 0 }, "0:0", "a"),
@@ -441,9 +456,10 @@ describe("LiveObject", () => {
 
       it("when value is a LiveList with LiveObjects", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<{
-            a: LiveList<LiveObject<{ b: number }>>;
-          }>(
+          await prepareIsolatedStorageTest<
+            { a: LiveList<LiveObject<{ b: number }>> },
+            FixmePresence
+          >(
             [
               createSerializedObject("0:0", {}),
               createSerializedList("0:1", "0:0", "a"),
@@ -482,9 +498,10 @@ describe("LiveObject", () => {
     });
 
     it("should delete property from the object", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        a?: number;
-      }>([createSerializedObject("0:0", { a: 0 })]);
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        { a?: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })]);
       assert({ a: 0 });
 
       storage.root.delete("a");
@@ -494,9 +511,10 @@ describe("LiveObject", () => {
     });
 
     it("should delete nested crdt", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        child?: LiveObject<{ a: number }>;
-      }>([
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        { child?: LiveObject<{ a: number }> },
+        FixmePresence
+      >([
         createSerializedObject("0:0", {}),
         createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
       ]);
@@ -510,9 +528,10 @@ describe("LiveObject", () => {
     });
 
     it("should not notify if property does not exist", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<{
-        a?: number;
-      }>([createSerializedObject("0:0", {})]);
+      const { root, subscribe } = await prepareIsolatedStorageTest<
+        { a?: number },
+        FixmePresence
+      >([createSerializedObject("0:0", {})]);
 
       const callback = jest.fn();
       subscribe(root, callback);
@@ -523,9 +542,10 @@ describe("LiveObject", () => {
     });
 
     it("should notify if property has been deleted", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<{
-        a?: number;
-      }>([createSerializedObject("0:0", { a: 1 })]);
+      const { root, subscribe } = await prepareIsolatedStorageTest<
+        { a?: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 1 })]);
 
       const callback = jest.fn();
       subscribe(root, callback);
@@ -539,9 +559,9 @@ describe("LiveObject", () => {
   describe("applyDeleteObjectKey", () => {
     it("should not notify if property does not exist", async () => {
       const { root, subscribe, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{
-          a?: number;
-        }>([createSerializedObject("0:0", {})]);
+        await prepareIsolatedStorageTest<{ a?: number }, FixmePresence>([
+          createSerializedObject("0:0", {}),
+        ]);
 
       const callback = jest.fn();
       subscribe(root, callback);
@@ -555,9 +575,9 @@ describe("LiveObject", () => {
 
     it("should notify if property has been deleted", async () => {
       const { root, subscribe, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<{
-          a?: number;
-        }>([createSerializedObject("0:0", { a: 1 })]);
+        await prepareIsolatedStorageTest<{ a?: number }, FixmePresence>([
+          createSerializedObject("0:0", { a: 1 }),
+        ]);
 
       const callback = jest.fn();
       subscribe(root, callback);
@@ -572,9 +592,10 @@ describe("LiveObject", () => {
 
   describe("subscriptions", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, subscribe } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })], 1);
 
       const callback = jest.fn();
 
@@ -589,10 +610,10 @@ describe("LiveObject", () => {
     });
 
     test("subscribe multiple actions", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        child: LiveObject<{ a: number }>;
-        child2: LiveObject<{ a: number }>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        { child: LiveObject<{ a: number }>; child2: LiveObject<{ a: number }> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -620,9 +641,12 @@ describe("LiveObject", () => {
     });
 
     test("deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
-      }>(
+      const { storage, subscribe } = await prepareStorageTest<
+        {
+          child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -663,9 +687,15 @@ describe("LiveObject", () => {
 
     test("deep subscribe remote operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<{
-          child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
-        }>(
+        await prepareStorageTest<
+          {
+            child: LiveObject<{
+              a: number;
+              subchild: LiveObject<{ b: number }>;
+            }>;
+          },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -714,9 +744,15 @@ describe("LiveObject", () => {
 
     test("subscribe subchild remote operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<{
-          child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
-        }>(
+        await prepareStorageTest<
+          {
+            child: LiveObject<{
+              a: number;
+              subchild: LiveObject<{ b: number }>;
+            }>;
+          },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -758,9 +794,10 @@ describe("LiveObject", () => {
 
     test("deep subscribe remote and local operation - delete object key", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<{
-          child: LiveObject<{ a?: number; b?: number }>;
-        }>(
+        await prepareStorageTest<
+          { child: LiveObject<{ a?: number; b?: number }> },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0, b: 0 }, "0:0", "child"),
@@ -775,12 +812,7 @@ describe("LiveObject", () => {
       const unsubscribe = subscribe(root, callback, { isDeep: true });
 
       applyRemoteOperations([
-        {
-          type: OpType.DeleteObjectKey,
-          key: "a",
-          id: "0:1",
-          opId: "external",
-        },
+        { type: OpType.DeleteObjectKey, key: "a", id: "0:1", opId: "external" },
       ]);
 
       root.get("child").delete("b");
@@ -807,9 +839,10 @@ describe("LiveObject", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("LiveObject updated", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        obj: LiveObject<{ a: number }>;
-      }>(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<
+        { obj: LiveObject<{ a: number }> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
@@ -865,9 +898,10 @@ describe("LiveObject", () => {
     });
 
     test("LiveObject updated nested", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        obj: LiveObject<{ a: number }>;
-      }>(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<
+        { obj: LiveObject<{ a: number }> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
@@ -937,7 +971,7 @@ describe("LiveObject", () => {
   describe("undo apply update", () => {
     test("subscription should gives the right update", async () => {
       const { root, assert, subscribe, undo } =
-        await prepareIsolatedStorageTest<{ a: number }>(
+        await prepareIsolatedStorageTest<{ a: number }, FixmePresence>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -960,12 +994,15 @@ describe("LiveObject", () => {
 
   describe("internal methods", () => {
     test("_detachChild", async () => {
-      const { root } = await prepareIsolatedStorageTest<{
-        obj: LiveObject<{
-          a: LiveObject<{ subA: number }>;
-          b: LiveObject<{ subA: number }>;
-        }>;
-      }>(
+      const { root } = await prepareIsolatedStorageTest<
+        {
+          obj: LiveObject<{
+            a: LiveObject<{ subA: number }>;
+            b: LiveObject<{ subA: number }>;
+          }>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "obj"),

--- a/packages/liveblocks-client/src/doc.test.ts
+++ b/packages/liveblocks-client/src/doc.test.ts
@@ -8,13 +8,15 @@ import {
   createSerializedList,
   createSerializedMap,
 } from "../test/utils";
+import type { JsonObject as FixmePresence } from "./json";
 
 describe("Storage", () => {
   describe("subscribe generic", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, subscribe } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })], 1);
 
       const callback = jest.fn();
 
@@ -38,9 +40,10 @@ describe("Storage", () => {
 
     test("remote action", async () => {
       const { storage, applyRemoteOperations, subscribe } =
-        await prepareStorageTest<{
-          a: number;
-        }>([createSerializedObject("0:0", { a: 0 })], 1);
+        await prepareStorageTest<{ a: number }, FixmePresence>(
+          [createSerializedObject("0:0", { a: 0 })],
+          1
+        );
 
       const callback = jest.fn();
 
@@ -68,9 +71,10 @@ describe("Storage", () => {
 
     test("remote action with multipe updates on same object", async () => {
       const { storage, applyRemoteOperations, subscribe } =
-        await prepareStorageTest<{
-          a: number;
-        }>([createSerializedObject("0:0", { a: 0 })], 1);
+        await prepareStorageTest<{ a: number }, FixmePresence>(
+          [createSerializedObject("0:0", { a: 0 })],
+          1
+        );
 
       const callback = jest.fn();
 
@@ -99,10 +103,10 @@ describe("Storage", () => {
 
     test("batch actions on a single LiveObject", async () => {
       const { storage, assertUndoRedo, subscribe, batch } =
-        await prepareStorageTest<{
-          a: number;
-          b: number;
-        }>([createSerializedObject("0:0", { a: 0, b: 0 })], 1);
+        await prepareStorageTest<{ a: number; b: number }, FixmePresence>(
+          [createSerializedObject("0:0", { a: 0, b: 0 })],
+          1
+        );
 
       const callback = jest.fn();
 
@@ -135,10 +139,10 @@ describe("Storage", () => {
     });
 
     test("batch actions on multiple LiveObjects", async () => {
-      const { storage, subscribe, batch } = await prepareStorageTest<{
-        a: number;
-        child: LiveObject<{ b: number }>;
-      }>(
+      const { storage, subscribe, batch } = await prepareStorageTest<
+        { a: number; child: LiveObject<{ b: number }> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", { a: 0 }),
           createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
@@ -173,12 +177,15 @@ describe("Storage", () => {
     });
 
     test("batch actions on multiple Live types", async () => {
-      const { storage, subscribe, batch } = await prepareStorageTest<{
-        a: number;
-        childObj: LiveObject<{ b: number }>;
-        childList: LiveList<string>;
-        childMap: LiveMap<string>;
-      }>(
+      const { storage, subscribe, batch } = await prepareStorageTest<
+        {
+          a: number;
+          childObj: LiveObject<{ b: number }>;
+          childList: LiveList<string>;
+          childMap: LiveMap<string>;
+        },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", { a: 0 }),
           createSerializedObject("0:1", { b: 0 }, "0:0", "childObj"),
@@ -229,9 +236,10 @@ describe("Storage", () => {
 
   describe("batching", () => {
     it("batching and undo", async () => {
-      const { storage, assert, undo, redo, batch } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, assert, undo, redo, batch } = await prepareStorageTest<
+        { items: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -265,9 +273,10 @@ describe("Storage", () => {
     });
 
     it("calling batch during a batch should throw", async () => {
-      const { storage, batch } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, batch } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })], 1);
 
       batch(() => {
         expect(() =>
@@ -279,9 +288,10 @@ describe("Storage", () => {
     });
 
     it("calling undo during a batch should throw", async () => {
-      const { undo, batch } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 0 })], 1);
+      const { undo, batch } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })], 1);
 
       batch(() => {
         expect(() => undo()).toThrow();
@@ -289,9 +299,10 @@ describe("Storage", () => {
     });
 
     it("calling redo during a batch should throw", async () => {
-      const { batch, redo } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 0 })], 1);
+      const { batch, redo } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })], 1);
 
       batch(() => {
         expect(() => redo()).toThrow();
@@ -301,9 +312,10 @@ describe("Storage", () => {
 
   describe("undo / redo", () => {
     it("list.push", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
+        { items: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -329,9 +341,10 @@ describe("Storage", () => {
     });
 
     it("max undo-redo stack", async () => {
-      const { storage, assert, undo } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, assert, undo } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 0 })], 1);
 
       for (let i = 0; i < 100; i++) {
         storage.root.set("a", i + 1);
@@ -350,9 +363,10 @@ describe("Storage", () => {
     });
 
     it("storage operation should clear redo stack", async () => {
-      const { storage, assert, undo, redo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { storage, assert, undo, redo } = await prepareStorageTest<
+        { items: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),

--- a/packages/liveblocks-client/src/doc.test.ts
+++ b/packages/liveblocks-client/src/doc.test.ts
@@ -14,8 +14,8 @@ describe("Storage", () => {
   describe("subscribe generic", () => {
     test("simple action", async () => {
       const { storage, subscribe } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 0 })], 1);
 
       const callback = jest.fn();
@@ -40,7 +40,7 @@ describe("Storage", () => {
 
     test("remote action", async () => {
       const { storage, applyRemoteOperations, subscribe } =
-        await prepareStorageTest<{ a: number }, FixmePresence>(
+        await prepareStorageTest<FixmePresence, { a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -71,7 +71,7 @@ describe("Storage", () => {
 
     test("remote action with multipe updates on same object", async () => {
       const { storage, applyRemoteOperations, subscribe } =
-        await prepareStorageTest<{ a: number }, FixmePresence>(
+        await prepareStorageTest<FixmePresence, { a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -103,7 +103,7 @@ describe("Storage", () => {
 
     test("batch actions on a single LiveObject", async () => {
       const { storage, assertUndoRedo, subscribe, batch } =
-        await prepareStorageTest<{ a: number; b: number }, FixmePresence>(
+        await prepareStorageTest<FixmePresence, { a: number; b: number }>(
           [createSerializedObject("0:0", { a: 0, b: 0 })],
           1
         );
@@ -140,8 +140,8 @@ describe("Storage", () => {
 
     test("batch actions on multiple LiveObjects", async () => {
       const { storage, subscribe, batch } = await prepareStorageTest<
-        { a: number; child: LiveObject<{ b: number }> },
-        FixmePresence
+        FixmePresence,
+        { a: number; child: LiveObject<{ b: number }> }
       >(
         [
           createSerializedObject("0:0", { a: 0 }),
@@ -178,13 +178,13 @@ describe("Storage", () => {
 
     test("batch actions on multiple Live types", async () => {
       const { storage, subscribe, batch } = await prepareStorageTest<
+        FixmePresence,
         {
           a: number;
           childObj: LiveObject<{ b: number }>;
           childList: LiveList<string>;
           childMap: LiveMap<string>;
-        },
-        FixmePresence
+        }
       >(
         [
           createSerializedObject("0:0", { a: 0 }),
@@ -237,8 +237,8 @@ describe("Storage", () => {
   describe("batching", () => {
     it("batching and undo", async () => {
       const { storage, assert, undo, redo, batch } = await prepareStorageTest<
-        { items: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -274,8 +274,8 @@ describe("Storage", () => {
 
     it("calling batch during a batch should throw", async () => {
       const { storage, batch } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 0 })], 1);
 
       batch(() => {
@@ -289,8 +289,8 @@ describe("Storage", () => {
 
     it("calling undo during a batch should throw", async () => {
       const { undo, batch } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 0 })], 1);
 
       batch(() => {
@@ -300,8 +300,8 @@ describe("Storage", () => {
 
     it("calling redo during a batch should throw", async () => {
       const { batch, redo } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 0 })], 1);
 
       batch(() => {
@@ -313,8 +313,8 @@ describe("Storage", () => {
   describe("undo / redo", () => {
     it("list.push", async () => {
       const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        { items: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -342,8 +342,8 @@ describe("Storage", () => {
 
     it("max undo-redo stack", async () => {
       const { storage, assert, undo } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 0 })], 1);
 
       for (let i = 0; i < 100; i++) {
@@ -364,8 +364,8 @@ describe("Storage", () => {
 
     it("storage operation should clear redo stack", async () => {
       const { storage, assert, undo, redo } = await prepareStorageTest<
-        { items: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -60,8 +60,8 @@ describe("2 ways tests with two clients", () => {
   describe("Object/LiveObject", () => {
     test("create object", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncObj: { a: number } },
-        FixmePresence
+        FixmePresence,
+        { syncObj: { a: number } }
       >([createSerializedObject("0:0", {})], 1);
 
       expect(state).toEqual({});
@@ -82,8 +82,8 @@ describe("2 ways tests with two clients", () => {
 
     test("update object", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncObj: { a: number } },
-        FixmePresence
+        FixmePresence,
+        { syncObj: { a: number } }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -110,8 +110,8 @@ describe("2 ways tests with two clients", () => {
 
     test("add nested object", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncObj: { a: any } },
-        FixmePresence
+        FixmePresence,
+        { syncObj: { a: any } }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -138,8 +138,8 @@ describe("2 ways tests with two clients", () => {
 
     test("create LiveList with one LiveRegister item in same batch", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { doc: any },
-        FixmePresence
+        FixmePresence,
+        { doc: any }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -161,8 +161,8 @@ describe("2 ways tests with two clients", () => {
 
     test("create nested LiveList with one LiveObject item in same batch", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { doc: any },
-        FixmePresence
+        FixmePresence,
+        { doc: any }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -184,8 +184,8 @@ describe("2 ways tests with two clients", () => {
 
     test("Add nested objects in same batch", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { doc: any },
-        FixmePresence
+        FixmePresence,
+        { doc: any }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -207,8 +207,8 @@ describe("2 ways tests with two clients", () => {
 
     test("delete object key", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncObj: { a?: number } },
-        FixmePresence
+        FixmePresence,
+        { syncObj: { a?: number } }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -237,8 +237,8 @@ describe("2 ways tests with two clients", () => {
   describe("Array/LiveList", () => {
     test("replace array of 3 elements to 1 element", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<number> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<number> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -266,8 +266,8 @@ describe("2 ways tests with two clients", () => {
 
     test("add item to array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -292,8 +292,8 @@ describe("2 ways tests with two clients", () => {
 
     test("replace first item in array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { list: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { list: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -316,8 +316,8 @@ describe("2 ways tests with two clients", () => {
 
     test("replace last item in array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { list: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { list: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -340,8 +340,8 @@ describe("2 ways tests with two clients", () => {
 
     test("insert item at beginning of array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -367,8 +367,8 @@ describe("2 ways tests with two clients", () => {
 
     test("swap items in array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -397,8 +397,8 @@ describe("2 ways tests with two clients", () => {
 
     test("array of objects", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<LiveObject<{ a: number }>> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<LiveObject<{ a: number }>> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -424,8 +424,8 @@ describe("2 ways tests with two clients", () => {
 
     test("remove first item from array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -452,8 +452,8 @@ describe("2 ways tests with two clients", () => {
 
     test("remove last item from array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -480,8 +480,8 @@ describe("2 ways tests with two clients", () => {
 
     test("remove all elements of array except first", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -508,8 +508,8 @@ describe("2 ways tests with two clients", () => {
     });
     test("remove all elements of array except last", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -536,8 +536,8 @@ describe("2 ways tests with two clients", () => {
     });
     test("remove all elements of array", async () => {
       const { storage, state, assert } = await prepareStorageImmutableTest<
-        { syncList: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { syncList: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -581,8 +581,8 @@ describe("2 ways tests with two clients", () => {
     test("new state contains a function", async () => {
       const { storage, state, assertStorage } =
         await prepareStorageImmutableTest<
-          { syncObj: { a: any } },
-          FixmePresence
+          FixmePresence,
+          { syncObj: { a: any } }
         >(
           [
             createSerializedObject("0:0", {}),
@@ -611,8 +611,8 @@ describe("2 ways tests with two clients", () => {
 
     test("Production env - new state contains a function", async () => {
       const { storage, state } = await prepareStorageImmutableTest<
-        { syncObj: { a: any } },
-        FixmePresence
+        FixmePresence,
+        { syncObj: { a: any } }
       >(
         [
           createSerializedObject("0:0", {}),

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./immutable";
 import { LiveObject } from "./LiveObject";
 import type { StorageUpdate } from "./types";
+import type { JsonObject as FixmePresence } from "./json";
 
 // TODO: Further improve this type
 type fixme = unknown;
@@ -58,9 +59,10 @@ describe("patchLiveObjectKey", () => {
 describe("2 ways tests with two clients", () => {
   describe("Object/LiveObject", () => {
     test("create object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a: number };
-      }>([createSerializedObject("0:0", {})], 1);
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncObj: { a: number } },
+        FixmePresence
+      >([createSerializedObject("0:0", {})], 1);
 
       expect(state).toEqual({});
 
@@ -79,9 +81,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("update object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a: number };
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncObj: { a: number } },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -106,9 +109,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("add nested object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a: any };
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncObj: { a: any } },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -133,9 +137,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("create LiveList with one LiveRegister item in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        doc: any;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { doc: any },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "doc"),
@@ -155,9 +160,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("create nested LiveList with one LiveObject item in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        doc: any;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { doc: any },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "doc"),
@@ -177,9 +183,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("Add nested objects in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        doc: any;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { doc: any },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "doc"),
@@ -199,9 +206,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("delete object key", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a?: number };
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncObj: { a?: number } },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -228,9 +236,10 @@ describe("2 ways tests with two clients", () => {
 
   describe("Array/LiveList", () => {
     test("replace array of 3 elements to 1 element", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<number>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<number> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -256,9 +265,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("add item to array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -281,9 +291,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("replace first item in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        list: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { list: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "list"),
@@ -304,9 +315,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("replace last item in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        list: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { list: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "list"),
@@ -327,9 +339,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("insert item at beginning of array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -353,9 +366,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("swap items in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -382,9 +396,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("array of objects", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<LiveObject<{ a: number }>>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<LiveObject<{ a: number }>> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -408,9 +423,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("remove first item from array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -435,9 +451,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("remove last item from array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -462,9 +479,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("remove all elements of array except first", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -489,9 +507,10 @@ describe("2 ways tests with two clients", () => {
       assert({ syncList: ["a"] }, 3, 2);
     });
     test("remove all elements of array except last", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -516,9 +535,10 @@ describe("2 ways tests with two clients", () => {
       assert({ syncList: ["c"] }, 3, 2);
     });
     test("remove all elements of array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
+      const { storage, state, assert } = await prepareStorageImmutableTest<
+        { syncList: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -560,9 +580,10 @@ describe("2 ways tests with two clients", () => {
 
     test("new state contains a function", async () => {
       const { storage, state, assertStorage } =
-        await prepareStorageImmutableTest<{
-          syncObj: { a: any };
-        }>(
+        await prepareStorageImmutableTest<
+          { syncObj: { a: any } },
+          FixmePresence
+        >(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -589,9 +610,10 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("Production env - new state contains a function", async () => {
-      const { storage, state } = await prepareStorageImmutableTest<{
-        syncObj: { a: any };
-      }>(
+      const { storage, state } = await prepareStorageImmutableTest<
+        { syncObj: { a: any } },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),

--- a/packages/liveblocks-client/src/live.ts
+++ b/packages/liveblocks-client/src/live.ts
@@ -145,9 +145,9 @@ export type UpdateStorageMessage = {
 /**
  * Messages that can be sent from the client to the server.
  */
-export type ClientMessage =
+export type ClientMessage<TPresence extends JsonObject> =
   | ClientEventMessage
-  | UpdatePresenceClientMessage
+  | UpdatePresenceClientMessage<TPresence>
   | UpdateStorageClientMessage
   | FetchStorageClientMessage;
 
@@ -164,9 +164,9 @@ export type ClientEventMessage = {
   event: Json;
 };
 
-export type UpdatePresenceClientMessage = {
+export type UpdatePresenceClientMessage<TPresence extends JsonObject> = {
   type: ClientMessageType.UpdatePresence;
-  data: Presence;
+  data: TPresence;
   targetActor?: number;
 };
 

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -816,8 +816,8 @@ describe("room", () => {
 
     test("batch without operations should not add an item to the undo stack", async () => {
       const { storage, assert, undo, batch } = await prepareStorageTest<
-        { a: number },
-        FixmePresence
+        FixmePresence,
+        { a: number }
       >([createSerializedObject("0:0", { a: 1 })], 1);
 
       storage.root.set("a", 2);
@@ -834,7 +834,7 @@ describe("room", () => {
 
     test("batch storage with changes from server", async () => {
       const { storage, assert, undo, redo, batch, subscribe, refSubscribe } =
-        await prepareStorageTest<{ items: LiveList<string> }, FixmePresence>(
+        await prepareStorageTest<FixmePresence, { items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -889,7 +889,7 @@ describe("room", () => {
         subscribe,
         refSubscribe,
         updatePresence,
-      } = await prepareStorageTest<{ items: LiveList<string> }, FixmePresence>(
+      } = await prepareStorageTest<FixmePresence, { items: LiveList<string> }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1042,7 +1042,7 @@ describe("room", () => {
   describe("offline", () => {
     test("disconnect and reconnect with offline changes", async () => {
       const { storage, assert, machine, refStorage, reconnect, ws } =
-        await prepareStorageTest<{ items: LiveList<string> }, FixmePresence>(
+        await prepareStorageTest<FixmePresence, { items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1103,8 +1103,8 @@ describe("room", () => {
 
     test("disconnect and reconnect with remote changes", async () => {
       const { assert, machine } = await prepareIsolatedStorageTest<
-        { items: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >(
         [
           createSerializedObject("0:0", {}),
@@ -1297,8 +1297,8 @@ describe("room", () => {
   describe("defaultStorage", () => {
     test("initialize room with defaultStorage should send operation only once", async () => {
       const { assert, assertMessagesSent } = await prepareIsolatedStorageTest<
-        { items: LiveList<string> },
-        FixmePresence
+        FixmePresence,
+        { items: LiveList<string> }
       >([createSerializedObject("0:0", {})], 1, { items: new LiveList() });
 
       assert({

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -25,6 +25,7 @@ import { makeStateMachine, defaultState, createRoom } from "./room";
 import type { Authentication, Others } from "./types";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
+import type { JsonObject as FixmePresence } from "./json";
 
 const defaultContext = {
   roomId: "room-id",
@@ -260,10 +261,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      {
-        type: ClientMessageType.UpdatePresence,
-        data: { x: 0 },
-      },
+      { type: ClientMessageType.UpdatePresence, data: { x: 0 } },
     ]);
   });
 
@@ -279,10 +277,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      {
-        type: ClientMessageType.UpdatePresence,
-        data: { x: 0 },
-      },
+      { type: ClientMessageType.UpdatePresence, data: { x: 0 } },
     ]);
   });
 
@@ -297,10 +292,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      {
-        type: ClientMessageType.UpdatePresence,
-        data: {},
-      },
+      { type: ClientMessageType.UpdatePresence, data: {} },
     ]);
   });
 
@@ -323,10 +315,7 @@ describe("room", () => {
       defaultContext.throttleDelay - 30
     );
     expect(effects.send).toHaveBeenCalledWith([
-      {
-        type: ClientMessageType.UpdatePresence,
-        data: { x: 0 },
-      },
+      { type: ClientMessageType.UpdatePresence, data: { x: 0 } },
     ]);
     expect(state.buffer.presence).toEqual({ x: 1 });
   });
@@ -469,10 +458,7 @@ describe("room", () => {
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
-        {
-          type: ClientMessageType.UpdatePresence,
-          data: {},
-        },
+        { type: ClientMessageType.UpdatePresence, data: {} },
       ]);
     });
 
@@ -495,14 +481,8 @@ describe("room", () => {
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
-        {
-          type: ClientMessageType.UpdatePresence,
-          data: {},
-        },
-        {
-          type: ClientMessageType.ClientEvent,
-          event: { type: "EVENT" },
-        },
+        { type: ClientMessageType.UpdatePresence, data: {} },
+        { type: ClientMessageType.ClientEvent, event: { type: "EVENT" } },
       ]);
     });
   });
@@ -835,9 +815,10 @@ describe("room", () => {
     });
 
     test("batch without operations should not add an item to the undo stack", async () => {
-      const { storage, assert, undo, batch } = await prepareStorageTest<{
-        a: number;
-      }>([createSerializedObject("0:0", { a: 1 })], 1);
+      const { storage, assert, undo, batch } = await prepareStorageTest<
+        { a: number },
+        FixmePresence
+      >([createSerializedObject("0:0", { a: 1 })], 1);
 
       storage.root.set("a", 2);
 
@@ -853,9 +834,7 @@ describe("room", () => {
 
     test("batch storage with changes from server", async () => {
       const { storage, assert, undo, redo, batch, subscribe, refSubscribe } =
-        await prepareStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareStorageTest<{ items: LiveList<string> }, FixmePresence>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -910,9 +889,7 @@ describe("room", () => {
         subscribe,
         refSubscribe,
         updatePresence,
-      } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
+      } = await prepareStorageTest<{ items: LiveList<string> }, FixmePresence>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1065,9 +1042,7 @@ describe("room", () => {
   describe("offline", () => {
     test("disconnect and reconnect with offline changes", async () => {
       const { storage, assert, machine, refStorage, reconnect, ws } =
-        await prepareStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareStorageTest<{ items: LiveList<string> }, FixmePresence>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1127,9 +1102,10 @@ describe("room", () => {
     });
 
     test("disconnect and reconnect with remote changes", async () => {
-      const { assert, machine } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
+      const { assert, machine } = await prepareIsolatedStorageTest<
+        { items: LiveList<string> },
+        FixmePresence
+      >(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1292,11 +1268,7 @@ describe("room", () => {
       );
 
       expect(others?.toArray()).toEqual([
-        {
-          connectionId: 1,
-          id: undefined,
-          info: undefined,
-        },
+        { connectionId: 1, id: undefined, info: undefined },
       ]);
 
       // Full UpdatePresence sent as an answer to "UserJoined" message
@@ -1324,19 +1296,17 @@ describe("room", () => {
 
   describe("defaultStorage", () => {
     test("initialize room with defaultStorage should send operation only once", async () => {
-      const { assert, assertMessagesSent } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>([createSerializedObject("0:0", {})], 1, { items: new LiveList() });
+      const { assert, assertMessagesSent } = await prepareIsolatedStorageTest<
+        { items: LiveList<string> },
+        FixmePresence
+      >([createSerializedObject("0:0", {})], 1, { items: new LiveList() });
 
       assert({
         items: [],
       });
 
       assertMessagesSent([
-        {
-          data: {},
-          type: ClientMessageType.UpdatePresence,
-        },
+        { data: {}, type: ClientMessageType.UpdatePresence },
         { type: ClientMessageType.FetchStorage },
         {
           type: ClientMessageType.UpdateStorage,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -54,6 +54,8 @@ import { LiveObject } from "./LiveObject";
 import { LiveList } from "./LiveList";
 import { AbstractCrdt, ApplyResult } from "./AbstractCrdt";
 
+type FixmePresence = JsonObject;
+
 export type Machine = {
   // Internal
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
@@ -1312,7 +1314,7 @@ See v0.13 release notes for more information.
 
   function clearListeners() {
     for (const key in state.listeners) {
-      state.listeners[key as keyof State["listeners"]] = [];
+      state.listeners[key as keyof State<TPresence>["listeners"]] = [];
     }
   }
 
@@ -1539,7 +1541,7 @@ See v0.13 release notes for more information.
 export function defaultState(
   initialPresence?: Presence,
   initialStorage?: JsonObject
-): State {
+): State<FixmePresence> {
   return {
     connection: { state: "closed" },
     token: null,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -215,7 +215,7 @@ type HistoryItem = Array<Op | { type: "presence"; data: Presence }>;
 
 type IdFactory = () => string;
 
-export type State<TPresence extends JsonObject = JsonObject> = {
+export type State<TPresence extends JsonObject> = {
   connection: Connection;
   token: string | null;
   lastConnectionId: number | null;
@@ -295,7 +295,7 @@ type Context = {
   liveblocksServer: string;
 };
 
-export function makeStateMachine<TPresence extends JsonObject = JsonObject>(
+export function makeStateMachine<TPresence extends JsonObject>(
   state: State<TPresence>,
   context: Context,
   mockedEffects?: Effects<TPresence>

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -213,7 +213,7 @@ type HistoryItem = Array<Op | { type: "presence"; data: Presence }>;
 
 type IdFactory = () => string;
 
-export type State = {
+export type State<TPresence extends JsonObject = JsonObject> = {
   connection: Connection;
   token: string | null;
   lastConnectionId: number | null;
@@ -221,7 +221,7 @@ export type State = {
   lastFlushTime: number;
   buffer: {
     presence: Presence | null;
-    messages: ClientMessage[];
+    messages: ClientMessage<TPresence>[];
     storageOperations: Op[];
   };
   timeoutHandles: {
@@ -272,12 +272,12 @@ export type State = {
   offlineOperations: Map<string, Op>;
 };
 
-export type Effects = {
+export type Effects<TPresence extends JsonObject> = {
   authenticate(
     auth: (room: string) => Promise<AuthorizeResponse>,
     createWebSocket: (token: string) => WebSocket
   ): void;
-  send(messages: ClientMessage[]): void;
+  send(messages: ClientMessage<TPresence>[]): void;
   delayFlush(delay: number): number;
   startHeartbeatInterval(): number;
   schedulePongTimeout(): number;
@@ -293,12 +293,12 @@ type Context = {
   liveblocksServer: string;
 };
 
-export function makeStateMachine(
-  state: State,
+export function makeStateMachine<TPresence extends JsonObject = JsonObject>(
+  state: State<TPresence>,
   context: Context,
-  mockedEffects?: Effects
+  mockedEffects?: Effects<TPresence>
 ): Machine {
-  const effects: Effects = mockedEffects || {
+  const effects: Effects<TPresence> = mockedEffects || {
     authenticate(
       auth: (room: string) => Promise<AuthorizeResponse>,
       createWebSocket: (token: string) => WebSocket
@@ -322,7 +322,9 @@ export function makeStateMachine(
           .catch((er: any) => authenticationFailure(er));
       }
     },
-    send(messageOrMessages: ClientMessage | ClientMessage[]) {
+    send(
+      messageOrMessages: ClientMessage<TPresence> | ClientMessage<TPresence>[]
+    ) {
       if (state.socket == null) {
         throw new Error("Can't send message if socket is null");
       }
@@ -956,7 +958,11 @@ See v0.13 release notes for more information.
       // TODO: Consider storing it on the backend
       state.buffer.messages.push({
         type: ClientMessageType.UpdatePresence,
-        data: state.me!,
+        data: state.me as TPresence,
+        //             ^^^^^^^^^^^^
+        //             TODO: Soon, state.buffer.presence will become
+        //             a TPresence and this force-cast will no longer be
+        //             necessary.
         targetActor: message.actor,
       });
       tryFlushing();
@@ -1201,7 +1207,7 @@ See v0.13 release notes for more information.
       return;
     }
 
-    const messages: ClientMessage[] = [];
+    const messages: ClientMessage<TPresence>[] = [];
 
     const ops = Array.from(offlineOps.values());
 
@@ -1259,12 +1265,16 @@ See v0.13 release notes for more information.
     }
   }
 
-  function flushDataToMessages(state: State) {
-    const messages: ClientMessage[] = [];
+  function flushDataToMessages(state: State<TPresence>) {
+    const messages: ClientMessage<TPresence>[] = [];
     if (state.buffer.presence) {
       messages.push({
         type: ClientMessageType.UpdatePresence,
-        data: state.buffer.presence,
+        data: state.buffer.presence as unknown as TPresence,
+        //                          ^^^^^^^^^^^^^^^^^^^^^^^
+        //                          TODO: In 0.17, state.buffer.presence will
+        //                          become a TPresence and this force-cast will
+        //                          no longer be necessary.
       });
     }
     for (const event of state.buffer.messages) {

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -175,9 +175,8 @@ const defaultContext = {
 
 async function prepareRoomWithStorage<
   TStorage extends LsonObject,
-  // TODO: 1. Flip these params for consistency
-  // TODO: 2. Remove JsonObject default type param
-  TPresence extends JsonObject = JsonObject
+  // TODO: Flip these params for consistency
+  TPresence extends JsonObject
 >(
   items: SerializedCrdtWithId[],
   actor: number = 0,
@@ -216,9 +215,8 @@ async function prepareRoomWithStorage<
 
 export async function prepareIsolatedStorageTest<
   TStorage extends LsonObject,
-  // TODO: 1. Flip these params for consistency
-  // TODO: 2. Remove JsonObject default type param
-  TPresence extends JsonObject = JsonObject
+  // TODO: Flip these params for consistency
+  TPresence extends JsonObject
 >(items: SerializedCrdtWithId[], actor: number = 0, defaultStorage = {}) {
   const messagesSent: ClientMessage<TPresence>[] = [];
 
@@ -262,9 +260,8 @@ export async function prepareIsolatedStorageTest<
  */
 export async function prepareStorageTest<
   TStorage extends LsonObject,
-  // TODO: 1. Flip these params for consistency
-  // TODO: 2. Remove JsonObject default type param
-  TPresence extends JsonObject = JsonObject
+  // TODO: Flip these params for consistency
+  TPresence extends JsonObject
 >(items: SerializedCrdtWithId[], actor: number = 0) {
   let currentActor = actor;
   const operations: Op[] = [];
@@ -402,9 +399,8 @@ export async function reconnect(
 
 export async function prepareStorageImmutableTest<
   TStorage extends LsonObject,
-  // TODO: 1. Flip these params for consistency
-  // TODO: 2. Remove JsonObject default type param
-  TPresence extends JsonObject = JsonObject
+  // TODO: Flip these params for consistency
+  TPresence extends JsonObject
 >(items: SerializedCrdtWithId[], actor: number = 0) {
   let state: ToJson<TStorage> = {} as any;
   let refState: ToJson<TStorage> = {} as any;

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -174,9 +174,8 @@ const defaultContext = {
 };
 
 async function prepareRoomWithStorage<
-  TStorage extends LsonObject,
-  // TODO: Flip these params for consistency
-  TPresence extends JsonObject
+  TPresence extends JsonObject,
+  TStorage extends LsonObject
 >(
   items: SerializedCrdtWithId[],
   actor: number = 0,
@@ -214,15 +213,14 @@ async function prepareRoomWithStorage<
 }
 
 export async function prepareIsolatedStorageTest<
-  TStorage extends LsonObject,
-  // TODO: Flip these params for consistency
-  TPresence extends JsonObject
+  TPresence extends JsonObject,
+  TStorage extends LsonObject
 >(items: SerializedCrdtWithId[], actor: number = 0, defaultStorage = {}) {
   const messagesSent: ClientMessage<TPresence>[] = [];
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
-    TStorage,
-    TPresence
+    TPresence,
+    TStorage
   >(
     items,
     actor,
@@ -259,19 +257,18 @@ export async function prepareIsolatedStorageTest<
  * Assertion on the storage validate both rooms
  */
 export async function prepareStorageTest<
-  TStorage extends LsonObject,
-  // TODO: Flip these params for consistency
-  TPresence extends JsonObject
+  TPresence extends JsonObject,
+  TStorage extends LsonObject
 >(items: SerializedCrdtWithId[], actor: number = 0) {
   let currentActor = actor;
   const operations: Op[] = [];
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TStorage, TPresence>(items, -1);
+    await prepareRoomWithStorage<TPresence, TStorage>(items, -1);
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
-    TStorage,
-    TPresence
+    TPresence,
+    TStorage
   >(items, currentActor, (messages: ClientMessage<TPresence>[]) => {
     for (const message of messages) {
       if (message.type === ClientMessageType.UpdateStorage) {
@@ -398,9 +395,8 @@ export async function reconnect(
 }
 
 export async function prepareStorageImmutableTest<
-  TStorage extends LsonObject,
-  // TODO: Flip these params for consistency
-  TPresence extends JsonObject
+  TPresence extends JsonObject,
+  TStorage extends LsonObject
 >(items: SerializedCrdtWithId[], actor: number = 0) {
   let state: ToJson<TStorage> = {} as any;
   let refState: ToJson<TStorage> = {} as any;
@@ -408,11 +404,11 @@ export async function prepareStorageImmutableTest<
   let totalStorageOps = 0;
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TStorage, TPresence>(items, -1);
+    await prepareRoomWithStorage<TPresence, TStorage>(items, -1);
 
   const { machine, storage } = await prepareRoomWithStorage<
-    TStorage,
-    TPresence
+    TPresence,
+    TStorage
   >(items, actor, (messages: ClientMessage<TPresence>[]) => {
     for (const message of messages) {
       if (message.type === ClientMessageType.UpdateStorage) {

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -270,7 +270,7 @@ export async function prepareStorageTest<
   const operations: Op[] = [];
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TStorage>(items, -1);
+    await prepareRoomWithStorage<TStorage, TPresence>(items, -1);
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
     TStorage,
@@ -412,7 +412,7 @@ export async function prepareStorageImmutableTest<
   let totalStorageOps = 0;
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TStorage>(items, -1);
+    await prepareRoomWithStorage<TStorage, TPresence>(items, -1);
 
   const { machine, storage } = await prepareRoomWithStorage<
     TStorage,

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -173,7 +173,7 @@ const defaultContext = {
   WebSocketPolyfill: MockWebSocket as any,
 };
 
-async function prepareRoomWithStorage<T extends LsonObject>(
+async function prepareRoomWithStorage<TStorage extends LsonObject>(
   items: SerializedCrdtWithId[],
   actor: number = 0,
   onSend: (messages: ClientMessage[]) => void = () => {},
@@ -190,7 +190,7 @@ async function prepareRoomWithStorage<T extends LsonObject>(
   machine.authenticationSuccess({ actor }, ws as any);
   ws.open();
 
-  const getStoragePromise = machine.getStorage<T>();
+  const getStoragePromise = machine.getStorage<TStorage>();
 
   const clonedItems = deepClone(items);
   machine.onMessage(
@@ -209,14 +209,14 @@ async function prepareRoomWithStorage<T extends LsonObject>(
   };
 }
 
-export async function prepareIsolatedStorageTest<T extends LsonObject>(
+export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
   items: SerializedCrdtWithId[],
   actor: number = 0,
   defaultStorage = {}
 ) {
   const messagesSent: ClientMessage[] = [];
 
-  const { machine, storage, ws } = await prepareRoomWithStorage<T>(
+  const { machine, storage, ws } = await prepareRoomWithStorage<TStorage>(
     items,
     actor,
     (messages: ClientMessage[]) => {
@@ -251,7 +251,7 @@ export async function prepareIsolatedStorageTest<T extends LsonObject>(
  * All operations made on the main room are forwarded to the other room
  * Assertion on the storage validate both rooms
  */
-export async function prepareStorageTest<T extends LsonObject>(
+export async function prepareStorageTest<TStorage extends LsonObject>(
   items: SerializedCrdtWithId[],
   actor: number = 0
 ) {
@@ -259,9 +259,9 @@ export async function prepareStorageTest<T extends LsonObject>(
   const operations: Op[] = [];
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<T>(items, -1);
+    await prepareRoomWithStorage<TStorage>(items, -1);
 
-  const { machine, storage, ws } = await prepareRoomWithStorage<T>(
+  const { machine, storage, ws } = await prepareRoomWithStorage<TStorage>(
     items,
     currentActor,
     (messages: ClientMessage[]) => {
@@ -390,19 +390,19 @@ export async function reconnect(
   );
 }
 
-export async function prepareStorageImmutableTest<T extends LsonObject>(
+export async function prepareStorageImmutableTest<TStorage extends LsonObject>(
   items: SerializedCrdtWithId[],
   actor: number = 0
 ) {
-  let state: ToJson<T> = {} as any;
-  let refState: ToJson<T> = {} as any;
+  let state: ToJson<TStorage> = {} as any;
+  let refState: ToJson<TStorage> = {} as any;
 
   let totalStorageOps = 0;
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<T>(items, -1);
+    await prepareRoomWithStorage<TStorage>(items, -1);
 
-  const { machine, storage } = await prepareRoomWithStorage<T>(
+  const { machine, storage } = await prepareRoomWithStorage<TStorage>(
     items,
     actor,
     (messages: ClientMessage[]) => {
@@ -426,8 +426,8 @@ export async function prepareStorageImmutableTest<T extends LsonObject>(
     }
   );
 
-  state = liveObjectToJson(storage.root) as ToJson<T>;
-  refState = liveObjectToJson(refStorage.root) as ToJson<T>;
+  state = liveObjectToJson(storage.root) as ToJson<TStorage>;
+  refState = liveObjectToJson(refStorage.root) as ToJson<TStorage>;
 
   const root = refStorage.root;
   refMachine.subscribe(


### PR DESCRIPTION
Another carefully cherry-picked change from #156 , where we add type params to some of our internal types, and fix type param order for further consistency. This change should have no noticable effect on end users, and as such can land in 0.16.x.
