### PR TITLE
Upgrade examples to 0.16.17

### DIFF
--- a/e2e/next-sandbox/package-lock.json
+++ b/e2e/next-sandbox/package-lock.json
@@ -7,11 +7,11 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.14",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "0.3.0",
-        "@liveblocks/react": "^0.16.14",
-        "@liveblocks/redux": "^0.16.14",
-        "@liveblocks/zustand": "^0.16.14",
+        "@liveblocks/react": "^0.16.17",
+        "@liveblocks/redux": "^0.16.17",
+        "@liveblocks/zustand": "^0.16.17",
         "@reduxjs/toolkit": "1.8.1",
         "encoding": "^0.1.13",
         "next": "12.1.5",
@@ -1812,9 +1812,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.15.tgz",
-      "integrity": "sha512-cymqQL53V/ow1xz628viIniEv3QCLkwhqsx/txuKR1ziIHyTpqBMzYPUlDUNqCjCzLL/WuyK+kfFpK6Ux9wiBA=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -1825,29 +1825,29 @@
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.15.tgz",
-      "integrity": "sha512-fs6+GO3KZ8Vil2JdtkCclS3A0duT5hs8mCzGWvPzGHjdwethokJL5d6T1zoNTwb7qIoy0/7TPDPh8bd0a4ZiPA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.15",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.15.tgz",
-      "integrity": "sha512-xiihMxD06ZXgbxcALPzd13YjlXBkkcOkiB8sLSH2t7ed8ejR8D4h/Zvpe+8GECZ4t0HJyfKX5ql5yxZhas3j4w==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.17.tgz",
+      "integrity": "sha512-EE/9NBWBm3BU+Hpo8zDGnHMM73NPYX5LisLMzUjO/4NUJyrxP4z2A83h98eIJB0vExUnswJo+2WdgHUX3aQk7Q==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.15",
+        "@liveblocks/client": "0.16.17",
         "redux": "^4"
       }
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.15.tgz",
-      "integrity": "sha512-oV+l1EVXUWKQhujmWQ2FJyNR90CGfJYqvKCBRXWHYBaMTQmD5eqFQyghS6yasr5Dj1wNcnwfFjE8gBavqaCZZQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.17.tgz",
+      "integrity": "sha512-Nrtvz7KXx7iDD+Ux0oGWQASnzDbVp2RJ2tt4T5tm02QLBx58hju3FvjxHtiBU1+nZUD+y1Y7szdtry/PWIk2GA==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.15",
+        "@liveblocks/client": "0.16.17",
         "zustand": "^3"
       }
     },
@@ -9011,9 +9011,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.15.tgz",
-      "integrity": "sha512-cymqQL53V/ow1xz628viIniEv3QCLkwhqsx/txuKR1ziIHyTpqBMzYPUlDUNqCjCzLL/WuyK+kfFpK6Ux9wiBA=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",
@@ -9024,21 +9024,21 @@
       }
     },
     "@liveblocks/react": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.15.tgz",
-      "integrity": "sha512-fs6+GO3KZ8Vil2JdtkCclS3A0duT5hs8mCzGWvPzGHjdwethokJL5d6T1zoNTwb7qIoy0/7TPDPh8bd0a4ZiPA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@liveblocks/redux": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.15.tgz",
-      "integrity": "sha512-xiihMxD06ZXgbxcALPzd13YjlXBkkcOkiB8sLSH2t7ed8ejR8D4h/Zvpe+8GECZ4t0HJyfKX5ql5yxZhas3j4w==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.17.tgz",
+      "integrity": "sha512-EE/9NBWBm3BU+Hpo8zDGnHMM73NPYX5LisLMzUjO/4NUJyrxP4z2A83h98eIJB0vExUnswJo+2WdgHUX3aQk7Q==",
       "requires": {}
     },
     "@liveblocks/zustand": {
-      "version": "0.16.15",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.15.tgz",
-      "integrity": "sha512-oV+l1EVXUWKQhujmWQ2FJyNR90CGfJYqvKCBRXWHYBaMTQmD5eqFQyghS6yasr5Dj1wNcnwfFjE8gBavqaCZZQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.17.tgz",
+      "integrity": "sha512-Nrtvz7KXx7iDD+Ux0oGWQASnzDbVp2RJ2tt4T5tm02QLBx58hju3FvjxHtiBU1+nZUD+y1Y7szdtry/PWIk2GA==",
       "requires": {}
     },
     "@next/env": {

--- a/e2e/next-sandbox/package.json
+++ b/e2e/next-sandbox/package.json
@@ -9,11 +9,11 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.14",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "0.3.0",
-    "@liveblocks/react": "^0.16.14",
-    "@liveblocks/redux": "^0.16.14",
-    "@liveblocks/zustand": "^0.16.14",
+    "@liveblocks/react": "^0.16.17",
+    "@liveblocks/redux": "^0.16.17",
+    "@liveblocks/zustand": "^0.16.17",
     "@reduxjs/toolkit": "1.8.1",
     "encoding": "^0.1.13",
     "next": "12.1.5",

--- a/e2e/node-sandbox/package-lock.json
+++ b/e2e/node-sandbox/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "node-sandbox",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "node-fetch": "2.6.7",
         "ws": "^8.5.0"
       },
