### PR TITLE
Type `patchLiveObjectKey` more correctly

### DIFF
--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -71,22 +71,29 @@ function isPlainObject(obj: unknown): obj is { [key: string]: unknown } {
   );
 }
 
-function anyToCrdt(obj: unknown): any {
-  //                              ^^^ AbstractCrdt?
-  if (obj == null) {
-    return obj;
-  }
-  if (Array.isArray(obj)) {
-    return new LiveList(obj.map(anyToCrdt));
-  }
-  if (isPlainObject(obj)) {
+/**
+ * Deeply converts all nested lists to LiveLists, and all nested objects to
+ * LiveObjects.
+ *
+ * As such, the returned result will not contain any Json arrays or Json
+ * objects anymore.
+ */
+function deepLiveify(value: Lson | LsonObject): Lson {
+  if (Array.isArray(value)) {
+    return new LiveList(value.map(deepLiveify));
+  } else if (isPlainObject(value)) {
     const init: LsonObject = {};
-    for (const key in obj) {
-      init[key] = anyToCrdt(obj[key]);
+    for (const key in value) {
+      const val = value[key];
+      if (val === undefined) {
+        continue;
+      }
+      init[key] = deepLiveify(val);
     }
     return new LiveObject(init);
+  } else {
+    return value;
   }
-  return obj;
 }
 
 export function patchLiveList<T extends Lson>(
@@ -141,7 +148,8 @@ export function patchLiveList<T extends Lson>(
   if (i > prevEnd) {
     if (i <= nextEnd) {
       while (i <= nextEnd) {
-        liveList.insert(anyToCrdt(next[i]), i);
+        liveList.insert(deepLiveify(next[i]) as T, i);
+        //                                   ^^^^ FIXME Not entirely true
         i++;
       }
     }
@@ -164,13 +172,15 @@ export function patchLiveList<T extends Lson>(
       ) {
         patchLiveObject(liveListNode, prevNode, nextNode);
       } else {
-        liveList.set(i, anyToCrdt(nextNode));
+        liveList.set(i, deepLiveify(nextNode) as T);
+        //                                    ^^^^ FIXME Not entirely true
       }
 
       i++;
     }
     while (i <= nextEnd) {
-      liveList.insert(anyToCrdt(next[i]), i);
+      liveList.insert(deepLiveify(next[i]) as T, i);
+      //                                   ^^^^ FIXME Not entirely true
       i++;
     }
     let localI = i;
@@ -181,11 +191,11 @@ export function patchLiveList<T extends Lson>(
   }
 }
 
-export function patchLiveObjectKey<O extends LsonObject>(
+export function patchLiveObjectKey<O extends LsonObject, K extends keyof O>(
   liveObject: LiveObject<O>,
-  key: keyof O,
-  prev: unknown,
-  next: unknown
+  key: K,
+  prev?: Lson,
+  next?: Lson
 ): void {
   if (process.env.NODE_ENV !== "production") {
     const nonSerializableValue = findNonSerializableValue(next);
@@ -202,7 +212,8 @@ export function patchLiveObjectKey<O extends LsonObject>(
   if (next === undefined) {
     liveObject.delete(key);
   } else if (value === undefined) {
-    liveObject.set(key, anyToCrdt(next));
+    liveObject.set(key, deepLiveify(next) as O[K]);
+    //                                    ^^^^^^^ FIXME Not entirely true
   } else if (prev === next) {
     return;
   } else if (isLiveList(value) && Array.isArray(prev) && Array.isArray(next)) {
@@ -216,7 +227,8 @@ export function patchLiveObjectKey<O extends LsonObject>(
     //                          ^^^^^^^^^^^^^       ^^^^^^^^^^^^^
     //                          FIXME! Unsafe cast! Verify instead of cast.
   } else {
-    liveObject.set(key, anyToCrdt(next));
+    liveObject.set(key, deepLiveify(next) as O[K]);
+    //                                    ^^^^^^^ FIXME Not entirely true
   }
 }
 

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -191,12 +191,11 @@ export function patchLiveList<T extends Lson>(
   }
 }
 
-export function patchLiveObjectKey<O extends LsonObject, K extends keyof O>(
-  liveObject: LiveObject<O>,
-  key: K,
-  prev?: Lson,
-  next?: Lson
-): void {
+export function patchLiveObjectKey<
+  O extends LsonObject,
+  K extends keyof O,
+  V extends Lson
+>(liveObject: LiveObject<O>, key: K, prev?: V, next?: V): void {
   if (process.env.NODE_ENV !== "production") {
     const nonSerializableValue = findNonSerializableValue(next);
     if (nonSerializableValue) {

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -21,9 +21,9 @@ import {
   missingClient,
 } from "./errors";
 
-export type Mapping<T> = Partial<{
-  [Property in keyof T]: boolean;
-}>;
+export type Mapping<T> = {
+  [K in keyof T]?: boolean;
+};
 
 const ACTION_TYPES = {
   ENTER: "@@LIVEBLOCKS/ENTER",
@@ -346,11 +346,11 @@ export const enhancer = internalEnhancer as <T>(options: {
   presenceMapping?: Mapping<T>;
 }) => StoreEnhancer;
 
-function patchLiveblocksStorage<O extends LsonObject, T>(
+function patchLiveblocksStorage<O extends LsonObject>(
   root: LiveObject<O>,
-  oldState: T,
-  newState: T,
-  mapping: Mapping<T>
+  oldState: O,
+  newState: O,
+  mapping: Mapping<O>
 ) {
   for (const key in mapping) {
     if (

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -17,7 +17,7 @@ import type { StateCreator } from "zustand";
 import create from "zustand";
 
 import { list, MockWebSocket, obj, waitFor } from "../test/utils";
-import type { Mapping } from ".";
+import type { Mapping, ZustandState } from ".";
 import { middleware } from ".";
 import {
   mappingShouldBeAnObject,
@@ -63,7 +63,7 @@ async function waitForSocketToBeConnected() {
   return socket;
 }
 
-type BasicStore = {
+interface BasicStore extends ZustandState {
   value: number;
   setValue: (newValue: number) => void;
 
@@ -78,7 +78,7 @@ type BasicStore = {
 
   cursor: { x: number; y: number };
   setCursor: (cursor: { x: number; y: number }) => void;
-};
+}
 
 const basicStateCreator: StateCreator<BasicStore> = (set) => ({
   value: 0,
@@ -98,7 +98,7 @@ const basicStateCreator: StateCreator<BasicStore> = (set) => ({
 });
 
 function prepareClientAndStore<
-  T extends Record<string, unknown>,
+  T extends ZustandState,
   TPresence extends Presence = Presence
 >(
   stateCreator: StateCreator<T>,
@@ -121,7 +121,7 @@ function prepareClientAndBasicStore() {
   });
 }
 
-async function prepareWithStorage<T extends Record<string, unknown>>(
+async function prepareWithStorage<T extends ZustandState>(
   stateCreator: StateCreator<T>,
   options: {
     storageMapping: Mapping<T>;

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -70,9 +70,9 @@ export type LiveblocksState<
   };
 };
 
-export type Mapping<T> = Partial<{
-  [Property in keyof T]: boolean;
-}>;
+export type Mapping<T> = {
+  [K in keyof T]?: boolean;
+};
 
 type Options<T> = {
   /**

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   Client,
+  Json,
   LiveObject,
   LsonObject,
   Presence,
@@ -21,6 +22,17 @@ import {
   missingClient,
   missingMapping,
 } from "./errors";
+
+function isJson(value: unknown): value is Json {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    (Array.isArray(value) && value.every(isJson)) ||
+    (typeof value === "object" && Object.values(value).every(isJson))
+  );
+}
 
 export type ZustandState =
   // TODO: Properly type out the constraints for this type here!
@@ -356,7 +368,19 @@ function patchLiveblocksStorage<
     }
 
     if (oldState[key] !== newState[key]) {
-      patchLiveObjectKey(root, key, oldState[key], newState[key]);
+      const oldVal: unknown = oldState[key];
+      const newVal: unknown = newState[key];
+
+      // Ensure to only patch values that are actually legal Json values. The
+      // old and new states could well contain functions (the Zustand setters),
+      // and we definitely want to rule those out, even if they make it into
+      // the mapping.
+      if (
+        (oldVal === undefined || isJson(oldVal)) &&
+        (newVal === undefined || isJson(newVal))
+      ) {
+        patchLiveObjectKey(root, key, oldVal, newVal);
+      }
     }
   }
 }

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -22,8 +22,12 @@ import {
   missingMapping,
 } from "./errors";
 
+export type ZustandState =
+  // TODO: Properly type out the constraints for this type here!
+  Record<string, unknown>;
+
 export type LiveblocksState<
-  TState,
+  TState extends ZustandState,
   TPresence extends Presence = Presence
 > = TState & {
   /**
@@ -86,7 +90,7 @@ type Options<T> = {
 };
 
 export function middleware<
-  T extends Record<string, unknown>,
+  T extends ZustandState,
   TPresence extends Record<string, unknown> = Presence
 >(
   config: StateCreator<
@@ -295,7 +299,7 @@ function patchPresenceState<T>(presence: any, mapping: Mapping<T>) {
   return partialState;
 }
 
-function updateZustandLiveblocksState<T>(
+function updateZustandLiveblocksState<T extends ZustandState>(
   set: (
     callbackOrPartial: (
       current: LiveblocksState<T>
@@ -335,7 +339,7 @@ function updatePresence<T>(
 
 function patchLiveblocksStorage<
   O extends LsonObject,
-  TState extends Record<string, unknown>,
+  TState extends ZustandState,
   TPresence extends Presence
 >(
   root: LiveObject<O>,


### PR DESCRIPTION
This had a few consequences where TypeScript now correctly pointed out some edge cases in the Redux and Zustand packages.