### PR TITLE
Lint import sort order

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: { project: ["./tsconfig.json"] },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "eslint-plugin-simple-import-sort"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     // ----------------------------------------------------------------------
@@ -21,6 +21,12 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "no-constant-condition": "off",
+
+    // -----------------------------
+    // Enable auto-fixes for imports
+    // -----------------------------
+    "simple-import-sort/imports": ["error"],
+    "@typescript-eslint/consistent-type-imports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-client/package-lock.json
+++ b/packages/liveblocks-client/package-lock.json
@@ -25,6 +25,7 @@
         "@typescript-eslint/parser": "^5.17.0",
         "babel-jest": "^26.6.3",
         "eslint": "^8.12.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^26.6.3",
         "jest-each": "^27.5.1",
         "msw": "^0.39.1",
@@ -4104,6 +4105,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -14592,6 +14602,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.1.1",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -54,6 +54,7 @@
     "@typescript-eslint/parser": "^5.17.0",
     "babel-jest": "^26.6.3",
     "eslint": "^8.12.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^26.6.3",
     "jest-each": "^27.5.1",
     "msw": "^0.39.1",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
     "test": "jest --watch",
     "test-ci": "jest"

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -1,5 +1,5 @@
-import { OpType } from "./live";
 import type { CreateOp, Op, SerializedCrdt } from "./live";
+import { OpType } from "./live";
 import type { StorageUpdate } from "./types";
 
 export type ApplyResult =

