### PR TITLE
Move deprecation helpers into separate module

### DIFF
--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -1,5 +1,6 @@
 import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
+import { deprecateIf } from "./deprecation";
 import type {
   CreateMapOp,
   CreateOp,
@@ -12,7 +13,6 @@ import type { Lson } from "./lson";
 import type { LiveMapUpdates } from "./types";
 import {
   creationOpToLiveStructure,
-  deprecateIf,
   deserialize,
   isCrdt,
   selfOrRegister,

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,3 +1,4 @@
+import { deprecateIf } from "./deprecation";
 import type { InternalRoom } from "./room";
 import { createRoom } from "./room";
 import type {
@@ -9,7 +10,6 @@ import type {
   Room,
   RoomInitializers,
 } from "./types";
-import { deprecateIf } from "./utils";
 
 type EnterOptions<TPresence, TStorage> = Resolve<
   // Enter options are just room initializers, plus an internal option

--- a/packages/liveblocks-client/src/deprecation.ts
+++ b/packages/liveblocks-client/src/deprecation.ts
@@ -38,3 +38,31 @@ export function deprecateIf(
     }
   }
 }
+
+/**
+ * Throws a deprecation error in the dev console.
+ *
+ * Only triggers in dev mode. In production, this is a no-op.
+ */
+export function throwUsageError(message: string) {
+  if (process.env.NODE_ENV !== "production") {
+    const usageError = new Error(message);
+    usageError.name = "Usage error";
+    throw usageError;
+  }
+}
+
+/**
+ * Conditionally throws a usage error in the dev console if the first argument
+ * is truthy. Use this to "escalate" usage patterns that in previous versions
+ * we already warned about with deprecation warnings.
+ *
+ * Only has effect in dev mode. In production, this is a no-op.
+ */
+export function errorIf(condition: unknown, message: string) {
+  if (process.env.NODE_ENV !== "production") {
+    if (condition) {
+      throwUsageError(message);
+    }
+  }
+}

--- a/packages/liveblocks-client/src/deprecation.ts
+++ b/packages/liveblocks-client/src/deprecation.ts
@@ -1,0 +1,40 @@
+/**
+ * Tools to help with the controlled deprecation of public APIs.
+ *
+ * First warn, then error, then remove eventually.
+ */
+
+// Keeps a set of deprecation messages in memory that it has warned about
+// already. There will be only one deprecation message in the console, no
+// matter how often it gets called.
+const _emittedDeprecationWarnings: Set<string> = new Set();
+
+/**
+ * Displays a deprecation warning in the dev console. Only in dev mode, and
+ * only once per message/key. In production, this is a no-op.
+ */
+export function deprecate(message: string, key = message) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!_emittedDeprecationWarnings.has(key)) {
+      _emittedDeprecationWarnings.add(key);
+      console.error(`DEPRECATION WARNING: ${message}`);
+    }
+  }
+}
+
+/**
+ * Conditionally displays a deprecation warning in the dev
+ * console if the first argument is truthy. Only in dev mode, and
+ * only once per message/key. In production, this is a no-op.
+ */
+export function deprecateIf(
+  condition: unknown,
+  message: string,
+  key = message
+) {
+  if (process.env.NODE_ENV !== "production") {
+    if (condition) {
+      deprecate(message, key);
+    }
+  }
+}

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -19,7 +19,7 @@ export type {
 export type { Resolve, RoomInitializers } from "./types";
 
 export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";
-export { deprecate, deprecateIf } from "./utils";
+export { deprecate, deprecateIf } from "./deprecation";
 
 export {
   lsonToJson,

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -19,7 +19,12 @@ export type {
 export type { Resolve, RoomInitializers } from "./types";
 
 export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";
-export { deprecate, deprecateIf } from "./deprecation";
+export {
+  deprecate,
+  deprecateIf,
+  errorIf,
+  throwUsageError,
+} from "./deprecation";
 
 export {
   lsonToJson,

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -23,41 +23,6 @@ import type {
   StorageUpdate,
 } from "./types";
 
-// Keeps a set of deprecation messages in memory that it has warned about
-// already. There will be only one deprecation message in the console, no
-// matter how often it gets called.
-const _emittedDeprecationWarnings: Set<string> = new Set();
-
-/**
- * Displays a deprecation warning in the dev console. Only in dev mode, and
- * only once per message/key. In production, this is a no-op.
- */
-export function deprecate(message: string, key = message) {
-  if (process.env.NODE_ENV !== "production") {
-    if (!_emittedDeprecationWarnings.has(key)) {
-      _emittedDeprecationWarnings.add(key);
-      console.error(`DEPRECATION WARNING: ${message}`);
-    }
-  }
-}
-
-/**
- * Conditionally displays a deprecation warning in the dev
- * console if the first argument is truthy. Only in dev mode, and
- * only once per message/key. In production, this is a no-op.
- */
-export function deprecateIf(
-  condition: unknown,
-  message: string,
-  key = message
-) {
-  if (process.env.NODE_ENV !== "production") {
-    if (condition) {
-      deprecate(message, key);
-    }
-  }
-}
-
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {
     if (array[i] === item) {


### PR DESCRIPTION
Just a bit of reorganization, moving `deprecate` and `deprecateIf` into a separate module. Also added two new helpers for the next step in the deprecation process:

- `errorIf` (like `deprecateIf`, but more severe)
- `throwUsageError` (like `deprecate`, but more severe)
