### PR TITLE
Remove `any`-typed response from `fetchAuthEndpoint`

### DIFF
--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -121,7 +121,7 @@ describe("room / auth", () => {
 
     expect(consoleErrorSpy.mock.calls[0][1]).toEqual(
       new Error(
-        'Expected a json when doing a POST request on "/mocked-api/not-json". SyntaxError: Unexpected token h in JSON at position 1'
+        'Expected a JSON response when doing a POST request on "/mocked-api/not-json". SyntaxError: Unexpected token h in JSON at position 1'
       )
     );
   });
@@ -144,7 +144,7 @@ describe("room / auth", () => {
 
     expect(consoleErrorSpy.mock.calls[0][1]).toEqual(
       new Error(
-        'Expected a json with a string token when doing a POST request on "/mocked-api/missing-token", but got {}'
+        'Expected a JSON response of the form `{ token: "..." }` when doing a POST request on "/mocked-api/missing-token", but got {}'
       )
     );
   });

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -63,10 +63,10 @@ import {
   getTreesDiffOperations,
   isLiveList,
   isLiveNode,
+  isPlainObject,
   isSameNodeOrChildOf,
   mergeStorageUpdates,
   remove,
-  isPlainObject,
   tryParseJson,
 } from "./utils";
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -66,6 +66,7 @@ import {
   isSameNodeOrChildOf,
   mergeStorageUpdates,
   remove,
+  isPlainObject,
   tryParseJson,
 } from "./utils";
 
@@ -1721,7 +1722,7 @@ function fetchAuthEndpoint(
     room: string;
     publicApiKey?: string;
   }
-): Promise<any> {
+): Promise<{ token: string }> {
   return fetch(endpoint, {
     method: "POST",
     headers: {
@@ -1736,22 +1737,23 @@ function fetchAuthEndpoint(
         );
       }
 
-      return res.json().catch((er) => {
+      return (res.json() as Promise<Json>).catch((er) => {
         throw new AuthenticationError(
-          `Expected a json when doing a POST request on "${endpoint}". ${er}`
+          `Expected a JSON response when doing a POST request on "${endpoint}". ${er}`
         );
       });
     })
-    .then((authResponse) => {
-      if (typeof authResponse.token !== "string") {
+    .then((data) => {
+      if (!isPlainObject(data) || typeof data.token !== "string") {
         throw new AuthenticationError(
-          `Expected a json with a string token when doing a POST request on "${endpoint}", but got ${JSON.stringify(
-            authResponse
+          `Expected a JSON response of the form \`{ token: "..." }\` when doing a POST request on "${endpoint}", but got ${JSON.stringify(
+            data
           )}`
         );
       }
 
-      return authResponse;
+      const { token } = data;
+      return { token };
     });
 }
 


### PR DESCRIPTION
This type-checks the response from the server more carefully, and returns a known type.