### PR TITLE
Add types to immutability helpers

### DIFF
--- a/packages/liveblocks-client/e2e/utils.ts
+++ b/packages/liveblocks-client/e2e/utils.ts
@@ -7,7 +7,11 @@ import WebSocket from "ws";
 
 import type { Room } from "../src";
 import { createClient } from "../src/client";
-import { lsonToJson, patchImmutableObject } from "../src/immutable";
+import {
+  liveObjectToJson,
+  lsonToJson,
+  patchImmutableObject,
+} from "../src/immutable";
 import type { LiveObject } from "../src/LiveObject";
 import type { LsonObject, ToJson } from "../src/types";
 import {
@@ -81,7 +85,7 @@ export function prepareTestsConflicts<T extends LsonObject>(
 
       if (publicApiKey == null) {
         throw new Error(
-          `Environment variable "LIVEBLOCKS_PUBLIC_KEY" is missing.`
+          'Environment variable "LIVEBLOCKS_PUBLIC_KEY" is missing.'
         );
       }
 
@@ -144,8 +148,8 @@ export function prepareTestsConflicts<T extends LsonObject>(
 
     socketUtils.pauseAllSockets();
 
-    let immutableStorage1 = lsonToJson(root1);
-    let immutableStorage2 = lsonToJson(root2);
+    let immutableStorage1 = liveObjectToJson(root1);
+    let immutableStorage2 = liveObjectToJson(root2);
 
     const room1Updates: JsonStorageUpdate[][] = [];
     const room2Updates: JsonStorageUpdate[][] = [];

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -341,9 +341,7 @@ function patchImmutableNode<S extends Json>(
         for (const listUpdate of update.updates) {
           if (listUpdate.type === "set") {
             newState = newState.map((item, index) =>
-              index === listUpdate.index
-                ? lsonToJson(listUpdate.item)
-                : item
+              index === listUpdate.index ? lsonToJson(listUpdate.item) : item
             );
           } else if (listUpdate.type === "insert") {
             if (listUpdate.index === newState.length) {

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -295,6 +295,10 @@ function patchImmutableNode<S extends Json>(
   path: Array<string | number>,
   update: StorageUpdate
 ): S {
+  // FIXME: Split this function up into a few smaller ones! In each of them,
+  // the types can be define much more narrowly and correctly, and there will
+  // be less type shoehorning necessary.
+
   const pathItem = path.pop();
   if (pathItem === undefined) {
     switch (update.type) {

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -4,6 +4,7 @@ import { LiveObject } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
 import type {
   Json,
+  JsonObject,
   LiveNode,
   Lson,
   LsonObject,
@@ -271,20 +272,26 @@ function getParentsPath(node: LiveNode): Array<string | number> {
   return path;
 }
 
-export function patchImmutableObject<T>(state: T, updates: StorageUpdate[]): T {
+export function patchImmutableObject<S extends JsonObject>(
+  state: S,
+  updates: StorageUpdate[]
+): S {
   return updates.reduce(
     (state, update) => patchImmutableObjectWithUpdate(state, update),
     state
   );
 }
 
-function patchImmutableObjectWithUpdate<T>(state: T, update: StorageUpdate): T {
+function patchImmutableObjectWithUpdate<S extends JsonObject>(
+  state: S,
+  update: StorageUpdate
+): S {
   const path = getParentsPath(update.node);
   return patchImmutableNode(state, path, update);
 }
 
-function patchImmutableNode(
-  state: any,
+function patchImmutableNode<S extends Json>(
+  state: S,
   path: Array<string | number>,
   update: StorageUpdate
 ): any {
@@ -292,12 +299,17 @@ function patchImmutableNode(
   if (pathItem === undefined) {
     switch (update.type) {
       case "LiveObject": {
-        if (typeof state !== "object") {
+        if (
+          state === null ||
+          typeof state !== "object" ||
+          Array.isArray(state)
+        ) {
           throw new Error(
             "Internal: received update on LiveObject but state was not an object"
           );
         }
-        const newState = Object.assign({}, state);
+
+        const newState = Object.assign({}, state as JsonObject);
 
         for (const key in update.updates) {
           if (update.updates[key]?.type === "update") {
@@ -310,21 +322,32 @@ function patchImmutableNode(
           }
         }
 
-        return newState;
+        return newState as S;
+        //              ^^^^
+        //              FIXME Not completely true, because we could have been
+        //              updating keys from StorageUpdate here that aren't in S,
+        //              technically.
       }
+
       case "LiveList": {
-        if (Array.isArray(state) === false) {
+        if (!Array.isArray(state)) {
           throw new Error(
             "Internal: received update on LiveList but state was not an array"
           );
         }
 
-        let newState: any[] = state.map((x: any) => x);
+        let newState: Json[] = state.map((x: Json) => x);
 
         for (const listUpdate of update.updates) {
           if (listUpdate.type === "set") {
             newState = newState.map((item, index) =>
-              index === listUpdate.index ? listUpdate.item : item
+              index === listUpdate.index
+                ? (listUpdate.item as Json)
+                : //               ^^^^^^^^
+                  //               FIXME Definitely a bug here. listUpdate.item
+                  //               can contain Lson values, but we're trying to
+                  //               return a Json-only list.
+                  item
             );
           } else if (listUpdate.type === "insert") {
             if (listUpdate.index === newState.length) {
@@ -360,15 +383,24 @@ function patchImmutableNode(
           }
         }
 
-        return newState;
+        return newState as S;
+        //              ^^^^
+        //              FIXME Not completely true, because we could have been
+        //              updating keys from StorageUpdate here that aren't in S,
+        //              technically.
       }
+
       case "LiveMap": {
-        if (typeof state !== "object") {
+        if (
+          state === null ||
+          typeof state !== "object" ||
+          Array.isArray(state)
+        ) {
           throw new Error(
             "Internal: received update on LiveMap but state was not an object"
           );
         }
-        const newState = Object.assign({}, state);
+        const newState = Object.assign({}, state as JsonObject);
 
         for (const key in update.updates) {
           if (update.updates[key]?.type === "update") {
@@ -381,7 +413,11 @@ function patchImmutableNode(
           }
         }
 
-        return newState;
+        return newState as S;
+        //              ^^^^
+        //              FIXME Not completely true, because we could have been
+        //              updating keys from StorageUpdate here that aren't in S,
+        //              technically.
       }
     }
   }
@@ -394,10 +430,17 @@ function patchImmutableNode(
       update
     );
     return newArray;
+  } else if (state !== null && typeof state === "object") {
+    const node = state[pathItem];
+    if (node === undefined) {
+      return state;
+    } else {
+      return {
+        ...state,
+        [pathItem]: patchImmutableNode(node, path, update),
+      };
+    }
   } else {
-    return {
-      ...state,
-      [pathItem]: patchImmutableNode(state[pathItem], path, update),
-    };
+    return state;
   }
 }

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -342,12 +342,8 @@ function patchImmutableNode<S extends Json>(
           if (listUpdate.type === "set") {
             newState = newState.map((item, index) =>
               index === listUpdate.index
-                ? (listUpdate.item as Json)
-                : //               ^^^^^^^^
-                  //               FIXME Definitely a bug here. listUpdate.item
-                  //               can contain Lson values, but we're trying to
-                  //               return a Json-only list.
-                  item
+                ? lsonToJson(listUpdate.item)
+                : item
             );
           } else if (listUpdate.type === "insert") {
             if (listUpdate.index === newState.length) {


### PR DESCRIPTION
This does another pass to remove a few more `any`s from the codebase. While doing so, I hit quite a few edge cases that TypeScript is correctly calling out, and that we should address later. For now, I've not bothered to fix these bugs as they are mostly not bugs on the happy paths, so we may not have encountered them.
