### PR TITLE
Expose `EnsureJson` helper

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -17,3 +17,18 @@ export type {
   StorageUpdate,
   User,
 } from "./types";
+
+/**
+ * Helper type to help users adopt to Lson types from interface definitions.
+ * You should only use this to wrap interfaces you don't control. For more
+ * information, see
+ * https://liveblocks.io/docs/guides/limits#lson-constraint-and-interfaces
+ */
+// prettier-ignore
+export type EnsureJson<T> =
+  // Retain `unknown` fields
+  [unknown] extends [T] ? T :
+  // Retain functions
+  T extends (...args: any[]) => any ? T :
+  // Resolve all other values explicitly
+  { [K in keyof T]: EnsureJson<T[K]> };


### PR DESCRIPTION
After a lot of research, back and forth, and debating, we decided to expose the `EnsureJson` helper publicly after all, to help users adapt to Live data structures with interfaces they don't control. Once this has been released publicly, we'll put up a guide with more details on the why on https://liveblocks.io/docs/guides/limits#lson-constraint-and-interfaces, and how to work around this TypeScript limitation.
