### PR TITLE
Remove `maxConnections` field from room auth token

### DIFF
--- a/packages/liveblocks-client/src/AuthToken.ts
+++ b/packages/liveblocks-client/src/AuthToken.ts
@@ -122,10 +122,18 @@ function parseJwtToken(token: string): JwtMetadata {
   }
 }
 
-export function parseRoomAuthToken(token: string): RoomAuthToken & JwtMetadata {
-  const data = parseJwtToken(token);
+export function parseRoomAuthToken(
+  tokenString: string
+): RoomAuthToken & JwtMetadata {
+  const data = parseJwtToken(tokenString);
   if (data && isRoomAuthToken(data)) {
-    return data;
+    const {
+      // If this legacy field is found on the token, pretend it wasn't there,
+      // to make all internally used token payloads uniform
+      maxConnections: _legacyField,
+      ...token
+    } = data;
+    return token;
   } else {
     throw new Error("Authentication error: invalid room auth token");
   }

--- a/packages/liveblocks-client/src/AuthToken.ts
+++ b/packages/liveblocks-client/src/AuthToken.ts
@@ -23,7 +23,6 @@ export type RoomAuthToken = {
   roomId: string; // Discriminating field for AuthToken type
   scopes: string[]; // Think Scope[], but it could also hold scopes from the future, hence string[]
   actor: number;
-  maxConnections: number;
   maxConnectionsPerRoom?: number;
 
   // Extra payload as defined by the customer's own authorization
@@ -86,7 +85,6 @@ export function isRoomAuthToken(data: JsonObject): data is RoomAuthToken {
   //     roomId: string,
   //     actor: number,
   //     scopes: array(scope),
-  //     maxConnections: number,
   //     maxConnectionsPerRoom: optional(number),
   //     id: optional(string),
   //     info: optional(json),
@@ -98,7 +96,6 @@ export function isRoomAuthToken(data: JsonObject): data is RoomAuthToken {
     typeof data.actor === "number" &&
     (data.id === undefined || typeof data.id === "string") &&
     isStringList(data.scopes) &&
-    typeof data.maxConnections === "number" &&
     (data.maxConnectionsPerRoom === undefined ||
       typeof data.maxConnectionsPerRoom === "number")
     // NOTE: Nothing to validate for `info` field. It's already Json | undefined,

--- a/packages/liveblocks-client/src/client.node.test.ts
+++ b/packages/liveblocks-client/src/client.node.test.ts
@@ -10,7 +10,7 @@ import { createClient } from ".";
 import type { ClientOptions } from "./types";
 
 const token =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdLCJtYXhDb25uZWN0aW9ucyI6MjAwMH0.-DP9zVtvtkzWsjEpLeP6CuO9mZKC_5Opal3yN4tI6uo";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.IQFyw54-b4F6P0MTSzmBVwdZi2pwPaxZwzgkE2l0Mi4";
 
 const fetchMock = (async () =>
   new Response(JSON.stringify({ token }))) as unknown as typeof fetch;

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -44,7 +44,6 @@ const defaultRoomToken: RoomAuthToken = {
   roomId: "my-room",
   actor: 0,
   scopes: [],
-  maxConnections: 42,
 };
 
 function setupStateMachine<TPresence extends JsonObject>(

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -57,7 +57,7 @@ function setupStateMachine<TPresence extends JsonObject>(
 
 describe("room / auth", () => {
   const token =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdLCJtYXhDb25uZWN0aW9ucyI6MjAwMH0.-DP9zVtvtkzWsjEpLeP6CuO9mZKC_5Opal3yN4tI6uo";
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.IQFyw54-b4F6P0MTSzmBVwdZi2pwPaxZwzgkE2l0Mi4";
   const server = setupServer(
     rest.post("/mocked-api/auth", (_req, res, ctx) => {
       return res(ctx.json({ token }));

--- a/packages/liveblocks-client/src/utils.test.ts
+++ b/packages/liveblocks-client/src/utils.test.ts
@@ -283,7 +283,7 @@ describe("findNonSerializableValue", () => {
 describe("b64decode", () => {
   test("payload contains characters with accents", () => {
     const tokenPayload =
-      "eyJyb29tSWQiOiJNaDNtTGQ1OUxWSjdLQTJlVWIwTWUiLCJhcHBJZCI6IjYxNDBlMzMyMjliY2ExNWQxNDYxMzBhOSIsImFjdG9yIjo5LCJzY29wZXMiOlsicm9vbTpyZWFkIiwicm9vbTp3cml0ZSIsIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIl0sImluZm8iOnsibmFtZSI6IkNoYXJsacOpIExheW5lIiwicGljdHVyZSI6Ii9hdmF0YXJzLzcucG5nIn0sIm1heENvbm5lY3Rpb25zIjoyMDAwLCJpYXQiOjE2NTM1MTYwODYsImV4cCI6MTY1MzUxOTY4Nn0";
+      "eyJyb29tSWQiOiJNaDNtTGQ1OUxWSjdLQTJlVWIwTWUiLCJhcHBJZCI6IjYxNDBlMzMyMjliY2ExNWQxNDYxMzBhOSIsImFjdG9yIjo5LCJzY29wZXMiOlsicm9vbTpyZWFkIiwicm9vbTp3cml0ZSIsIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIl0sImluZm8iOnsibmFtZSI6IkNoYXJsacOpIExheW5lIiwicGljdHVyZSI6Ii9hdmF0YXJzLzcucG5nIn0sImlhdCI6MTY1MzUxNjA4NiwiZXhwIjoxNjUzNTE5Njg2fQ";
     const json = tryParseJson(b64decode(tokenPayload));
 
     expect(json).toEqual({
@@ -295,7 +295,6 @@ describe("b64decode", () => {
         name: "Charlié Layne",
         picture: "/avatars/7.png",
       },
-      maxConnections: 2000,
       roomId: "Mh3mLd59LVJ7KA2eUb0Me",
       scopes: [
         "room:read",

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -32,7 +32,6 @@ function makeRoomToken(actor: number): RoomAuthToken {
     roomId: "my-room",
     actor,
     scopes: [],
-    maxConnections: 42,
   };
 }
 

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -106,7 +106,7 @@ const server = setupServer(
     return res(
       ctx.json({
         token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdLCJtYXhDb25uZWN0aW9ucyI6MjAwMH0.-DP9zVtvtkzWsjEpLeP6CuO9mZKC_5Opal3yN4tI6uo",
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.IQFyw54-b4F6P0MTSzmBVwdZi2pwPaxZwzgkE2l0Mi4",
       })
     );
   }),

--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -34,7 +34,7 @@ const server = setupServer(
     return res(
       ctx.json({
         token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdLCJtYXhDb25uZWN0aW9ucyI6MjAwMH0.-DP9zVtvtkzWsjEpLeP6CuO9mZKC_5Opal3yN4tI6uo",
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.IQFyw54-b4F6P0MTSzmBVwdZi2pwPaxZwzgkE2l0Mi4",
       })
     );
   }),

--- a/packages/liveblocks-zustand/src/index.test.ts
+++ b/packages/liveblocks-zustand/src/index.test.ts
@@ -34,7 +34,7 @@ const server = setupServer(
     return res(
       ctx.json({
         token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdLCJtYXhDb25uZWN0aW9ucyI6MjAwMH0.-DP9zVtvtkzWsjEpLeP6CuO9mZKC_5Opal3yN4tI6uo",
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.IQFyw54-b4F6P0MTSzmBVwdZi2pwPaxZwzgkE2l0Mi4",
       })
     );
   }),


### PR DESCRIPTION
Follow-up on https://github.com/liveblocks/liveblocks-cloudflare/pull/100#pullrequestreview-1000647981.

This field is a legacy construct that isn't needed, so we should stop relying on this field to exist on tokens. This PR removes the requirement from the runtime token checks, and even actively strips the `maxConnections` field if it exists — as if it was never sent.

I intend to backport this fix to v0.16.17 once merged.