### PR TITLE
Deprecate storage hooks

### DIFF
--- a/packages/liveblocks-client/package-lock.json
+++ b/packages/liveblocks-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/client",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/client",
-      "version": "0.16.13",
+      "version": "0.17.0-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/client",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "description": "A client that lets you interact with Liveblocks servers.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/packages/liveblocks-react/package-lock.json
+++ b/packages/liveblocks-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/react",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/react",
-      "version": "0.16.13",
+      "version": "0.17.0-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -38,7 +38,7 @@
         "whatwg-fetch": "^3.6.2"
       },
       "peerDependencies": {
-        "@liveblocks/client": "0.16.13",
+        "@liveblocks/client": "0.17.0-test1",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.13.tgz",
-      "integrity": "sha512-u2wU2Jf8l8luML5H4P68I145eDxjteeWw89c3Sk1WZFLyhOIh5+chm8lEIu3MDLMlsL/MCD8NQJNPQltHu+/Ig==",
+      "version": "0.17.0-test1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.0-test1.tgz",
+      "integrity": "sha512-QVLHAC1FDlwl80Rbo7/2aSkEQZFSueNMX925aN+ieCzuiMyFksb2WiHxVxginjlHOTc7uKatDc+6X/Nlg67+7w==",
       "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -14013,9 +14013,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.13.tgz",
-      "integrity": "sha512-u2wU2Jf8l8luML5H4P68I145eDxjteeWw89c3Sk1WZFLyhOIh5+chm8lEIu3MDLMlsL/MCD8NQJNPQltHu+/Ig==",
+      "version": "0.17.0-test1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.0-test1.tgz",
+      "integrity": "sha512-QVLHAC1FDlwl80Rbo7/2aSkEQZFSueNMX925aN+ieCzuiMyFksb2WiHxVxginjlHOTc7uKatDc+6X/Nlg67+7w==",
       "peer": true
     },
     "@nodelib/fs.scandir": {

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "description": "A set of React hooks and providers to use Liveblocks declaratively.",
   "main": "./index.js",
   "module": "./index.mjs",
@@ -29,7 +29,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@liveblocks/client": "0.16.13",
+    "@liveblocks/client": "0.17.0-test1",
     "react": "^16.14.0 || ^17 || ^18"
   },
   "devDependencies": {

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -114,6 +114,80 @@ export function useHistory(): History {
 
 /**
  * @deprecated Please use `configureRoom()` instead of importing
+ * `useList` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useList<TValue extends Lson>(
+  key: string
+): LiveList<TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useList` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useList<TValue extends Lson>(
+  key: string,
+  items: TValue[]
+): LiveList<TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useList` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useList<TValue extends Lson>(
+  key: string,
+  items?: TValue[] | undefined
+): LiveList<TValue> | null {
+  deprecate(
+    "Please use `configureRoom()` instead of importing `useList` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
+  );
+  return _hooks.deprecated_useList(key as any, items as any);
+}
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useMap` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string
+): LiveMap<TKey, TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useMap` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string,
+  entries: readonly (readonly [TKey, TValue])[] | null
+): LiveMap<TKey, TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useMap` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string,
+  entries?: readonly (readonly [TKey, TValue])[] | null | undefined
+): LiveMap<TKey, TValue> | null {
+  deprecate(
+    "Please use `configureRoom()` instead of importing `useMap` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
+  );
+  return _hooks.deprecated_useMap(key as any, entries as any);
+}
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
  * `useMyPresence` from `@liveblocks/react` directly. See
  * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
  * details.
@@ -129,6 +203,43 @@ export function useMyPresence<TPresence extends JsonObject>(): [
     TPresence,
     (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) => void
   ];
+}
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useObject` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string
+): LiveObject<TData> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useObject` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string,
+  initialData: TData
+): LiveObject<TData> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useObject` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string,
+  initialData?: TData
+): LiveObject<TData> | null {
+  deprecate(
+    "Please use `configureRoom()` instead of importing `useObject` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
+  );
+  return _hooks.deprecated_useObject(key as any, initialData as any);
 }
 
 /**
@@ -233,115 +344,4 @@ export function useUpdateMyPresence<TPresence extends JsonObject>(): (
     overrides: Partial<TPresence>,
     options?: { addToHistory: boolean }
   ) => void;
-}
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useList` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useList<TValue extends Lson>(
-  key: string
-): LiveList<TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useList` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useList<TValue extends Lson>(
-  key: string,
-  items: TValue[]
-): LiveList<TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useList` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useList<TValue extends Lson>(
-  key: string,
-  items?: TValue[] | undefined
-): LiveList<TValue> | null {
-  deprecate(
-    "Please use `configureRoom()` instead of importing `useList` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
-  );
-  return _hooks.deprecated_useList(key as any, items as any);
-}
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useMap` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useMap<TKey extends string, TValue extends Lson>(
-  key: string
-): LiveMap<TKey, TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useMap` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useMap<TKey extends string, TValue extends Lson>(
-  key: string,
-  entries: readonly (readonly [TKey, TValue])[] | null
-): LiveMap<TKey, TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useMap` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useMap<TKey extends string, TValue extends Lson>(
-  key: string,
-  entries?: readonly (readonly [TKey, TValue])[] | null | undefined
-): LiveMap<TKey, TValue> | null {
-  deprecate(
-    "Please use `configureRoom()` instead of importing `useMap` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
-  );
-  return _hooks.deprecated_useMap(key as any, entries as any);
-}
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useObject` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useObject<TData extends LsonObject>(
-  key: string
-): LiveObject<TData> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useObject` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useObject<TData extends LsonObject>(
-  key: string,
-  initialData: TData
-): LiveObject<TData> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useObject` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useObject<TData extends LsonObject>(
-  key: string,
-  initialData?: TData
-): LiveObject<TData> | null {
-  deprecate(
-    "Please use `configureRoom()` instead of importing `useObject` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
-  );
-  return _hooks.deprecated_useObject(key as any, initialData as any);
 }

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -114,80 +114,6 @@ export function useHistory(): History {
 
 /**
  * @deprecated Please use `configureRoom()` instead of importing
- * `useList` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useList<TValue extends Lson>(
-  key: string
-): LiveList<TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useList` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useList<TValue extends Lson>(
-  key: string,
-  items: TValue[]
-): LiveList<TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useList` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useList<TValue extends Lson>(
-  key: string,
-  items?: TValue[] | undefined
-): LiveList<TValue> | null {
-  deprecate(
-    "Please use `configureRoom()` instead of importing `useList` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
-  );
-  return _hooks.useList(key as any, items as any);
-}
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useMap` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useMap<TKey extends string, TValue extends Lson>(
-  key: string
-): LiveMap<TKey, TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useMap` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useMap<TKey extends string, TValue extends Lson>(
-  key: string,
-  entries: readonly (readonly [TKey, TValue])[] | null
-): LiveMap<TKey, TValue> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useMap` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useMap<TKey extends string, TValue extends Lson>(
-  key: string,
-  entries?: readonly (readonly [TKey, TValue])[] | null | undefined
-): LiveMap<TKey, TValue> | null {
-  deprecate(
-    "Please use `configureRoom()` instead of importing `useMap` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
-  );
-  return _hooks.useMap(key as any, entries as any);
-}
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
  * `useMyPresence` from `@liveblocks/react` directly. See
  * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
  * details.
@@ -203,43 +129,6 @@ export function useMyPresence<TPresence extends JsonObject>(): [
     TPresence,
     (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) => void
   ];
-}
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useObject` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useObject<TData extends LsonObject>(
-  key: string
-): LiveObject<TData> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useObject` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useObject<TData extends LsonObject>(
-  key: string,
-  initialData: TData
-): LiveObject<TData> | null;
-
-/**
- * @deprecated Please use `configureRoom()` instead of importing
- * `useObject` from `@liveblocks/react` directly. See
- * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
- * details.
- */
-export function useObject<TData extends LsonObject>(
-  key: string,
-  initialData?: TData
-): LiveObject<TData> | null {
-  deprecate(
-    "Please use `configureRoom()` instead of importing `useObject` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
-  );
-  return _hooks.useObject(key as any, initialData as any);
 }
 
 /**
@@ -344,4 +233,115 @@ export function useUpdateMyPresence<TPresence extends JsonObject>(): (
     overrides: Partial<TPresence>,
     options?: { addToHistory: boolean }
   ) => void;
+}
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useList` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useList<TValue extends Lson>(
+  key: string
+): LiveList<TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useList` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useList<TValue extends Lson>(
+  key: string,
+  items: TValue[]
+): LiveList<TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useList` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useList<TValue extends Lson>(
+  key: string,
+  items?: TValue[] | undefined
+): LiveList<TValue> | null {
+  deprecate(
+    "Please use `configureRoom()` instead of importing `useList` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
+  );
+  return _hooks.deprecated_useList(key as any, items as any);
+}
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useMap` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string
+): LiveMap<TKey, TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useMap` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string,
+  entries: readonly (readonly [TKey, TValue])[] | null
+): LiveMap<TKey, TValue> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useMap` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useMap<TKey extends string, TValue extends Lson>(
+  key: string,
+  entries?: readonly (readonly [TKey, TValue])[] | null | undefined
+): LiveMap<TKey, TValue> | null {
+  deprecate(
+    "Please use `configureRoom()` instead of importing `useMap` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
+  );
+  return _hooks.deprecated_useMap(key as any, entries as any);
+}
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useObject` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string
+): LiveObject<TData> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useObject` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string,
+  initialData: TData
+): LiveObject<TData> | null;
+
+/**
+ * @deprecated Please use `configureRoom()` instead of importing
+ * `useObject` from `@liveblocks/react` directly. See
+ * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
+ * details.
+ */
+export function useObject<TData extends LsonObject>(
+  key: string,
+  initialData?: TData
+): LiveObject<TData> | null {
+  deprecate(
+    "Please use `configureRoom()` instead of importing `useObject` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
+  );
+  return _hooks.deprecated_useObject(key as any, initialData as any);
 }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -366,18 +366,18 @@ export function configureRoom<
    * @example
    * const shapesById = useMap<string, Shape>("shapes");
    */
-  function useMap<TKey extends string, TValue extends Lson>(
+  function deprecated_useMap<TKey extends string, TValue extends Lson>(
     key: string
   ): LiveMap<TKey, TValue> | null;
   /**
    * @deprecated We no longer recommend initializing the
    * entries from the useMap() hook. For details, see https://bit.ly/3Niy5aP.
    */
-  function useMap<TKey extends string, TValue extends Lson>(
+  function deprecated_useMap<TKey extends string, TValue extends Lson>(
     key: string,
     entries: readonly (readonly [TKey, TValue])[] | null
   ): LiveMap<TKey, TValue> | null;
-  function useMap<TKey extends string, TValue extends Lson>(
+  function deprecated_useMap<TKey extends string, TValue extends Lson>(
     key: string,
     entries?: readonly (readonly [TKey, TValue])[] | null | undefined
   ): LiveMap<TKey, TValue> | null {
@@ -439,16 +439,18 @@ Please see https://bit.ly/3Niy5aP for details.`
    * @example
    * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
    */
-  function useList<TValue extends Lson>(key: string): LiveList<TValue> | null;
+  function deprecated_useList<TValue extends Lson>(
+    key: string
+  ): LiveList<TValue> | null;
   /**
    * @deprecated We no longer recommend initializing the
    * items from the useList() hook. For details, see https://bit.ly/3Niy5aP.
    */
-  function useList<TValue extends Lson>(
+  function deprecated_useList<TValue extends Lson>(
     key: string,
     items: TValue[]
   ): LiveList<TValue> | null;
-  function useList<TValue extends Lson>(
+  function deprecated_useList<TValue extends Lson>(
     key: string,
     items?: TValue[] | undefined
   ): LiveList<TValue> | null {
@@ -512,18 +514,18 @@ Please see https://bit.ly/3Niy5aP for details.`
    * @example
    * const object = useObject("obj");
    */
-  function useObject<TData extends LsonObject>(
+  function deprecated_useObject<TData extends LsonObject>(
     key: string
   ): LiveObject<TData> | null;
   /**
    * @deprecated We no longer recommend initializing the fields from the
    * useObject() hook. For details, see https://bit.ly/3Niy5aP.
    */
-  function useObject<TData extends LsonObject>(
+  function deprecated_useObject<TData extends LsonObject>(
     key: string,
     initialData: TData
   ): LiveObject<TData> | null;
-  function useObject<TData extends LsonObject>(
+  function deprecated_useObject<TData extends LsonObject>(
     key: string,
     initialData?: TData
   ): LiveObject<TData> | null {
@@ -575,6 +577,24 @@ Please see https://bit.ly/3Niy5aP for details.`
       );
       return null;
     }
+  }
+
+  function useList<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null {
+    return deprecated_useList(key) as unknown as TStorage[TKey];
+  }
+
+  function useMap<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null {
+    return deprecated_useMap(key) as unknown as TStorage[TKey];
+  }
+
+  function useObject<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null {
+    return deprecated_useObject(key) as unknown as TStorage[TKey];
   }
 
   /**
@@ -693,5 +713,9 @@ Please see https://bit.ly/3Niy5aP for details.`
     useStorage,
     useUndo,
     useUpdateMyPresence,
+
+    deprecated_useList,
+    deprecated_useMap,
+    deprecated_useObject,
   };
 }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -703,9 +703,12 @@ Please see https://bit.ly/3Niy5aP for details.`
     useEventListener,
     useHistory,
     useList,
+    deprecated_useList,
     useMap,
+    deprecated_useMap,
     useMyPresence,
     useObject,
+    deprecated_useObject,
     useOthers,
     useRedo,
     useRoom,
@@ -713,9 +716,5 @@ Please see https://bit.ly/3Niy5aP for details.`
     useStorage,
     useUndo,
     useUpdateMyPresence,
-
-    deprecated_useList,
-    deprecated_useMap,
-    deprecated_useObject,
   };
 }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -123,15 +123,10 @@ export function configureRoom<
    * tree.
    */
   function useRoom(): Room<TPresence, TStorage> {
-    const room = React.useContext(RoomContext) as Room<
-      TPresence, // FIXME Remove once we lift presence to the create() level
-      TStorage // FIXME Remove once we lift presence to the create() level
-    > | null;
-
+    const room = React.useContext(RoomContext);
     if (room == null) {
       throw new Error("RoomProvider is missing from the react tree");
     }
-
     return room;
   }
 

--- a/packages/liveblocks-redux/package-lock.json
+++ b/packages/liveblocks-redux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/redux",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/redux",
-      "version": "0.16.13",
+      "version": "0.17.0-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -39,7 +39,7 @@
         "whatwg-fetch": "^3.6.2"
       },
       "peerDependencies": {
-        "@liveblocks/client": "0.16.13",
+        "@liveblocks/client": "0.17.0-test1",
         "redux": "^4"
       }
     },
@@ -2557,9 +2557,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.13.tgz",
-      "integrity": "sha512-u2wU2Jf8l8luML5H4P68I145eDxjteeWw89c3Sk1WZFLyhOIh5+chm8lEIu3MDLMlsL/MCD8NQJNPQltHu+/Ig==",
+      "version": "0.17.0-test1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.0-test1.tgz",
+      "integrity": "sha512-QVLHAC1FDlwl80Rbo7/2aSkEQZFSueNMX925aN+ieCzuiMyFksb2WiHxVxginjlHOTc7uKatDc+6X/Nlg67+7w==",
       "peer": true
     },
     "node_modules/@mswjs/cookies": {
@@ -13939,9 +13939,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.13.tgz",
-      "integrity": "sha512-u2wU2Jf8l8luML5H4P68I145eDxjteeWw89c3Sk1WZFLyhOIh5+chm8lEIu3MDLMlsL/MCD8NQJNPQltHu+/Ig==",
+      "version": "0.17.0-test1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.0-test1.tgz",
+      "integrity": "sha512-QVLHAC1FDlwl80Rbo7/2aSkEQZFSueNMX925aN+ieCzuiMyFksb2WiHxVxginjlHOTc7uKatDc+6X/Nlg67+7w==",
       "peer": true
     },
     "@mswjs/cookies": {

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/redux",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "description": "A store enhancer to integrate Liveblocks into Redux stores.",
   "main": "./index.js",
   "module": "./index.mjs",
@@ -31,7 +31,7 @@
     "directory": "packages/liveblocks-redux"
   },
   "peerDependencies": {
-    "@liveblocks/client": "0.16.13",
+    "@liveblocks/client": "0.17.0-test1",
     "redux": "^4"
   },
   "devDependencies": {

--- a/packages/liveblocks-zustand/package-lock.json
+++ b/packages/liveblocks-zustand/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/zustand",
-      "version": "0.16.13",
+      "version": "0.17.0-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -38,7 +38,7 @@
         "zustand": "^3.6.9"
       },
       "peerDependencies": {
-        "@liveblocks/client": "0.16.13",
+        "@liveblocks/client": "0.17.0-test1",
         "zustand": "^3"
       }
     },
@@ -2796,9 +2796,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.13.tgz",
-      "integrity": "sha512-u2wU2Jf8l8luML5H4P68I145eDxjteeWw89c3Sk1WZFLyhOIh5+chm8lEIu3MDLMlsL/MCD8NQJNPQltHu+/Ig==",
+      "version": "0.17.0-test1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.0-test1.tgz",
+      "integrity": "sha512-QVLHAC1FDlwl80Rbo7/2aSkEQZFSueNMX925aN+ieCzuiMyFksb2WiHxVxginjlHOTc7uKatDc+6X/Nlg67+7w==",
       "peer": true
     },
     "node_modules/@mswjs/cookies": {
@@ -14210,9 +14210,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.16.13",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.16.13.tgz",
-      "integrity": "sha512-u2wU2Jf8l8luML5H4P68I145eDxjteeWw89c3Sk1WZFLyhOIh5+chm8lEIu3MDLMlsL/MCD8NQJNPQltHu+/Ig==",
+      "version": "0.17.0-test1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.0-test1.tgz",
+      "integrity": "sha512-QVLHAC1FDlwl80Rbo7/2aSkEQZFSueNMX925aN+ieCzuiMyFksb2WiHxVxginjlHOTc7uKatDc+6X/Nlg67+7w==",
       "peer": true
     },
     "@mswjs/cookies": {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "0.16.13",
+  "version": "0.17.0-test1",
   "description": "A middleware to integrate Liveblocks into Zustand stores.",
   "main": "./index.js",
   "module": "./index.mjs",
@@ -31,7 +31,7 @@
     "directory": "packages/liveblocks-zustand"
   },
   "peerDependencies": {
-    "@liveblocks/client": "0.16.13",
+    "@liveblocks/client": "0.17.0-test1",
     "zustand": "^3"
   },
   "devDependencies": {


### PR DESCRIPTION
**PR stack:**

- #326
  - #333  👈 This PR

---

This build further on the code-generated compatibility layer introduced in #326. It extends it by allowing the factory (aka new-style) layer to export both `useMap` and `deprecated_useMap`, and if such a `deprecated_`-prefixed export is found there, the compat layer will be generated from _those_ functions instead.

This allows us to start changing the type params for these functions slightly. For example, when users are using classic `useMap` (from a direct import) and use type annotations in those call sites, then those remain working, but when the switch is made to the new factory-style `useMap`, then those type annotations will start to error, and the new returned type will automatically become `TStorage[TKey]` for those calls. The fix then is to remove those type annotations.