--- a/packages/liveblocks-client/src/LiveList.test.ts
+++ b/packages/liveblocks-client/src/LiveList.test.ts
@@ -1,6 +1,4 @@
-import { LiveList } from "./LiveList";
 import {
-  reconnect,
   createSerializedList,
   createSerializedObject,
   createSerializedRegister,
@@ -9,17 +7,15 @@ import {
   FOURTH_POSITION,
   prepareIsolatedStorageTest,
   prepareStorageTest,
+  reconnect,
   SECOND_POSITION,
   THIRD_POSITION,
 } from "../test/utils";
-import { LiveObject } from "./LiveObject";
+import type { SerializedCrdtWithId } from "./live";
+import { CrdtType, OpType, WebsocketCloseCodes } from "./live";
+import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
-import {
-  CrdtType,
-  OpType,
-  SerializedCrdtWithId,
-  WebsocketCloseCodes,
-} from "./live";
+import { LiveObject } from "./LiveObject";
 
 describe("LiveList", () => {
   describe("not attached", () => {

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -1,25 +1,24 @@
+import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
-import type { Doc, ApplyResult } from "./AbstractCrdt";
+import type {
+  CreateListOp,
+  CreateOp,
+  Op,
+  SerializedCrdt,
+  SerializedCrdtWithId,
+  SerializedList,
+} from "./live";
+import { CrdtType, OpType } from "./live";
+import { LiveRegister } from "./LiveRegister";
+import type { Lson } from "./lson";
+import { compare, makePosition } from "./position";
+import type { LiveListUpdateDelta, LiveListUpdates } from "./types";
 import {
+  creationOpToLiveStructure,
   deserialize,
   selfOrRegister,
   selfOrRegisterValue,
-  creationOpToLiveStructure,
 } from "./utils";
-import {
-  SerializedList,
-  SerializedCrdtWithId,
-  Op,
-  CreateListOp,
-  OpType,
-  SerializedCrdt,
-  CrdtType,
-  CreateOp,
-} from "./live";
-import { makePosition, compare } from "./position";
-import type { LiveListUpdateDelta, LiveListUpdates } from "./types";
-import { LiveRegister } from "./LiveRegister";
-import type { Lson } from "./lson";
 
 type LiveListItem = [crdt: AbstractCrdt, position: string];
 

--- a/packages/liveblocks-client/src/LiveMap.test.ts
+++ b/packages/liveblocks-client/src/LiveMap.test.ts
@@ -1,21 +1,17 @@
 import {
-  prepareStorageTest,
-  createSerializedObject,
-  createSerializedMap,
-  createSerializedRegister,
   createSerializedList,
+  createSerializedMap,
+  createSerializedObject,
+  createSerializedRegister,
   prepareIsolatedStorageTest,
+  prepareStorageTest,
   reconnect,
 } from "../test/utils";
-import { LiveMap } from "./LiveMap";
+import type { SerializedCrdtWithId } from "./live";
+import { CrdtType, OpType, WebsocketCloseCodes } from "./live";
 import { LiveList } from "./LiveList";
+import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
-import {
-  CrdtType,
-  OpType,
-  SerializedCrdtWithId,
-  WebsocketCloseCodes,
-} from "./live";
 
 describe("LiveMap", () => {
   describe("not attached", () => {

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -1,4 +1,15 @@
-import { AbstractCrdt, Doc, ApplyResult } from "./AbstractCrdt";
+import type { ApplyResult, Doc } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
+import type {
+  CreateMapOp,
+  CreateOp,
+  Op,
+  SerializedCrdt,
+  SerializedCrdtWithId,
+} from "./live";
+import { CrdtType, OpType } from "./live";
+import type { Lson } from "./lson";
+import type { LiveMapUpdates } from "./types";
 import {
   creationOpToLiveStructure,
   deserialize,
@@ -6,17 +17,6 @@ import {
   selfOrRegister,
   selfOrRegisterValue,
 } from "./utils";
-import {
-  Op,
-  CreateMapOp,
-  OpType,
-  SerializedCrdtWithId,
-  CrdtType,
-  SerializedCrdt,
-  CreateOp,
-} from "./live";
-import type { LiveMapUpdates } from "./types";
-import type { Lson } from "./lson";
 
 /**
  * The LiveMap class is similar to a JavaScript Map that is synchronized on all clients.

--- a/packages/liveblocks-client/src/LiveObject.test.ts
+++ b/packages/liveblocks-client/src/LiveObject.test.ts
@@ -1,18 +1,14 @@
-import { LiveObject } from "./LiveObject";
 import {
-  prepareStorageTest,
+  createSerializedList,
   createSerializedObject,
   prepareIsolatedStorageTest,
+  prepareStorageTest,
   reconnect,
-  createSerializedList,
 } from "../test/utils";
-import {
-  CrdtType,
-  OpType,
-  SerializedCrdtWithId,
-  WebsocketCloseCodes,
-} from "./live";
 import { LiveList } from ".";
+import type { SerializedCrdtWithId } from "./live";
+import { CrdtType, OpType, WebsocketCloseCodes } from "./live";
+import { LiveObject } from "./LiveObject";
 
 describe("LiveObject", () => {
   describe("roomId", () => {

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -1,24 +1,23 @@
+import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
-import type { Doc, ApplyResult } from "./AbstractCrdt";
-import { creationOpToLiveStructure, deserialize, isCrdt } from "./utils";
-import {
-  CrdtType,
+import type { JsonObject } from "./json";
+import type {
   CreateObjectOp,
   CreateOp,
   DeleteObjectKeyOp,
   Op,
-  OpType,
   SerializedCrdt,
   SerializedCrdtWithId,
   UpdateObjectOp,
 } from "./live";
+import { CrdtType, OpType } from "./live";
+import type { LsonObject, ToJson } from "./lson";
 import type {
+  LiveObjectUpdateDelta,
   LiveObjectUpdates,
   UpdateDelta,
-  LiveObjectUpdateDelta,
 } from "./types";
-import type { JsonObject } from "./json";
-import type { LsonObject, ToJson } from "./lson";
+import { creationOpToLiveStructure, deserialize, isCrdt } from "./utils";
 
 /**
  * The LiveObject class is similar to a JavaScript object that is synchronized on all clients.

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -1,14 +1,13 @@
+import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
-import type { Doc, ApplyResult } from "./AbstractCrdt";
-import {
-  SerializedCrdtWithId,
-  CrdtType,
-  Op,
-  OpType,
-  SerializedCrdt,
-  CreateOp,
-} from "./live";
 import type { Json } from "./json";
+import type {
+  CreateOp,
+  Op,
+  SerializedCrdt,
+  SerializedCrdtWithId,
+} from "./live";
+import { CrdtType, OpType } from "./live";
 
 /**
  * @internal

--- a/packages/liveblocks-client/src/client.node.test.ts
+++ b/packages/liveblocks-client/src/client.node.test.ts
@@ -2,11 +2,12 @@
  * @jest-environment node
  */
 
-import { createClient } from ".";
 // We're using node-fetch 2.X because 3+ only support ESM and jest is a pain to use with ESM
 import { Response } from "node-fetch";
-import type { ClientOptions } from "./types";
+
 import { MockWebSocket } from "../test/utils";
+import { createClient } from ".";
+import type { ClientOptions } from "./types";
 
 (global as any).atob = (data: string) => Buffer.from(data, "base64");
 

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,4 +1,5 @@
-import { createRoom, InternalRoom } from "./room";
+import type { InternalRoom } from "./room";
+import { createRoom } from "./room";
 import type {
   Authentication,
   Client,

--- a/packages/liveblocks-client/src/doc.test.ts
+++ b/packages/liveblocks-client/src/doc.test.ts
@@ -1,13 +1,13 @@
+import {
+  createSerializedList,
+  createSerializedMap,
+  createSerializedObject,
+  prepareStorageTest,
+} from "../test/utils";
 import { OpType } from "./live";
 import type { LiveList } from "./LiveList";
 import type { LiveMap } from "./LiveMap";
 import type { LiveObject } from "./LiveObject";
-import {
-  prepareStorageTest,
-  createSerializedObject,
-  createSerializedList,
-  createSerializedMap,
-} from "../test/utils";
 
 describe("Storage", () => {
   describe("subscribe generic", () => {

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -1,18 +1,18 @@
-import { LiveList, LiveMap } from ".";
 import {
   createSerializedList,
   createSerializedObject,
   createSerializedRegister,
-  prepareStorageImmutableTest,
   FIRST_POSITION,
+  FOURTH_POSITION,
+  prepareStorageImmutableTest,
   SECOND_POSITION,
   THIRD_POSITION,
-  FOURTH_POSITION,
 } from "../test/utils";
+import { LiveList, LiveMap } from ".";
 import {
-  patchLiveObjectKey,
   patchImmutableObject,
   patchLiveObject,
+  patchLiveObjectKey,
 } from "./immutable";
 import { LiveObject } from "./LiveObject";
 import type { StorageUpdate } from "./types";

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -1,10 +1,10 @@
 import { AbstractCrdt } from "./AbstractCrdt";
+import type { Json } from "./json";
 import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
 import type { Lson, LsonObject } from "./lson";
-import type { Json } from "./json";
 import type { StorageUpdate } from "./types";
 import { findNonSerializableValue } from "./utils";
 

--- a/packages/liveblocks-client/src/lson.ts
+++ b/packages/liveblocks-client/src/lson.ts
@@ -1,7 +1,7 @@
+import type { Json } from "./json";
 import type { LiveList } from "./LiveList";
 import type { LiveMap } from "./LiveMap";
 import type { LiveObject } from "./LiveObject";
-import type { Json } from "./json";
 
 /**
  * Think of Lson as a sibling of the Json data tree, except that the nested

--- a/packages/liveblocks-client/src/position.test.ts
+++ b/packages/liveblocks-client/src/position.test.ts
@@ -1,4 +1,4 @@
-import { posCodes, makePosition, pos, min, max } from "./position";
+import { makePosition, max, min, pos, posCodes } from "./position";
 
 const mid = (min + max) >> 1;
 

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -1,30 +1,31 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
 import {
-  prepareStorageTest,
-  createSerializedObject,
   createSerializedList,
-  mockEffects,
-  MockWebSocket,
-  serverMessage,
+  createSerializedObject,
   createSerializedRegister,
   FIRST_POSITION,
+  mockEffects,
+  MockWebSocket,
   prepareIsolatedStorageTest,
+  prepareStorageTest,
   reconnect,
+  serverMessage,
   waitFor,
   withDateNow,
 } from "../test/utils";
 import { lsonToJson } from "./immutable";
+import type { SerializedCrdtWithId } from "./live";
 import {
   ClientMessageType,
   CrdtType,
-  SerializedCrdtWithId,
   ServerMessageType,
   WebsocketCloseCodes,
 } from "./live";
 import { LiveList } from "./LiveList";
-import { makeStateMachine, defaultState, createRoom } from "./room";
+import { createRoom, defaultState, makeStateMachine } from "./room";
 import type { Authentication, Others } from "./types";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 
 const defaultContext = {
   roomId: "room-id",

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1,3 +1,30 @@
+import type { ApplyResult } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
+import type { Json, JsonObject } from "./json";
+import { isJsonArray, isJsonObject, parseJson } from "./json";
+import type {
+  ClientMessage,
+  EventMessage,
+  InitialDocumentStateMessage,
+  Op,
+  RoomStateMessage,
+  SerializedCrdt,
+  SerializedCrdtWithId,
+  ServerMessage,
+  UpdatePresenceMessage,
+  UserJoinMessage,
+  UserLeftMessage,
+} from "./live";
+import {
+  ClientMessageType,
+  OpType,
+  ServerMessageType,
+  WebsocketCloseCodes,
+} from "./live";
+import { LiveList } from "./LiveList";
+import type { LiveMap } from "./LiveMap";
+import { LiveObject } from "./LiveObject";
+import type { Lson, LsonObject } from "./lson";
 import type {
   Authentication,
   AuthenticationToken,
@@ -21,9 +48,6 @@ import type {
   StorageUpdate,
   User,
 } from "./types";
-import type { Json, JsonObject } from "./json";
-import { isJsonObject, isJsonArray, parseJson } from "./json";
-import type { Lson, LsonObject } from "./lson";
 import {
   compact,
   getTreesDiffOperations,
@@ -32,27 +56,6 @@ import {
   mergeStorageUpdates,
   remove,
 } from "./utils";
-import {
-  ClientMessage,
-  ClientMessageType,
-  EventMessage,
-  InitialDocumentStateMessage,
-  Op,
-  OpType,
-  RoomStateMessage,
-  SerializedCrdt,
-  SerializedCrdtWithId,
-  ServerMessage,
-  ServerMessageType,
-  UpdatePresenceMessage,
-  UserJoinMessage,
-  UserLeftMessage,
-  WebsocketCloseCodes,
-} from "./live";
-import type { LiveMap } from "./LiveMap";
-import { LiveObject } from "./LiveObject";
-import { LiveList } from "./LiveList";
-import { AbstractCrdt, ApplyResult } from "./AbstractCrdt";
 
 type FixmePresence = JsonObject;
 

--- a/packages/liveblocks-client/src/types.ts
+++ b/packages/liveblocks-client/src/types.ts
@@ -1,7 +1,7 @@
+import type { Json, JsonObject } from "./json";
 import type { LiveList } from "./LiveList";
 import type { LiveMap } from "./LiveMap";
 import type { LiveObject } from "./LiveObject";
-import type { Json, JsonObject } from "./json";
 import type { Lson, LsonObject } from "./lson";
 
 /**

--- a/packages/liveblocks-client/src/utils.test.ts
+++ b/packages/liveblocks-client/src/utils.test.ts
@@ -1,12 +1,13 @@
 import each from "jest-each";
 
 import { FIRST_POSITION, SECOND_POSITION, withDateNow } from "../test/utils";
-import { CrdtType, OpType, SerializedCrdt } from "./live";
+import type { SerializedCrdt } from "./live";
+import { CrdtType, OpType } from "./live";
 import {
-  getTreesDiffOperations,
-  findNonSerializableValue,
-  isTokenValid,
   compact,
+  findNonSerializableValue,
+  getTreesDiffOperations,
+  isTokenValid,
 } from "./utils";
 
 describe("compact", () => {

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -1,20 +1,20 @@
 import type { AbstractCrdt, Doc } from "./AbstractCrdt";
-import {
-  SerializedCrdtWithId,
-  CrdtType,
-  SerializedList,
-  SerializedMap,
+import type { Json } from "./json";
+import { isJsonObject, parseJson } from "./json";
+import type {
+  CreateOp,
   Op,
   SerializedCrdt,
-  OpType,
+  SerializedCrdtWithId,
+  SerializedList,
+  SerializedMap,
   SerializedObject,
-  CreateOp,
 } from "./live";
+import { CrdtType, OpType } from "./live";
 import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
-import { Json, isJsonObject, parseJson } from "./json";
 import type { Lson, LsonObject } from "./lson";
 import type {
   LiveListUpdates,

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -1,19 +1,17 @@
 import type { AbstractCrdt } from "../src/AbstractCrdt";
 import { lsonToJson, patchImmutableObject } from "../src/immutable";
-import {
+import type { Json, JsonObject } from "../src/json";
+import type {
   ClientMessage,
-  ClientMessageType,
-  CrdtType,
   Op,
   SerializedCrdtWithId,
   ServerMessage,
-  ServerMessageType,
 } from "../src/live";
-import type { Json, JsonObject } from "../src/json";
+import { ClientMessageType, CrdtType, ServerMessageType } from "../src/live";
 import type { LsonObject, ToJson } from "../src/lson";
 import { makePosition } from "../src/position";
-import { defaultState, makeStateMachine } from "../src/room";
 import type { Effects, Machine } from "../src/room";
+import { defaultState, makeStateMachine } from "../src/room";
 import type { Authentication } from "../src/types";
 import { remove } from "../src/utils";
 

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: { project: ["./tsconfig.json"] },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "eslint-plugin-simple-import-sort"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     // -------------------------------
@@ -11,6 +11,12 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "no-constant-condition": "off",
+
+    // -----------------------------
+    // Enable auto-fixes for imports
+    // -----------------------------
+    "simple-import-sort/imports": ["error"],
+    "@typescript-eslint/consistent-type-imports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-node/package-lock.json
+++ b/packages/liveblocks-node/package-lock.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/parser": "^5.18.0",
         "babel-jest": "^26.6.3",
         "eslint": "^8.12.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^26.6.3",
         "typescript": "^4.1.5"
       }
@@ -3730,6 +3731,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -13042,6 +13052,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -22,6 +22,7 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.json",
     "build:cjs": "tsc -p tsconfig-cjs.json",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --watch",
     "test-ci": "jest --passWithNoTests"

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "^5.18.0",
     "babel-jest": "^26.6.3",
     "eslint": "^8.12.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^26.6.3",
     "typescript": "^4.1.5"
   },

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: { project: ["./tsconfig.json"] },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "eslint-plugin-simple-import-sort"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     // ----------------------------------------------------------------------
@@ -19,6 +19,12 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "no-constant-condition": "off",
+
+    // -----------------------------
+    // Enable auto-fixes for imports
+    // -----------------------------
+    "simple-import-sort/imports": ["error"],
+    "@typescript-eslint/consistent-type-imports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-react/package-lock.json
+++ b/packages/liveblocks-react/package-lock.json
@@ -28,6 +28,7 @@
         "babel-jest": "^26.6.3",
         "babel-runtime": "^6.26.0",
         "eslint": "^8.12.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^26.6.3",
         "msw": "^0.27.1",
         "react-error-boundary": "^3.1.1",
@@ -4485,6 +4486,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -14426,6 +14436,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "start": "rollup -c -w",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --watch",
     "test-ci": "jest"

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -51,6 +51,7 @@
     "babel-jest": "^26.6.3",
     "babel-runtime": "^6.26.0",
     "eslint": "^8.12.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^26.6.3",
     "msw": "^0.27.1",
     "react-error-boundary": "^3.1.1",

--- a/packages/liveblocks-react/src/client.tsx
+++ b/packages/liveblocks-react/src/client.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import type { Client } from "@liveblocks/client";
+import * as React from "react";
 
 type LiveblocksProviderProps = {
   children: React.ReactNode;

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-import { useClient } from "./client";
 import type {
   BroadcastOptions,
   History,
@@ -11,9 +9,12 @@ import type {
   Room,
   User,
 } from "@liveblocks/client";
-import { LiveMap, LiveList, LiveObject } from "@liveblocks/client";
-import { deprecateIf } from "@liveblocks/client/internal";
+import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
+import { deprecateIf } from "@liveblocks/client/internal";
+import * as React from "react";
+
+import { useClient } from "./client";
 import useRerender from "./useRerender";
 
 type RoomProviderProps<TStorage> = Resolve<

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -1,4 +1,9 @@
-import * as React from "react";
+import { createClient } from "@liveblocks/client";
+import {
+  ClientMessageType,
+  CrdtType,
+  ServerMessageType,
+} from "@liveblocks/client/internal";
 import {
   act,
   fireEvent,
@@ -8,12 +13,8 @@ import {
 } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { createClient } from "@liveblocks/client";
-import {
-  ClientMessageType,
-  CrdtType,
-  ServerMessageType,
-} from "@liveblocks/client/internal";
+import * as React from "react";
+
 import {
   LiveblocksProvider,
   RoomProvider,

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: { project: ["./tsconfig.json"] },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "eslint-plugin-simple-import-sort"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     // ----------------------------------------------------------------------
@@ -19,6 +19,12 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "no-constant-condition": "off",
+
+    // -----------------------------
+    // Enable auto-fixes for imports
+    // -----------------------------
+    "simple-import-sort/imports": ["error"],
+    "@typescript-eslint/consistent-type-imports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-redux/package-lock.json
+++ b/packages/liveblocks-redux/package-lock.json
@@ -25,6 +25,7 @@
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
         "eslint": "^8.12.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^27.4.7",
         "msw": "^0.36.4",
         "redux": "^4.1.2",
@@ -4995,6 +4996,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -15064,6 +15074,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "eslint": "^8.12.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^27.4.7",
     "msw": "^0.36.4",
     "redux": "^4.1.2",

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
     "test": "jest --watch",
     "test-ci": "jest",

--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -1,27 +1,28 @@
-import { createClient } from "@liveblocks/client";
 import type { JsonObject } from "@liveblocks/client";
-import type { LiveblocksState, Mapping } from ".";
-import { enhancer, actions } from ".";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
-import type { Reducer } from "@reduxjs/toolkit";
-import { configureStore } from "@reduxjs/toolkit";
-import { list, MockWebSocket, obj, waitFor } from "../test/utils";
-import {
-  ClientMessageType,
-  OpType,
-  ServerMessageType,
-} from "@liveblocks/client/internal";
+import { createClient } from "@liveblocks/client";
 import type {
   RoomStateMessage,
   SerializedCrdtWithId,
   ServerMessage,
 } from "@liveblocks/client/internal";
 import {
-  missingClient,
+  ClientMessageType,
+  OpType,
+  ServerMessageType,
+} from "@liveblocks/client/internal";
+import type { Reducer } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+import { list, MockWebSocket, obj, waitFor } from "../test/utils";
+import type { LiveblocksState, Mapping } from ".";
+import { actions, enhancer } from ".";
+import {
   mappingShouldBeAnObject,
-  mappingValueShouldBeABoolean,
   mappingShouldNotHaveTheSameKeys,
+  mappingValueShouldBeABoolean,
+  missingClient,
 } from "./errors";
 window.WebSocket = MockWebSocket as any;
 

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -1,17 +1,18 @@
 import type {
   Client,
-  User,
-  Room,
   LiveObject,
   LsonObject,
   Presence,
+  Room,
+  User,
 } from "@liveblocks/client";
 import {
+  lsonToJson,
   patchImmutableObject,
   patchLiveObjectKey,
-  lsonToJson,
 } from "@liveblocks/client/internal";
 import type { StoreEnhancer } from "redux";
+
 import {
   mappingShouldBeAnObject,
   mappingShouldNotHaveTheSameKeys,

--- a/packages/liveblocks-redux/test/utils.ts
+++ b/packages/liveblocks-redux/test/utils.ts
@@ -1,4 +1,5 @@
-import { CrdtType, SerializedCrdtWithId } from "@liveblocks/client/internal";
+import type { SerializedCrdtWithId } from "@liveblocks/client/internal";
+import { CrdtType } from "@liveblocks/client/internal";
 
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: { project: ["./tsconfig.json"] },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "eslint-plugin-simple-import-sort"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     // ----------------------------------------------------------------------
@@ -21,6 +21,12 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "no-constant-condition": "off",
+
+    // -----------------------------
+    // Enable auto-fixes for imports
+    // -----------------------------
+    "simple-import-sort/imports": ["error"],
+    "@typescript-eslint/consistent-type-imports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-zustand/package-lock.json
+++ b/packages/liveblocks-zustand/package-lock.json
@@ -24,6 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
         "eslint": "^8.12.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^27.4.7",
         "msw": "^0.36.4",
         "rollup": "^2.64.0",
@@ -5219,6 +5220,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -15281,6 +15291,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "eslint": "^8.12.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^27.4.7",
     "msw": "^0.36.4",
     "rollup": "^2.64.0",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -18,6 +18,7 @@
   ],
   "scripts": {
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
     "test": "jest --watch",
     "test-ci": "jest",

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -1,11 +1,5 @@
-import { rest } from "msw";
-import { setupServer } from "msw/node";
-import { createClient } from "@liveblocks/client";
 import type { JsonObject, Presence } from "@liveblocks/client";
-import type { Mapping } from ".";
-import { middleware } from ".";
-import create from "zustand";
-import type { StateCreator } from "zustand";
+import { createClient } from "@liveblocks/client";
 import type {
   RoomStateMessage,
   SerializedCrdtWithId,
@@ -16,7 +10,14 @@ import {
   OpType,
   ServerMessageType,
 } from "@liveblocks/client/internal";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import type { StateCreator } from "zustand";
+import create from "zustand";
+
 import { list, MockWebSocket, obj, waitFor } from "../test/utils";
+import type { Mapping } from ".";
+import { middleware } from ".";
 import {
   mappingShouldBeAnObject,
   mappingShouldNotHaveTheSameKeys,

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -1,4 +1,3 @@
-import type { StateCreator, SetState, GetState, StoreApi } from "zustand";
 import type {
   Client,
   LiveObject,
@@ -12,6 +11,8 @@ import {
   patchImmutableObject,
   patchLiveObjectKey,
 } from "@liveblocks/client/internal";
+import type { GetState, SetState, StateCreator, StoreApi } from "zustand";
+
 import {
   mappingShouldBeAnObject,
   mappingShouldNotHaveTheSameKeys,

--- a/packages/liveblocks-zustand/test/utils.ts
+++ b/packages/liveblocks-zustand/test/utils.ts
@@ -1,4 +1,5 @@
-import { CrdtType, SerializedCrdtWithId } from "@liveblocks/client/internal";
+import type { SerializedCrdtWithId } from "@liveblocks/client/internal";
+import { CrdtType } from "@liveblocks/client/internal";
 
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {


### PR DESCRIPTION
This PR sets up an ESLint rule to enforce sort order (via [`eslint-plugin-simple-import-sort`](https://github.com/lydell/eslint-plugin-simple-import-sort)). The benefit of this plugin is that it auto-fixes these for you upon save (if your editor runs `eslint --fix` on save). Another benefit of this plugin is that it sorts by the _from_-string first, which helps to keep imports stable when you add new members, which makes these Git-diff friendly and thus maximally reduces changes of merge conflicts.

Also, I've enabled the [`consistent-type-imports`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md#consistent-type-imports) rule from `@typescript-eslint` here, which takes the burden away from us to manually figure out if an import should be a normal or a type import. This plugin can figure that out based on the usage of the imported item.

Basically: "just" add or remove imports as you need, and the combination of these two plugins will make sure to reformat things in the defined order for you.
