### PR TITLE
ESLint: use objct shorthand syntax when possible

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     // ------------------------
     // Customized default rules
     // ------------------------
+    "object-shorthand": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -282,7 +282,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
             {
               index: newIndex,
               item: child instanceof LiveRegister ? child.data : child,
-              previousIndex: previousIndex,
+              previousIndex,
               type: "move",
             },
           ];
@@ -493,7 +493,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         storageUpdates.set(this._id!, {
           node: this,
           type: "LiveList",
-          updates: [{ index: index, type: "delete" }],
+          updates: [{ index, type: "delete" }],
         });
 
         this._doc.dispatch(

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -343,7 +343,7 @@ export class LiveMap<
     const innerIterator = this._map.entries();
 
     return {
-      [Symbol.iterator]: function () {
+      [Symbol.iterator]() {
         return this;
       },
       next() {
@@ -386,7 +386,7 @@ export class LiveMap<
     const innerIterator = this._map.values();
 
     return {
-      [Symbol.iterator]: function () {
+      [Symbol.iterator]() {
         return this;
       },
       next() {

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -48,14 +48,14 @@ describe("room / auth", () => {
         return res(
           ctx.json({
             actor: 0,
-            token: token,
+            token,
           })
         );
       } else {
         return res(
           ctx.json({
             actor: 1,
-            token: token,
+            token,
           })
         );
       }

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -484,7 +484,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
       addToUndoStack(reverse);
       state.redoStack = [];
       dispatch(ops);
-      notify({ storageUpdates: storageUpdates });
+      notify({ storageUpdates });
     }
   }
 
@@ -1180,7 +1180,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
     messages.push({
       type: ClientMessageType.UpdateStorage,
-      ops: ops,
+      ops,
     });
 
     notify(result.updates);

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -161,7 +161,7 @@ export function getTreesDiffOperations(
       // Delete crdt
       ops.push({
         type: OpType.DeleteCrdt,
-        id: id,
+        id,
       });
     }
   });
@@ -176,7 +176,7 @@ export function getTreesDiffOperations(
         ) {
           ops.push({
             type: OpType.UpdateObject,
-            id: id,
+            id,
             data: crdt.data,
           });
         }
@@ -184,7 +184,7 @@ export function getTreesDiffOperations(
       if (crdt.parentKey !== currentCrdt.parentKey) {
         ops.push({
           type: OpType.SetParentKey,
-          id: id,
+          id,
           parentKey: crdt.parentKey!,
         });
       }
@@ -194,7 +194,7 @@ export function getTreesDiffOperations(
         case CrdtType.Register:
           ops.push({
             type: OpType.CreateRegister,
-            id: id,
+            id,
             parentId: crdt.parentId,
             parentKey: crdt.parentKey,
             data: crdt.data,
@@ -203,7 +203,7 @@ export function getTreesDiffOperations(
         case CrdtType.List:
           ops.push({
             type: OpType.CreateList,
-            id: id,
+            id,
             parentId: crdt.parentId,
             parentKey: crdt.parentKey,
           });
@@ -211,7 +211,7 @@ export function getTreesDiffOperations(
         case CrdtType.Object:
           ops.push({
             type: OpType.CreateObject,
-            id: id,
+            id,
             parentId: crdt.parentId,
             parentKey: crdt.parentKey,
             data: crdt.data,
@@ -220,7 +220,7 @@ export function getTreesDiffOperations(
         case CrdtType.Map:
           ops.push({
             type: OpType.CreateMap,
-            id: id,
+            id,
             parentId: crdt.parentId,
             parentKey: crdt.parentKey,
           });
@@ -242,7 +242,7 @@ function mergeObjectStorageUpdates<A extends LsonObject, B extends LsonObject>(
   }
   return {
     ...second,
-    updates: updates,
+    updates,
   };
 }
 
@@ -261,7 +261,7 @@ function mergeMapStorageUpdates<
   }
   return {
     ...second,
-    updates: updates,
+    updates,
   };
 }
 
@@ -338,7 +338,7 @@ export function findNonSerializableValue(
   if (!isPlain) {
     return {
       path: path || "root",
-      value: value,
+      value,
     };
   }
 

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -293,7 +293,7 @@ export async function prepareStorageTest<TStorage extends LsonObject>(
     currentActor = actor;
     const ws = new MockWebSocket("");
     machine.connect();
-    machine.authenticationSuccess({ actor: actor }, ws as any);
+    machine.authenticationSuccess({ actor }, ws as any);
     ws.open();
 
     if (newItems) {
@@ -342,7 +342,7 @@ export async function reconnect(
 ) {
   const ws = new MockWebSocket("");
   machine.connect();
-  machine.authenticationSuccess({ actor: actor }, ws);
+  machine.authenticationSuccess({ actor }, ws);
   ws.open();
 
   machine.onMessage(

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------
+    "object-shorthand": "error",
     "no-restricted-syntax": [
       "error",
       {

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     // ------------------------
     // Customized default rules
     // ------------------------
+    "object-shorthand": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
     // ------------------------
     // Customized default rules
     // ------------------------
+    "object-shorthand": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     // ------------------------
     // Customized default rules
     // ------------------------
+    "object-shorthand": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore


### PR DESCRIPTION
Not important, but nice to have consistent syntax everywhere.