### PR TITLE
Pick good defaults for `jest` runs

### DIFF
--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -33,9 +33,9 @@
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
-    "test": "jest --watch --config=./jest.config.js",
-    "test-ci": "jest",
-    "test-e2e": "jest --config=./jest.config.e2e.js"
+    "test": "jest --watch --silent --verbose --config=./jest.config.js",
+    "test-ci": "jest --silent --verbose",
+    "test-e2e": "jest --silent --verbose --config=./jest.config.e2e.js"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -24,8 +24,8 @@
     "build:cjs": "tsc -p tsconfig-cjs.json",
     "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
-    "test": "jest --watch",
-    "test-ci": "jest --passWithNoTests"
+    "test": "jest --watch --silent --verbose",
+    "test-ci": "jest --silent --verbose --passWithNoTests"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -23,8 +23,8 @@
     "start": "rollup -c -w",
     "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
-    "test": "jest --watch",
-    "test-ci": "jest"
+    "test": "jest --watch --silent --verbose",
+    "test-ci": "jest --silent --verbose"
   },
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -20,8 +20,8 @@
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
-    "test": "jest --watch",
-    "test-ci": "jest",
+    "test": "jest --watch --silent --verbose",
+    "test-ci": "jest --silent --verbose",
     "dtslint": "dtslint --localTs node_modules/typescript/lib --expectOnly types"
   },
   "license": "Apache-2.0",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -20,8 +20,8 @@
     "build": "rollup -c && cp ./package.json ./README.md ./lib",
     "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
-    "test": "jest --watch",
-    "test-ci": "jest",
+    "test": "jest --watch --silent --verbose",
+    "test-ci": "jest --silent --verbose",
     "dtslint": "dtslint --localTs node_modules/typescript/lib --expectOnly types"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This runs `jest` using the options `--silent` (which suppresses all those `console.warn()` and `console.error()` spy tests), and `--verbose` will display the tests results of all the individual tests, seeing all the green checks that are there, to get a better sense at the vastness of the test suite.

Compare before and after. The same tests, and they're all green, but it's much quicker to tell now:

<img width="682" alt="Screen Shot 2022-05-25 at 11 17 05@2x" src="https://user-images.githubusercontent.com/83844/170228094-d3289556-3e3b-468b-b8ef-965a563b113a.png">

vs

<img width="747" alt="Screen Shot 2022-05-25 at 11 17 22@2x" src="https://user-images.githubusercontent.com/83844/170228126-64d5fd22-2bff-45b6-a924-f42f436cd0cd.png">
