### PR TITLE
Upgrade E2E test apps to use non-deprecated APIs only

### DIFF
--- a/e2e/next-sandbox/pages/offline/index.tsx
+++ b/e2e/next-sandbox/pages/offline/index.tsx
@@ -1,4 +1,4 @@
-import { Room } from "@liveblocks/client";
+import { LiveList, Room } from "@liveblocks/client";
 import {
   RoomProvider,
   useList,
@@ -34,7 +34,7 @@ export default function Home() {
   }
   return (
     <LiveblocksProvider client={client}>
-      <RoomProvider id={roomId}>
+      <RoomProvider id={roomId} initialStorage={{ items: new LiveList() }}>
         <Sandbox />
       </RoomProvider>
     </LiveblocksProvider>

--- a/e2e/node-sandbox/index.test.js
+++ b/e2e/node-sandbox/index.test.js
@@ -22,8 +22,8 @@ describe("node e2e", () => {
     let roomAOthers = [];
     let roomBOthers = [];
 
-    const roomA = clientA.enter("node-e2e", { defaultPresence: { name: "A" } });
-    const roomB = clientB.enter("node-e2e", { defaultPresence: { name: "B" } });
+    const roomA = clientA.enter("node-e2e", { initialPresence: { name: "A" } });
+    const roomB = clientB.enter("node-e2e", { initialPresence: { name: "B" } });
 
     roomA.subscribe("others", (others) => (roomAOthers = others.toArray()));
     roomB.subscribe("others", (others) => (roomBOthers = others.toArray()));


### PR DESCRIPTION
We'll need to give all of our examples the same treatment, but that is a much more labor-intensive process.

Fixes #313.
