### PR TITLE
Turn deprecation warnings into errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# v0.17.0 (not yet released)
+
+## `@liveblocks/client`
+
+Some APIs are being **deprecated**:
+
+- The `defaultPresence` option to `client.enter()` will get renamed to `initialPresence`
+- The `defaultStorageRoot` option to `client.enter()` will get renamed to `initialStorage`
+
+## `@liveblocks/react`
+
+Some APIs are being **deprecated**:
+
+- The RoomProvider's `defaultPresence` will get renamed to `initialPresence`
+- The RoomProvider's `defaultStorageRoot` will get renamed to `initialStorage`
+- The second argument to `useList()`, `useObject()`, and `useMap()` is deprecated
+
+For information, please see https://bit.ly/3Niy5aP.
+
 # v0.16.5 (not yet released)
 
 - Various internal refactorings
@@ -10,23 +29,8 @@
 ## All packages
 
 - Improve our generated bundles. They are now even more tree-shakable, and smaller!
-
-## `@liveblocks/client`
-
-Some APIs are being **deprecated** and may start showing console warnings when used:
-
-- The `defaultPresence` option to `client.enter()` will get renamed to `initialPresence`
-- The `defaultStorageRoot` option to `client.enter()` will get renamed to `initialStorage`
-
-## `@liveblocks/react`
-
-Some APIs are being **deprecated** and may start showing console warnings when used:
-
-- The RoomProvider's `defaultPresence` will get renamed to `initialPresence`
-- The RoomProvider's `defaultStorageRoot` will get renamed to `initialStorage`
-- The second argument to `useList()`, `useObject()`, and `useMap()` is deprecated
-
-For information, please see https://bit.ly/3Niy5aP.
+- Some APIs are being deprecation and will show warnings in the dev console
+  when used
 
 # v0.16.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Various Live structures now take mandatory type params:
 
   - The `defaultPresence` option to `client.enter()` will get renamed to `initialPresence`
   - The `defaultStorageRoot` option to `client.enter()` will get renamed to `initialStorage`
+  - Calling `new LiveMap(null)` will stop working. Please use `new LiveMap()`, or `new LiveMap([])`
 
 - In **@liveblocks/react**:
 

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -1,6 +1,6 @@
 import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
