### PR TITLE
ESLint: also auto-sort exports

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     "import/no-duplicates": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -1,18 +1,16 @@
-export { LiveObject } from "./LiveObject";
-export { LiveMap } from "./LiveMap";
+export { createClient } from "./client";
+export type { Json, JsonObject } from "./json";
 export { LiveList } from "./LiveList";
+export { LiveMap } from "./LiveMap";
+export { LiveObject } from "./LiveObject";
+export type { Lson, LsonObject } from "./lson";
 export type {
+  BroadcastOptions,
+  Client,
+  History,
   Others,
   Presence,
   Room,
-  Client,
-  User,
-  BroadcastOptions,
   StorageUpdate,
-  History,
+  User,
 } from "./types";
-
-export type { Json, JsonObject } from "./json";
-export type { Lson, LsonObject } from "./lson";
-
-export { createClient } from "./client";

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -11,23 +11,21 @@
  * https://join.team/liveblocks ;)
  */
 
-export type {
-  RoomStateMessage,
-  SerializedCrdtWithId,
-  ServerMessage,
-} from "./live";
-export type { Resolve, RoomInitializers } from "./types";
-
-export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";
 export {
   deprecate,
   deprecateIf,
   errorIf,
   throwUsageError,
 } from "./deprecation";
-
 export {
   lsonToJson,
   patchImmutableObject,
   patchLiveObjectKey,
 } from "./immutable";
+export type {
+  RoomStateMessage,
+  SerializedCrdtWithId,
+  ServerMessage,
+} from "./live";
+export { ClientMessageType, CrdtType, OpType, ServerMessageType } from "./live";
+export type { Resolve, RoomInitializers } from "./types";

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     "import/no-duplicates": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "import/no-duplicates": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
 
     // ------------------------
     // Customized default rules

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     "import/no-duplicates": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
 
     // ------------------------
     // Customized default rules


### PR DESCRIPTION
Similarly to how we auto-sort imports now, we can auto-sort exports. No longer spend brain cycles figuring out where to put an export.
