### PR TITLE
Deprecate concrete `Presence` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Various Live structures now take mandatory type params:
 - `LiveMap<K, V>` (just like `Map<K, V>`)
 - `LiveObject<{ a: number, b: string }>` (just like, for example, `{ a: number, b: string }`)
 - `LiveList<T>` (just like `Array<T>`)
+- All APIs that work with Presence data will now require it to be JSON-serializable
+- The built-in `Presence` type is now deprecated and will get removed in 0.18.
+  The idea is that you bring whatever type definition for Presence that makes
+  sense to your own app instead.
 
 ### Breaking changes
 
@@ -21,8 +25,6 @@ Various Live structures now take mandatory type params:
   - The `defaultPresence` option to `client.enter()` will get renamed to `initialPresence`
   - The `defaultStorageRoot` option to `client.enter()` will get renamed to `initialStorage`
   - Calling `new LiveMap(null)` will stop working. Please use `new LiveMap()`, or `new LiveMap([])`
-  - The `Presence` type will get removed, the idea is that you bring the type definition for
-    Presence that makes sense to your own app
 
 - In **@liveblocks/react**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Various Live structures now take mandatory type params:
   - The `defaultPresence` option to `client.enter()` will get renamed to `initialPresence`
   - The `defaultStorageRoot` option to `client.enter()` will get renamed to `initialStorage`
   - Calling `new LiveMap(null)` will stop working. Please use `new LiveMap()`, or `new LiveMap([])`
+  - The `Presence` type will get removed, the idea is that you bring the type definition for
+    Presence that makes sense to your own app
 
 - In **@liveblocks/react**:
 

--- a/examples/nextjs-live-cursors-chat/pages/index.tsx
+++ b/examples/nextjs-live-cursors-chat/pages/index.tsx
@@ -131,7 +131,8 @@ function Example() {
     };
   }, [updateMyPresence]);
 
