### PR TITLE
fix e2e offline tests

### DIFF
--- a/e2e/next-sandbox/test/offline/index.test.ts
+++ b/e2e/next-sandbox/test/offline/index.test.ts
@@ -29,7 +29,7 @@ test.describe("Offline", () => {
     });
   });
 
-  test.skip("one client offline with offline changes - connection issue (code 1005)", async () => {
+  test("one client offline with offline changes - connection issue (code 1005)", async () => {
     await pages[0].click("#clear");
     await assertContainText(pages, "0");
 
@@ -57,7 +57,7 @@ test.describe("Offline", () => {
     await assertContainText(pages, "0");
   });
 
-  test.skip("one client offline with offline changes - app server issue (code 4002)", async () => {
+  test("one client offline with offline changes - app server issue (code 4002)", async () => {
     await pages[0].click("#clear");
     await assertContainText(pages, "0");
 
@@ -93,7 +93,7 @@ test.describe("Offline", () => {
     await assertContainText(pages, "0");
   });
 
-  test.skip("fuzzy", async () => {
+  test("fuzzy", async () => {
     await pages[0].click("#clear");
     await assertContainText(pages, "0");
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1465,7 +1465,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
 
   function simulateSocketClose() {
     if (state.socket) {
-      state.socket.close();
+      state.socket = null;
     }
   }
 
@@ -1474,9 +1474,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
     wasClean: boolean;
     reason: string;
   }) {
-    if (state.socket) {
-      onClose(event);
-    }
+    onClose(event);
   }
 
   return {


### PR DESCRIPTION
Websocket server now sends a close handshake when the client closes the connection.
To simulate an internet connection loss, the internal method is now deleting the websocket object.