### PR TITLE
Use v6 in all tests

### DIFF
--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -29,7 +29,7 @@ import {
 const defaultContext = {
   roomId: "room-id",
   throttleDelay: 100,
-  liveblocksServer: "wss://live.liveblocks.io/v5",
+  liveblocksServer: "wss://live.liveblocks.io/v6",
   authentication: {
     type: "private",
     url: "/api/auth",

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -132,7 +132,7 @@ export const FIFTH_POSITION = makePosition(FOURTH_POSITION);
 const defaultContext = {
   roomId: "room-id",
   throttleDelay: -1, // No throttle for standard storage test
-  liveblocksServer: "wss://live.liveblocks.io/v5",
+  liveblocksServer: "wss://live.liveblocks.io/v6",
   authentication: {
     type: "private",
     url: "/api/auth",


### PR DESCRIPTION
Use v6 everywhere, starting with 0.17.