### PR TITLE
Remove more `any`s

### DIFF
--- a/packages/liveblocks-client/src/client.node.test.ts
+++ b/packages/liveblocks-client/src/client.node.test.ts
@@ -9,8 +9,6 @@ import { MockWebSocket } from "../test/utils";
 import { createClient } from ".";
 import type { ClientOptions } from "./types";
 
-(global as any).atob = (data: string) => Buffer.from(data, "base64");
-
 const token =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb29tSWQiOiJrNXdtaDBGOVVMbHJ6TWdadFMyWl8iLCJhcHBJZCI6IjYwNWE0ZmQzMWEzNmQ1ZWE3YTJlMDkxNCIsImFjdG9yIjowLCJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2N30.AinBUN1gzA1-QdwrQ3cT1X4tNM_7XYCkKgHH94M5wszX-1AEDIgsBdM_7qN9cv0Y7SDFTUVGYLinHgpBonE8tYiNTe4uSpVUmmoEWuYLgsdUccHj5IJYlxPDGb1mgesSNKdeyfkFnu8nFjramLQXBa5aBb5Xq721m4Lgy2dtL_nFicavhpyCsdTVLSjloCDlQpQ99UPY--3ODNbbznHGYu8IyI1DnqQgDPlbAbFPRF6CBZiaUZjSFTRGnVVPE0VN3NunKHimMagBfHrl4AMmxG4kFN8ImK1_7oXC_br1cqoyyBTs5_5_XeA9MTLwbNDX8YBPtjKP1z2qTDpEc22Oxw";
 
@@ -94,7 +92,7 @@ describe("createClient", () => {
   test("should throw if throttle is not a number", () => {
     expect(() =>
       createClientAndEnter({
-        throttle: "invalid" as any,
+        throttle: "invalid" as unknown as number, // Deliberately use wrong type at runtime
         authEndpoint: "api/auth",
         WebSocketPolyfill: MockWebSocket,
         fetchPolyfill: fetchMock,

--- a/packages/liveblocks-client/src/client.node.test.ts
+++ b/packages/liveblocks-client/src/client.node.test.ts
@@ -12,9 +12,8 @@ import type { ClientOptions } from "./types";
 const token =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb29tSWQiOiJrNXdtaDBGOVVMbHJ6TWdadFMyWl8iLCJhcHBJZCI6IjYwNWE0ZmQzMWEzNmQ1ZWE3YTJlMDkxNCIsImFjdG9yIjowLCJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2N30.AinBUN1gzA1-QdwrQ3cT1X4tNM_7XYCkKgHH94M5wszX-1AEDIgsBdM_7qN9cv0Y7SDFTUVGYLinHgpBonE8tYiNTe4uSpVUmmoEWuYLgsdUccHj5IJYlxPDGb1mgesSNKdeyfkFnu8nFjramLQXBa5aBb5Xq721m4Lgy2dtL_nFicavhpyCsdTVLSjloCDlQpQ99UPY--3ODNbbznHGYu8IyI1DnqQgDPlbAbFPRF6CBZiaUZjSFTRGnVVPE0VN3NunKHimMagBfHrl4AMmxG4kFN8ImK1_7oXC_br1cqoyyBTs5_5_XeA9MTLwbNDX8YBPtjKP1z2qTDpEc22Oxw";
 
-async function fetchMock() {
-  return new Response(JSON.stringify({ token }));
-}
+const fetchMock = (async () =>
+  new Response(JSON.stringify({ token }))) as unknown as typeof fetch;
 
 async function authEndpointCallback() {
   return {

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -262,7 +262,7 @@ export type AuthEndpoint = string | AuthEndpointCallback;
  */
 export type ClientOptions = {
   throttle?: number;
-  fetchPolyfill?: any;
+  fetchPolyfill?: typeof fetch;
   WebSocketPolyfill?: any;
 } & (
   | { publicApiKey: string; authEndpoint?: never }

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -26,7 +26,7 @@ import type { Lson, LsonObject } from "./Lson";
  * This trick comes from:
  * https://effectivetypescript.com/2022/02/25/gentips-4-display/
  */
-export type Resolve<T> = T extends (...args: any[]) => any
+export type Resolve<T> = T extends (...args: unknown[]) => unknown
   ? T
   : { [K in keyof T]: T[K] };
 

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -450,7 +450,7 @@ export type Room = {
      * Subscribes to changes made on a {@link LiveObject}. Returns an unsubscribe function.
      * In a future version, we will also expose what exactly changed in the {@link LiveObject}.
      *
-     * @param listener the callback this called when the {@link LiveObject} changes.
+     * @param callback the callback this called when the {@link LiveObject} changes.
      *
      * @returns Unsubscribe function.
      *
@@ -467,7 +467,7 @@ export type Room = {
      * Subscribes to changes made on a {@link LiveList}. Returns an unsubscribe function.
      * In a future version, we will also expose what exactly changed in the {@link LiveList}.
      *
-     * @param listener the callback this called when the {@link LiveList} changes.
+     * @param callback the callback this called when the {@link LiveList} changes.
      *
      * @returns Unsubscribe function.
      *
@@ -485,7 +485,7 @@ export type Room = {
      * Subscribes to changes made on a {@link LiveMap} and all the nested data structures. Returns an unsubscribe function.
      * In a future version, we will also expose what exactly changed in the {@link LiveMap}.
      *
-     * @param listener the callback this called when the {@link LiveMap} changes.
+     * @param callback the callback this called when the {@link LiveMap} changes.
      *
      * @returns Unsubscribe function.
      *
@@ -504,7 +504,7 @@ export type Room = {
      * Subscribes to changes made on a {@link LiveObject} and all the nested data structures. Returns an unsubscribe function.
      * In a future version, we will also expose what exactly changed in the {@link LiveObject}.
      *
-     * @param listener the callback this called when the {@link LiveObject} changes.
+     * @param callback the callback this called when the {@link LiveObject} changes.
      *
      * @returns Unsubscribe function.
      *
@@ -523,7 +523,7 @@ export type Room = {
      * Subscribes to changes made on a {@link LiveList} and all the nested data structures. Returns an unsubscribe function.
      * In a future version, we will also expose what exactly changed in the {@link LiveList}.
      *
-     * @param listener the callback this called when the {@link LiveList} changes.
+     * @param callback the callback this called when the {@link LiveList} changes.
      *
      * @returns Unsubscribe function.
      *

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -97,7 +97,7 @@ export type LiveObjectUpdates<TData extends LsonObject> = {
 export type LiveListUpdateDelta =
   | {
       index: number;
-      item: any; // Serializable Or LiveStructure
+      item: Lson;
       type: "insert";
     }
   | {
@@ -107,12 +107,12 @@ export type LiveListUpdateDelta =
   | {
       index: number;
       previousIndex: number;
-      item: any; // Serializable Or LiveStructure
+      item: Lson;
       type: "move";
     }
   | {
       index: number;
-      item: any; // Serializable Or LiveStructure
+      item: Lson;
       type: "set";
     };
 


### PR DESCRIPTION
Working towards the goal of removing all `any`s before the 0.17 release, this does a few more. I'm working on more, but still running into some issues (for example, #286, and some typing around WebSockets). These are the ones that should already be good to go.