### PR TITLE
Parameterize `ServerMessage` type

### DIFF
--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -11,7 +11,11 @@
  * https://join.team/liveblocks ;)
  */
 
-export type { SerializedCrdtWithId, ServerMessage } from "./live";
+export type {
+  RoomStateMessage,
+  SerializedCrdtWithId,
+  ServerMessage,
+} from "./live";
 export type { Resolve, RoomInitializers } from "./types";
 
 export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";

--- a/packages/liveblocks-client/src/live.ts
+++ b/packages/liveblocks-client/src/live.ts
@@ -1,5 +1,4 @@
 import type { Json, JsonObject } from "./json";
-import type { Presence } from "./types";
 
 /**
  * Messages that can be sent from the server to the client.

--- a/packages/liveblocks-client/src/live.ts
+++ b/packages/liveblocks-client/src/live.ts
@@ -4,9 +4,9 @@ import type { Presence } from "./types";
 /**
  * Messages that can be sent from the server to the client.
  */
-export type ServerMessage =
+export type ServerMessage<TPresence extends JsonObject> =
   // For Presence
-  | UpdatePresenceMessage // Broadcasted
+  | UpdatePresenceMessage<TPresence> // Broadcasted
   | UserJoinMessage // Broadcasted
   | UserLeftMessage // Broadcasted
   | EventMessage // Broadcasted
@@ -53,7 +53,7 @@ export type RoomStateMessage = {
  * those cases, the `targetActor` field indicates the newly connected client,
  * so all other existing clients can ignore this broadcasted message.
  */
-export type UpdatePresenceMessage = {
+export type UpdatePresenceMessage<TPresence extends JsonObject> = {
   type: ServerMessageType.UpdatePresence;
   /**
    * The User whose Presence has changed.
@@ -64,7 +64,7 @@ export type UpdatePresenceMessage = {
    * this will be the full Presence, otherwise it only contain the fields that
    * have changed since the last broadcast.
    */
-  data: Presence;
+  data: TPresence;
   /**
    * If this message was sent in response to a newly joined user, this field
    * indicates which client this message is for. Other existing clients may

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -870,7 +870,7 @@ See v0.13 release notes for more information.
   }
 
   function onUpdatePresenceMessage(
-    message: UpdatePresenceMessage
+    message: UpdatePresenceMessage<TPresence>
   ): OthersEvent | undefined {
     const user = state.users[message.actor];
     // If the other user initial presence hasn't been received yet, we discard the presence update.
@@ -973,16 +973,18 @@ See v0.13 release notes for more information.
     return { type: "enter", user: state.users[message.actor] };
   }
 
-  function parseServerMessage(data: Json): ServerMessage | null {
+  function parseServerMessage(data: Json): ServerMessage<TPresence> | null {
     if (!isJsonObject(data)) {
       return null;
     }
 
-    return data as ServerMessage;
-    //          ^^^^^^^^^^^^^^^^ FIXME: Properly validate incoming external data instead!
+    return data as ServerMessage<TPresence>;
+    //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ FIXME: Properly validate incoming external data instead!
   }
 
-  function parseServerMessages(text: string): ServerMessage[] | null {
+  function parseServerMessages(
+    text: string
+  ): ServerMessage<TPresence>[] | null {
     const data: Json | undefined = parseJson(text);
     if (data === undefined) {
       return null;
@@ -999,7 +1001,7 @@ See v0.13 release notes for more information.
       return;
     }
 
-    const messages: ServerMessage[] | null = parseServerMessages(event.data);
+    const messages = parseServerMessages(event.data);
     if (messages === null || messages.length === 0) {
       // Unknown incoming message... ignore it
       return;

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -547,7 +547,7 @@ export function mockEffects(): Effects<JsonObject> {
   };
 }
 
-export function serverMessage(message: ServerMessage) {
+export function serverMessage(message: ServerMessage<JsonObject>) {
   return new MessageEvent("message", {
     data: JSON.stringify(message),
   });

--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@liveblocks/client";
+import type { JsonObject } from "@liveblocks/client";
 import type { LiveblocksState, Mapping } from ".";
 import { enhancer, actions } from ".";
 import { rest } from "msw";
@@ -12,6 +13,7 @@ import {
   ServerMessageType,
 } from "@liveblocks/client/internal";
 import type {
+  RoomStateMessage,
   SerializedCrdtWithId,
   ServerMessage,
 } from "@liveblocks/client/internal";
@@ -167,7 +169,7 @@ async function prepareWithStorage<T extends Record<string, unknown>>(
     }),
   } as MessageEvent);
 
-  function sendMessage(serverMessage: ServerMessage) {
+  function sendMessage(serverMessage: ServerMessage<JsonObject>) {
     socket.callbacks.message[0]!({
       data: JSON.stringify(serverMessage),
     } as MessageEvent);
@@ -390,7 +392,7 @@ describe("middleware", () => {
               info: { name: "Testy McTester" },
             },
           },
-        } as ServerMessage),
+        } as RoomStateMessage),
       } as MessageEvent);
 
       expect(store.getState().liveblocks.others).toEqual([

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -1,12 +1,13 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { createClient } from "@liveblocks/client";
-import type { Presence } from "@liveblocks/client";
+import type { JsonObject, Presence } from "@liveblocks/client";
 import type { Mapping } from ".";
 import { middleware } from ".";
 import create from "zustand";
 import type { StateCreator } from "zustand";
 import type {
+  RoomStateMessage,
   SerializedCrdtWithId,
   ServerMessage,
 } from "@liveblocks/client/internal";
@@ -147,7 +148,7 @@ async function prepareWithStorage<T extends Record<string, unknown>>(
     }),
   } as MessageEvent);
 
-  function sendMessage(serverMessage: ServerMessage) {
+  function sendMessage(serverMessage: ServerMessage<JsonObject>) {
     socket.callbacks.message[0]!({
       data: JSON.stringify(serverMessage),
     } as MessageEvent);
@@ -345,7 +346,7 @@ describe("middleware", () => {
               info: { name: "Testy McTester" },
             },
           },
-        } as ServerMessage),
+        } as RoomStateMessage),
       } as MessageEvent);
 
       expect(store.getState().liveblocks.others).toEqual([


### PR DESCRIPTION
Fixes #219. Also a carefully cherry-picked subset from #156 which can be landed safely in 0.16.x.