### PR TITLE
Fix example to use new APIs

### DIFF
--- a/examples/nextjs-live-cursors-chat/pages/index.tsx
+++ b/examples/nextjs-live-cursors-chat/pages/index.tsx
@@ -294,7 +294,7 @@ export default function Page() {
   return (
     <RoomProvider
       id={roomId}
-      defaultPresence={() => ({
+      initialPresence={() => ({
         cursor: null,
         message: "",
       })}


### PR DESCRIPTION
Stumbled upon this example that I was using for a random test. In 0.17, we start actively erroring when using this API (in dev mode only), but we may need to update more examples against the 0.17 version, which is currently in development on `main`.