-import { deprecateIf } from "./deprecation";
+import { errorIf } from "./deprecation";
 import type {
   CreateMapOp,
   CreateOp,
@@ -43,7 +43,7 @@ export class LiveMap<
     entries?: readonly (readonly [TKey, TValue])[] | undefined | null
   ) {
     super();
-    deprecateIf(
+    errorIf(
       entries === null,
       "Support for calling `new LiveMap(null)` will be removed in @liveblocks/client 0.18. Please call as `new LiveMap()`, or `new LiveMap([])`."
     );

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,4 +1,4 @@
-import { deprecateIf } from "./deprecation";
+import { errorIf } from "./deprecation";
 import type { InternalRoom } from "./room";
 import { createRoom } from "./room";
 import type {
@@ -68,15 +68,13 @@ export function createClient(options: ClientOptions): Client {
       return internalRoom.room;
     }
 
-    deprecateIf(
+    errorIf(
       options.defaultPresence,
-      "Argument `defaultPresence` will be removed in @liveblocks/client 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP",
-      "defaultPresence"
+      "Argument `defaultPresence` will be removed in @liveblocks/client 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP"
     );
-    deprecateIf(
+    errorIf(
       options.defaultStorageRoot,
-      "Argument `defaultStorageRoot` will be removed in @liveblocks/client 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP",
-      "defaultStorageRoot"
+      "Argument `defaultStorageRoot` will be removed in @liveblocks/client 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP"
     );
 
     internalRoom = createRoom(

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -11,7 +11,7 @@ import type {
 } from "@liveblocks/client";
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
-import { deprecateIf } from "@liveblocks/client/internal";
+import { errorIf } from "@liveblocks/client/internal";
 import * as React from "react";
 
 import { useClient } from "./client";
@@ -60,15 +60,13 @@ export function create() {
       }
     }
 
-    deprecateIf(
+    errorIf(
       defaultPresence,
-      "RoomProvider's `defaultPresence` prop will be removed in @liveblocks/react 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP",
-      "defaultPresence"
+      "RoomProvider's `defaultPresence` prop will be removed in @liveblocks/react 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP"
     );
-    deprecateIf(
+    errorIf(
       defaultStorageRoot,
-      "RoomProvider's `defaultStorageRoot` prop will be removed in @liveblocks/react 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP",
-      "defaultStorageRoot"
+      "RoomProvider's `defaultStorageRoot` prop will be removed in @liveblocks/react 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP"
     );
 
     const client = useClient();
@@ -387,7 +385,7 @@ export function create() {
     key: string,
     entries?: readonly (readonly [TKey, TValue])[] | null | undefined
   ): LiveMap<TKey, TValue> | null {
-    deprecateIf(
+    errorIf(
       entries,
       `Support for initializing entries in useMap() directly will be removed in @liveblocks/react 0.18.
 
@@ -410,7 +408,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     if (value.status === "ok") {
       return value.value;
     } else {
-      deprecateIf(
+      errorIf(
         value.status === "notfound",
         `Key ${JSON.stringify(
           key
@@ -458,7 +456,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     key: string,
     items?: TValue[] | undefined
   ): LiveList<TValue> | null {
-    deprecateIf(
+    errorIf(
       items,
       `Support for initializing items in useList() directly will be removed in @liveblocks/react 0.18.
 
@@ -483,7 +481,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     if (value.status === "ok") {
       return value.value;
     } else {
-      deprecateIf(
+      errorIf(
         value.status === "notfound",
         `Key ${JSON.stringify(
           key
@@ -533,7 +531,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     key: string,
     initialData?: TData
   ): LiveObject<TData> | null {
-    deprecateIf(
+    errorIf(
       initialData,
       `Support for initializing data in useObject() directly will be removed in @liveblocks/react 0.18.
 
@@ -558,7 +556,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     if (value.status === "ok") {
       return value.value;
     } else {
-      deprecateIf(
+      errorIf(
         value.status === "notfound",
         `Key ${JSON.stringify(
           key

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -1,4 +1,4 @@
-import { createClient } from "@liveblocks/client";
+import { createClient, LiveObject } from "@liveblocks/client";
 import {
   ClientMessageType,
   CrdtType,
@@ -150,7 +150,7 @@ describe("presence", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room" defaultPresence={() => ({ x: 1 })}>
+        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
           <PresenceComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -192,7 +192,7 @@ describe("presence", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room" defaultPresence={() => ({ x: 1 })}>
+        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
           <PresenceComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -217,7 +217,7 @@ describe("presence", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room" defaultPresence={() => ({ x: 1 })}>
+        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
           <PresenceComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -239,7 +239,7 @@ describe("presence", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room" defaultPresence={() => ({ x: 1 })}>
+        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
           <PresenceComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -276,7 +276,7 @@ describe("presence", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room" defaultPresence={() => ({ x: 1 })}>
+        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
           <PresenceComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -370,7 +370,7 @@ describe("presence", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room" defaultPresence={() => ({ x: 1 })}>
+        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
           <PresenceComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -416,8 +416,7 @@ describe("presence", () => {
 });
 
 function ObjectComponent() {
-  const obj = useObject("obj", { a: 0 });
-
+  const obj = useObject("obj");
   return (
     <div data-testid={testIds.liveObject}>
       {obj == null ? "Loading" : JSON.stringify(obj.toObject())}
@@ -449,7 +448,10 @@ describe("Storage", () => {
 
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room">
+        <RoomProvider
+          id="room"
+          initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
+        >
           <ObjectComponent />
         </RoomProvider>
       </LiveblocksProvider>
@@ -485,10 +487,12 @@ describe("Storage", () => {
 
   test("unmounting useObject while storage is loading should not cause a memory leak", async () => {
     const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
       <LiveblocksProvider client={client}>
-        <RoomProvider id="room">
+        <RoomProvider
+          id="room"
+          initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
+        >
           <UnmountContainer>
             <ObjectComponent />
           </UnmountContainer>


### PR DESCRIPTION
This PR is **intended to land in 0.17**!

This escalates deprecation warnings we were throwing since 0.16.x and makes them (dev only) errors that will get thrown, so they're harder to miss/ignore.

Fixes #225.
