### PR TITLE
Remove `intent` field from root object's `Op` type

### DIFF
--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -291,10 +291,10 @@ export abstract class AbstractCrdt {
    * @internal
    */
   abstract _serialize(
-    parentId?: string,
-    parentKey?: string,
+    parentId: string,
+    parentKey: string,
     doc?: Doc
-  ): CreateOp[];
+  ): CreateChildOp[];
 
   /**
    * @internal

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -1,6 +1,7 @@
 import { assertNever } from "./assert";
 import type {
   CreateChildOp,
+  CreateOp,
   LiveNode,
   Op,
   SerializedCrdt,
@@ -289,7 +290,11 @@ export abstract class AbstractCrdt {
   /**
    * @internal
    */
-  abstract _serialize(parentId: string, parentKey: string, doc?: Doc): Op[];
+  abstract _serialize(
+    parentId?: string,
+    parentKey?: string,
+    doc?: Doc
+  ): CreateOp[];
 
   /**
    * @internal

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -1314,7 +1314,7 @@ function sortListItem(items: LiveNode[]) {
  * serializing a LiveStructure should not know anything about intent
  */
 function addIntentAndDeletedIdToOperation(
-  ops: Op[],
+  ops: CreateChildOp[],
   deletedId: string | undefined
 ) {
   if (ops.length === 0) {
@@ -1324,17 +1324,6 @@ function addIntentAndDeletedIdToOperation(
   }
 
   const firstOp = ops[0];
-  if (
-    firstOp.type !== OpCode.CREATE_LIST &&
-    firstOp.type !== OpCode.CREATE_OBJECT &&
-    firstOp.type !== OpCode.CREATE_REGISTER &&
-    firstOp.type !== OpCode.CREATE_MAP
-  ) {
-    throw new Error(
-      "Internal error. Serialized LiveStructure first op should be CreateOp"
-    );
-  }
-
   firstOp.intent = "set";
   firstOp.deletedId = deletedId;
 }

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -79,12 +79,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   /**
    * @internal
    */
-  _serialize(parentId: string, parentKey: string, doc?: Doc): Op[] {
+  _serialize(parentId: string, parentKey: string, doc?: Doc): CreateChildOp[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
     }
 
-    const ops = [];
+    const ops: CreateChildOp[] = [];
     const op: CreateListOp = {
       id: this._id,
       opId: doc?.generateOpId(),

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -63,12 +63,12 @@ export class LiveMap<
   /**
    * @internal
    */
-  _serialize(parentId: string, parentKey: string, doc?: Doc): Op[] {
+  _serialize(parentId: string, parentKey: string, doc?: Doc): CreateChildOp[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
     }
 
-    const ops = [];
+    const ops: CreateChildOp[] = [];
     const op: CreateMapOp = {
       id: this._id,
       opId: doc?.generateOpId(),

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -4,6 +4,7 @@ import { nn } from "./assert";
 import type {
   CreateChildOp,
   CreateObjectOp,
+  CreateOp,
   CreateRootObjectOp,
   DeleteObjectKeyOp,
   IdTuple,
@@ -55,14 +56,20 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   /**
    * @internal
    */
-  _serialize(parentId?: string, parentKey?: string, doc?: Doc): Op[] {
+  _serialize(parentId: string, parentKey: string, doc?: Doc): CreateChildOp[];
+  _serialize(
+    parentId?: undefined,
+    parentKey?: undefined,
+    doc?: Doc
+  ): CreateOp[];
+  _serialize(parentId?: string, parentKey?: string, doc?: Doc): CreateOp[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
     }
 
     const opId = doc?.generateOpId();
 
-    const ops = [];
+    const ops: CreateOp[] = [];
     const op: CreateObjectOp | CreateRootObjectOp =
       parentId !== undefined && parentKey !== undefined
         ? {

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -3,6 +3,7 @@ import { AbstractCrdt } from "./AbstractCrdt";
 import { nn } from "./assert";
 import type {
   CreateChildOp,
+  CreateRegisterOp,
   IdTuple,
   Json,
   LiveNode,
@@ -43,7 +44,11 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   /**
    * INTERNAL
    */
-  _serialize(parentId: string, parentKey: string, doc?: Doc): Op[] {
+  _serialize(
+    parentId: string,
+    parentKey: string,
+    doc?: Doc
+  ): CreateRegisterOp[] {
     if (this._id == null || parentId == null || parentKey == null) {
       throw new Error(
         "Cannot serialize register if parentId or parentKey is undefined"

--- a/packages/liveblocks-client/src/types/Op.ts
+++ b/packages/liveblocks-client/src/types/Op.ts
@@ -50,12 +50,14 @@ export type CreateObjectOp = {
   data: JsonObject;
 };
 
-export type CreateRootObjectOp = Resolve<
-  Omit<CreateObjectOp, "parentId" | "parentKey"> & {
-    parentId?: never;
-    parentKey?: never;
-  }
->;
+export type CreateRootObjectOp = {
+  opId?: string;
+  id: string;
+  type: OpCode.CREATE_OBJECT;
+  data: JsonObject;
+  parentId?: never;
+  parentKey?: never;
+};
 
 export type CreateListOp = {
   opId?: string;


### PR DESCRIPTION
This PR fixes the PR feedback from https://github.com/liveblocks/liveblocks-cloudflare/pull/80#discussion_r884374547. `intent` (and `deletedId`) are always set together and are only set on "child" ops, never for the root object.

While changing this, I found more type issues that could be solved by being more precise in the `_serialize()` type signature, which was a nice side benefit.
