### PR TITLE
More explicit state management for parent links

### DIFF
--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -69,13 +69,13 @@ type Orphaned = {
 };
 
 function HasParent(node: LiveNode, key: string): HasParent {
-  return { tag: "HasParent", node, key };
+  return Object.freeze({ tag: "HasParent", node, key });
 }
 
-const NoParent: NoParent = { tag: "NoParent" };
+const NoParent: NoParent = Object.freeze({ tag: "NoParent" });
 
 function Orphaned(oldKey: string): Orphaned {
-  return { tag: "Orphaned", oldKey };
+  return Object.freeze({ tag: "Orphaned", oldKey });
 }
 
 /**

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -257,9 +257,6 @@ export abstract class AbstractCrdt {
       this.__doc.deleteItem(this.__id);
     }
 
-    // NOTE: Ideally, we should be able to set `this.__parentInfo = undefined`
-    // here, but for now we'll need to retain the last known parent key as
-    // a kind of memento :(
     switch (this.parent.type) {
       case "HasParent": {
         this._parent = Orphaned(this.parent.key);

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -135,7 +135,7 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  get _parent(): LiveNode | null {
+  get _parentNode(): LiveNode | null {
     const p = this.__parentInfo;
     switch (p.tag) {
       case "HasParent":
@@ -178,8 +178,8 @@ export abstract class AbstractCrdt {
   _apply(op: Op, _isLocal: boolean): ApplyResult {
     switch (op.type) {
       case OpCode.DELETE_CRDT: {
-        if (this._parent != null && this._parentKey != null) {
-          return this._parent._detachChild(crdtAsLiveNode(this));
+        if (this._parentNode != null && this._parentKey != null) {
+          return this._parentNode._detachChild(crdtAsLiveNode(this));
         }
 
         return { modified: false };

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -194,8 +194,8 @@ export abstract class AbstractCrdt {
   _apply(op: Op, _isLocal: boolean): ApplyResult {
     switch (op.type) {
       case OpCode.DELETE_CRDT: {
-        if (this._parentNode != null && this._parentKey != null) {
-          return this._parentNode._detachChild(crdtAsLiveNode(this));
+        if (this.parent.type === "HasParent") {
+          return this.parent.node._detachChild(crdtAsLiveNode(this));
         }
 
         return { modified: false };

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -105,11 +105,11 @@ export abstract class AbstractCrdt {
       case "HasParent":
         return p.key;
 
-      case "Orphaned":
-        return p.oldKey;
-
       case "NoParent":
         throw new Error("Parent key is missing");
+
+      case "Orphaned":
+        return p.oldKey;
 
       default:
         return assertNever(p, "Unknown state");
@@ -150,10 +150,10 @@ export abstract class AbstractCrdt {
       case "HasParent":
         return p.node;
 
-      case "Orphaned":
+      case "NoParent":
         return null;
 
-      case "NoParent":
+      case "Orphaned":
         return null;
 
       default:
@@ -170,11 +170,11 @@ export abstract class AbstractCrdt {
       case "HasParent":
         return p.key;
 
-      case "Orphaned":
-        return p.oldKey;
-
       case "NoParent":
         return null;
+
+      case "Orphaned":
+        return p.oldKey;
 
       default:
         return assertNever(p, "Unknown state");

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -54,28 +54,28 @@ function crdtAsLiveNode(
 }
 
 type HasParent = {
-  readonly tag: "HasParent";
+  readonly type: "HasParent";
   readonly node: LiveNode;
   readonly key: string;
 };
 
 type NoParent = {
-  readonly tag: "NoParent";
+  readonly type: "NoParent";
 };
 
 type Orphaned = {
-  readonly tag: "Orphaned";
+  readonly type: "Orphaned";
   readonly oldKey: string;
 };
 
 function HasParent(node: LiveNode, key: string): HasParent {
-  return Object.freeze({ tag: "HasParent", node, key });
+  return Object.freeze({ type: "HasParent", node, key });
 }
 
-const NoParent: NoParent = Object.freeze({ tag: "NoParent" });
+const NoParent: NoParent = Object.freeze({ type: "NoParent" });
 
 function Orphaned(oldKey: string): Orphaned {
-  return Object.freeze({ tag: "Orphaned", oldKey });
+  return Object.freeze({ type: "Orphaned", oldKey });
 }
 
 /**
@@ -110,7 +110,7 @@ export abstract class AbstractCrdt {
    * @internal
    */
   _getParentKeyOrThrow(): string {
-    switch (this.parent.tag) {
+    switch (this.parent.type) {
       case "HasParent":
         return this.parent.key;
 
@@ -154,7 +154,7 @@ export abstract class AbstractCrdt {
    * @internal
    */
   get _parentNode(): LiveNode | null {
-    switch (this.parent.tag) {
+    switch (this.parent.type) {
       case "HasParent":
         return this.parent.node;
 
@@ -173,7 +173,7 @@ export abstract class AbstractCrdt {
    * @internal
    */
   get _parentKey(): string | null {
-    switch (this.parent.tag) {
+    switch (this.parent.type) {
       case "HasParent":
         return this.parent.key;
 
@@ -209,7 +209,7 @@ export abstract class AbstractCrdt {
    * @internal
    */
   _setParentLink(newParentNode: LiveNode, newParentKey: string): void {
-    switch (this.parent.tag) {
+    switch (this.parent.type) {
       case "HasParent":
         if (this.parent.node !== newParentNode) {
           throw new Error("Cannot attach parent if it already exist");
@@ -260,7 +260,7 @@ export abstract class AbstractCrdt {
     // NOTE: Ideally, we should be able to set `this.__parentInfo = undefined`
     // here, but for now we'll need to retain the last known parent key as
     // a kind of memento :(
-    switch (this.parent.tag) {
+    switch (this.parent.type) {
       case "HasParent": {
         this._parent = Orphaned(this.parent.key);
         break;

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -54,9 +54,10 @@ function crdtAsLiveNode(
 
 export abstract class AbstractCrdt {
   //                  ^^^^^^^^^^^^ TODO: Make this an interface
-  private __parent?: LiveNode;
   private __doc?: Doc;
   private __id?: string;
+
+  private __parent?: LiveNode;
   private __parentKey?: string;
 
   /**

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -100,11 +100,20 @@ export abstract class AbstractCrdt {
    * @internal
    */
   _getParentKeyOrThrow(): string {
-    const key = this._parentKey;
-    if (key === null) {
-      throw new Error("Parent key is missing");
+    const p = this.__parentInfo;
+    switch (p.tag) {
+      case "HasParent":
+        return p.key;
+
+      case "Orphaned":
+        return p.oldKey;
+
+      case "NoParent":
+        throw new Error("Parent key is missing");
+
+      default:
+        return assertNever(p, "Unknown state");
     }
-    return key;
   }
 
   /**

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -812,16 +812,14 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * @internal
    */
   _toSerializedCrdt(): SerializedList {
+    if (this.parent.type !== "HasParent") {
+      throw new Error("Cannot serialize LiveList if parent is missing");
+    }
+
     return {
       type: CrdtType.LIST,
-      parentId: nn(
-        this._parentNode?._id,
-        "Cannot serialize List if parentId is missing"
-      ),
-      parentKey: nn(
-        this._parentKey,
-        "Cannot serialize List if parentKey is missing"
-      ),
+      parentId: nn(this.parent.node._id, "Parent node expected to have ID"),
+      parentKey: this.parent.key,
     };
   }
 

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -815,7 +815,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return {
       type: CrdtType.LIST,
       parentId: nn(
-        this._parent?._id,
+        this._parentNode?._id,
         "Cannot serialize List if parentId is missing"
       ),
       parentKey: nn(

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -210,7 +210,7 @@ export class LiveMap<
     return {
       type: CrdtType.MAP,
       parentId: nn(
-        this._parent?._id,
+        this._parentNode?._id,
         "Cannot serialize Map if parentId is missing"
       ),
       parentKey: nn(

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -207,16 +207,14 @@ export class LiveMap<
    * @internal
    */
   _toSerializedCrdt(): SerializedMap {
+    if (this.parent.type !== "HasParent") {
+      throw new Error("Cannot serialize LiveMap if parent is missing");
+    }
+
     return {
       type: CrdtType.MAP,
-      parentId: nn(
-        this._parentNode?._id,
-        "Cannot serialize Map if parentId is missing"
-      ),
-      parentKey: nn(
-        this._parentKey,
-        "Cannot serialize Map if parentKey is missing"
-      ),
+      parentId: nn(this.parent.node._id, "Parent node expected to have ID"),
+      parentKey: this.parent.key,
     };
   }
 

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -274,11 +274,11 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       }
     }
 
-    if (this._parentInfo.tag === "HasParent" && this._parentInfo.node._id) {
+    if (this.parent.tag === "HasParent" && this.parent.node._id) {
       return {
         type: CrdtType.OBJECT,
-        parentId: this._parentInfo.node._id,
-        parentKey: this._parentInfo.key,
+        parentId: this.parent.node._id,
+        parentKey: this.parent.key,
         data,
       };
     } else {

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -274,11 +274,11 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       }
     }
 
-    if (this._parent?._id !== undefined && this._parentKey !== undefined) {
+    if (this._parentInfo?.node?._id) {
       return {
         type: CrdtType.OBJECT,
-        parentId: this._parent._id,
-        parentKey: this._parentKey,
+        parentId: this._parentInfo.node._id,
+        parentKey: this._parentInfo.key,
         data,
       };
     } else {

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -274,7 +274,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       }
     }
 
-    if (this._parentInfo?.node?._id) {
+    if (this._parentInfo.tag === "HasParent" && this._parentInfo.node._id) {
       return {
         type: CrdtType.OBJECT,
         parentId: this._parentInfo.node._id,

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -274,7 +274,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       }
     }
 
-    if (this.parent.tag === "HasParent" && this.parent.node._id) {
+    if (this.parent.type === "HasParent" && this.parent.node._id) {
       return {
         type: CrdtType.OBJECT,
         parentId: this.parent.node._id,

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -66,16 +66,14 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
    * INTERNAL
    */
   _toSerializedCrdt(): SerializedRegister {
+    if (this.parent.type !== "HasParent") {
+      throw new Error("Cannot serialize LiveRegister if parent is missing");
+    }
+
     return {
       type: CrdtType.REGISTER,
-      parentId: nn(
-        this._parentNode?._id,
-        "Cannot serialize Register if parentId is missing"
-      ),
-      parentKey: nn(
-        this._parentKey,
-        "Cannot serialize Register if parentKey is missing"
-      ),
+      parentId: nn(this.parent.node._id, "Parent node expected to have ID"),
+      parentKey: this.parent.key,
       data: this.data,
     };
   }

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -69,7 +69,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     return {
       type: CrdtType.REGISTER,
       parentId: nn(
-        this._parent?._id,
+        this._parentNode?._id,
         "Cannot serialize Register if parentId is missing"
       ),
       parentKey: nn(

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -244,13 +244,13 @@ export function patchLiveObject<O extends LsonObject>(
 
 function getParentsPath(node: LiveNode): Array<string | number> {
   const path = [];
-  while (node._parentKey != null && node._parentNode != null) {
-    if (isLiveList(node._parentNode)) {
-      path.push(node._parentNode._indexOfPosition(node._parentKey));
+  while (node.parent.type === "HasParent") {
+    if (isLiveList(node.parent.node)) {
+      path.push(node.parent.node._indexOfPosition(node.parent.key));
     } else {
-      path.push(node._parentKey);
+      path.push(node.parent.key);
     }
-    node = node._parentNode;
+    node = node.parent.node;
   }
   return path;
 }

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -244,13 +244,13 @@ export function patchLiveObject<O extends LsonObject>(
 
 function getParentsPath(node: LiveNode): Array<string | number> {
   const path = [];
-  while (node._parentKey != null && node._parent != null) {
-    if (isLiveList(node._parent)) {
-      path.push(node._parent._indexOfPosition(node._parentKey));
+  while (node._parentKey != null && node._parentNode != null) {
+    if (isLiveList(node._parentNode)) {
+      path.push(node._parentNode._indexOfPosition(node._parentKey));
     } else {
       path.push(node._parentKey);
     }
-    node = node._parent;
+    node = node._parentNode;
   }
   return path;
 }

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -613,7 +613,13 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
         const applyOpResult = applyOp(op, source);
         if (applyOpResult.modified) {
-          const parentId = applyOpResult.modified.node._parentNode?._id;
+          const parentId =
+            applyOpResult.modified.node.parent.type === "HasParent"
+              ? nn(
+                  applyOpResult.modified.node.parent.node._id,
+                  "Expected parent node to have an ID"
+                )
+              : undefined;
 
           // If the parent is the root (undefined) or was created in the same batch, we don't want to notify
           // storage updates for the children.
@@ -663,8 +669,8 @@ export function makeStateMachine<TPresence extends JsonObject>(
           return { modified: false };
         }
 
-        if (isLiveList(item._parentNode)) {
-          return item._parentNode._setChildKey(op.parentKey, item, source);
+        if (item.parent.type === "HasParent" && isLiveList(item.parent.node)) {
+          return item.parent.node._setChildKey(op.parentKey, item, source);
         }
         return { modified: false };
       }

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -613,7 +613,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
         const applyOpResult = applyOp(op, source);
         if (applyOpResult.modified) {
-          const parentId = applyOpResult.modified.node._parent?._id;
+          const parentId = applyOpResult.modified.node._parentNode?._id;
 
           // If the parent is the root (undefined) or was created in the same batch, we don't want to notify
           // storage updates for the children.
@@ -663,8 +663,8 @@ export function makeStateMachine<TPresence extends JsonObject>(
           return { modified: false };
         }
 
-        if (isLiveList(item._parent)) {
-          return item._parent._setChildKey(op.parentKey, item, source);
+        if (isLiveList(item._parentNode)) {
+          return item._parentNode._setChildKey(op.parentKey, item, source);
         }
         return { modified: false };
       }

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -59,8 +59,8 @@ export function isSameNodeOrChildOf(node: LiveNode, parent: LiveNode): boolean {
   if (node === parent) {
     return true;
   }
-  if (node._parentNode) {
-    return isSameNodeOrChildOf(node._parentNode, parent);
+  if (node.parent.type === "HasParent") {
+    return isSameNodeOrChildOf(node.parent.node, parent);
   }
   return false;
 }

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -59,8 +59,8 @@ export function isSameNodeOrChildOf(node: LiveNode, parent: LiveNode): boolean {
   if (node === parent) {
     return true;
   }
-  if (node._parent) {
-    return isSameNodeOrChildOf(node._parent, parent);
+  if (node._parentNode) {
+    return isSameNodeOrChildOf(node._parentNode, parent);
   }
   return false;
 }


### PR DESCRIPTION
This PR makes the state management around "parent links" more explicit inside the AbstractCrdt base class.
