### PR TITLE
Uncertainty cleanups

### DIFF
--- a/e2e/next-sandbox/pages/offline/index.tsx
+++ b/e2e/next-sandbox/pages/offline/index.tsx
@@ -10,13 +10,13 @@ import {
 import React, { useState } from "react";
 
 type RoomWithDevTools = Room & {
-  internalDevTools: {
-    closeWebsocket: () => void;
-    sendCloseEvent: (event: {
+  __INTERNAL_DO_NOT_USE: {
+    simulateCloseWebsocket(): void;
+    simulateSendCloseEvent(event: {
       code: number;
       wasClean: boolean;
-      reason: any;
-    }) => void;
+      reason: string;
+    }): void;
   };
 };
 
@@ -80,7 +80,7 @@ function Sandbox() {
       <button
         id="closeWebsocket"
         onClick={() => {
-          room.internalDevTools.closeWebsocket();
+          room.__INTERNAL_DO_NOT_USE.simulateCloseWebsocket();
           setStatus("offline");
         }}
       >
@@ -89,7 +89,7 @@ function Sandbox() {
       <button
         id="sendCloseEventConnectionError"
         onClick={() => {
-          room.internalDevTools.sendCloseEvent({
+          room.__INTERNAL_DO_NOT_USE.simulateSendCloseEvent({
             reason: "Fake connection error",
             code: 1005,
             wasClean: true,
@@ -101,7 +101,7 @@ function Sandbox() {
       <button
         id="sendCloseEventAppError"
         onClick={() => {
-          room.internalDevTools.sendCloseEvent({
+          room.__INTERNAL_DO_NOT_USE.simulateSendCloseEvent({
             reason: "App error",
             code: 4002,
             wasClean: true,

--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     // now they're too noisy to enable.
     // ----------------------------------------------------------------------
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-assertion": "off",
 
     // -------------------------------
     // Not interested in these checks:
@@ -23,6 +22,7 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "no-constant-condition": "off",
+    "@typescript-eslint/no-non-null-assertion": "off", // Because we have a custom no-restricted-syntax rule for this
 
     // -----------------------------
     // Enable auto-fixes for imports
@@ -73,6 +73,11 @@ module.exports = {
         selector: "ArrowFunctionExpression[async=true]",
         message:
           "Using `async` functions will emit extra support code in our CommonJS bundle, increasing its size. Using the Promise API instead will lead to a smaller bundle.",
+      },
+      {
+        selector: "TSNonNullExpression",
+        message:
+          "Non-null assertions mask real problems. Please use `nn(...)` (from src/assert.ts) instead.",
       },
       // {
       //   selector: "ForOfStatement",

--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     // These checks are still GOOD IDEAS to re-enable later on, but for right
     // now they're too noisy to enable.
     // ----------------------------------------------------------------------
-    "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     // now they're too noisy to enable.
     // ----------------------------------------------------------------------
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
 
     // -------------------------------

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -1,4 +1,4 @@
-import type { CreateOp, Op, SerializedCrdt, StorageUpdate } from "./types";
+import type { CreateChildOp, Op, SerializedCrdt, StorageUpdate } from "./types";
 import { OpCode } from "./types";
 
 export type ApplyResult =
@@ -128,7 +128,7 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  abstract _attachChild(op: CreateOp, source: OpSource): ApplyResult;
+  abstract _attachChild(op: CreateChildOp, source: OpSource): ApplyResult;
 
   /**
    * @internal

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -1055,7 +1055,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const existingItem = this._items[index];
     const position = existingItem._getParentKeyOrThrow();
 
-    const existingId = nn(existingItem._id);
+    const existingId = existingItem._id;
     existingItem._detach();
 
     const value = selfOrRegister(item);
@@ -1309,7 +1309,10 @@ function sortListItem(items: AbstractCrdt[]) {
  * As soon as we refactor the operations structure,
  * serializing a LiveStructure should not know anything about intent
  */
-function addIntentAndDeletedIdToOperation(ops: Op[], deletedId: string) {
+function addIntentAndDeletedIdToOperation(
+  ops: Op[],
+  deletedId: string | undefined
+) {
   if (ops.length === 0) {
     throw new Error(
       "Internal error. Serialized LiveStructure should have at least 1 operation"

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -62,11 +62,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       return list;
     }
 
-    for (const entry of children) {
-      const child = deserialize(entry, parentToChildren, doc);
+    for (const [id, crdt] of children) {
+      const child = deserialize([id, crdt], parentToChildren, doc);
 
-      child._setParentLink(list, entry[1].parentKey!);
-
+      child._setParentLink(list, crdt.parentKey);
       list._items.push(child);
       sortListItem(list._items);
     }

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -271,7 +271,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       };
     } else {
       // Item associated to the set ack does not exist either deleted localy or via remote undo/redo
-      const orphan = this._doc!.getItem(op.id);
+      const orphan = nn(this._doc).getItem(op.id);
 
       if (orphan && this._implicitlyDeletedItems.has(orphan)) {
         orphan._setParentLink(this, op.parentKey);
@@ -402,7 +402,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         };
       }
     } else {
-      const orphan = this._doc!.getItem(op.id);
+      const orphan = nn(this._doc).getItem(op.id);
 
       if (orphan && this._implicitlyDeletedItems.has(orphan)) {
         // Implicit delete after set
@@ -444,7 +444,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       return { modified: false };
     }
 
-    child._attach(id, this._doc!);
+    child._attach(id, nn(this._doc));
     child._setParentLink(this, key);
 
     const existingItemIndex = this._indexOfPosition(key);
@@ -487,7 +487,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
     const indexOfItemWithSameKey = this._indexOfPosition(key);
 
-    child._attach(id, this._doc!);
+    child._attach(id, nn(this._doc));
     child._setParentLink(this, key);
 
     const newKey = key;
@@ -500,7 +500,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
       this._items[indexOfItemWithSameKey] = child;
 
-      const reverse = existingItem._serialize(this._id!, key, this._doc);
+      const reverse = existingItem._serialize(nn(this._id), key, this._doc);
       addIntentAndDeletedIdToOperation(reverse, op.id);
 
       const delta = [setDelta(indexOfItemWithSameKey, child)];
@@ -674,7 +674,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     newKey: string,
     child: AbstractCrdt
   ): ApplyResult {
-    const previousKey = child._parentKey!;
+    const previousKey = nn(child._parentKey);
 
     if (this._implicitlyDeletedItems.has(child)) {
       const existingItemIndex = this._indexOfPosition(newKey);
@@ -751,7 +751,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     newKey: string,
     child: AbstractCrdt
   ): ApplyResult {
-    const previousKey = child._parentKey!;
+    const previousKey = nn(child._parentKey);
 
     const previousIndex = this._items.indexOf(child);
     const existingItemIndex = this._indexOfPosition(newKey);
@@ -1056,7 +1056,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const existingItem = this._items[index];
     const position = existingItem._getParentKeyOrThrow();
 
-    const existingId = existingItem._id!;
+    const existingId = nn(existingItem._id);
     existingItem._detach();
 
     const value = selfOrRegister(item);
@@ -1199,7 +1199,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   } {
     const newItem = creationOpToLiveStructure(op);
 
-    newItem._attach(op.id, this._doc!);
+    newItem._attach(op.id, nn(this._doc));
     newItem._setParentLink(this, key);
 
     this._items.push(newItem);

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -1016,7 +1016,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         item._detach();
         const childId = item._id;
         if (childId) {
-          ops.push({ id: childId, type: OpCode.DELETE_CRDT });
+          ops.push({
+            type: OpCode.DELETE_CRDT,
+            id: childId,
+            opId: this._doc.generateOpId(),
+          });
           reverseOps.push(
             ...item._serialize(nn(this._id), item._getParentKeyOrThrow())
           );

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -135,13 +135,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * @internal
    */
-  private _applyRemoteSet(op: CreateOp): ApplyResult {
+  private _applyRemoteSet(op: CreateChildOp): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
     }
 
-    const { id } = op;
-    const key = nn(op.parentKey);
+    const { id, parentKey: key } = op;
     const child = creationOpToLiveStructure(op);
     child._attach(id, this._doc);
     child._setParentLink(this, key);

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -77,15 +77,9 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * @internal
    */
-  _serialize(parentId?: string, parentKey?: string, doc?: Doc): Op[] {
+  _serialize(parentId: string, parentKey: string, doc?: Doc): Op[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
-    }
-
-    if (parentId == null || parentKey == null) {
-      throw new Error(
-        "Cannot serialize list if parentId or parentKey is undefined"
-      );
     }
 
     const ops = [];

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -1,5 +1,6 @@
 import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import { nn } from "./assert";
 import { LiveRegister } from "./LiveRegister";
 import { comparePosition as compare, makePosition } from "./position";
 import type {
@@ -783,7 +784,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       reverse: [
         {
           type: OpCode.SET_PARENT_KEY,
-          id: child._id!,
+          id: nn(child._id),
           parentKey: previousKey,
         },
       ],
@@ -820,8 +821,14 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   _toSerializedCrdt(): SerializedList {
     return {
       type: CrdtType.LIST,
-      parentId: this._parent?._id!,
-      parentKey: this._parentKey!,
+      parentId: nn(
+        this._parent?._id,
+        "Cannot serialize List if parentId is missing"
+      ),
+      parentKey: nn(
+        this._parentKey,
+        "Cannot serialize List if parentKey is missing"
+      ),
     };
   }
 

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -101,15 +101,8 @@ export class LiveMap<
       return map;
     }
 
-    for (const entry of children) {
-      const crdt = entry[1];
-      if (crdt.parentKey == null) {
-        throw new Error(
-          "Tried to deserialize a crdt but it does not have a parentKey and is not the root"
-        );
-      }
-
-      const child = deserialize(entry, parentToChildren, doc);
+    for (const [id, crdt] of children) {
+      const child = deserialize([id, crdt], parentToChildren, doc);
       child._setParentLink(map, crdt.parentKey);
       map._map.set(crdt.parentKey, child);
     }

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -61,15 +61,9 @@ export class LiveMap<
   /**
    * @internal
    */
-  _serialize(parentId?: string, parentKey?: string, doc?: Doc): Op[] {
+  _serialize(parentId: string, parentKey: string, doc?: Doc): Op[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
-    }
-
-    if (parentId == null || parentKey == null) {
-      throw new Error(
-        "Cannot serialize map if parentId or parentKey is undefined"
-      );
     }
 
     const ops = [];

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -1,5 +1,6 @@
 import type { ApplyResult, Doc, OpSource } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
+import { nn } from "./assert";
 import { errorIf } from "./deprecation";
 import type {
   CreateMapOp,
@@ -203,8 +204,14 @@ export class LiveMap<
   _toSerializedCrdt(): SerializedMap {
     return {
       type: CrdtType.MAP,
-      parentId: this._parent?._id!,
-      parentKey: this._parentKey!,
+      parentId: nn(
+        this._parent?._id,
+        "Cannot serialize Map if parentId is missing"
+      ),
+      parentKey: nn(
+        this._parentKey,
+        "Cannot serialize Map if parentKey is missing"
+      ),
     };
   }
 

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -1,4 +1,4 @@
-import type { ApplyResult, Doc, OpSource } from "./AbstractCrdt";
+import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
 import { nn } from "./assert";
 import { errorIf } from "./deprecation";
@@ -127,7 +127,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
+  _attachChild(op: CreateOp): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
     }

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -132,8 +132,7 @@ export class LiveMap<
       throw new Error("Can't attach child if doc is not present");
     }
 
-    const { id, parentKey } = op;
-    const key = nn(parentKey) as TKey;
+    const { id, parentKey: key } = op;
 
     const child = creationOpToLiveStructure(op);
 
@@ -141,7 +140,8 @@ export class LiveMap<
       return { modified: false };
     }
 
-    const previousValue = this._map.get(key);
+    const previousValue = this._map.get(key as TKey);
+    //                                      ^^^^^^^ TODO: Fix me!
     let reverse: Op[];
     if (previousValue) {
       const thisId = nn(this._id);
@@ -153,7 +153,8 @@ export class LiveMap<
 
     child._setParentLink(this, key);
     child._attach(id, this._doc);
-    this._map.set(key, child);
+    this._map.set(key as TKey, child);
+    //                ^^^^^^^ TODO: Fix me!
 
     return {
       modified: {

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -3,8 +3,8 @@ import { AbstractCrdt } from "./AbstractCrdt";
 import { nn } from "./assert";
 import { errorIf } from "./deprecation";
 import type {
+  CreateChildOp,
   CreateMapOp,
-  CreateOp,
   IdTuple,
   LiveMapUpdates,
   Lson,
@@ -127,7 +127,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _attachChild(op: CreateOp): ApplyResult {
+  _attachChild(op: CreateChildOp): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
     }

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -115,15 +115,8 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       return liveObj;
     }
 
-    for (const entry of children) {
-      const crdt = entry[1];
-      if (crdt.parentKey == null) {
-        throw new Error(
-          "Tried to deserialize a crdt but it does not have a parentKey and is not the root"
-        );
-      }
-
-      const child = deserialize(entry, parentToChildren, doc);
+    for (const [id, crdt] of children) {
+      const child = deserialize([id, crdt], parentToChildren, doc);
       child._setParentLink(liveObj, crdt.parentKey);
       liveObj._map.set(crdt.parentKey, child);
     }

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -2,8 +2,8 @@ import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
 import { nn } from "./assert";
 import type {
+  CreateChildOp,
   CreateObjectOp,
-  CreateOp,
   CreateRootObjectOp,
   DeleteObjectKeyOp,
   IdTuple,
@@ -141,7 +141,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   /**
    * @internal
    */
-  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
+  _attachChild(op: CreateChildOp, source: OpSource): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
     }

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -146,8 +146,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       throw new Error("Can't attach child if doc is not present");
     }
 
-    const { id, opId } = op;
-    const key = nn(op.parentKey);
+    const { id, opId, parentKey: key } = op;
     const child = creationOpToLiveStructure(op);
 
     if (this._doc.getItem(id) !== undefined) {

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -1,5 +1,6 @@
 import type { ApplyResult, Doc, OpSource } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
+import { nn } from "./assert";
 import type {
   CreateOp,
   IdTuple,
@@ -66,8 +67,14 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   _toSerializedCrdt(): SerializedRegister {
     return {
       type: CrdtType.REGISTER,
-      parentId: this._parent?._id!,
-      parentKey: this._parentKey!,
+      parentId: nn(
+        this._parent?._id,
+        "Cannot serialize Register if parentId is missing"
+      ),
+      parentKey: nn(
+        this._parentKey,
+        "Cannot serialize Register if parentKey is missing"
+      ),
       data: this.data,
     };
   }

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -2,7 +2,7 @@ import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
 import { nn } from "./assert";
 import type {
-  CreateOp,
+  CreateChildOp,
   IdTuple,
   Json,
   Op,
@@ -79,7 +79,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     };
   }
 
-  _attachChild(_op: CreateOp): ApplyResult {
+  _attachChild(_op: CreateChildOp): ApplyResult {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -1,4 +1,4 @@
-import type { ApplyResult, Doc, OpSource } from "./AbstractCrdt";
+import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
 import { nn } from "./assert";
 import type {
@@ -79,7 +79,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     };
   }
 
-  _attachChild(_op: CreateOp, source: OpSource): ApplyResult {
+  _attachChild(_op: CreateOp): ApplyResult {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/liveblocks-client/src/assert.ts
+++ b/packages/liveblocks-client/src/assert.ts
@@ -1,0 +1,35 @@
+/**
+ * Asserts that a certain condition holds. If it does not hold, will throw
+ * a runtime error in dev mode.
+ *
+ * In production, nothing is asserted and this acts as a no-op.
+ */
+export function assert(condition: boolean, errmsg: string): asserts condition {
+  if (process.env.NODE_ENV !== "production" && !condition) {
+    const err = new Error(errmsg);
+    err.name = "Assertion failure";
+    throw err;
+  }
+}
+
+/**
+ * Asserts that a given value is non-nullable. This is similar to TypeScript's
+ * `!` operator, but will throw an error at runtime (dev-mode only) indicating
+ * an incorrect assumption.
+ *
+ * Instead of:
+ *
+ *     foo!.bar
+ *
+ * Use:
+ *
+ *     nn(foo).bar
+ *
+ */
+export function nn<T>(
+  value: T,
+  errmsg: string = "Expected value to be non-nullable"
+): NonNullable<T> {
+  assert(value != null, errmsg);
+  return value as NonNullable<T>;
+}

--- a/packages/liveblocks-client/src/assert.ts
+++ b/packages/liveblocks-client/src/assert.ts
@@ -1,4 +1,27 @@
 /**
+ * Helper function that can be used to implement exhaustive switch statements
+ * with TypeScript. Example usage:
+ *
+ *    type Fruit = "🍎" | "🍌";
+ *
+ *    switch (fruit) {
+ *      case "🍎":
+ *      case "🍌":
+ *        return doSomething();
+ *
+ *      default:
+ *        return assertNever(fruit, "Unknown fruit");
+ *    }
+ *
+ * If now the Fruit union is extended (i.e. add "🍒"), TypeScript will catch
+ * this *statically*, rather than at runtime, and force you to handle the
+ * 🍒 case.
+ */
+export function assertNever(_value: never, errmsg: string): never {
+  throw new Error(errmsg);
+}
+
+/**
  * Asserts that a certain condition holds. If it does not hold, will throw
  * a runtime error in dev mode.
  *

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -9,7 +9,7 @@ import { findNonSerializableValue } from "./utils";
 function lsonObjectToJson<O extends LsonObject>(
   obj: O
 ): { [K in keyof O]: Json } {
-  const result: { [K in keyof O]: Json } = {} as any;
+  const result = {} as { [K in keyof O]: Json };
   for (const key in obj) {
     const val = obj[key];
     if (val !== undefined) {
@@ -28,7 +28,7 @@ export function liveObjectToJson<O extends LsonObject>(
 function liveMapToJson<TKey extends string>(
   map: LiveMap<TKey, Lson>
 ): { [K in TKey]: Json } {
-  const result: { [K in TKey]: Json } = {} as any;
+  const result = {} as { [K in TKey]: Json };
   for (const [key, value] of map.entries()) {
     result[key] = lsonToJson(value);
   }

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -366,7 +366,10 @@ function patchImmutableNode(
 
         for (const key in update.updates) {
           if (update.updates[key]?.type === "update") {
-            newState[key] = lsonToJson(update.node.get(key)!);
+            const value = update.node.get(key);
+            if (value !== undefined) {
+              newState[key] = lsonToJson(value);
+            }
           } else if (update.updates[key]?.type === "delete") {
             delete newState[key];
           }

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -11,7 +11,7 @@
  * https://join.team/liveblocks ;)
  */
 
-export { assertNever } from "./assert";
+export { assertNever, nn } from "./assert";
 export {
   deprecate,
   deprecateIf,

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -11,6 +11,7 @@
  * https://join.team/liveblocks ;)
  */
 
+export { assertNever } from "./assert";
 export {
   deprecate,
   deprecateIf,
@@ -71,4 +72,3 @@ export {
 } from "./types";
 export { parseJson } from "./types/Json";
 export { isChildCrdt, isRootCrdt } from "./types/SerializedCrdt";
-export { assertNever } from "./utils";

--- a/packages/liveblocks-client/src/position.ts
+++ b/packages/liveblocks-client/src/position.ts
@@ -2,22 +2,23 @@ export const min = 32;
 export const max = 126;
 
 export function makePosition(before?: string, after?: string): string {
-  // No children
-  if (before == null && after == null) {
-    return pos([min + 1]);
+  // Between
+  if (before != null && after != null) {
+    return pos(makePositionFromCodes(posCodes(before), posCodes(after)));
   }
 
   // Insert at the end
-  if (before != null && after == null) {
+  else if (before != null) {
     return getNextPosition(before);
   }
 
   // Insert at the start
-  if (before == null && after != null) {
+  else if (after != null) {
     return getPreviousPosition(after);
   }
 
-  return pos(makePositionFromCodes(posCodes(before!), posCodes(after!)));
+  // No children
+  return pos([min + 1]);
 }
 
 function getPreviousPosition(after: string) {

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -105,8 +105,7 @@ describe("room / auth", () => {
 
     const tokenExpDate = 1616727267;
     withDateNow(tokenExpDate - 600, async () => {
-      // @ts-ignore
-      room.room.internalDevTools.sendCloseEvent({
+      room.room.__INTERNAL_DO_NOT_USE.simulateSendCloseEvent({
         reason: "App error",
         code: 4002,
         wasClean: true,
@@ -134,8 +133,7 @@ describe("room / auth", () => {
 
     const tokenExpDate = 1616727267;
     withDateNow(tokenExpDate + 1, async () => {
-      // @ts-ignore
-      room.room.internalDevTools.sendCloseEvent({
+      room.room.__INTERNAL_DO_NOT_USE.simulateSendCloseEvent({
         reason: "App error",
         code: 4002,
         wasClean: true,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1,5 +1,6 @@
 import type { ApplyResult } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import { nn } from "./assert";
 import { LiveList } from "./LiveList";
 import type { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
@@ -607,7 +608,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
         const applyOpResult = applyOp(op, source);
         if (applyOpResult.modified) {
-          const parentId = applyOpResult.modified.node._parent?._id!;
+          const parentId = nn(applyOpResult.modified.node._parent?._id);
 
           // If the parent was created in the same batch, we don't want to notify
           // storage updates for the children.

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -264,8 +264,7 @@ export type State<TPresence extends JsonObject> = {
       storageUpdates: Map<string, StorageUpdate>;
     };
   };
-  offlineOperations: Map<string | undefined, Op>;
-  //                              ^^^^^^^^^ NOTE: Bug? Unintended?
+  offlineOperations: Map<string, Op>;
 };
 
 export type Effects<TPresence extends JsonObject> = {
@@ -1202,10 +1201,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
     if (storageOps.length > 0) {
       storageOps.forEach((op) => {
-        state.offlineOperations.set(
-          /* NOTE: Should we wrap this in a nn()? */ op.opId,
-          op
-        );
+        state.offlineOperations.set(nn(op.opId), op);
       });
     }
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -568,8 +568,8 @@ export function makeStateMachine<TPresence extends JsonObject>(
       },
     };
 
-    const createdNodeIds = new Set<string | undefined>();
-    //                                      ^^^^^^^^^ NOTE: Bug? Unintended?
+    const createdNodeIds = new Set<string>();
+
     for (const op of item) {
       if (op.type === "presence") {
         const reverse = {
@@ -610,13 +610,11 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
         const applyOpResult = applyOp(op, source);
         if (applyOpResult.modified) {
-          const parentId =
-            // NOTE: Do we intend to wrap this in a nn() here?
-            applyOpResult.modified.node._parent?._id;
+          const parentId = applyOpResult.modified.node._parent?._id;
 
-          // If the parent was created in the same batch, we don't want to notify
+          // If the parent is the root (undefined) or was created in the same batch, we don't want to notify
           // storage updates for the children.
-          if (!createdNodeIds.has(parentId)) {
+          if (!parentId || !createdNodeIds.has(parentId)) {
             result.updates.storageUpdates.set(
               nn(applyOpResult.modified.node._id),
               mergeStorageUpdates(

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -120,7 +120,7 @@ export type Machine = {
   subscribe(type: "connection", listener: ConnectionCallback): () => void;
   subscribe<K extends RoomEventName>(
     firstParam: K | AbstractCrdt | ((updates: StorageUpdate[]) => void),
-    listener?: RoomEventCallbackMap[K] | any,
+    listener?: RoomEventCallbackMap[K],
     options?: { isDeep: boolean }
   ): () => void;
 
@@ -1620,10 +1620,9 @@ export function createRoom(
       resume: machine.resumeHistory,
     },
 
-    // @ts-ignore
-    internalDevTools: {
-      closeWebsocket: machine.simulateSocketClose,
-      sendCloseEvent: machine.simulateSendCloseEvent,
+    __INTERNAL_DO_NOT_USE: {
+      simulateCloseWebsocket: machine.simulateSocketClose,
+      simulateSendCloseEvent: machine.simulateSendCloseEvent,
     },
   };
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -614,10 +614,10 @@ export function makeStateMachine<TPresence extends JsonObject>(
           // storage updates for the children.
           if (!createdNodeIds.has(parentId)) {
             result.updates.storageUpdates.set(
-              applyOpResult.modified.node._id!,
+              nn(applyOpResult.modified.node._id),
               mergeStorageUpdates(
                 result.updates.storageUpdates.get(
-                  applyOpResult.modified.node._id!
+                  nn(applyOpResult.modified.node._id)
                 ) as any, // FIXME
                 applyOpResult.modified
               )
@@ -630,7 +630,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
             op.type === OpCode.CREATE_MAP ||
             op.type === OpCode.CREATE_OBJECT
           ) {
-            createdNodeIds.add(applyOpResult.modified.node._id!);
+            createdNodeIds.add(nn(applyOpResult.modified.node._id));
           }
         }
       }
@@ -667,7 +667,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
       case OpCode.CREATE_LIST:
       case OpCode.CREATE_MAP:
       case OpCode.CREATE_REGISTER: {
-        const parent = state.items.get(op.parentId!);
+        const parent = state.items.get(nn(op.parentId));
         if (parent == null) {
           return { modified: false };
         }
@@ -1199,7 +1199,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
     if (storageOps.length > 0) {
       storageOps.forEach((op) => {
-        state.offlineOperations.set(op.opId!, op);
+        state.offlineOperations.set(nn(op.opId), op);
       });
     }
 
@@ -1341,7 +1341,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
     return _getInitialStatePromise.then(() => {
       return {
-        root: state.root! as LiveObject<TStorage>,
+        root: nn(state.root) as LiveObject<TStorage>,
       };
     });
   }

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -668,7 +668,11 @@ export function makeStateMachine<TPresence extends JsonObject>(
       case OpCode.CREATE_LIST:
       case OpCode.CREATE_MAP:
       case OpCode.CREATE_REGISTER: {
-        const parent = state.items.get(nn(op.parentId));
+        if (op.parentId === undefined) {
+          return { modified: false };
+        }
+
+        const parent = state.items.get(op.parentId);
         if (parent == null) {
           return { modified: false };
         }

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -603,7 +603,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
         if (isLocal) {
           source = OpSource.UNDOREDO_RECONNECT;
         } else {
-          const deleted = state.offlineOperations.delete(op.opId!);
+          const deleted = state.offlineOperations.delete(nn(op.opId));
           source = deleted ? OpSource.ACK : OpSource.REMOTE;
         }
 

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -633,6 +633,18 @@ export type Room = {
    * });
    */
   batch: (fn: () => void) => void;
+
+  /**
+   * @internal Utilities only used for unit testing.
+   */
+  __INTERNAL_DO_NOT_USE: {
+    simulateCloseWebsocket(): void;
+    simulateSendCloseEvent(event: {
+      code: number;
+      wasClean: boolean;
+      reason: string;
+    }): void;
+  };
 };
 
 export enum WebsocketCloseCodes {

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -1,4 +1,5 @@
 import type { AbstractCrdt, Doc } from "./AbstractCrdt";
+import { nn } from "./assert";
 import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
@@ -171,7 +172,7 @@ export function getTreesDiffOperations(
         ops.push({
           type: OpCode.SET_PARENT_KEY,
           id,
-          parentKey: crdt.parentKey!,
+          parentKey: nn(crdt.parentKey, "Parent key must not be missing"),
         });
       }
     } else {

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -21,29 +21,6 @@ import type {
 import { CrdtType, OpCode } from "./types";
 import { isJsonObject, parseJson } from "./types/Json";
 
-/**
- * Helper function that can be used to implement exhaustive switch statements
- * with TypeScript. Example usage:
- *
- *    type Fruit = "🍎" | "🍌";
- *
- *    switch (fruit) {
- *      case "🍎":
- *      case "🍌":
- *        return doSomething();
- *
- *      default:
- *        return assertNever(fruit, "Unknown fruit");
- *    }
- *
- * If now the Fruit union is extended (i.e. add "🍒"), TypeScript will catch
- * this *statically*, rather than at runtime, and force you to handle the
- * 🍒 case.
- */
-export function assertNever(_value: never, errmsg: string): never {
-  throw new Error(errmsg);
-}
-
 export function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {
     if (array[i] === item) {

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     // -------------------------------
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": "off",
-    "no-constant-condition": "off",
 
     // -----------------------------
     // Enable auto-fixes for imports

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     // now they're too noisy to enable.
     // ----------------------------------------------------------------------
     "@typescript-eslint/no-explicit-any": "off",
-    // "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
 
     // -------------------------------

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     // These checks are still GOOD IDEAS to re-enable later on, but for right
     // now they're too noisy to enable.
     // ----------------------------------------------------------------------
-    // "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     // "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
     "@typescript-eslint/no-non-null-assertion": "off",


### PR DESCRIPTION
This PR avoids using the non-null assertion operator (`!`) in TypeScript, because they can mask real problems with the code. The steps I've taken here are pretty mechanical refactorings:

- I've added a `nn()` helper, which stands for "non-nullable". By making this a method, we can let it throw a runtime error during development if ever such assertion turns out not to be true. In production, this will be a no-op, just like the non-null assertion (`!`) operator is.
- Next, I've mechanically refactored all call sites using that pattern, and replaced those with `nn()` calls. In some cases, I was able to refactor the code in a different way which avoided the operator altogether.

Running our unit test suite pointed out two places in the code where actually seem to rely on the fact that we inject/use `undefined` values at runtime. Protecting against those values actually makes the test suite fail. I've annotated those places clearly, and may need some help to interpret the edge cases.

Also, there can be more cases like this that aren't covered by our unit tests of course!