@@ -873,9 +872,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -4737,9 +4736,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/e2e/node-sandbox/package.json
+++ b/e2e/node-sandbox/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "node-fetch": "2.6.7",
     "ws": "^8.5.0"
   },

--- a/examples/javascript-live-cursors/package-lock.json
+++ b/examples/javascript-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9"
+        "@liveblocks/client": "^0.16.17"
       },
       "devDependencies": {
         "esbuild": "^0.12.2",
@@ -15,9 +15,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/esbuild": {
       "version": "0.12.2",
@@ -46,9 +46,9 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "esbuild": {
       "version": "0.12.2",

--- a/examples/javascript-live-cursors/package.json
+++ b/examples/javascript-live-cursors/package.json
@@ -6,7 +6,7 @@
     "build": "esbuild app.js --bundle --outfile=static/app.js"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9"
+    "@liveblocks/client": "^0.16.17"
   },
   "devDependencies": {
     "esbuild": "^0.12.2",

--- a/examples/javascript-todo-list/app.js
+++ b/examples/javascript-todo-list/app.js
@@ -17,7 +17,9 @@ async function run() {
     publicApiKey: PUBLIC_KEY,
   });
 
-  const room = client.enter(roomId);
+  const room = client.enter(roomId, {
+    initialStorage: { todos: new LiveList() },
+  });
 
   const whoIsHere = document.getElementById("who_is_here");
   const todoInput = document.getElementById("todo_input");
@@ -37,11 +39,6 @@ async function run() {
   const { root } = await room.getStorage();
 
   let todos = root.get("todos");
-
-  if (todos == null) {
-    todos = new LiveList();
-    root.set("todos", todos);
-  }
 
   todoInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {

--- a/examples/javascript-todo-list/package-lock.json
+++ b/examples/javascript-todo-list/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9"
+        "@liveblocks/client": "^0.16.17"
       },
       "devDependencies": {
         "esbuild": "^0.14.25",
@@ -15,9 +15,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/esbuild": {
       "version": "0.14.25",
@@ -392,9 +392,9 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "esbuild": {
       "version": "0.14.25",

--- a/examples/javascript-todo-list/package.json
+++ b/examples/javascript-todo-list/package.json
@@ -11,6 +11,6 @@
     "prettier": "^2.6.2"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9"
+    "@liveblocks/client": "^0.16.17"
   }
 }

--- a/examples/nextjs-live-avatars/package-lock.json
+++ b/examples/nextjs-live-avatars/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "0.3.0",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/react": "^0.16.17",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -65,11 +65,11 @@
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -1958,9 +1958,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",
@@ -1971,9 +1971,9 @@
       }
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-live-avatars/package.json
+++ b/examples/nextjs-live-avatars/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "0.3.0",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/react": "^0.16.17",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors-chat/package-lock.json
+++ b/examples/nextjs-live-cursors-chat/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -33,16 +33,16 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -1752,14 +1752,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-live-cursors-chat/package.json
+++ b/examples/nextjs-live-cursors-chat/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors-scroll/package-lock.json
+++ b/examples/nextjs-live-cursors-scroll/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -33,16 +33,16 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -1752,14 +1752,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-live-cursors-scroll/package.json
+++ b/examples/nextjs-live-cursors-scroll/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors-scroll/pages/index.tsx
+++ b/examples/nextjs-live-cursors-scroll/pages/index.tsx
@@ -187,9 +187,9 @@ export default function Page() {
       /**
        * Initialize the cursor position to null when joining the room
        */
-      defaultPresence={() => ({
+      initialPresence={{
         cursor: null,
-      })}
+      }}
     >
       <Example />
     </RoomProvider>

--- a/examples/nextjs-live-cursors/package-lock.json
+++ b/examples/nextjs-live-cursors/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -50,16 +50,16 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -1940,14 +1940,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-live-cursors/package.json
+++ b/examples/nextjs-live-cursors/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors/pages/index.tsx
+++ b/examples/nextjs-live-cursors/pages/index.tsx
@@ -100,9 +100,9 @@ export default function Page() {
       /**
        * Initialize the cursor position to null when joining the room
        */
-      defaultPresence={() => ({
+      initialPresence={{
         cursor: null,
-      })}
+      }}
     >
       <Example />
     </RoomProvider>

--- a/examples/nextjs-live-selection/package-lock.json
+++ b/examples/nextjs-live-selection/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -21,16 +21,16 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -449,14 +449,14 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-live-selection/package.json
+++ b/examples/nextjs-live-selection/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-selection/pages/index.tsx
+++ b/examples/nextjs-live-selection/pages/index.tsx
@@ -129,9 +129,9 @@ export default function Page() {
   return (
     <RoomProvider
       id={roomId}
-      defaultPresence={() => ({
+      initialPresence={{
         selectedId: null,
-      })}
+      }}
     >
       <Example />
     </RoomProvider>

--- a/examples/nextjs-logo-builder/package-lock.json
+++ b/examples/nextjs-logo-builder/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "^0.3.0",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/react": "^0.16.17",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -35,11 +35,11 @@
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -473,9 +473,9 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",
@@ -486,9 +486,9 @@
       }
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-logo-builder/package.json
+++ b/examples/nextjs-logo-builder/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "^0.3.0",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/react": "^0.16.17",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-logo-builder/pages/_app.tsx
+++ b/examples/nextjs-logo-builder/pages/_app.tsx
@@ -15,7 +15,13 @@ function App({ Component, pageProps }: AppProps) {
 
   return (
     <LiveblocksProvider client={client}>
-      <RoomProvider id={roomId}>
+      <RoomProvider
+        id={roomId}
+        initialStorage={{
+          name: "Acme Inc.",
+          theme: "light",
+        }}
+      >
         <Head>
           <title>Liveblocks</title>
           <meta name="robots" content="noindex" />

--- a/examples/nextjs-logo-builder/pages/index.tsx
+++ b/examples/nextjs-logo-builder/pages/index.tsx
@@ -46,10 +46,7 @@ export default function Example() {
    * It's using the storage block so the data is persisted even after all the users leave the room.
    * For more information: https://liveblocks.io/docs/api-reference/liveblocks-react#useObject
    */
-  const data = useObject<Logo>("logo", {
-    name: "Acme Inc.",
-    theme: "light",
-  });
+  const data = useObject<Logo>("logo");
 
   if (!data) {
     return (

--- a/examples/nextjs-threejs-shoe/package-lock.json
+++ b/examples/nextjs-threejs-shoe/package-lock.json
@@ -12,9 +12,9 @@
         "drei": "2.2.12",
         "next": "^12.1.6",
         "next-transpile-modules": "^9.0.0",
-        "react": "18.1.0",
+        "react": "17.0.2",
         "react-colorful": "^5.5.0",
-        "react-dom": "18.1.0",
+        "react-dom": "17.0.2",
         "react-three-fiber": "5.3.10",
         "three": "0.123.0"
       },
@@ -554,11 +554,12 @@
       }
     },
     "node_modules/react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -574,15 +575,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
-      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.22.0"
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^18.1.0"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-merge-refs": {
@@ -664,11 +666,12 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/scheduler": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
-      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/source-map-js": {
@@ -1077,11 +1080,12 @@
       "dev": true
     },
     "react": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
-      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "react-colorful": {
@@ -1091,12 +1095,13 @@
       "requires": {}
     },
     "react-dom": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
-      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.22.0"
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       }
     },
     "react-merge-refs": {
@@ -1160,11 +1165,12 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "scheduler": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
-      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "requires": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "source-map-js": {

--- a/examples/nextjs-threejs-shoe/package-lock.json
+++ b/examples/nextjs-threejs-shoe/package-lock.json
@@ -12,9 +12,9 @@
         "drei": "2.2.12",
         "next": "^12.1.6",
         "next-transpile-modules": "^9.0.0",
-        "react": "^18.1.0",
+        "react": "18.1.0",
         "react-colorful": "^5.5.0",
-        "react-dom": "^18.1.0",
+        "react-dom": "18.1.0",
         "react-three-fiber": "5.3.10",
         "three": "0.123.0"
       },
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001338",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
-      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
+      "version": "1.0.30001352",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
+      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
       "funding": [
         {
           "type": "opencollective",
@@ -489,6 +489,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/next/node_modules/styled-jsx": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -664,25 +683,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha1-scPcRtlEmLV4t/05hbgaznExzH0="
-    },
-    "node_modules/styled-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
     },
     "node_modules/three": {
       "version": "0.123.0",
@@ -911,9 +911,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001338",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
-      "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ=="
+      "version": "1.0.30001352",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
+      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA=="
     },
     "debounce": {
       "version": "1.2.1",
@@ -1015,6 +1015,14 @@
         "caniuse-lite": "^1.0.30001332",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.2"
+      },
+      "dependencies": {
+        "styled-jsx": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+          "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+          "requires": {}
+        }
       }
     },
     "next-transpile-modules": {
@@ -1168,12 +1176,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha1-scPcRtlEmLV4t/05hbgaznExzH0="
-    },
-    "styled-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "requires": {}
     },
     "three": {
       "version": "0.123.0",

--- a/examples/nextjs-threejs-shoe/package-lock.json
+++ b/examples/nextjs-threejs-shoe/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "drei": "2.2.12",
         "next": "^12.1.6",
         "next-transpile-modules": "^9.0.0",
@@ -34,16 +34,16 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -773,14 +773,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-threejs-shoe/package.json
+++ b/examples/nextjs-threejs-shoe/package.json
@@ -13,9 +13,9 @@
     "drei": "2.2.12",
     "next": "^12.1.6",
     "next-transpile-modules": "^9.0.0",
-    "react": "^18.1.0",
+    "react": "17.0.2",
     "react-colorful": "^5.5.0",
-    "react-dom": "^18.1.0",
+    "react-dom": "17.0.2",
     "react-three-fiber": "5.3.10",
     "three": "0.123.0"
   },

--- a/examples/nextjs-threejs-shoe/package.json
+++ b/examples/nextjs-threejs-shoe/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "drei": "2.2.12",
     "next": "^12.1.6",
     "next-transpile-modules": "^9.0.0",

--- a/examples/nextjs-threejs-shoe/pages/_app.js
+++ b/examples/nextjs-threejs-shoe/pages/_app.js
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useMemo } from "react";
 import { useRouter } from "next/router";
 import { LiveblocksProvider, RoomProvider } from "@liveblocks/react";
-import { createClient } from "@liveblocks/client";
+import { createClient, LiveObject } from "@liveblocks/client";
 
 const client = createClient({
   publicApiKey: process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY,
@@ -17,7 +17,7 @@ function App({ Component, pageProps }) {
      * to be able to use Liveblocks react hooks in your components
      **/
     <LiveblocksProvider client={client}>
-      <RoomProvider id={roomId}>
+      <RoomProvider id={roomId} initialStorage={{ colors: new LiveObject() }}>
         <Head>
           <title>Liveblocks</title>
           <meta name="robots" content="noindex" />

--- a/examples/nextjs-threejs-shoe/pages/index.js
+++ b/examples/nextjs-threejs-shoe/pages/index.js
@@ -6,7 +6,7 @@ import { HexColorPicker } from "react-colorful";
 import styles from "./index.module.css";
 
 /**
- * This file shows how to create a simple collaborative form.
+ * This file shows how to create a simple 3D editor using react-three-fiber and Liveblocks
  *
  * We use the storage block to persist the show colors even after everyone leaves the room.
  */

--- a/examples/nextjs-whiteboard-advanced/package-lock.json
+++ b/examples/nextjs-whiteboard-advanced/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "0.3.0",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/react": "^0.16.17",
         "nanoid": "^3.1.25",
         "next": "^12.1.6",
         "perfect-freehand": "^0.5.3",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -67,11 +67,11 @@
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -2135,9 +2135,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",
@@ -2148,9 +2148,9 @@
       }
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@next/env": {

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "0.3.0",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/react": "^0.16.17",
     "nanoid": "^3.1.25",
     "next": "^12.1.6",
     "perfect-freehand": "^0.5.3",

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -50,12 +50,16 @@ export default function Room() {
   return (
     <RoomProvider
       id={roomId}
-      defaultPresence={() => ({
+      initialPresence={{
         selection: [],
         cursor: null,
         pencilDraft: null,
         penColor: null,
-      })}
+      }}
+      initialStorage={{
+        layers: new LiveMap<string, LiveObject<Layer>>(),
+        layerIds: new LiveList(),
+      }}
     >
       <div className={styles.container}>
         <WhiteboardTool />

--- a/examples/nuxtjs-live-avatars/package-lock.json
+++ b/examples/nuxtjs-live-avatars/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "^0.3.0",
         "core-js": "^3.9.1",
         "express": "^4.17.1",
@@ -1599,9 +1599,9 @@
       "dev": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -18878,9 +18878,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",

--- a/examples/nuxtjs-live-avatars/package.json
+++ b/examples/nuxtjs-live-avatars/package.json
@@ -9,7 +9,7 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "^0.3.0",
     "core-js": "^3.9.1",
     "express": "^4.17.1",

--- a/examples/react-dashboard/package-lock.json
+++ b/examples/react-dashboard/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1",
@@ -2791,16 +2791,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -18041,14 +18041,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/react-dashboard/package.json
+++ b/examples/react-dashboard/package.json
@@ -3,8 +3,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",

--- a/examples/react-dashboard/src/App.js
+++ b/examples/react-dashboard/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   XAxis,
   YAxis,
@@ -232,10 +232,7 @@ function Example() {
 
 export default function App() {
   return (
-    <RoomProvider
-      id={roomId}
-      defaultPresence={() => ({ cardId: null, cursor: null })}
-    >
+    <RoomProvider id={roomId} initialPresence={{ cardId: null, cursor: null }}>
       <Example />
     </RoomProvider>
   );

--- a/examples/react-todo-list/package-lock.json
+++ b/examples/react-todo-list/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
@@ -2728,16 +2728,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -17871,14 +17871,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/react-todo-list/package.json
+++ b/examples/react-todo-list/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",

--- a/examples/react-todo-list/src/index.js
+++ b/examples/react-todo-list/src/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { createClient } from "@liveblocks/client";
+import { createClient, LiveList } from "@liveblocks/client";
 import { LiveblocksProvider, RoomProvider } from "@liveblocks/react";
 import App from "./App";
 import "./index.css";
@@ -21,18 +21,17 @@ const client = createClient({
   publicApiKey: PUBLIC_KEY,
 });
 
-function Page() {
-  return (
-    <RoomProvider id={roomId}>
-      <App />
-    </RoomProvider>
-  );
-}
-
 ReactDOM.render(
   <React.StrictMode>
     <LiveblocksProvider client={client}>
-      <Page />
+      <RoomProvider
+        id={roomId}
+        initialStorage={{
+          todos: new LiveList(),
+        }}
+      >
+        <App />
+      </RoomProvider>
     </LiveblocksProvider>
   </React.StrictMode>,
   document.getElementById("root")

--- a/examples/react-whiteboard/package-lock.json
+++ b/examples/react-whiteboard/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/react": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/react": "^0.16.17",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1"
@@ -2725,16 +2725,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -17497,14 +17497,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/react": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.9.tgz",
-      "integrity": "sha512-/jLBQRKxE+KYTinHngpBoAaS0ttjofxFgI9TdBxkUsIJYvR9D+jusqMOSIa0Ja4fz44Cfw34DC8DHAxTp3jOMg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.16.17.tgz",
+      "integrity": "sha512-I0WvNI+X/I+ymbVF/+W4GOCaZnsaqje01Mp9BGt7u7joL1ZNBQuva1zWPINE6pNWTk75y/pmG4o56YoC+ek4FQ==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/react-whiteboard/package.json
+++ b/examples/react-whiteboard/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/react": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/react": "^0.16.17",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1"

--- a/examples/react-whiteboard/src/index.js
+++ b/examples/react-whiteboard/src/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import { createClient } from "@liveblocks/client";
+import { createClient, LiveMap } from "@liveblocks/client";
 import { LiveblocksProvider, RoomProvider } from "@liveblocks/react";
 import "./index.css";
 
@@ -21,20 +21,19 @@ const client = createClient({
   publicApiKey: PUBLIC_KEY,
 });
 
-function Page() {
-  return (
-    <RoomProvider id={roomId}>
-      <App />
-    </RoomProvider>
-  );
-}
-
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
   <React.StrictMode>
     <LiveblocksProvider client={client}>
-      <Page />
+      <RoomProvider
+        id={roomId}
+        initialStorage={{
+          shapes: new LiveMap(),
+        }}
+      >
+        <App />
+      </RoomProvider>
     </LiveblocksProvider>
   </React.StrictMode>
 );

--- a/examples/redux-todo-list/package-lock.json
+++ b/examples/redux-todo-list/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/redux": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/redux": "^0.16.17",
         "@reduxjs/toolkit": "^1.7.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2728,16 +2728,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.9.tgz",
-      "integrity": "sha512-JGW0agxWpb3Bv0WEjLuz5sJFNhSYltR6a7aurznXH0jz/Vmdt/5fh3WzA84wVIyjrEhNuLLa7/ltfqsD4Se59g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.17.tgz",
+      "integrity": "sha512-EE/9NBWBm3BU+Hpo8zDGnHMM73NPYX5LisLMzUjO/4NUJyrxP4z2A83h98eIJB0vExUnswJo+2WdgHUX3aQk7Q==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "redux": "^4"
       }
     },
@@ -17626,14 +17626,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/redux": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.9.tgz",
-      "integrity": "sha512-JGW0agxWpb3Bv0WEjLuz5sJFNhSYltR6a7aurznXH0jz/Vmdt/5fh3WzA84wVIyjrEhNuLLa7/ltfqsD4Se59g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.17.tgz",
+      "integrity": "sha512-EE/9NBWBm3BU+Hpo8zDGnHMM73NPYX5LisLMzUjO/4NUJyrxP4z2A83h98eIJB0vExUnswJo+2WdgHUX3aQk7Q==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/redux-todo-list/package.json
+++ b/examples/redux-todo-list/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/redux": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/redux": "^0.16.17",
     "@reduxjs/toolkit": "^1.7.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/redux-whiteboard/package-lock.json
+++ b/examples/redux-whiteboard/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/redux": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/redux": "^0.16.17",
         "@reduxjs/toolkit": "^1.7.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2728,16 +2728,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.9.tgz",
-      "integrity": "sha512-JGW0agxWpb3Bv0WEjLuz5sJFNhSYltR6a7aurznXH0jz/Vmdt/5fh3WzA84wVIyjrEhNuLLa7/ltfqsD4Se59g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.17.tgz",
+      "integrity": "sha512-EE/9NBWBm3BU+Hpo8zDGnHMM73NPYX5LisLMzUjO/4NUJyrxP4z2A83h98eIJB0vExUnswJo+2WdgHUX3aQk7Q==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "redux": "^4"
       }
     },
@@ -17626,14 +17626,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/redux": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.9.tgz",
-      "integrity": "sha512-JGW0agxWpb3Bv0WEjLuz5sJFNhSYltR6a7aurznXH0jz/Vmdt/5fh3WzA84wVIyjrEhNuLLa7/ltfqsD4Se59g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.16.17.tgz",
+      "integrity": "sha512-EE/9NBWBm3BU+Hpo8zDGnHMM73NPYX5LisLMzUjO/4NUJyrxP4z2A83h98eIJB0vExUnswJo+2WdgHUX3aQk7Q==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/redux-whiteboard/package.json
+++ b/examples/redux-whiteboard/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/redux": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/redux": "^0.16.17",
     "@reduxjs/toolkit": "^1.7.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/solidjs-live-avatars/package-lock.json
+++ b/examples/solidjs-live-avatars/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "solid-js": "^1.3.13"
       },
       "devDependencies": {
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -1755,9 +1755,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",

--- a/examples/solidjs-live-avatars/package.json
+++ b/examples/solidjs-live-avatars/package.json
@@ -12,7 +12,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "solid-js": "^1.3.13"
   }
 }

--- a/examples/solidjs-live-cursors/package-lock.json
+++ b/examples/solidjs-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@motionone/solid": "^10.8.1",
         "@solid-primitives/keyed": "^1.0.0",
         "motion": "^10.8.1",
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@motionone/animation": {
       "version": "10.8.0",
@@ -1898,9 +1898,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@motionone/animation": {
       "version": "10.8.0",

--- a/examples/solidjs-live-cursors/package.json
+++ b/examples/solidjs-live-cursors/package.json
@@ -12,7 +12,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@motionone/solid": "^10.8.1",
     "@solid-primitives/keyed": "^1.0.0",
     "motion": "^10.8.1",

--- a/examples/sveltekit-live-avatars/package-lock.json
+++ b/examples/sveltekit-live-avatars/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "^0.3.0"
       },
       "devDependencies": {
@@ -55,9 +55,9 @@
       "dev": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -2148,9 +2148,9 @@
       "dev": true
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",

--- a/examples/sveltekit-live-avatars/package.json
+++ b/examples/sveltekit-live-avatars/package.json
@@ -24,7 +24,7 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "^0.3.0"
   }
 }

