### PR TITLE
Prettify rollup build output

### DIFF
--- a/packages/liveblocks-client/package-lock.json
+++ b/packages/liveblocks-client/package-lock.json
@@ -34,6 +34,7 @@
         "rollup": "^2.68.0",
         "rollup-plugin-command": "^1.1.3",
         "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-prettier": "^2.2.2",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.7.2",
         "whatwg-fetch": "^3.6.2",
@@ -4854,6 +4855,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -10266,10 +10276,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -11077,6 +11111,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
@@ -11467,6 +11517,28 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^1.0.0 || ^2.0.0",
+        "rollup": "^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/rollup-plugin-terser": {
@@ -16140,6 +16212,12 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
     "diff-sequences": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
@@ -20272,10 +20350,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "log-symbols": {
@@ -20876,6 +20978,13 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true
+    },
     "pretty-format": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
@@ -21158,6 +21267,21 @@
             "sourcemap-codec": "^1.4.8"
           }
         }
+      }
+    },
+    "rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "requires": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
       }
     },
     "rollup-plugin-terser": {

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -64,6 +64,7 @@
     "rollup": "^2.68.0",
     "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-dts": "^4.2.2",
+    "rollup-plugin-prettier": "^2.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.7.2",
     "whatwg-fetch": "^3.6.2",

--- a/packages/liveblocks-client/rollup.config.js
+++ b/packages/liveblocks-client/rollup.config.js
@@ -2,6 +2,7 @@ import babelPlugin from "@rollup/plugin-babel";
 import commandPlugin from "rollup-plugin-command";
 import dts from "rollup-plugin-dts";
 import path from "path";
+import prettierPlugin from "rollup-plugin-prettier";
 import replaceText from "@rollup/plugin-replace";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
@@ -14,14 +15,11 @@ function execute(cmd, wait = true) {
 }
 
 function stripComments() {
-  return terserPlugin({
-    mangle: false,
-    output: {
-      beautify: true,
-      indent_level: 1,
-      comments: false,
-    },
-  });
+  return terserPlugin({ mangle: false, output: { comments: false } });
+}
+
+function prettier() {
+  return prettierPlugin({ parser: "typescript", tabWidth: 2 });
 }
 
 /**
@@ -68,7 +66,7 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments()],
+    plugins: [typescriptCompile(), stripComments(), prettier()],
   };
 }
 
@@ -87,6 +85,7 @@ function buildCJS(srcFiles, external = []) {
       resolve({ extensions }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
+      prettier(),
     ],
   };
 }
@@ -128,6 +127,7 @@ function buildDTS(srcFiles = [], external = []) {
     external,
     plugins: [
       dts(),
+      prettier(),
 
       // We no longer need this tmp dir from step 1 here, so clean it up ASAP
       // to avoid confusion

--- a/packages/liveblocks-react/package-lock.json
+++ b/packages/liveblocks-react/package-lock.json
@@ -31,6 +31,7 @@
         "rollup": "^2.39.0",
         "rollup-plugin-command": "^1.1.3",
         "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-prettier": "^2.2.2",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.7.2",
         "whatwg-fetch": "^3.6.2"
@@ -4620,6 +4621,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
       "dev": true,
@@ -8610,10 +8620,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "node_modules/lodash.sortby": {
@@ -9557,6 +9591,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "26.6.2",
       "dev": true,
@@ -10160,6 +10210,37 @@
       "peerDependencies": {
         "rollup": "^2.55",
         "typescript": "^4.1"
+      }
+    },
+    "node_modules/rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^1.0.0 || ^2.0.0",
+        "rollup": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-prettier/node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/rollup-plugin-terser": {
@@ -15251,6 +15332,12 @@
       "version": "3.1.0",
       "dev": true
     },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
     "diff-sequences": {
       "version": "26.6.2",
       "dev": true
@@ -17974,10 +18061,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "lodash.sortby": {
@@ -18638,6 +18749,13 @@
       "version": "1.1.2",
       "dev": true
     },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true
+    },
     "pretty-format": {
       "version": "26.6.2",
       "dev": true,
@@ -19046,6 +19164,32 @@
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "magic-string": "^0.26.1"
+      }
+    },
+    "rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "requires": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        }
       }
     },
     "rollup-plugin-terser": {

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -54,6 +54,7 @@
     "rollup": "^2.39.0",
     "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-dts": "^4.2.2",
+    "rollup-plugin-prettier": "^2.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.7.2",
     "whatwg-fetch": "^3.6.2"

--- a/packages/liveblocks-react/rollup.config.js
+++ b/packages/liveblocks-react/rollup.config.js
@@ -2,6 +2,7 @@ import babelPlugin from "@rollup/plugin-babel";
 import commandPlugin from "rollup-plugin-command";
 import dts from "rollup-plugin-dts";
 import path from "path";
+import prettierPlugin from "rollup-plugin-prettier";
 import replaceText from "@rollup/plugin-replace";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
@@ -14,16 +15,12 @@ function execute(cmd, wait = true) {
 }
 
 function stripComments() {
-  return terserPlugin({
-    mangle: false,
-    output: {
-      beautify: true,
-      indent_level: 1,
-      comments: false,
-    },
-  });
+  return terserPlugin({ mangle: false, output: { comments: false } });
 }
 
+function prettier() {
+  return prettierPlugin({ parser: "typescript", tabWidth: 2 });
+}
 /**
  * TypeScript plugin configured to only produce *.js code files, no *.d.ts
  * files.
@@ -68,7 +65,7 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments()],
+    plugins: [typescriptCompile(), stripComments(), prettier()],
   };
 }
 
@@ -87,6 +84,7 @@ function buildCJS(srcFiles, external = []) {
       resolve({ extensions }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
+      prettier(),
     ],
   };
 }
@@ -128,6 +126,7 @@ function buildDTS(srcFiles = [], external = []) {
     external,
     plugins: [
       dts(),
+      prettier(),
 
       // We no longer need this tmp dir from step 1 here, so clean it up ASAP
       // to avoid confusion

--- a/packages/liveblocks-redux/package-lock.json
+++ b/packages/liveblocks-redux/package-lock.json
@@ -33,6 +33,7 @@
         "rollup": "^2.64.0",
         "rollup-plugin-command": "^1.1.3",
         "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-prettier": "^2.2.2",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.7.2",
         "whatwg-fetch": "^3.6.2"
@@ -9083,10 +9084,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "node_modules/lodash.sortby": {
@@ -10120,6 +10145,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -10660,6 +10701,46 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^1.0.0 || ^2.0.0",
+        "rollup": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-prettier/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/rollup-plugin-prettier/node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/rollup-plugin-terser": {
@@ -18793,10 +18874,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "lodash.sortby": {
@@ -19574,6 +19679,13 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true
+    },
     "pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -19975,6 +20087,38 @@
           "dev": true,
           "requires": {
             "sourcemap-codec": "^1.4.8"
+          }
+        }
+      }
+    },
+    "rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "requires": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
           }
         }
       }

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -59,6 +59,7 @@
     "rollup": "^2.64.0",
     "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-dts": "^4.2.2",
+    "rollup-plugin-prettier": "^2.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.7.2",
     "whatwg-fetch": "^3.6.2"

--- a/packages/liveblocks-redux/rollup.config.js
+++ b/packages/liveblocks-redux/rollup.config.js
@@ -2,6 +2,7 @@ import babelPlugin from "@rollup/plugin-babel";
 import commandPlugin from "rollup-plugin-command";
 import dts from "rollup-plugin-dts";
 import path from "path";
+import prettierPlugin from "rollup-plugin-prettier";
 import replaceText from "@rollup/plugin-replace";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
@@ -14,14 +15,11 @@ function execute(cmd, wait = true) {
 }
 
 function stripComments() {
-  return terserPlugin({
-    mangle: false,
-    output: {
-      beautify: true,
-      indent_level: 1,
-      comments: false,
-    },
-  });
+  return terserPlugin({ mangle: false, output: { comments: false } });
+}
+
+function prettier() {
+  return prettierPlugin({ parser: "typescript", tabWidth: 2 });
 }
 
 /**
@@ -68,7 +66,7 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments()],
+    plugins: [typescriptCompile(), stripComments(), prettier()],
   };
 }
 
@@ -87,6 +85,7 @@ function buildCJS(srcFiles, external = []) {
       resolve({ extensions }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
+      prettier(),
     ],
   };
 }
@@ -128,6 +127,7 @@ function buildDTS(srcFiles = [], external = []) {
     external,
     plugins: [
       dts(),
+      prettier(),
 
       // We no longer need this tmp dir from step 1 here, so clean it up ASAP
       // to avoid confusion

--- a/packages/liveblocks-zustand/package-lock.json
+++ b/packages/liveblocks-zustand/package-lock.json
@@ -31,6 +31,7 @@
         "rollup": "^2.64.0",
         "rollup-plugin-command": "^1.1.3",
         "rollup-plugin-dts": "^4.2.2",
+        "rollup-plugin-prettier": "^2.2.2",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.7.2",
         "whatwg-fetch": "^3.6.2",
@@ -9290,10 +9291,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "node_modules/lodash.sortby": {
@@ -10214,6 +10239,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
@@ -10718,6 +10759,46 @@
       "peerDependencies": {
         "rollup": "^2.55",
         "typescript": "^4.1"
+      }
+    },
+    "node_modules/rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^1.0.0 || ^2.0.0",
+        "rollup": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-prettier/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/rollup-plugin-prettier/node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/rollup-plugin-terser": {
@@ -19038,10 +19119,34 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.hasin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.hasin/-/lodash.hasin-4.5.2.tgz",
+      "integrity": "sha512-AFAitwTSq1Ka/1J9uBaVxpLBP5OI3INQvkl4wKcgIYxoA0S3aqO1QWXHR9aCcOrWtPFqP7GzlFncZfe0Jz0kNw==",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "dev": true
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==",
       "dev": true
     },
     "lodash.sortby": {
@@ -19728,6 +19833,13 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "dev": true,
+      "peer": true
+    },
     "pretty-format": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
@@ -20098,6 +20210,38 @@
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "magic-string": "^0.26.1"
+      }
+    },
+    "rollup-plugin-prettier": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-prettier/-/rollup-plugin-prettier-2.2.2.tgz",
+      "integrity": "sha512-dj5RhTuW8vTVrjxGsKy7rO/ywhKgo8Wihm776e/Po0ZYj/Yu4kr+B6vmnYmZ46Y1kslE1UGoXvBygwmlJ0ifrw==",
+      "dev": true,
+      "requires": {
+        "@types/prettier": "^1.0.0 || ^2.0.0",
+        "diff": "5.0.0",
+        "lodash.hasin": "4.5.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.isnil": "4.0.0",
+        "lodash.omitby": "4.6.0",
+        "magic-string": "0.25.7"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        }
       }
     },
     "rollup-plugin-terser": {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -57,6 +57,7 @@
     "rollup": "^2.64.0",
     "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-dts": "^4.2.2",
+    "rollup-plugin-prettier": "^2.2.2",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.7.2",
     "whatwg-fetch": "^3.6.2",

--- a/packages/liveblocks-zustand/rollup.config.js
+++ b/packages/liveblocks-zustand/rollup.config.js
@@ -2,6 +2,7 @@ import babelPlugin from "@rollup/plugin-babel";
 import commandPlugin from "rollup-plugin-command";
 import dts from "rollup-plugin-dts";
 import path from "path";
+import prettierPlugin from "rollup-plugin-prettier";
 import replaceText from "@rollup/plugin-replace";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
@@ -14,14 +15,11 @@ function execute(cmd, wait = true) {
 }
 
 function stripComments() {
-  return terserPlugin({
-    mangle: false,
-    output: {
-      beautify: true,
-      indent_level: 1,
-      comments: false,
-    },
-  });
+  return terserPlugin({ mangle: false, output: { comments: false } });
+}
+
+function prettier() {
+  return prettierPlugin({ parser: "typescript", tabWidth: 2 });
 }
 
 /**
@@ -68,7 +66,7 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments()],
+    plugins: [typescriptCompile(), stripComments(), prettier()],
   };
 }
 
@@ -87,6 +85,7 @@ function buildCJS(srcFiles, external = []) {
       resolve({ extensions }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
+      prettier(),
     ],
   };
 }
@@ -128,6 +127,7 @@ function buildDTS(srcFiles = [], external = []) {
     external,
     plugins: [
       dts(),
+      prettier(),
 
       // We no longer need this tmp dir from step 1 here, so clean it up ASAP
       // to avoid confusion


### PR DESCRIPTION
This PR sets up our Rollup builds to run prettier over the build output. Since we expect the packages to be included and [processed by a bundler](https://liveblocks.io/docs/guides/troubleshooting#process-not-defined), we don't ship minified builds ourselves. As such, we might as well prettify the output to make it easier to inspect what's in there.