-  useEventListener(({ event }: { event: ReactionEvent }) => {
+  useEventListener((eventData) => {
+    const event = eventData.event as ReactionEvent;
     setReactions((reactions) =>
       reactions.concat([
         {

--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -85,6 +85,16 @@ module.exports = {
         selector: 'TSTypeReference[typeName.name="AbstractCrdt"]',
         message: "Don't refer to AbstractCrdt as a type. Use LiveNode instead.",
       },
+
+      // Ensure we always specify all the type params in this code base. Even
+      // though many of these are (temporarily) optional, they are only
+      // optional for our end users, not internally.
+      {
+        selector:
+          "TSTypeReference[typeName.name=/^(Room|Machine|State|Effects|InternalRoom|User|OthersEvent|MyPresenceCallback|OthersEventCallback)$/][typeParameters.params.length != 1]",
+        message: "Missing type params.",
+      },
+
       // {
       //   selector: "ForOfStatement",
       //   message:

--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -91,7 +91,7 @@ module.exports = {
       // optional for our end users, not internally.
       {
         selector:
-          "TSTypeReference[typeName.name=/^(Room|Machine|State|Effects|InternalRoom|User|OthersEvent|MyPresenceCallback|OthersEventCallback)$/][typeParameters.params.length != 1]",
+          "TSTypeReference[typeName.name=/^(Room|Machine|State|Effects|InternalRoom|User|OthersEvent|MyPresenceCallback|RoomEventCallbackMap|OthersEventCallback)$/][typeParameters.params.length != 1]",
         message: "Missing type params.",
       },
 

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -5,7 +5,7 @@ import type {
   Authentication,
   Client,
   ClientOptions,
-  Presence,
+  JsonObject,
   Resolve,
   Room,
   RoomInitializers,
@@ -61,7 +61,10 @@ export function createClient(options: ClientOptions): Client {
 
   function enter<TStorage>(
     roomId: string,
-    options: EnterOptions<Presence, TStorage> = {}
+    options: EnterOptions<JsonObject, TStorage> = {}
+    //                    ^^^^^^^^^^
+    //                    TODO: Generalize this to TPresence, but it will
+    //                    require a breaking API change for enter's type params
   ): Room {
     let internalRoom = rooms.get(roomId);
     if (internalRoom) {

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -11,7 +11,7 @@ import type {
   RoomInitializers,
 } from "./types";
 
-type EnterOptions<TPresence, TStorage> = Resolve<
+type EnterOptions<TPresence extends JsonObject, TStorage> = Resolve<
   // Enter options are just room initializers, plus an internal option
   RoomInitializers<TPresence, TStorage> & {
     /**

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -6,6 +6,7 @@ import type {
   Client,
   ClientOptions,
   JsonObject,
+  LsonObject,
   Resolve,
   Room,
   RoomInitializers,
@@ -63,8 +64,7 @@ export function createClient(options: ClientOptions): Client {
       : null;
   }
 
-  // TODO: In the interest of consistency, swap the param order in 0.18
-  function enter<TStorage, TPresence extends JsonObject = JsonObject>(
+  function enter<TPresence extends JsonObject, TStorage extends LsonObject>(
     roomId: string,
     options: EnterOptions<TPresence, TStorage> = {}
   ): Room<TPresence> {

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -12,7 +12,7 @@ export type {
   Lson,
   LsonObject,
   Others,
-  Presence,
+  Presence, // Deprecated! Will get removed in 0.18
   Room,
   StorageUpdate,
   User,

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -1022,13 +1022,11 @@ describe("room", () => {
     });
 
     test("disconnect and reconnect should keep user current presence", async () => {
-      const { machine, refMachine, reconnect, ws } = await prepareStorageTest(
-        [createSerializedObject("0:0", {})],
-        1
-      );
+      const { machine, refMachine, reconnect, ws } = await prepareStorageTest<
+        never,
+        { x: number }
+      >([createSerializedObject("0:0", {})], 1);
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - if you want to test presence, then prepareStorageTest isn't the right factory!
       machine.updatePresence({ x: 1 });
 
       ws.closeFromBackend(

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -18,7 +18,6 @@ import {
 import type { RoomAuthToken } from "./AuthToken";
 import { lsonToJson } from "./immutable";
 import { LiveList } from "./LiveList";
-import type { State } from "./room";
 import { createRoom, defaultState, makeStateMachine } from "./room";
 import type { Authentication, IdTuple, Others, SerializedCrdt } from "./types";
 import {
@@ -49,8 +48,8 @@ const defaultRoomToken: RoomAuthToken = {
 function setupStateMachine<TPresence extends JsonObject>(
   initialPresence?: TPresence
 ) {
-  const effects = mockEffects();
-  const state = defaultState(initialPresence) as State<TPresence>;
+  const effects = mockEffects<TPresence>();
+  const state = defaultState<TPresence>(initialPresence);
   const machine = makeStateMachine<TPresence>(state, defaultContext, effects);
   return { machine, state, effects };
 }

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -773,7 +773,7 @@ describe("room", () => {
         subscribe,
         refSubscribe,
         updatePresence,
-      } = await prepareStorageTest<{ items: LiveList<string> }>(
+      } = await prepareStorageTest<{ items: LiveList<string> }, { x: number }>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -794,11 +794,7 @@ describe("room", () => {
       refSubscribe("others", refPresenceSubscriber);
 
       batch(() => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - if you want to test presence, then prepareStorageTest isn't the right factory!
         updatePresence({ x: 0 });
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore - if you want to test presence, then prepareStorageTest isn't the right factory!
         updatePresence({ x: 1 });
         items.push("A");
         items.push("B");

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -794,7 +794,11 @@ describe("room", () => {
       refSubscribe("others", refPresenceSubscriber);
 
       batch(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - if you want to test presence, then prepareStorageTest isn't the right factory!
         updatePresence({ x: 0 });
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - if you want to test presence, then prepareStorageTest isn't the right factory!
         updatePresence({ x: 1 });
         items.push("A");
         items.push("B");
@@ -1028,6 +1032,8 @@ describe("room", () => {
         1
       );
 
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - if you want to test presence, then prepareStorageTest isn't the right factory!
       machine.updatePresence({ x: 1 });
 
       ws.closeFromBackend(

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -87,12 +87,7 @@ export type Machine<TPresence extends JsonObject> = {
 
   // onWakeUp,
   onVisibilityChange(visibilityState: DocumentVisibilityState): void;
-  getUndoStack(): HistoryItem<JsonObject>[];
-  //                          ^^^^^^^^^^
-  //                          TODO: Generalize this to TPresence, but this will
-  //                          require a breaking change of the Machine type (=
-  //                          public API), which will need to take a TPresence
-  //                          type arg
+  getUndoStack(): HistoryItem<TPresence>[];
   getItemsCount(): number;
 
   // Core

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -149,11 +149,17 @@ export type Machine<TPresence extends JsonObject> = {
   selectors: {
     // Core
     getConnectionState(): ConnectionState;
-    getSelf<_ extends JsonObject = JsonObject>(): User<TPresence> | null;
+    getSelf<
+      _ = unknown // TODO Remove this unused type param
+    >(): User<TPresence> | null;
 
     // Presence
-    getPresence<_ extends JsonObject>(): TPresence;
-    getOthers<_ extends JsonObject>(): Others<TPresence>;
+    getPresence<
+      _ = unknown // TODO Remove this unused type param
+    >(): TPresence;
+    getOthers<
+      _ = unknown // TODO Remove this unused type param
+    >(): Others<TPresence>;
   };
 };
 
@@ -762,8 +768,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
   }
 
   function getSelf<
-    _ extends JsonObject = JsonObject
-    //^ TODO Remove this unused type param
+    _ = unknown // TODO Remove this unused type param
   >(): User<TPresence> | null {
     return state.connection.state === "open" ||
       state.connection.state === "connecting"
@@ -797,11 +802,9 @@ export function makeStateMachine<TPresence extends JsonObject>(
     effects.authenticate(auth, createWebSocket);
   }
 
-  function updatePresence<_ extends JsonObject>(
-    //                    ^ TODO: Remove this type argument (breaking change)
-    overrides: Partial<TPresence>,
-    options?: { addToHistory: boolean }
-  ) {
+  function updatePresence<
+    _ = unknown // TODO: Remove this type argument
+  >(overrides: Partial<TPresence>, options?: { addToHistory: boolean }) {
     const oldValues = {} as TPresence;
 
     if (state.buffer.presence == null) {
@@ -1317,13 +1320,21 @@ export function makeStateMachine<TPresence extends JsonObject>(
     }
   }
 
-  function getPresence<_ extends JsonObject>(): TPresence {
-    //                 ^ TODO: Remove type param (breaking change)
+  function getPresence<
+    /**
+     * @deprecated Avoid using this type param, annotate it on the room instead.
+     */
+    _ = unknown // TODO: Remove type param (breaking change)
+  >(): TPresence {
     return state.me as TPresence;
   }
 
-  function getOthers<_ extends JsonObject>(): Others<TPresence> {
-    //               ^ TODO: Remove type param (breaking change)
+  function getOthers<
+    /**
+     * @deprecated Avoid using this type param, annotate it on the room instead.
+     */
+    _ = unknown // TODO: Remove type param (breaking change)
+  >(): Others<TPresence> {
     return state.others as Others<TPresence>;
   }
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -149,17 +149,11 @@ export type Machine<TPresence extends JsonObject> = {
   selectors: {
     // Core
     getConnectionState(): ConnectionState;
-    getSelf<
-      _ = unknown // TODO Remove this unused type param
-    >(): User<TPresence> | null;
+    getSelf(): User<TPresence> | null;
 
     // Presence
-    getPresence<
-      _ = unknown // TODO Remove this unused type param
-    >(): TPresence;
-    getOthers<
-      _ = unknown // TODO Remove this unused type param
-    >(): Others<TPresence>;
+    getPresence(): TPresence;
+    getOthers(): Others<TPresence>;
   };
 };
 
@@ -767,9 +761,7 @@ export function makeStateMachine<TPresence extends JsonObject>(
     return state.connection.state;
   }
 
-  function getSelf<
-    _ = unknown // TODO Remove this unused type param
-  >(): User<TPresence> | null {
+  function getSelf(): User<TPresence> | null {
     return state.connection.state === "open" ||
       state.connection.state === "connecting"
       ? {
@@ -802,9 +794,10 @@ export function makeStateMachine<TPresence extends JsonObject>(
     effects.authenticate(auth, createWebSocket);
   }
 
-  function updatePresence<
-    _ = unknown // TODO: Remove this type argument
-  >(overrides: Partial<TPresence>, options?: { addToHistory: boolean }) {
+  function updatePresence(
+    overrides: Partial<TPresence>,
+    options?: { addToHistory: boolean }
+  ) {
     const oldValues = {} as TPresence;
 
     if (state.buffer.presence == null) {
@@ -1320,21 +1313,11 @@ export function makeStateMachine<TPresence extends JsonObject>(
     }
   }
 
-  function getPresence<
-    /**
-     * @deprecated Avoid using this type param, annotate it on the room instead.
-     */
-    _ = unknown // TODO: Remove type param (breaking change)
-  >(): TPresence {
+  function getPresence(): TPresence {
     return state.me as TPresence;
   }
 
-  function getOthers<
-    /**
-     * @deprecated Avoid using this type param, annotate it on the room instead.
-     */
-    _ = unknown // TODO: Remove type param (breaking change)
-  >(): Others<TPresence> {
+  function getOthers(): Others<TPresence> {
     return state.others as Others<TPresence>;
   }
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -69,7 +69,9 @@ import {
   tryParseJson,
 } from "./utils";
 
-export type Machine<TPresence extends JsonObject> = {
+export type Machine<
+  TPresence extends JsonObject = JsonObject // XXX Default arg needed here? Isn't this a private API?
+> = {
   // Internal
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
   onMessage(event: MessageEvent<string>): void;
@@ -298,7 +300,9 @@ type Context = {
   liveblocksServer: string;
 };
 
-export function makeStateMachine<TPresence extends JsonObject>(
+export function makeStateMachine<
+  TPresence extends JsonObject = JsonObject // XXX Default arg needed here? Isn't this a private API?
+>(
   state: State<TPresence>,
   context: Context,
   mockedEffects?: Effects<TPresence>

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1597,7 +1597,9 @@ export function defaultState<TPresence extends JsonObject>(
   };
 }
 
-export type InternalRoom<TPresence extends JsonObject = JsonObject> = {
+export type InternalRoom<
+  TPresence extends JsonObject = JsonObject // XXX Default arg needed here? Isn't this a private API?
+> = {
   room: Room<TPresence>;
   connect: () => void;
   disconnect: () => void;
@@ -1606,7 +1608,7 @@ export type InternalRoom<TPresence extends JsonObject = JsonObject> = {
 };
 
 export function createRoom<
-  TPresence extends JsonObject = JsonObject,
+  TPresence extends JsonObject = JsonObject, // XXX Default arg needed here? Isn't this a private API?
   TStorage extends Record<string, any> = Record<string, any>
   //               ^^^^^^^^^^^^^^^^^^^
   //               FIXME: Generalize this to LsonObject

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -69,9 +69,7 @@ import {
   tryParseJson,
 } from "./utils";
 
-export type Machine<
-  TPresence extends JsonObject = JsonObject // XXX Default arg needed here? Isn't this a private API?
-> = {
+export type Machine<TPresence extends JsonObject> = {
   // Internal
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
   onMessage(event: MessageEvent<string>): void;
@@ -300,9 +298,7 @@ type Context = {
   liveblocksServer: string;
 };
 
-export function makeStateMachine<
-  TPresence extends JsonObject = JsonObject // XXX Default arg needed here? Isn't this a private API?
->(
+export function makeStateMachine<TPresence extends JsonObject>(
   state: State<TPresence>,
   context: Context,
   mockedEffects?: Effects<TPresence>
@@ -1605,9 +1601,7 @@ export function defaultState<TPresence extends JsonObject>(
   };
 }
 
-export type InternalRoom<
-  TPresence extends JsonObject = JsonObject // XXX Default arg needed here? Isn't this a private API?
-> = {
+export type InternalRoom<TPresence extends JsonObject> = {
   room: Room<TPresence>;
   connect: () => void;
   disconnect: () => void;
@@ -1616,8 +1610,8 @@ export type InternalRoom<
 };
 
 export function createRoom<
-  TPresence extends JsonObject = JsonObject, // XXX Default arg needed here? Isn't this a private API?
-  TStorage extends Record<string, any> = Record<string, any>
+  TPresence extends JsonObject,
+  TStorage extends Record<string, any>
   //               ^^^^^^^^^^^^^^^^^^^
   //               FIXME: Generalize this to LsonObject
 >(

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1610,6 +1610,8 @@ export type InternalRoom<TPresence extends JsonObject = JsonObject> = {
 export function createRoom<
   TPresence extends JsonObject = JsonObject,
   TStorage extends Record<string, any> = Record<string, any>
+  //               ^^^^^^^^^^^^^^^^^^^
+  //               FIXME: Generalize this to LsonObject
 >(
   options: RoomInitializers<TPresence, TStorage>,
   context: Context

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -51,15 +51,15 @@ export type ErrorCallback = (error: Error) => void;
 
 export type ConnectionCallback = (state: ConnectionState) => void;
 
-export type RoomEventCallbackMap = {
-  "my-presence": MyPresenceCallback;
-  others: OthersEventCallback;
+export type RoomEventCallbackMap<TPresence extends JsonObject = JsonObject> = {
+  "my-presence": MyPresenceCallback<TPresence>;
+  others: OthersEventCallback<TPresence>;
   event: EventCallback;
   error: ErrorCallback;
   connection: ConnectionCallback;
 };
 
-export type RoomEventName = keyof RoomEventCallbackMap;
+export type RoomEventName = keyof RoomEventCallbackMap<never>;
 
 export type UpdateDelta =
   | {
@@ -182,21 +182,23 @@ export type Client = {
    *
    * @param roomId The id of the room
    */
-  getRoom(roomId: string): Room | null;
+  getRoom<TPresence extends JsonObject = JsonObject>(
+    roomId: string
+  ): Room<TPresence> | null;
 
   /**
    * Enters a room and returns it.
    * @param roomId The id of the room
    * @param options Optional. You can provide initializers for the Presence or Storage when entering the Room.
    */
-  enter<TStorage extends Record<string, any> = Record<string, any>>(
+  enter<
+    // TODO: In the interest of consistency, swap these type params in 0.18
+    TStorage extends Record<string, any> = Record<string, any>,
+    TPresence extends JsonObject = JsonObject
+  >(
     roomId: string,
-    options?: RoomInitializers<JsonObject, TStorage>
-    //                         ^^^^^^^^^^
-    //                         TODO: Generalize this to TPresence, but it
-    //                         requires a breaking type-level change on enter's
-    //                         type params
-  ): Room;
+    options?: RoomInitializers<TPresence, TStorage>
+  ): Room<TPresence>;
 
   /**
    * Leaves a room.

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -152,6 +152,8 @@ export type StorageCallback = (updates: StorageUpdate[]) => void;
 export type RoomInitializers<
   TPresence extends JsonObject,
   TStorage extends Record<string, any>
+  //               ^^^^^^^^^^^^^^^^^^^
+  //               FIXME: Generalize this to LsonObject
 > = Resolve<{
   /**
    * The initial Presence to use and announce when you enter the Room. The

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -412,7 +412,13 @@ export type Room<TPresence extends JsonObject = JsonObject> = {
      *   // Do something
      * });
      */
-    <_ extends JsonObject>(
+    <
+      /**
+       * @deprecated This type argument is ignored. If you want to annotate this
+       * type manually, please annotate the Room instance instead.
+       */
+      _ = unknown
+    >(
       type: "my-presence",
       listener: MyPresenceCallback<TPresence>
     ): () => void;
@@ -426,7 +432,13 @@ export type Room<TPresence extends JsonObject = JsonObject> = {
      *   // Do something
      * });
      */
-    <_ extends JsonObject>(
+    <
+      /**
+       * @deprecated This type argument is ignored. If you want to annotate this
+       * type manually, please annotate the Room instance instead.
+       */
+      _ = unknown
+    >(
       type: "others",
       listener: OthersEventCallback<TPresence>
     ): () => void;
@@ -571,7 +583,13 @@ export type Room<TPresence extends JsonObject = JsonObject> = {
    * @example
    * const user = room.getSelf();
    */
-  getSelf<_ extends JsonObject = JsonObject>(): User<TPresence> | null;
+  getSelf<
+    /**
+     * @deprecated This type argument is ignored. If you want to annotate this
+     * type manually, please annotate the Room instance instead.
+     */
+    _ = unknown
+  >(): User<TPresence> | null;
 
   /**
    * Gets the presence of the current user.
@@ -579,7 +597,13 @@ export type Room<TPresence extends JsonObject = JsonObject> = {
    * @example
    * const presence = room.getPresence();
    */
-  getPresence: <_ extends JsonObject>() => TPresence;
+  getPresence: <
+    /**
+     * @deprecated This type argument is ignored. If you want to annotate this
+     * type manually, please annotate the Room instance instead.
+     */
+    _ = unknown
+  >() => TPresence;
 
   /**
    * Gets all the other users in the room.
@@ -587,7 +611,13 @@ export type Room<TPresence extends JsonObject = JsonObject> = {
    * @example
    * const others = room.getOthers();
    */
-  getOthers: <_ extends JsonObject>() => Others<TPresence>;
+  getOthers: <
+    /**
+     * @deprecated This type argument is ignored. If you want to annotate this
+     * type manually, please annotate the Room instance instead.
+     */
+    _ = unknown
+  >() => Others<TPresence>;
 
   /**
    * Updates the presence of the current user. Only pass the properties you want to update. No need to send the full presence.
@@ -601,7 +631,13 @@ export type Room<TPresence extends JsonObject = JsonObject> = {
    * const presence = room.getPresence();
    * // presence is equivalent to { x: 0, y: 0 }
    */
-  updatePresence: <_ extends JsonObject>(
+  updatePresence: <
+    /**
+     * @deprecated This type argument is ignored. If you want to annotate this
+     * type manually, please annotate the Room instance instead.
+     */
+    _ = unknown
+  >(
     overrides: Partial<TPresence>,
     options?: {
       /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -244,6 +244,21 @@ export type User<TPresence extends Presence = Presence> = {
   _hasReceivedInitialPresence?: boolean;
 };
 
+/**
+ * @deprecated Whatever you want to store as presence is app-specific. Please
+ * define your own Presence type instead of importing it from
+ * `@liveblocks/client`, for example:
+ *
+ *    type Presence = {
+ *      name: string,
+ *      cursor: {
+ *        x: number,
+ *        y: number,
+ *      } | null,
+ *    }
+ *
+ * As long as it only contains JSON-serializable values, you're good!
+ */
 export type Presence = JsonObject;
 
 type AuthEndpointCallback = (room: string) => Promise<{ token: string }>;

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -244,7 +244,7 @@ export type User<TPresence extends Presence = Presence> = {
   _hasReceivedInitialPresence?: boolean;
 };
 
-export type Presence = Record<string, unknown>;
+export type Presence = JsonObject;
 
 type AuthEndpointCallback = (room: string) => Promise<{ token: string }>;
 

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -149,7 +149,10 @@ export type StorageUpdate =
 
 export type StorageCallback = (updates: StorageUpdate[]) => void;
 
-export type RoomInitializers<TPresence, TStorage> = Resolve<{
+export type RoomInitializers<
+  TPresence extends JsonObject,
+  TStorage extends Record<string, any>
+> = Resolve<{
   /**
    * The initial Presence to use and announce when you enter the Room. The
    * Presence is available on all users in the Room (me & others).
@@ -390,7 +393,7 @@ export interface History {
   resume: () => void;
 }
 
-export type Room = {
+export type Room<TPresence extends JsonObject = JsonObject> = {
   /**
    * The id of the room.
    */
@@ -407,7 +410,7 @@ export type Room = {
      *   // Do something
      * });
      */
-    <TPresence extends JsonObject>(
+    <_ extends JsonObject>(
       type: "my-presence",
       listener: MyPresenceCallback<TPresence>
     ): () => void;
@@ -421,7 +424,7 @@ export type Room = {
      *   // Do something
      * });
      */
-    <TPresence extends JsonObject>(
+    <_ extends JsonObject>(
       type: "others",
       listener: OthersEventCallback<TPresence>
     ): () => void;
@@ -566,7 +569,7 @@ export type Room = {
    * @example
    * const user = room.getSelf();
    */
-  getSelf<TPresence extends JsonObject = JsonObject>(): User<TPresence> | null;
+  getSelf<_ extends JsonObject = JsonObject>(): User<TPresence> | null;
 
   /**
    * Gets the presence of the current user.
@@ -574,7 +577,7 @@ export type Room = {
    * @example
    * const presence = room.getPresence();
    */
-  getPresence: <TPresence extends JsonObject>() => TPresence;
+  getPresence: <_ extends JsonObject>() => TPresence;
 
   /**
    * Gets all the other users in the room.
@@ -582,7 +585,7 @@ export type Room = {
    * @example
    * const others = room.getOthers();
    */
-  getOthers: <TPresence extends JsonObject>() => Others<TPresence>;
+  getOthers: <_ extends JsonObject>() => Others<TPresence>;
 
   /**
    * Updates the presence of the current user. Only pass the properties you want to update. No need to send the full presence.
@@ -596,7 +599,7 @@ export type Room = {
    * const presence = room.getPresence();
    * // presence is equivalent to { x: 0, y: 0 }
    */
-  updatePresence: <TPresence extends JsonObject>(
+  updatePresence: <_ extends JsonObject>(
     overrides: Partial<TPresence>,
     options?: {
       /**

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -162,8 +162,8 @@ async function prepareRoomWithStorage<
   const effects = mockEffects();
   (effects.send as jest.MockedFunction<any>).mockImplementation(onSend);
 
-  const state = defaultState({}, defaultStorage);
-  const machine = makeStateMachine(state, defaultContext, effects);
+  const state = defaultState<TPresence>({} as TPresence, defaultStorage);
+  const machine = makeStateMachine<TPresence>(state, defaultContext, effects);
   const ws = new MockWebSocket("");
 
   machine.connect();
@@ -360,11 +360,14 @@ export async function prepareStorageTest<TStorage extends LsonObject>(
 /**
  * Join the same room with 2 different clients and stop sending socket messages when the storage is initialized
  */
-export function prepareStorageUpdateTest<T extends LsonObject>(
+export function prepareStorageUpdateTest<
+  T extends LsonObject,
+  TPresence extends JsonObject = JsonObject
+>(
   items: IdTuple<SerializedCrdt>[],
   callback: (args: {
     root: LiveObject<T>;
-    machine: Machine;
+    machine: Machine<TPresence>;
     assert: (updates: JsonStorageUpdate[][]) => void;
   }) => Promise<void>
 ): () => Promise<void> {
@@ -418,8 +421,8 @@ export function prepareStorageUpdateTest<T extends LsonObject>(
   };
 }
 
-export async function reconnect(
-  machine: Machine,
+export async function reconnect<TPresence extends JsonObject = JsonObject>(
+  machine: Machine<TPresence>,
   actor: number,
   newItems: IdTuple<SerializedCrdt>[]
 ) {

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -235,20 +235,20 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
  * All operations made on the main room are forwarded to the other room
  * Assertion on the storage validate both rooms
  */
-export async function prepareStorageTest<TStorage extends LsonObject>(
-  items: IdTuple<SerializedCrdt>[],
-  actor: number = 0
-) {
+export async function prepareStorageTest<
+  TStorage extends LsonObject,
+  TPresence extends JsonObject = never
+>(items: IdTuple<SerializedCrdt>[], actor: number = 0) {
   let currentActor = actor;
   const operations: Op[] = [];
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<never, TStorage>(items, -1);
+    await prepareRoomWithStorage<TPresence, TStorage>(items, -1);
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
-    never,
+    TPresence,
     TStorage
-  >(items, currentActor, (messages: ClientMsg<never>[]) => {
+  >(items, currentActor, (messages: ClientMsg<TPresence>[]) => {
     for (const message of messages) {
       if (message.type === ClientMsgCode.UPDATE_STORAGE) {
         operations.push(...message.ops);

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -572,7 +572,9 @@ export function createSerializedRegister(
   return [id, { type: CrdtType.REGISTER, parentId, parentKey, data }];
 }
 
-export function mockEffects(): Effects<JsonObject> {
+export function mockEffects<
+  TPresence extends JsonObject
+>(): Effects<TPresence> {
   return {
     authenticate: jest.fn(),
     delayFlush: jest.fn(),

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -2,10 +2,10 @@ import type {
   BroadcastOptions,
   History,
   Json,
+  JsonObject,
   Lson,
   LsonObject,
   Others,
-  Presence,
   Room,
   User,
 } from "@liveblocks/client";
@@ -24,7 +24,9 @@ type RoomProviderProps<TStorage> = Resolve<
      */
     id: string;
     children: React.ReactNode;
-  } & RoomInitializers<Presence, TStorage>
+  } & RoomInitializers<JsonObject, TStorage>
+  //                   ^^^^^^^^^^
+  //                   FIXME: Generalize to TPresence
 >;
 
 type LookupResult<T> =
@@ -130,12 +132,14 @@ export function create() {
    *
    * // At the next render, "myPresence" will be equal to "{ x: 0, y: 0 }"
    */
-  function useMyPresence<T extends Presence>(): [
-    T,
-    (overrides: Partial<T>, options?: { addToHistory: boolean }) => void
+  function useMyPresence<TPresence extends JsonObject>(): [
+    TPresence,
+    (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) => void
   ] {
-    const room = useRoom();
-    const presence = room.getPresence<T>();
+    const room = useRoom() as unknown as Room<TPresence>;
+    //                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //                     FIXME No longer needed once TPresence moves to the factory level
+    const presence = room.getPresence<TPresence>();
     const rerender = useRerender();
 
     React.useEffect(() => {
@@ -146,7 +150,7 @@ export function create() {
     }, [room]);
 
     const setPresence = React.useCallback(
-      (overrides: Partial<T>, options?: { addToHistory: boolean }) =>
+      (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) =>
         room.updatePresence(overrides, options),
       [room]
     );
@@ -167,14 +171,14 @@ export function create() {
    *
    * // At the next render, the presence of the current user will be equal to "{ x: 0, y: 0 }"
    */
-  function useUpdateMyPresence<T extends Presence>(): (
-    overrides: Partial<T>,
+  function useUpdateMyPresence<TPresence extends JsonObject>(): (
+    overrides: Partial<TPresence>,
     options?: { addToHistory: boolean }
   ) => void {
     const room = useRoom();
 
     return React.useCallback(
-      (overrides: Partial<T>, options?: { addToHistory: boolean }) => {
+      (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) => {
         room.updatePresence(overrides, options);
       },
       [room]
@@ -199,8 +203,10 @@ export function create() {
    *   })
    * }
    */
-  function useOthers<T extends Presence>(): Others<T> {
-    const room = useRoom();
+  function useOthers<TPresence extends JsonObject>(): Others<TPresence> {
+    const room = useRoom() as unknown as Room<TPresence>;
+    //                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //                     FIXME No longer needed once TPresence moves to the factory level
     const rerender = useRerender();
 
     React.useEffect(() => {
@@ -317,9 +323,11 @@ export function create() {
    * const user = useSelf();
    */
   function useSelf<
-    TPresence extends Presence = Presence
+    TPresence extends JsonObject = JsonObject
   >(): User<TPresence> | null {
-    const room = useRoom();
+    const room = useRoom() as unknown as Room<TPresence>;
+    //                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //                     FIXME No longer needed once TPresence moves to the factory level
     const rerender = useRerender();
 
     React.useEffect(() => {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -287,13 +287,7 @@ export function create() {
    * });
    */
   function useEventListener(
-    callback: ({
-      connectionId,
-      event,
-    }: {
-      connectionId: number;
-      event: Json;
-    }) => void
+    callback: (eventData: { connectionId: number; event: Json }) => void
   ): void {
     const room = useRoom();
     const savedCallback = React.useRef(callback);
@@ -303,8 +297,8 @@ export function create() {
     });
 
     React.useEffect(() => {
-      const listener = (e: { connectionId: number; event: Json }) => {
-        savedCallback.current(e);
+      const listener = (eventData: { connectionId: number; event: Json }) => {
+        savedCallback.current(eventData);
       };
 
       const unsubscribe = room.subscribe("event", listener);

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -1,8 +1,8 @@
 import type {
   Client,
+  JsonObject,
   LiveObject,
   LsonObject,
-  Presence,
   Room,
   User,
 } from "@liveblocks/client";
@@ -37,7 +37,7 @@ const ACTION_TYPES = {
 
 export type LiveblocksState<
   TState,
-  TPresence extends Presence = Presence
+  TPresence extends JsonObject = JsonObject
 > = TState & {
   /**
    * Liveblocks extra state attached by the enhancer
@@ -376,11 +376,11 @@ function broadcastInitialPresence<T>(
   }
 }
 
-function updatePresence<T>(
+function updatePresence<TPresence extends JsonObject>(
   room: Room,
-  oldState: T,
-  newState: T,
-  presenceMapping: Mapping<T>
+  oldState: TPresence,
+  newState: TPresence,
+  presenceMapping: Mapping<TPresence>
 ) {
   for (const key in presenceMapping) {
     if (typeof newState[key] === "function") {

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, Presence } from "@liveblocks/client";
+import type { JsonObject } from "@liveblocks/client";
 import { createClient } from "@liveblocks/client";
 import type {
   IdTuple,
@@ -98,7 +98,7 @@ const basicStateCreator: StateCreator<BasicStore> = (set) => ({
 
 function prepareClientAndStore<
   T extends ZustandState,
-  TPresence extends Presence = Presence
+  TPresence extends JsonObject = JsonObject
 >(
   stateCreator: StateCreator<T>,
   options: {

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -1,9 +1,9 @@
 import type {
   Client,
   Json,
+  JsonObject,
   LiveObject,
   LsonObject,
-  Presence,
   Room,
   User,
 } from "@liveblocks/client";
@@ -40,7 +40,7 @@ export type ZustandState =
 
 export type LiveblocksState<
   TState extends ZustandState,
-  TPresence extends Presence = Presence
+  TPresence extends JsonObject = JsonObject
 > = TState & {
   /**
    * Liveblocks extra state attached by the middleware
@@ -103,7 +103,7 @@ type Options<T> = {
 
 export function middleware<
   T extends ZustandState,
-  TPresence extends Record<string, unknown> = Presence
+  TPresence extends JsonObject = JsonObject
 >(
   config: StateCreator<
     T,
@@ -344,7 +344,8 @@ function updatePresence<T>(
     }
 
     if (oldState[key] !== newState[key]) {
-      room.updatePresence({ [key]: newState[key] });
+      const val = newState[key] as unknown as Json | undefined;
+      room.updatePresence({ [key]: val });
     }
   }
 }
@@ -352,7 +353,7 @@ function updatePresence<T>(
 function patchLiveblocksStorage<
   O extends LsonObject,
   TState extends ZustandState,
-  TPresence extends Presence
+  TPresence extends JsonObject
 >(
   root: LiveObject<O>,
   oldState: LiveblocksState<TState, TPresence>,


### PR DESCRIPTION
**PR Stack:**

- #291  👈 This PR!
  - #316

---

In 0.17, we want to deprecate the use of the built-in concrete `Presence` type. This PR marks the `Presence` type deprecated, and stops using it in our own packages entirely, in favor of `JsonObject` constraints.

Users using the `Presence` type should have no problem adopting. If they keep using the deprecated type, it will keep working (because it's an alias for `JsonObject`). If they roll their own type definition, that's fine, or if they switch to use the opaque `JsonObject` type deliberately, that's also fine. The only case in which things will break is if their Presence data contains fields that aren't JSON-serializable that got accepted before.

Fixes #289 .

### 🏁 Checklist

Things to-do:

- [x] Go over each public API that has seen changes here
- [x] Go over each private API, and clean those up (no breaking changes)