--- a/examples/sveltekit-live-cursors/package-lock.json
+++ b/examples/sveltekit-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "@liveblocks/node": "^0.3.0"
       },
       "devDependencies": {
@@ -55,9 +55,9 @@
       "dev": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/node": {
       "version": "0.3.0",
@@ -2148,9 +2148,9 @@
       "dev": true
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/node": {
       "version": "0.3.0",

--- a/examples/sveltekit-live-cursors/package.json
+++ b/examples/sveltekit-live-cursors/package.json
@@ -24,7 +24,7 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "@liveblocks/node": "^0.3.0"
   }
 }

--- a/examples/vuejs-live-cursors/package-lock.json
+++ b/examples/vuejs-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
         "core-js": "^3.6.5",
         "vue": "^2.6.11"
       },
@@ -1764,9 +1764,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -15721,9 +15721,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/examples/vuejs-live-cursors/package.json
+++ b/examples/vuejs-live-cursors/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
     "core-js": "^3.6.5",
     "vue": "^2.6.11"
   },

--- a/examples/vuejs-live-cursors/src/App.vue
+++ b/examples/vuejs-live-cursors/src/App.vue
@@ -36,7 +36,7 @@
 import Vue from "vue";
 import { createClient } from "@liveblocks/client";
 
-let PUBLIC_KEY = "pk_live_kLnGu3ec6QmMdg6V1C0hbcap";
+let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 let roomId = "vuejs-live-cursors";
 
 overrideApiKeyAndRoomId();

