### PR TITLE
Remove duplicate `tryParseJson` helper

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -64,7 +64,7 @@ module.exports = {
         selector:
           "CallExpression[callee.object.name='JSON'][callee.property.name='parse']",
         message:
-          "Using `JSON.parse()` is type-unsafe. Prefer using the `parseJson()` utility method (from `src/json`).",
+          "Using `JSON.parse()` is type-unsafe. Prefer using the `tryParseJson()` utility method (from `src/utils`).",
       },
       {
         selector: "FunctionDeclaration[async=true]",

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -71,6 +71,5 @@ export {
   ServerMsgCode,
   WebsocketCloseCodes,
 } from "./types";
-export { parseJson } from "./types/Json";
 export { isChildCrdt, isRootCrdt } from "./types/SerializedCrdt";
-export { b64decode,tryParseJson } from "./utils";
+export { b64decode, tryParseJson } from "./utils";

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -55,7 +55,7 @@ import {
   WebsocketCloseCodes,
 } from "./types";
 import type { DocumentVisibilityState } from "./types/_compat";
-import { isJsonArray, isJsonObject, parseJson } from "./types/Json";
+import { isJsonArray, isJsonObject, tryParseJson } from "./types/Json";
 import { isRootCrdt } from "./types/SerializedCrdt";
 import {
   b64decode,
@@ -970,7 +970,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
   }
 
   function parseServerMessages(text: string): ServerMsg<TPresence>[] | null {
-    const data: Json | undefined = parseJson(text);
+    const data: Json | undefined = tryParseJson(text);
     if (data === undefined) {
       return null;
     } else if (isJsonArray(data)) {

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -55,7 +55,7 @@ import {
   WebsocketCloseCodes,
 } from "./types";
 import type { DocumentVisibilityState } from "./types/_compat";
-import { isJsonArray, isJsonObject, tryParseJson } from "./types/Json";
+import { isJsonArray, isJsonObject } from "./types/Json";
 import { isRootCrdt } from "./types/SerializedCrdt";
 import {
   b64decode,

--- a/packages/liveblocks-client/src/types/Json.ts
+++ b/packages/liveblocks-client/src/types/Json.ts
@@ -13,19 +13,6 @@ export type JsonScalar = string | number | boolean | null;
 export type JsonArray = Json[];
 export type JsonObject = { [key: string]: Json | undefined };
 
-/**
- * Alternative to JSON.parse() that will not throw in production. If the passed
- * string cannot be parsed, this will return `undefined`.
- */
-export function tryParseJson(rawMessage: string): Json | undefined {
-  try {
-    // eslint-disable-next-line no-restricted-syntax
-    return JSON.parse(rawMessage);
-  } catch (e) {
-    return undefined;
-  }
-}
-
 export function isJsonArray(data: Json): data is JsonArray {
   return Array.isArray(data);
 }

--- a/packages/liveblocks-client/src/types/Json.ts
+++ b/packages/liveblocks-client/src/types/Json.ts
@@ -17,7 +17,7 @@ export type JsonObject = { [key: string]: Json | undefined };
  * Alternative to JSON.parse() that will not throw in production. If the passed
  * string cannot be parsed, this will return `undefined`.
  */
-export function parseJson(rawMessage: string): Json | undefined {
+export function tryParseJson(rawMessage: string): Json | undefined {
   try {
     // eslint-disable-next-line no-restricted-syntax
     return JSON.parse(rawMessage);

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -21,7 +21,7 @@ import type {
   StorageUpdate,
 } from "./types";
 import { CrdtType, OpCode } from "./types";
-import { isJsonObject, tryParseJson } from "./types/Json";
+import { isJsonObject } from "./types/Json";
 
 export function remove<T>(array: T[], item: T): void {
   for (let i = 0; i < array.length; i++) {
@@ -430,6 +430,19 @@ export function values<O extends { [key: string]: unknown }>(
   obj: O
 ): O[keyof O][] {
   return Object.values(obj) as O[keyof O][];
+}
+
+/**
+ * Alternative to JSON.parse() that will not throw in production. If the passed
+ * string cannot be parsed, this will return `undefined`.
+ */
+export function tryParseJson(rawMessage: string): Json | undefined {
+  try {
+    // eslint-disable-next-line no-restricted-syntax
+    return JSON.parse(rawMessage);
+  } catch (e) {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -21,7 +21,7 @@ import type {
   StorageUpdate,
 } from "./types";
 import { CrdtType, OpCode } from "./types";
-import { isJsonObject, parseJson } from "./types/Json";
+import { isJsonObject, tryParseJson } from "./types/Json";
 
 export function remove<T>(array: T[], item: T): void {
   for (let i = 0; i < array.length; i++) {
@@ -372,7 +372,7 @@ export function isTokenValid(token: string): boolean {
     return false;
   }
 
-  const data = parseJson(atob(tokenParts[1]));
+  const data = tryParseJson(atob(tokenParts[1]));
   if (
     data === undefined ||
     !isJsonObject(data) ||
@@ -430,19 +430,6 @@ export function values<O extends { [key: string]: unknown }>(
   obj: O
 ): O[keyof O][] {
   return Object.values(obj) as O[keyof O][];
-}
-
-/**
- * Alternative to JSON.parse() that will not throw in production. If the passed
- * string cannot be parsed, this will return `undefined`.
- */
-export function tryParseJson(rawMessage: string): Json | undefined {
-  try {
-    // eslint-disable-next-line no-restricted-syntax
-    return JSON.parse(rawMessage);
-  } catch (e) {
-    return undefined;
-  }
 }
 
 /**


### PR DESCRIPTION
Turns out we [already had this helper](https://github.com/liveblocks/liveblocks/blob/34ddbf4245a67d3fb10ed9f9b6cb8743797f5f6c/packages/liveblocks-client/src/types/Json.ts#L16-L27) in the client codebase! 🙈

This PR renames that helper to `tryParseJson` and removes the duplicate.