### PR TITLE
Require explicit annotations at module boundaries

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     // Customized default rules
     // ------------------------
     "object-shorthand": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore
@@ -98,6 +99,7 @@ module.exports = {
       // Special config for test files
       rules: {
         "no-restricted-syntax": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off",
       },
     },
   ],

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -54,32 +54,32 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  protected get _doc() {
+  protected get _doc(): Doc | undefined {
     return this.__doc;
   }
 
-  get roomId() {
+  get roomId(): string | null {
     return this.__doc ? this.__doc.roomId : null;
   }
 
   /**
    * @internal
    */
-  get _id() {
+  get _id(): string | undefined {
     return this.__id;
   }
 
   /**
    * @internal
    */
-  get _parent() {
+  get _parent(): AbstractCrdt | undefined {
     return this.__parent;
   }
 
   /**
    * @internal
    */
-  get _parentKey() {
+  get _parentKey(): string | undefined {
     return this.__parentKey;
   }
 
@@ -103,7 +103,7 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  _setParentLink(parent: AbstractCrdt, key: string) {
+  _setParentLink(parent: AbstractCrdt, key: string): void {
     if (this.__parent != null && this.__parent !== parent) {
       throw new Error("Cannot attach parent if it already exist");
     }
@@ -115,7 +115,7 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  _attach(id: string, doc: Doc) {
+  _attach(id: string, doc: Doc): void {
     if (this.__id || this.__doc) {
       throw new Error("Cannot attach if CRDT is already attached");
     }
@@ -134,7 +134,7 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  _detach() {
+  _detach(): void {
     if (this.__doc && this.__id) {
       this.__doc.deleteItem(this.__id);
     }

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -54,8 +54,8 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     [id]: IdTuple<SerializedList>,
     parentToChildren: ParentToChildNodeMap,
     doc: Doc
-  ) {
-    const list = new LiveList([]);
+  ): LiveList<Lson> {
+    const list = new LiveList();
     list._attach(id, doc);
 
     const children = parentToChildren.get(id);
@@ -113,7 +113,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * @internal
    */
-  _attach(id: string, doc: Doc) {
+  _attach(id: string, doc: Doc): void {
     super._attach(id, doc);
 
     for (const item of this._items) {
@@ -124,7 +124,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * @internal
    */
-  _detach() {
+  _detach(): void {
     super._detach();
 
     for (const item of this._items) {
@@ -810,7 +810,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * @internal
    */
-  _apply(op: Op, isLocal: boolean) {
+  _apply(op: Op, isLocal: boolean): ApplyResult {
     return super._apply(op, isLocal);
   }
 
@@ -834,7 +834,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * Returns the number of elements.
    */
-  get length() {
+  get length(): number {
     return this._items.length;
   }
 
@@ -842,7 +842,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * Adds one element to the end of the LiveList.
    * @param element The element to add to the end of the LiveList.
    */
-  push(element: TItem) {
+  push(element: TItem): void {
     return this.insert(element, this.length);
   }
 
@@ -851,7 +851,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * @param element The element to insert.
    * @param index The index at which you want to insert the element.
    */
-  insert(element: TItem, index: number) {
+  insert(element: TItem, index: number): void {
     if (index < 0 || index > this._items.length) {
       throw new Error(
         `Cannot insert list item at index "${index}". index should be between 0 and ${this._items.length}`
@@ -892,7 +892,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * @param index The index of the element to move
    * @param targetIndex The index where the element should be after moving.
    */
-  move(index: number, targetIndex: number) {
+  move(index: number, targetIndex: number): void {
     if (targetIndex < 0) {
       throw new Error("targetIndex cannot be less than 0");
     }
@@ -965,7 +965,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * Deletes an element at the specified index
    * @param index The index of the element to delete
    */
-  delete(index: number) {
+  delete(index: number): void {
     if (index < 0 || index >= this._items.length) {
       throw new Error(
         `Cannot delete list item at index "${index}". index should be between 0 and ${
@@ -1002,7 +1002,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  clear() {
+  clear(): void {
     if (this._doc) {
       const ops: Op[] = [];
       const reverseOps: Op[] = [];
@@ -1043,7 +1043,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  set(index: number, item: TItem) {
+  set(index: number, item: TItem): void {
     if (index < 0 || index >= this._items.length) {
       throw new Error(
         `Cannot set list item at index "${index}". index should be between 0 and ${

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -92,7 +92,7 @@ export class LiveMap<
     [id, _item]: IdTuple<SerializedMap>,
     parentToChildren: ParentToChildNodeMap,
     doc: Doc
-  ) {
+  ): LiveMap<string, Lson> {
     const map = new LiveMap();
     map._attach(id, doc);
 
@@ -114,7 +114,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _attach(id: string, doc: Doc) {
+  _attach(id: string, doc: Doc): void {
     super._attach(id, doc);
 
     for (const [_key, value] of this._map) {
@@ -169,7 +169,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _detach() {
+  _detach(): void {
     super._detach();
 
     for (const item of this._map.values()) {
@@ -237,7 +237,7 @@ export class LiveMap<
    * @param key The key of the element to add. Should be a string.
    * @param value The value of the element to add. Should be serializable to JSON.
    */
-  set(key: TKey, value: TValue) {
+  set(key: TKey, value: TValue): void {
     const oldValue = this._map.get(key);
 
     if (oldValue) {
@@ -273,7 +273,7 @@ export class LiveMap<
   /**
    * Returns the number of elements in the LiveMap.
    */
-  get size() {
+  get size(): number {
     return this._map.size;
   }
 
@@ -400,7 +400,7 @@ export class LiveMap<
    */
   forEach(
     callback: (value: TValue, key: TKey, map: LiveMap<TKey, TValue>) => void
-  ) {
+  ): void {
     for (const entry of this) {
       callback(entry[1], entry[0], this);
     }

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -95,7 +95,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     [id, item]: IdTuple<SerializedObject | SerializedRootObject>,
     parentToChildren: ParentToChildNodeMap,
     doc: Doc
-  ) {
+  ): LiveObject<LsonObject> {
     const liveObj = new LiveObject(item.data);
     liveObj._attach(id, doc);
     return this._deserializeChildren(liveObj, parentToChildren, doc);
@@ -128,7 +128,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   /**
    * @internal
    */
-  _attach(id: string, doc: Doc) {
+  _attach(id: string, doc: Doc): void {
     super._attach(id, doc);
 
     for (const [_key, value] of this._map) {
@@ -237,7 +237,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   /**
    * @internal
    */
-  _detach() {
+  _detach(): void {
     super._detach();
 
     for (const value of this._map.values()) {
@@ -409,7 +409,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
    * @param key The key of the property to add
    * @param value The value of the property to add
    */
-  set<TKey extends keyof O>(key: TKey, value: O[TKey]) {
+  set<TKey extends keyof O>(key: TKey, value: O[TKey]): void {
     // TODO: Find out why typescript complains
     this.update({ [key]: value } as any as Partial<O>);
   }
@@ -486,7 +486,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
    * Adds or updates multiple properties at once with an object.
    * @param overrides The object used to overrides properties
    */
-  update(overrides: Partial<O>) {
+  update(overrides: Partial<O>): void {
     if (this._doc == null || this._id == null) {
       for (const key in overrides) {
         const oldValue = this._map.get(key);

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -33,7 +33,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     [id, item]: IdTuple<SerializedRegister>,
     _parentToChildren: ParentToChildNodeMap,
     doc: Doc
-  ) {
+  ): LiveRegister<Json> {
     const register = new LiveRegister(item.data);
     register._attach(id, doc);
     return register;

--- a/packages/liveblocks-client/src/deprecation.ts
+++ b/packages/liveblocks-client/src/deprecation.ts
@@ -13,7 +13,7 @@ const _emittedDeprecationWarnings: Set<string> = new Set();
  * Displays a deprecation warning in the dev console. Only in dev mode, and
  * only once per message/key. In production, this is a no-op.
  */
-export function deprecate(message: string, key = message) {
+export function deprecate(message: string, key = message): void {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
       _emittedDeprecationWarnings.add(key);
@@ -31,7 +31,7 @@ export function deprecateIf(
   condition: unknown,
   message: string,
   key = message
-) {
+): void {
   if (process.env.NODE_ENV !== "production") {
     if (condition) {
       deprecate(message, key);
@@ -44,7 +44,7 @@ export function deprecateIf(
  *
  * Only triggers in dev mode. In production, this is a no-op.
  */
-export function throwUsageError(message: string) {
+export function throwUsageError(message: string): void {
   if (process.env.NODE_ENV !== "production") {
     const usageError = new Error(message);
     usageError.name = "Usage error";
@@ -59,7 +59,7 @@ export function throwUsageError(message: string) {
  *
  * Only has effect in dev mode. In production, this is a no-op.
  */
-export function errorIf(condition: unknown, message: string) {
+export function errorIf(condition: unknown, message: string): void {
   if (process.env.NODE_ENV !== "production") {
     if (condition) {
       throwUsageError(message);

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -101,7 +101,7 @@ export function patchLiveList<T extends Lson>(
   liveList: LiveList<T>,
   prev: Array<T>,
   next: Array<T>
-) {
+): void {
   let i = 0;
   let prevEnd = prev.length - 1;
   let nextEnd = next.length - 1;
@@ -234,7 +234,7 @@ export function patchLiveObject<O extends LsonObject>(
   root: LiveObject<O>,
   prev: O,
   next: O
-) {
+): void {
   const updates: Partial<O> = {};
 
   for (const key in next) {

--- a/packages/liveblocks-client/src/position.ts
+++ b/packages/liveblocks-client/src/position.ts
@@ -21,7 +21,7 @@ export function makePosition(before?: string, after?: string): string {
   return pos([min + 1]);
 }
 
-function getPreviousPosition(after: string) {
+function getPreviousPosition(after: string): string {
   const result = [];
   const afterCodes = posCodes(after);
   for (let i = 0; i < afterCodes.length; i++) {
@@ -42,7 +42,7 @@ function getPreviousPosition(after: string) {
   return pos(result);
 }
 
-function getNextPosition(before: string) {
+function getNextPosition(before: string): string {
   const result = [];
   const beforeCodes = posCodes(before);
   for (let i = 0; i < beforeCodes.length; i++) {
@@ -97,7 +97,7 @@ function makePositionFromCodes(before: number[], after: number[]): number[] {
   return result;
 }
 
-export function posCodes(str: string) {
+export function posCodes(str: string): number[] {
   const codes: number[] = [];
   for (let i = 0; i < str.length; i++) {
     codes.push(str.charCodeAt(i));
@@ -105,7 +105,7 @@ export function posCodes(str: string) {
   return codes;
 }
 
-export function pos(codes: number[]) {
+export function pos(codes: number[]): string {
   return String.fromCharCode(...codes);
 }
 

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -22,7 +22,7 @@ import type {
 import { CrdtType, OpCode } from "./types";
 import { isJsonObject, parseJson } from "./types/Json";
 
-export function remove<T>(array: T[], item: T) {
+export function remove<T>(array: T[], item: T): void {
   for (let i = 0; i < array.length; i++) {
     if (array[i] === item) {
       array.splice(i, 1);
@@ -100,7 +100,9 @@ export function isCrdt(obj: unknown): obj is AbstractCrdt {
   );
 }
 
-export function selfOrRegisterValue(obj: AbstractCrdt) {
+export function selfOrRegisterValue(obj: AbstractCrdt): any {
+  //                                                    ^^^
+  //                                                    FIXME: reflects the current _implicit_ any!
   if (obj instanceof LiveRegister) {
     return obj.data;
   }
@@ -365,7 +367,7 @@ export function findNonSerializableValue(
   return false;
 }
 
-export function isTokenValid(token: string) {
+export function isTokenValid(token: string): boolean {
   const tokenParts = token.split(".");
   if (tokenParts.length !== 3) {
     return false;

--- a/packages/liveblocks-node/.eslintrc.js
+++ b/packages/liveblocks-node/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
     // Custom syntax we want to forbid
     // -------------------------------
     "object-shorthand": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "error",
     "no-restricted-syntax": [
       "error",
       {

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     // Customized default rules
     // ------------------------
     "object-shorthand": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore

--- a/packages/liveblocks-redux/src/errors.ts
+++ b/packages/liveblocks-redux/src/errors.ts
@@ -1,12 +1,12 @@
 export const ERROR_PREFIX = "Invalid @liveblocks/redux middleware config.";
 
-export function missingClient() {
+export function missingClient(): Error {
   return new Error(`${ERROR_PREFIX} client is missing`);
 }
 
 export function mappingShouldBeAnObject(
   mappingType: "storageMapping" | "presenceMapping"
-) {
+): Error {
   return new Error(
     `${ERROR_PREFIX} ${mappingType} should be an object where the values are boolean.`
   );
@@ -15,19 +15,19 @@ export function mappingShouldBeAnObject(
 export function mappingValueShouldBeABoolean(
   mappingType: "storageMapping" | "presenceMapping",
   key: string
-) {
+): Error {
   return new Error(
     `${ERROR_PREFIX} ${mappingType}.${key} value should be a boolean`
   );
 }
 
-export function mappingShouldNotHaveTheSameKeys(key: string) {
+export function mappingShouldNotHaveTheSameKeys(key: string): Error {
   return new Error(
     `${ERROR_PREFIX} "${key}" is mapped on presenceMapping and storageMapping. A key shouldn't exist on both mapping.`
   );
 }
 
-export function mappingToFunctionIsNotAllowed(key: string) {
+export function mappingToFunctionIsNotAllowed(key: string): Error {
   return new Error(
     `${ERROR_PREFIX} mapping.${key} is invalid. Mapping to a function is not allowed.`
   );

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -315,7 +315,14 @@ export const actions = {
   leaveRoom,
 };
 
-function enterRoom(roomId: string, initialState?: any) {
+function enterRoom<T>(
+  roomId: string,
+  initialState?: T
+): {
+  type: string;
+  roomId: string;
+  initialState?: T;
+} {
   return {
     type: ACTION_TYPES.ENTER,
     roomId,
@@ -323,7 +330,10 @@ function enterRoom(roomId: string, initialState?: any) {
   };
 }
 
-function leaveRoom(roomId: string) {
+function leaveRoom(roomId: string): {
+  type: string;
+  roomId: string;
+} {
   return {
     type: ACTION_TYPES.LEAVE,
     roomId,

--- a/packages/liveblocks-redux/test/utils.ts
+++ b/packages/liveblocks-redux/test/utils.ts
@@ -1,3 +1,4 @@
+import type { Json } from "@liveblocks/client";
 import type {
   IdTuple,
   SerializedList,
@@ -8,7 +9,7 @@ import type {
 } from "@liveblocks/client/internal";
 import { CrdtType } from "@liveblocks/client/internal";
 
-export function remove<T>(array: T[], item: T) {
+export function remove<T>(array: T[], item: T): void {
   for (let i = 0; i < array.length; i++) {
     if (array[i] === item) {
       array.splice(i, 1);
@@ -38,26 +39,26 @@ export class MockWebSocket {
   addEventListener(
     event: "open" | "close" | "message",
     callback: (event: any) => void
-  ) {
+  ): void {
     this.callbacks[event].push(callback);
   }
 
   removeEventListener(
     event: "open" | "close" | "message",
     callback: (event: any) => void
-  ) {
+  ): void {
     // TODO: Fix TS issue
     remove(this.callbacks[event] as any, callback);
   }
 
-  send(message: string) {
+  send(message: string): void {
     this.sentMessages.push(message);
   }
 
-  close() {}
+  close(): void {}
 }
 
-export function wait(delay: number) {
+export function wait(delay: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
@@ -138,7 +139,7 @@ export function register(
   id: string,
   parentId: string,
   parentKey: string,
-  data: any
+  data: Json
 ): IdTuple<SerializedRegister> {
   return [
     id,

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     // Customized default rules
     // ------------------------
     "object-shorthand": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       // Unused variables are fine if they start with an underscore

--- a/packages/liveblocks-zustand/src/errors.ts
+++ b/packages/liveblocks-zustand/src/errors.ts
@@ -1,18 +1,18 @@
 export const ERROR_PREFIX = "Invalid @liveblocks/zustand middleware config.";
 
-export function missingClient() {
+export function missingClient(): Error {
   return new Error(`${ERROR_PREFIX} client is missing`);
 }
 
 export function missingMapping(
   mappingType: "storageMapping" | "presenceMapping"
-) {
+): Error {
   return new Error(`${ERROR_PREFIX} ${mappingType} is missing.`);
 }
 
 export function mappingShouldBeAnObject(
   mappingType: "storageMapping" | "presenceMapping"
-) {
+): Error {
   return new Error(
     `${ERROR_PREFIX} ${mappingType} should be an object where the values are boolean.`
   );
@@ -21,19 +21,19 @@ export function mappingShouldBeAnObject(
 export function mappingValueShouldBeABoolean(
   mappingType: "storageMapping" | "presenceMapping",
   key: string
-) {
+): Error {
   return new Error(
     `${ERROR_PREFIX} ${mappingType}.${key} value should be a boolean`
   );
 }
 
-export function mappingShouldNotHaveTheSameKeys(key: string) {
+export function mappingShouldNotHaveTheSameKeys(key: string): Error {
   return new Error(
     `${ERROR_PREFIX} "${key}" is mapped on presenceMapping and storageMapping. A key shouldn't exist on both mapping.`
   );
 }
 
-export function mappingToFunctionIsNotAllowed(key: string) {
+export function mappingToFunctionIsNotAllowed(key: string): Error {
   return new Error(
     `${ERROR_PREFIX} mapping.${key} is invalid. Mapping to a function is not allowed.`
   );

--- a/packages/liveblocks-zustand/test/utils.ts
+++ b/packages/liveblocks-zustand/test/utils.ts
@@ -1,3 +1,4 @@
+import type { Json } from "@liveblocks/client";
 import type {
   IdTuple,
   SerializedList,
@@ -8,7 +9,7 @@ import type {
 } from "@liveblocks/client/internal";
 import { CrdtType } from "@liveblocks/client/internal";
 
-export function remove<T>(array: T[], item: T) {
+export function remove<T>(array: T[], item: T): void {
   for (let i = 0; i < array.length; i++) {
     if (array[i] === item) {
       array.splice(i, 1);
@@ -38,26 +39,26 @@ export class MockWebSocket {
   addEventListener(
     event: "open" | "close" | "message",
     callback: (event: any) => void
-  ) {
+  ): void {
     this.callbacks[event].push(callback);
   }
 
   removeEventListener(
     event: "open" | "close" | "message",
     callback: (event: any) => void
-  ) {
+  ): void {
     // TODO: Fix TS issue
     remove(this.callbacks[event] as any, callback);
   }
 
-  send(message: string) {
+  send(message: string): void {
     this.sentMessages.push(message);
   }
 
-  close() {}
+  close(): void {}
 }
 
-export function wait(delay: number) {
+export function wait(delay: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
@@ -138,7 +139,7 @@ export function register(
   id: string,
   parentId: string,
   parentKey: string,
-  data: any
+  data: Json
 ): IdTuple<SerializedRegister> {
   return [
     id,


### PR DESCRIPTION
This configures ESLint to require explicit type annotations at all the module boundaries. Specifically, function return types. TypeScript is good at inferring return types for functions, but sometimes those are implicitly `any`, and as a result, using those functions leads to a false sense of safety.