--- a/examples/vuejs-live-cursors/src/App.vue
+++ b/examples/vuejs-live-cursors/src/App.vue
@@ -36,7 +36,7 @@
 import Vue from "vue";
 import { createClient } from "@liveblocks/client";
 
-let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
+let PUBLIC_KEY = "pk_live_kLnGu3ec6QmMdg6V1C0hbcap";
 let roomId = "vuejs-live-cursors";
 
 overrideApiKeyAndRoomId();
@@ -62,7 +62,7 @@ export default Vue.extend({
     };
   },
   mounted: function () {
-    const room = client.enter(roomId, { cursor: null });
+    const room = client.enter(roomId, { defaultPresence: { cursor: null } });
     this._room = room;
     this._unsubscribe = room.subscribe("my-presence", this.onPresenceChange);
     this._unsubscribeOthers = room.subscribe("others", this.onOthersChange);

--- a/examples/vuejs-live-cursors/src/App.vue
+++ b/examples/vuejs-live-cursors/src/App.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
     };
   },
   mounted: function () {
-    const room = client.enter(roomId, { defaultPresence: { cursor: null } });
+    const room = client.enter(roomId, { initialPresence: { cursor: null } });
     this._room = room;
     this._unsubscribe = room.subscribe("my-presence", this.onPresenceChange);
     this._unsubscribeOthers = room.subscribe("others", this.onOthersChange);

--- a/examples/zustand-todo-list/package-lock.json
+++ b/examples/zustand-todo-list/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/zustand": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/zustand": "^0.16.17",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1",
@@ -2726,16 +2726,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.9.tgz",
-      "integrity": "sha512-ezEQ6l2TNim0Ajd4IbiZNtxB5fXF8WzVIeTOiA3R3Xsv5vB4ICyuyxngViVfJix9Fv03zQ3X4VuHPBn6o+dBAQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.17.tgz",
+      "integrity": "sha512-Nrtvz7KXx7iDD+Ux0oGWQASnzDbVp2RJ2tt4T5tm02QLBx58hju3FvjxHtiBU1+nZUD+y1Y7szdtry/PWIk2GA==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "zustand": "^3"
       }
     },
