### PR TITLE
Disallow XXX comments

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -44,6 +44,12 @@ module.exports = {
       { args: "all", argsIgnorePattern: "^_.*", varsIgnorePattern: "^_.*" },
     ],
 
+    // --------------------------------------------------------------
+    // "The Code is the To-Do List"
+    // https://www.executeprogram.com/blog/the-code-is-the-to-do-list
+    // --------------------------------------------------------------
+    "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
+
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -33,6 +33,12 @@ module.exports = {
       { argsIgnorePattern: "^_.*", varsIgnorePattern: "^_.*" },
     ],
 
+    // --------------------------------------------------------------
+    // "The Code is the To-Do List"
+    // https://www.executeprogram.com/blog/the-code-is-the-to-do-list
+    // --------------------------------------------------------------
+    "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
+
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -41,6 +41,12 @@ module.exports = {
       { args: "all", argsIgnorePattern: "^_.*", varsIgnorePattern: "^_.*" },
     ],
 
+    // --------------------------------------------------------------
+    // "The Code is the To-Do List"
+    // https://www.executeprogram.com/blog/the-code-is-the-to-do-list
+    // --------------------------------------------------------------
+    "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
+
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -42,6 +42,12 @@ module.exports = {
       { args: "all", argsIgnorePattern: "^_.*", varsIgnorePattern: "^_.*" },
     ],
 
+    // --------------------------------------------------------------
+    // "The Code is the To-Do List"
+    // https://www.executeprogram.com/blog/the-code-is-the-to-do-list
+    // --------------------------------------------------------------
+    "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
+
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -44,6 +44,12 @@ module.exports = {
       { args: "all", argsIgnorePattern: "^_.*", varsIgnorePattern: "^_.*" },
     ],
 
+    // --------------------------------------------------------------
+    // "The Code is the To-Do List"
+    // https://www.executeprogram.com/blog/the-code-is-the-to-do-list
+    // --------------------------------------------------------------
+    "no-warning-comments": ["error", { terms: ["xxx"], location: "anywhere" }],
+
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------


### PR DESCRIPTION
Over the weekend, I read this blog post: [The Code Is the To-Do List](https://www.executeprogram.com/blog/the-code-is-the-to-do-list). In the past, I've used a similar flow, and it's really useful. With this ESLint setting enabled, you can chose to leave these blocking comments in your PRs and use this technique to leave todos for yourself, and to remain focused. (And if you don't want to use this, that's fine, too 😉)