### PR TITLE
Make `Client` instance mandatory in all `createRoomContext()` calls

### DIFF
--- a/packages/liveblocks-react/scripts/generate-compat.ts
+++ b/packages/liveblocks-react/scripts/generate-compat.ts
@@ -223,7 +223,7 @@ import type { RoomProviderProps } from "./factory";
 import { createRoomContext } from "./factory";
 import { deprecate } from "@liveblocks/client/internal";
 
-const _hooks = createRoomContext();
+const _hooks = createRoomContext("__legacy" as any);
 `;
 output += "\n";
 

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -24,7 +24,7 @@ import { deprecate } from "@liveblocks/client/internal";
 import type { RoomProviderProps } from "./factory";
 import { createRoomContext } from "./factory";
 
-const _hooks = createRoomContext();
+const _hooks = createRoomContext("__legacy" as any);
 
 /**
  * @deprecated Please use `createRoomContext()` instead of importing

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -39,9 +39,9 @@ type LookupResult<T> =
 export function createRoomContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject
->(client?: Client) {
+>(client: Client) {
   let useClient: () => Client;
-  if (client !== undefined) {
+  if ((client as unknown) !== "__legacy") {
     useClient = () => client;
   } else {
     useClient = _useClient;


### PR DESCRIPTION
This internally ignores the TypeScript and force-passes a sentinel value, but publicly enforces that these calls get initialized with a client. This avoid having to make the `client` argument optional.