@@ -17514,14 +17514,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/zustand": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.9.tgz",
-      "integrity": "sha512-ezEQ6l2TNim0Ajd4IbiZNtxB5fXF8WzVIeTOiA3R3Xsv5vB4ICyuyxngViVfJix9Fv03zQ3X4VuHPBn6o+dBAQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.17.tgz",
+      "integrity": "sha512-Nrtvz7KXx7iDD+Ux0oGWQASnzDbVp2RJ2tt4T5tm02QLBx58hju3FvjxHtiBU1+nZUD+y1Y7szdtry/PWIk2GA==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/zustand-todo-list/package.json
+++ b/examples/zustand-todo-list/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/zustand": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/zustand": "^0.16.17",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",

--- a/examples/zustand-whiteboard/package-lock.json
+++ b/examples/zustand-whiteboard/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.16.9",
-        "@liveblocks/zustand": "^0.16.9",
+        "@liveblocks/client": "^0.16.17",
+        "@liveblocks/zustand": "^0.16.17",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -2721,16 +2721,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.9.tgz",
-      "integrity": "sha512-ezEQ6l2TNim0Ajd4IbiZNtxB5fXF8WzVIeTOiA3R3Xsv5vB4ICyuyxngViVfJix9Fv03zQ3X4VuHPBn6o+dBAQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.17.tgz",
+      "integrity": "sha512-Nrtvz7KXx7iDD+Ux0oGWQASnzDbVp2RJ2tt4T5tm02QLBx58hju3FvjxHtiBU1+nZUD+y1Y7szdtry/PWIk2GA==",
       "peerDependencies": {
-        "@liveblocks/client": "0.16.9",
+        "@liveblocks/client": "0.16.17",
         "zustand": "^3"
       }
     },
