### PR TITLE
chore: add CI step for client specs e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -117,6 +117,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
+      - name: Run npm install
+        run: npm install
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -89,3 +89,36 @@ jobs:
           name: playwright-report
           path: e2e/next-sandbox/playwright-report
           retention-days: 14
+
+  e2e-client-specs-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    timeout-minutes: 60
+
+    env:
+      LIVEBLOCKS_PUBLIC_KEY: ${{ secrets.E2E_TEST_LIVEBLOCKS_PUBLIC_KEY }}
+
+    defaults:
+      run:
+        working-directory: packages/liveblocks-client
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Build
+        run: npm run build
+
+      - name: Run e2e client specs tests
+        run: npm run test-e2e


### PR DESCRIPTION
We added e2e tests that document and test conflict resolution on LiveList:
https://github.com/liveblocks/liveblocks/tree/main/packages/liveblocks-client/e2e

This PR added a new step in the CI to run those e2e tests.