### PR TITLE
Refactor test helpers

### DIFF
--- a/packages/liveblocks-client/src/LiveList.test.ts
+++ b/packages/liveblocks-client/src/LiveList.test.ts
@@ -450,7 +450,7 @@ describe("LiveList", () => {
   describe("apply CreateRegister", () => {
     it(`with intent "set" should replace existing item`, async () => {
       const { assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -481,7 +481,7 @@ describe("LiveList", () => {
 
     it(`with intent "set" should notify with a "set" update`, async () => {
       const { root, applyRemoteOperations, subscribe } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -518,7 +518,7 @@ describe("LiveList", () => {
 
     it(`with intent "set" should insert item if conflict with a delete operation`, async () => {
       const { root, assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -557,7 +557,7 @@ describe("LiveList", () => {
 
     it(`with intent "set" should notify with a "insert" update if no item exists at this position`, async () => {
       const { root, applyRemoteOperations, subscribe } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("root", {}),
             createSerializedList("0:0", "root", "items"),
@@ -595,7 +595,7 @@ describe("LiveList", () => {
 
     it("on existing position should give the right update", async () => {
       const { root, assert, applyRemoteOperations, subscribe } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -643,7 +643,7 @@ describe("LiveList", () => {
   describe("conflict", () => {
     it("list conflicts", async () => {
       const { root, assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -686,7 +686,7 @@ describe("LiveList", () => {
 
     it("list conflicts 2", async () => {
       const { root, applyRemoteOperations, assert } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -756,7 +756,7 @@ describe("LiveList", () => {
 
     it("list conflicts with offline", async () => {
       const { root, assert, applyRemoteOperations, machine } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -806,7 +806,7 @@ describe("LiveList", () => {
 
     it("list conflicts with undo redo and remote change", async () => {
       const { root, assert, applyRemoteOperations, machine } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -854,7 +854,7 @@ describe("LiveList", () => {
 
     it("list conflicts - move", async () => {
       const { root, assert, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<never, { items: LiveList<string> }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1234,10 +1234,9 @@ describe("LiveList", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1322,10 +1321,9 @@ describe("LiveList", () => {
     });
 
     test("Register moved in list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1399,10 +1397,9 @@ describe("LiveList", () => {
     });
 
     test("Register deleted from list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1469,10 +1466,9 @@ describe("LiveList", () => {
 
   describe("internal methods", () => {
     test("_detachChild", async () => {
-      const { root } = await prepareIsolatedStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { root } = await prepareIsolatedStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),

--- a/packages/liveblocks-client/src/LiveList.test.ts
+++ b/packages/liveblocks-client/src/LiveList.test.ts
@@ -62,10 +62,7 @@ describe("LiveList", () => {
   });
 
   it("create document with list in root", async () => {
-    const { assert } = await prepareStorageTest<
-      never,
-      { items: LiveList<never> }
-    >([
+    const { assert } = await prepareStorageTest<{ items: LiveList<never> }>([
       createSerializedObject("0:0", {}),
       createSerializedList("0:1", "0:0", "items"),
     ]);
@@ -76,10 +73,9 @@ describe("LiveList", () => {
   });
 
   it("init list with items", async () => {
-    const { assert } = await prepareStorageTest<
-      never,
-      { items: LiveList<LiveObject<{ a: number }>> }
-    >([
+    const { assert } = await prepareStorageTest<{
+      items: LiveList<LiveObject<{ a: number }>>;
+    }>([
       createSerializedObject("0:0", {}),
       createSerializedList("0:1", "0:0", "items"),
       createSerializedObject("0:2", { a: 0 }, "0:1", FIRST_POSITION),
@@ -94,10 +90,9 @@ describe("LiveList", () => {
 
   describe("push", () => {
     it("push LiveObject", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -131,10 +126,9 @@ describe("LiveList", () => {
     });
 
     it("push existing LiveObject should throw", async () => {
-      const { storage, assert } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, assert } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -157,10 +151,9 @@ describe("LiveList", () => {
     });
 
     it("push number", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<number> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<number>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -189,10 +182,9 @@ describe("LiveList", () => {
     });
 
     it("push LiveMap", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveMap<string, number>> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<LiveMap<string, number>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -217,10 +209,9 @@ describe("LiveList", () => {
 
   describe("insert", () => {
     it("insert LiveObject at position 0", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -252,7 +243,7 @@ describe("LiveList", () => {
         storage: doc,
         assert,
         assertUndoRedo,
-      } = await prepareStorageTest<never, { items: LiveList<number> }>([
+      } = await prepareStorageTest<{ items: LiveList<number> }>([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
         createSerializedRegister("0:2", "0:1", FIRST_POSITION, 0),
@@ -277,10 +268,9 @@ describe("LiveList", () => {
 
     it("delete child LiveObject should remove descendants", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
-        await prepareStorageTest<
-          never,
-          { items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>> }
-        >([
+        await prepareStorageTest<{
+          items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>>;
+        }>([
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
           createSerializedObject("0:2", {}, "0:1", "!"),
@@ -305,10 +295,9 @@ describe("LiveList", () => {
 
   describe("move", () => {
     it("list.move after current position", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >([
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
         createSerializedObject("0:2", { a: 0 }, "0:1", FIRST_POSITION),
@@ -334,10 +323,9 @@ describe("LiveList", () => {
 
   describe("clear", () => {
     it("should delete all items", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -394,10 +382,9 @@ describe("LiveList", () => {
     });
 
     it("set register", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -423,10 +410,9 @@ describe("LiveList", () => {
     });
 
     it("set nested object", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -912,10 +898,9 @@ describe("LiveList", () => {
       storage: doc,
       assert,
       assertUndoRedo,
-    } = await prepareStorageTest<
-      never,
-      { items: LiveList<LiveObject<{ b: number }>> }
-    >(
+    } = await prepareStorageTest<{
+      items: LiveList<LiveObject<{ b: number }>>;
+    }>(
       [
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
@@ -945,10 +930,9 @@ describe("LiveList", () => {
 
   describe("subscriptions", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -971,10 +955,9 @@ describe("LiveList", () => {
     });
 
     test("deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1010,7 +993,7 @@ describe("LiveList", () => {
 
     test("remote move operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<never, { items: LiveList<string> }>(
+        await prepareStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1047,7 +1030,7 @@ describe("LiveList", () => {
 
     test("remote delete item operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<never, { items: LiveList<string> }>(
+        await prepareStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -1078,10 +1061,9 @@ describe("LiveList", () => {
     });
 
     test("batch multiple actions", async () => {
-      const { storage, subscribe, batch, assert } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, subscribe, batch, assert } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1119,10 +1101,9 @@ describe("LiveList", () => {
     });
 
     test("batch multiple inserts", async () => {
-      const { storage, subscribe, batch, assert } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, subscribe, batch, assert } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1150,10 +1131,9 @@ describe("LiveList", () => {
     });
 
     test("clear with deep subscribe ", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1189,10 +1169,9 @@ describe("LiveList", () => {
     });
 
     test("move with deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { items: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        items: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),

--- a/packages/liveblocks-client/src/LiveMap.test.ts
+++ b/packages/liveblocks-client/src/LiveMap.test.ts
@@ -299,10 +299,9 @@ describe("LiveMap", () => {
 
     // https://github.com/liveblocks/liveblocks/issues/95
     it("should have deleted key when subscriber is called", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<
-        never,
-        { map: LiveMap<string, string> }
-      >(
+      const { root, subscribe } = await prepareIsolatedStorageTest<{
+        map: LiveMap<string, string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -324,10 +323,9 @@ describe("LiveMap", () => {
     });
 
     it("should call subscribe when key is deleted", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<
-        never,
-        { map: LiveMap<string, string> }
-      >(
+      const { root, subscribe } = await prepareIsolatedStorageTest<{
+        map: LiveMap<string, string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -350,10 +348,9 @@ describe("LiveMap", () => {
     });
 
     it("should not call subscribe when key is not deleted", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<
-        never,
-        { map: LiveMap<string, string> }
-      >(
+      const { root, subscribe } = await prepareIsolatedStorageTest<{
+        map: LiveMap<string, string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -636,10 +633,9 @@ describe("LiveMap", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to map", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<
-        never,
-        { map: LiveMap<string, string> }
-      >(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<{
+        map: LiveMap<string, string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -713,10 +709,9 @@ describe("LiveMap", () => {
 
   describe("internal methods", () => {
     test("_detachChild", async () => {
-      const { root } = await prepareIsolatedStorageTest<
-        never,
-        { map: LiveMap<string, LiveObject<{ a: number }>> }
-      >(
+      const { root } = await prepareIsolatedStorageTest<{
+        map: LiveMap<string, LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),

--- a/packages/liveblocks-client/src/LiveMap.test.ts
+++ b/packages/liveblocks-client/src/LiveMap.test.ts
@@ -95,10 +95,9 @@ describe("LiveMap", () => {
   });
 
   it("create document with map in root", async () => {
-    const { storage, assert } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveObject<{ a: number }>> }
-    >([
+    const { storage, assert } = await prepareStorageTest<{
+      map: LiveMap<string, LiveObject<{ a: number }>>;
+    }>([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
     ]);
@@ -110,10 +109,9 @@ describe("LiveMap", () => {
   });
 
   it("init map with items", async () => {
-    const { storage, assert } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveObject<{ a: number }>> }
-    >([
+    const { storage, assert } = await prepareStorageTest<{
+      map: LiveMap<string, LiveObject<{ a: number }>>;
+    }>([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
       createSerializedObject("0:2", { a: 0 }, "0:1", "first"),
@@ -142,10 +140,9 @@ describe("LiveMap", () => {
   });
 
   it("map.set object", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, number> }
-    >(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, number>;
+    }>(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -187,10 +184,9 @@ describe("LiveMap", () => {
 
   describe("delete", () => {
     it("should delete LiveObject", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { map: LiveMap<string, number> }
-      >([
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        map: LiveMap<string, number>;
+      }>([
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
         createSerializedRegister("0:2", "0:1", "first", 0),
@@ -232,10 +228,9 @@ describe("LiveMap", () => {
 
     it("should remove nested data structure from cache", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
-        await prepareStorageTest<
-          never,
-          { map: LiveMap<string, LiveObject<{ a: number }>> }
-        >(
+        await prepareStorageTest<{
+          map: LiveMap<string, LiveObject<{ a: number }>>;
+        }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedMap("0:1", "0:0", "map"),
@@ -266,10 +261,7 @@ describe("LiveMap", () => {
 
     it("should delete live list", async () => {
       const { storage, assert, assertUndoRedo, getItemsCount } =
-        await prepareStorageTest<
-          never,
-          { map: LiveMap<string, LiveList<number>> }
-        >(
+        await prepareStorageTest<{ map: LiveMap<string, LiveList<number>> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedMap("0:1", "0:0", "map"),
@@ -373,10 +365,9 @@ describe("LiveMap", () => {
   });
 
   it("map.set live object", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveObject<{ a: number }>> }
-    >(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, LiveObject<{ a: number }>>;
+    }>(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -400,10 +391,9 @@ describe("LiveMap", () => {
   });
 
   it("map.set already attached live object should throw", async () => {
-    const { storage } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveObject<{ a: number }>> }
-    >([
+    const { storage } = await prepareStorageTest<{
+      map: LiveMap<string, LiveObject<{ a: number }>>;
+    }>([
       createSerializedObject("0:0", {}),
       createSerializedMap("0:1", "0:0", "map"),
     ]);
@@ -418,13 +408,10 @@ describe("LiveMap", () => {
   });
 
   it("new Map with already attached live object should throw", async () => {
-    const { storage } = await prepareStorageTest<
-      never,
-      {
-        child: LiveObject<{ a: number }> | null;
-        map: LiveMap<string, LiveObject<{ a: number }>> | null;
-      }
-    >([createSerializedObject("0:0", { child: null, map: null })], 1);
+    const { storage } = await prepareStorageTest<{
+      child: LiveObject<{ a: number }> | null;
+      map: LiveMap<string, LiveObject<{ a: number }>> | null;
+    }>([createSerializedObject("0:0", { child: null, map: null })], 1);
 
     const root = storage.root;
     const child = new LiveObject({ a: 0 });
@@ -434,10 +421,9 @@ describe("LiveMap", () => {
   });
 
   it("map.set live object on existing key", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveObject<{ a: number }>> }
-    >(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, LiveObject<{ a: number }>>;
+    }>(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -463,10 +449,9 @@ describe("LiveMap", () => {
   });
 
   it("attach map with items to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, { a: number }> }
-    >([createSerializedObject("0:0", {})], 1);
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, { a: number }>;
+    }>([createSerializedObject("0:0", {})], 1);
 
     assert({} as any);
 
@@ -480,10 +465,9 @@ describe("LiveMap", () => {
   });
 
   it("attach map with live objects to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveObject<{ a: number }>> }
-    >([createSerializedObject("0:0", {})], 1);
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, LiveObject<{ a: number }>>;
+    }>([createSerializedObject("0:0", {})], 1);
 
     assert({} as any);
 
@@ -499,10 +483,9 @@ describe("LiveMap", () => {
   });
 
   it("attach map with objects to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, { a: number }> }
-    >([createSerializedObject("0:0", {})], 1);
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, { a: number }>;
+    }>([createSerializedObject("0:0", {})], 1);
 
     assert({} as any);
 
@@ -518,10 +501,9 @@ describe("LiveMap", () => {
   });
 
   it("add list in map", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveList<string>> }
-    >(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, LiveList<string>>;
+    }>(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -542,10 +524,9 @@ describe("LiveMap", () => {
   });
 
   it("add map in map", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { map: LiveMap<string, LiveMap<string, string>> }
-    >(
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      map: LiveMap<string, LiveMap<string, string>>;
+    }>(
       [
         createSerializedObject("0:0", {}),
         createSerializedMap("0:1", "0:0", "map"),
@@ -567,10 +548,9 @@ describe("LiveMap", () => {
 
   describe("subscriptions", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { map: LiveMap<string, string> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        map: LiveMap<string, string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),
@@ -593,10 +573,9 @@ describe("LiveMap", () => {
     });
 
     test("deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { map: LiveMap<string, LiveObject<{ a: number }>> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        map: LiveMap<string, LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedMap("0:1", "0:0", "map"),

--- a/packages/liveblocks-client/src/LiveObject.test.ts
+++ b/packages/liveblocks-client/src/LiveObject.test.ts
@@ -30,10 +30,9 @@ describe("LiveObject", () => {
     });
 
     it("should be null after being detached", async () => {
-      const { root } = await prepareIsolatedStorageTest<
-        never,
-        { child: LiveObject<{ a: number }> }
-      >(
+      const { root } = await prepareIsolatedStorageTest<{
+        child: LiveObject<{ a: number }>;
+      }>(
         [
           createSerializedObject("root", {}),
           createSerializedObject("0:0", { a: 0 }, "root", "child"),
@@ -392,7 +391,7 @@ describe("LiveObject", () => {
     describe("should ignore incoming updates if current op has not been acknowledged", () => {
       test("when value is not a crdt", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<never, { a: number }>(
+          await prepareIsolatedStorageTest<{ a: number }>(
             [createSerializedObject("0:0", { a: 0 })],
             1
           );
@@ -417,10 +416,7 @@ describe("LiveObject", () => {
 
       it("when value is a LiveObject", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<
-            never,
-            { a: LiveObject<{ subA: number }> }
-          >(
+          await prepareIsolatedStorageTest<{ a: LiveObject<{ subA: number }> }>(
             [
               createSerializedObject("0:0", {}),
               createSerializedObject("0:1", { subA: 0 }, "0:0", "a"),
@@ -450,10 +446,9 @@ describe("LiveObject", () => {
 
       it("when value is a LiveList with LiveObjects", async () => {
         const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<
-            never,
-            { a: LiveList<LiveObject<{ b: number }>> }
-          >(
+          await prepareIsolatedStorageTest<{
+            a: LiveList<LiveObject<{ b: number }>>;
+          }>(
             [
               createSerializedObject("0:0", {}),
               createSerializedList("0:1", "0:0", "a"),
@@ -522,10 +517,9 @@ describe("LiveObject", () => {
     });
 
     it("should not notify if property does not exist", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<
-        never,
-        { a?: number }
-      >([createSerializedObject("0:0", {})]);
+      const { root, subscribe } = await prepareIsolatedStorageTest<{
+        a?: number;
+      }>([createSerializedObject("0:0", {})]);
 
       const callback = jest.fn();
       subscribe(root, callback);
@@ -536,10 +530,9 @@ describe("LiveObject", () => {
     });
 
     it("should notify if property has been deleted", async () => {
-      const { root, subscribe } = await prepareIsolatedStorageTest<
-        never,
-        { a?: number }
-      >([createSerializedObject("0:0", { a: 1 })]);
+      const { root, subscribe } = await prepareIsolatedStorageTest<{
+        a?: number;
+      }>([createSerializedObject("0:0", { a: 1 })]);
 
       const callback = jest.fn();
       subscribe(root, callback);
@@ -553,7 +546,7 @@ describe("LiveObject", () => {
   describe("applyDeleteObjectKey", () => {
     it("should not notify if property does not exist", async () => {
       const { root, subscribe, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<never, { a?: number }>([
+        await prepareIsolatedStorageTest<{ a?: number }>([
           createSerializedObject("0:0", {}),
         ]);
 
@@ -569,7 +562,7 @@ describe("LiveObject", () => {
 
     it("should notify if property has been deleted", async () => {
       const { root, subscribe, applyRemoteOperations } =
-        await prepareIsolatedStorageTest<never, { a?: number }>([
+        await prepareIsolatedStorageTest<{ a?: number }>([
           createSerializedObject("0:0", { a: 1 }),
         ]);
 
@@ -833,10 +826,9 @@ describe("LiveObject", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("LiveObject updated", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<
-        never,
-        { obj: LiveObject<{ a: number }> }
-      >(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<{
+        obj: LiveObject<{ a: number }>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
@@ -892,10 +884,9 @@ describe("LiveObject", () => {
     });
 
     test("LiveObject updated nested", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<
-        never,
-        { obj: LiveObject<{ a: number; subObj?: LiveObject<{ b: number }> }> }
-      >(
+      const { assert, machine, root } = await prepareIsolatedStorageTest<{
+        obj: LiveObject<{ a: number; subObj?: LiveObject<{ b: number }> }>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
@@ -965,7 +956,7 @@ describe("LiveObject", () => {
   describe("undo apply update", () => {
     test("subscription should gives the right update", async () => {
       const { root, assert, subscribe, undo } =
-        await prepareIsolatedStorageTest<never, { a: number }>(
+        await prepareIsolatedStorageTest<{ a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -988,15 +979,12 @@ describe("LiveObject", () => {
 
   describe("internal methods", () => {
     test("_detachChild", async () => {
-      const { root } = await prepareIsolatedStorageTest<
-        never,
-        {
-          obj: LiveObject<{
-            a: LiveObject<{ subA: number }>;
-            b: LiveObject<{ subA: number }>;
-          }>;
-        }
-      >(
+      const { root } = await prepareIsolatedStorageTest<{
+        obj: LiveObject<{
+          a: LiveObject<{ subA: number }>;
+          b: LiveObject<{ subA: number }>;
+        }>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "obj"),

--- a/packages/liveblocks-client/src/LiveObject.test.ts
+++ b/packages/liveblocks-client/src/LiveObject.test.ts
@@ -135,10 +135,10 @@ describe("LiveObject", () => {
 
   it("update with LiveObject", async () => {
     const { storage, assert, operations, assertUndoRedo, getUndoStack } =
-      await prepareStorageTest<
-        never,
-        { child: LiveObject<{ a: number }> | null }
-      >([createSerializedObject("0:0", { child: null })], 1);
+      await prepareStorageTest<{ child: LiveObject<{ a: number }> | null }>(
+        [createSerializedObject("0:0", { child: null })],
+        1
+      );
 
     const root = storage.root;
 
@@ -195,16 +195,13 @@ describe("LiveObject", () => {
 
   it("remove nested grand child record with update", async () => {
     const { storage, assert, assertUndoRedo, getItemsCount } =
-      await prepareStorageTest<
-        never,
-        {
-          a: number;
-          child: LiveObject<{
-            b: number;
-            grandChild: LiveObject<{ c: number }>;
-          }> | null;
-        }
-      >([
+      await prepareStorageTest<{
+        a: number;
+        child: LiveObject<{
+          b: number;
+          grandChild: LiveObject<{ c: number }>;
+        }> | null;
+      }>([
         createSerializedObject("0:0", { a: 0 }),
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
         createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
@@ -233,10 +230,10 @@ describe("LiveObject", () => {
 
   it("remove nested child record with update", async () => {
     const { storage, assert, assertUndoRedo, getItemsCount } =
-      await prepareStorageTest<
-        never,
-        { a: number; child: LiveObject<{ b: number }> | null }
-      >([
+      await prepareStorageTest<{
+        a: number;
+        child: LiveObject<{ b: number }> | null;
+      }>([
         createSerializedObject("0:0", { a: 0 }),
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
       ]);
@@ -312,10 +309,10 @@ describe("LiveObject", () => {
   });
 
   it("update nested record", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      { a: number; child: LiveObject<{ b: number }> }
-    >([
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      a: number;
+      child: LiveObject<{ b: number }>;
+    }>([
       createSerializedObject("0:0", { a: 0 }),
       createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
     ]);
@@ -342,13 +339,10 @@ describe("LiveObject", () => {
   });
 
   it("update deeply nested record", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-      never,
-      {
-        a: number;
-        child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
-      }
-    >([
+    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+      a: number;
+      child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
+    }>([
       createSerializedObject("0:0", { a: 0 }),
       createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
       createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
@@ -487,10 +481,9 @@ describe("LiveObject", () => {
     });
 
     it("should delete property from the object", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { a?: number }
-      >([createSerializedObject("0:0", { a: 0 })]);
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        a?: number;
+      }>([createSerializedObject("0:0", { a: 0 })]);
       assert({ a: 0 });
 
       storage.root.delete("a");
@@ -500,10 +493,9 @@ describe("LiveObject", () => {
     });
 
     it("should delete nested crdt", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { child?: LiveObject<{ a: number }> }
-      >([
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        child?: LiveObject<{ a: number }>;
+      }>([
         createSerializedObject("0:0", {}),
         createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
       ]);
@@ -579,10 +571,10 @@ describe("LiveObject", () => {
 
   describe("subscriptions", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { a: number }
-      >([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, subscribe } = await prepareStorageTest<{ a: number }>(
+        [createSerializedObject("0:0", { a: 0 })],
+        1
+      );
 
       const callback = jest.fn();
 
@@ -597,10 +589,10 @@ describe("LiveObject", () => {
     });
 
     test("subscribe multiple actions", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { child: LiveObject<{ a: number }>; child2: LiveObject<{ a: number }> }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        child: LiveObject<{ a: number }>;
+        child2: LiveObject<{ a: number }>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -628,12 +620,9 @@ describe("LiveObject", () => {
     });
 
     test("deep subscribe", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        {
-          child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
-        }
-      >(
+      const { storage, subscribe } = await prepareStorageTest<{
+        child: LiveObject<{ a: number; subchild: LiveObject<{ b: number }> }>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -674,15 +663,12 @@ describe("LiveObject", () => {
 
     test("deep subscribe remote operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<
-          never,
-          {
-            child: LiveObject<{
-              a: number;
-              subchild: LiveObject<{ b: number }>;
-            }>;
-          }
-        >(
+        await prepareStorageTest<{
+          child: LiveObject<{
+            a: number;
+            subchild: LiveObject<{ b: number }>;
+          }>;
+        }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -731,15 +717,12 @@ describe("LiveObject", () => {
 
     test("subscribe subchild remote operation", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<
-          never,
-          {
-            child: LiveObject<{
-              a: number;
-              subchild: LiveObject<{ b: number }>;
-            }>;
-          }
-        >(
+        await prepareStorageTest<{
+          child: LiveObject<{
+            a: number;
+            subchild: LiveObject<{ b: number }>;
+          }>;
+        }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
@@ -781,10 +764,9 @@ describe("LiveObject", () => {
 
     test("deep subscribe remote and local operation - delete object key", async () => {
       const { storage, subscribe, applyRemoteOperations } =
-        await prepareStorageTest<
-          never,
-          { child: LiveObject<{ a?: number; b?: number }> }
-        >(
+        await prepareStorageTest<{
+          child: LiveObject<{ a?: number; b?: number }>;
+        }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0, b: 0 }, "0:0", "child"),

--- a/packages/liveblocks-client/src/doc.test.ts
+++ b/packages/liveblocks-client/src/doc.test.ts
@@ -12,10 +12,10 @@ import {
 describe("Storage", () => {
   describe("subscribe generic", () => {
     test("simple action", async () => {
-      const { storage, subscribe } = await prepareStorageTest<
-        never,
-        { a: number }
-      >([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, subscribe } = await prepareStorageTest<{ a: number }>(
+        [createSerializedObject("0:0", { a: 0 })],
+        1
+      );
 
       const callback = jest.fn();
 
@@ -39,7 +39,7 @@ describe("Storage", () => {
 
     test("remote action", async () => {
       const { storage, applyRemoteOperations, subscribe } =
-        await prepareStorageTest<never, { a: number }>(
+        await prepareStorageTest<{ a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -70,7 +70,7 @@ describe("Storage", () => {
 
     test("remote action with multipe updates on same object", async () => {
       const { storage, applyRemoteOperations, subscribe } =
-        await prepareStorageTest<never, { a: number }>(
+        await prepareStorageTest<{ a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
@@ -102,7 +102,7 @@ describe("Storage", () => {
 
     test("batch actions on a single LiveObject", async () => {
       const { storage, assertUndoRedo, subscribe, batch } =
-        await prepareStorageTest<never, { a: number; b: number }>(
+        await prepareStorageTest<{ a: number; b: number }>(
           [createSerializedObject("0:0", { a: 0, b: 0 })],
           1
         );
@@ -138,10 +138,10 @@ describe("Storage", () => {
     });
 
     test("batch actions on multiple LiveObjects", async () => {
-      const { storage, subscribe, batch } = await prepareStorageTest<
-        never,
-        { a: number; child: LiveObject<{ b: number }> }
-      >(
+      const { storage, subscribe, batch } = await prepareStorageTest<{
+        a: number;
+        child: LiveObject<{ b: number }>;
+      }>(
         [
           createSerializedObject("0:0", { a: 0 }),
           createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
@@ -176,15 +176,12 @@ describe("Storage", () => {
     });
 
     test("batch actions on multiple Live types", async () => {
-      const { storage, subscribe, batch } = await prepareStorageTest<
-        never,
-        {
-          a: number;
-          childObj: LiveObject<{ b: number }>;
-          childList: LiveList<string>;
-          childMap: LiveMap<string, string>;
-        }
-      >(
+      const { storage, subscribe, batch } = await prepareStorageTest<{
+        a: number;
+        childObj: LiveObject<{ b: number }>;
+        childList: LiveList<string>;
+        childMap: LiveMap<string, string>;
+      }>(
         [
           createSerializedObject("0:0", { a: 0 }),
           createSerializedObject("0:1", { b: 0 }, "0:0", "childObj"),
@@ -235,10 +232,9 @@ describe("Storage", () => {
 
   describe("batching", () => {
     it("batching and undo", async () => {
-      const { storage, assert, undo, redo, batch } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, assert, undo, redo, batch } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -272,7 +268,7 @@ describe("Storage", () => {
     });
 
     it("calling batch during a batch should throw", async () => {
-      const { storage, batch } = await prepareStorageTest<never, { a: number }>(
+      const { storage, batch } = await prepareStorageTest<{ a: number }>(
         [createSerializedObject("0:0", { a: 0 })],
         1
       );
@@ -287,7 +283,7 @@ describe("Storage", () => {
     });
 
     it("calling undo during a batch should throw", async () => {
-      const { undo, batch } = await prepareStorageTest<never, { a: number }>(
+      const { undo, batch } = await prepareStorageTest<{ a: number }>(
         [createSerializedObject("0:0", { a: 0 })],
         1
       );
@@ -298,7 +294,7 @@ describe("Storage", () => {
     });
 
     it("calling redo during a batch should throw", async () => {
-      const { batch, redo } = await prepareStorageTest<never, { a: number }>(
+      const { batch, redo } = await prepareStorageTest<{ a: number }>(
         [createSerializedObject("0:0", { a: 0 })],
         1
       );
@@ -311,10 +307,9 @@ describe("Storage", () => {
 
   describe("undo / redo", () => {
     it("list.push", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -340,10 +335,10 @@ describe("Storage", () => {
     });
 
     it("max undo-redo stack", async () => {
-      const { storage, assert, undo } = await prepareStorageTest<
-        never,
-        { a: number }
-      >([createSerializedObject("0:0", { a: 0 })], 1);
+      const { storage, assert, undo } = await prepareStorageTest<{ a: number }>(
+        [createSerializedObject("0:0", { a: 0 })],
+        1
+      );
 
       for (let i = 0; i < 100; i++) {
         storage.root.set("a", i + 1);
@@ -362,10 +357,9 @@ describe("Storage", () => {
     });
 
     it("storage operation should clear redo stack", async () => {
-      const { storage, assert, undo, redo } = await prepareStorageTest<
-        never,
-        { items: LiveList<string> }
-      >(
+      const { storage, assert, undo, redo } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),

--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -58,10 +58,9 @@ describe("patchLiveObjectKey", () => {
 describe("2 ways tests with two clients", () => {
   describe("Object/LiveObject", () => {
     test("create object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncObj: { a: number } }
-      >([createSerializedObject("0:0", {})], 1);
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncObj: { a: number };
+      }>([createSerializedObject("0:0", {})], 1);
 
       expect(state).toEqual({});
 
@@ -80,10 +79,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("update object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncObj: { a: number } }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncObj: { a: number };
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -108,10 +106,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("add nested object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncObj: { a: any } }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncObj: { a: any };
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -136,10 +133,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("create LiveList with one LiveRegister item in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { doc: any }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        doc: any;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "doc"),
@@ -159,10 +155,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("create nested LiveList with one LiveObject item in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { doc: any }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        doc: any;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "doc"),
@@ -182,10 +177,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("Add nested objects in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { doc: any }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        doc: any;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", {}, "0:0", "doc"),
@@ -205,10 +199,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("delete object key", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncObj: { a?: number } }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncObj: { a?: number };
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -235,10 +228,9 @@ describe("2 ways tests with two clients", () => {
 
   describe("Array/LiveList", () => {
     test("replace array of 3 elements to 1 element", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<number> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<number>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -264,10 +256,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("add item to array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -290,10 +281,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("replace first item in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { list: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        list: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "list"),
@@ -314,10 +304,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("replace last item in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { list: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        list: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "list"),
@@ -338,10 +327,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("insert item at beginning of array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -365,10 +353,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("swap items in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -395,10 +382,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("array of objects", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<LiveObject<{ a: number }>> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<LiveObject<{ a: number }>>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -422,10 +408,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("remove first item from array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -450,10 +435,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("remove last item from array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -478,10 +462,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("remove all elements of array except first", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -506,10 +489,9 @@ describe("2 ways tests with two clients", () => {
       assert({ syncList: ["a"] }, 3, 2);
     });
     test("remove all elements of array except last", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -534,10 +516,9 @@ describe("2 ways tests with two clients", () => {
       assert({ syncList: ["c"] }, 3, 2);
     });
     test("remove all elements of array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<
-        never,
-        { syncList: LiveList<string> }
-      >(
+      const { storage, state, assert } = await prepareStorageImmutableTest<{
+        syncList: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "syncList"),
@@ -579,7 +560,7 @@ describe("2 ways tests with two clients", () => {
 
     test("new state contains a function", async () => {
       const { storage, state, assertStorage } =
-        await prepareStorageImmutableTest<never, { syncObj: { a: any } }>(
+        await prepareStorageImmutableTest<{ syncObj: { a: any } }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
@@ -606,10 +587,9 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("Production env - new state contains a function", async () => {
-      const { storage, state } = await prepareStorageImmutableTest<
-        never,
-        { syncObj: { a: any } }
-      >(
+      const { storage, state } = await prepareStorageImmutableTest<{
+        syncObj: { a: any };
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -814,10 +814,9 @@ describe("room", () => {
     });
 
     test("batch without operations should not add an item to the undo stack", async () => {
-      const { storage, assert, undo, batch } = await prepareStorageTest<
-        never,
-        { a: number }
-      >([createSerializedObject("0:0", { a: 1 })], 1);
+      const { storage, assert, undo, batch } = await prepareStorageTest<{
+        a: number;
+      }>([createSerializedObject("0:0", { a: 1 })], 1);
 
       storage.root.set("a", 2);
 
@@ -833,7 +832,7 @@ describe("room", () => {
 
     test("batch storage with changes from server", async () => {
       const { storage, assert, undo, redo, batch, subscribe, refSubscribe } =
-        await prepareStorageTest<never, { items: LiveList<string> }>(
+        await prepareStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
@@ -888,7 +887,7 @@ describe("room", () => {
         subscribe,
         refSubscribe,
         updatePresence,
-      } = await prepareStorageTest<never, { items: LiveList<string> }>(
+      } = await prepareStorageTest<{ items: LiveList<string> }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1041,7 +1040,7 @@ describe("room", () => {
   describe("offline", () => {
     test("disconnect and reconnect with offline changes", async () => {
       const { storage, assert, machine, refStorage, reconnect, ws } =
-        await prepareStorageTest<never, { items: LiveList<string> }>(
+        await prepareStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -1101,13 +1101,10 @@ describe("room", () => {
     });
 
     test("disconnect and reconnect with remote changes", async () => {
-      const { assert, machine } = await prepareIsolatedStorageTest<
-        never,
-        {
-          items?: LiveList<string>;
-          items2?: LiveList<string>;
-        }
-      >(
+      const { assert, machine } = await prepareIsolatedStorageTest<{
+        items?: LiveList<string>;
+        items2?: LiveList<string>;
+      }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -1298,10 +1295,9 @@ describe("room", () => {
 
   describe("defaultStorage", () => {
     test("initialize room with defaultStorage should send operation only once", async () => {
-      const { assert, assertMessagesSent } = await prepareIsolatedStorageTest<
-        Record<string, never>,
-        { items: LiveList<string> }
-      >([createSerializedObject("0:0", {})], 1, { items: new LiveList() });
+      const { assert, assertMessagesSent } = await prepareIsolatedStorageTest<{
+        items: LiveList<string>;
+      }>([createSerializedObject("0:0", {})], 1, { items: new LiveList() });
 
       assert({
         items: [],

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -217,20 +217,20 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
  * All operations made on the main room are forwarded to the other room
  * Assertion on the storage validate both rooms
  */
-export async function prepareStorageTest<
-  TPresence extends JsonObject,
-  TStorage extends LsonObject
->(items: SerializedCrdtWithId[], actor: number = 0) {
+export async function prepareStorageTest<TStorage extends LsonObject>(
+  items: SerializedCrdtWithId[],
+  actor: number = 0
+) {
   let currentActor = actor;
   const operations: Op[] = [];
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TPresence, TStorage>(items, -1);
+    await prepareRoomWithStorage<never, TStorage>(items, -1);
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
-    TPresence,
+    never,
     TStorage
-  >(items, currentActor, (messages: ClientMessage<TPresence>[]) => {
+  >(items, currentActor, (messages: ClientMessage<never>[]) => {
     for (const message of messages) {
       if (message.type === ClientMessageType.UpdateStorage) {
         operations.push(...message.ops);

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -171,19 +171,20 @@ async function prepareRoomWithStorage<
   };
 }
 
-export async function prepareIsolatedStorageTest<
-  TPresence extends JsonObject,
-  TStorage extends LsonObject
->(items: SerializedCrdtWithId[], actor: number = 0, defaultStorage = {}) {
-  const messagesSent: ClientMessage<TPresence>[] = [];
+export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
+  items: SerializedCrdtWithId[],
+  actor: number = 0,
+  defaultStorage = {}
+) {
+  const messagesSent: ClientMessage<never>[] = [];
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
-    TPresence,
+    never,
     TStorage
   >(
     items,
     actor,
-    (messages: ClientMessage<TPresence>[]) => {
+    (messages: ClientMessage<never>[]) => {
       messagesSent.push(...messages);
     },
     defaultStorage
@@ -198,7 +199,7 @@ export async function prepareIsolatedStorageTest<
     ws,
     assert: (data: ToJson<TStorage>) =>
       expect(lsonToJson(storage.root)).toEqual(data),
-    assertMessagesSent: (messages: ClientMessage<TPresence>[]) => {
+    assertMessagesSent: (messages: ClientMessage<JsonObject>[]) => {
       expect(messagesSent).toEqual(messages);
     },
     applyRemoteOperations: (ops: Op[]) =>

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -356,8 +356,8 @@ export async function reconnect(
 }
 
 export async function prepareStorageImmutableTest<
-  TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TPresence extends JsonObject = never
 >(items: SerializedCrdtWithId[], actor: number = 0) {
   let state: ToJson<TStorage> = {} as any;
   let refState: ToJson<TStorage> = {} as any;


### PR DESCRIPTION
This PR simplifies the now-typesafe helpers back to their previous state, where Presence is mostly irrelevant in storage-based tests. When necessary though, it can still be provided as a secondary/optional argument.