@@ -17893,14 +17893,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.9.tgz",
-      "integrity": "sha512-xeg6USi/iqSDKDU9xPTpNXYaz/2GfNdAczKLpIOV/nU60XDx5uiQuP4+KCYY1eBtgfPnYnM9gndvFciTimgbIQ=="
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.17.tgz",
+      "integrity": "sha512-mWX/EGQNoWwzkEdUfdt82w9OMA5kKV3BraBt2YhZO4Zn04mfNmcOkr7V4S+EmJ4LyQ5QVNKYvA4gJQU1ahn5mQ=="
     },
     "@liveblocks/zustand": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.9.tgz",
-      "integrity": "sha512-ezEQ6l2TNim0Ajd4IbiZNtxB5fXF8WzVIeTOiA3R3Xsv5vB4ICyuyxngViVfJix9Fv03zQ3X4VuHPBn6o+dBAQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.16.17.tgz",
+      "integrity": "sha512-Nrtvz7KXx7iDD+Ux0oGWQASnzDbVp2RJ2tt4T5tm02QLBx58hju3FvjxHtiBU1+nZUD+y1Y7szdtry/PWIk2GA==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/zustand-whiteboard/package.json
+++ b/examples/zustand-whiteboard/package.json
@@ -3,8 +3,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.16.9",
-    "@liveblocks/zustand": "^0.16.9",
+    "@liveblocks/client": "^0.16.17",
+    "@liveblocks/zustand": "^0.16.17",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
Upgrade all examples to 0.16.17.

I ran all examples locally to make sure no warnings were thrown. I adapted the code to use the latest patterns. 

I had to downgrade react on the 3d shoe example because it's not compatible with other dependencies.