### PR TITLE
Address issue with parentKey potentially being sent in as a non-string

### DIFF
--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -248,6 +248,8 @@ export class LiveMap<
    * @returns The element associated with the specified key, or undefined if the key can't be found in the LiveMap.
    */
   get(key: TKey): TValue | undefined {
+    key = typeof key === "string" ? key : (String(key) as TKey); // For non-TS users
+
     const value = this._map.get(key);
     if (value == undefined) {
       return undefined;
@@ -263,6 +265,8 @@ export class LiveMap<
    * @param value The value of the element to add. Should be serializable to JSON.
    */
   set(key: TKey, value: TValue): void {
+    key = typeof key === "string" ? key : (String(key) as TKey); // For non-TS users
+
     const oldValue = this._map.get(key);
 
     if (oldValue) {
@@ -311,6 +315,8 @@ export class LiveMap<
    * @param key The key of the element to test for presence.
    */
   has(key: TKey): boolean {
+    key = typeof key === "string" ? key : (String(key) as TKey); // For non-TS users
+
     return this._map.has(key);
   }
 
@@ -320,6 +326,8 @@ export class LiveMap<
    * @returns true if an element existed and has been removed, or false if the element does not exist.
    */
   delete(key: TKey): boolean {
+    key = typeof key === "string" ? key : (String(key) as TKey); // For non-TS users
+
     const item = this._map.get(key);
 
     if (item == null) {

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -423,6 +423,8 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
    * @param value The value of the property to add
    */
   set<TKey extends keyof O>(key: TKey, value: O[TKey]): void {
+    key = typeof key === "string" ? key : (String(key) as TKey); // For non-TS users
+
     // TODO: Find out why typescript complains
     this.update({ [key]: value } as unknown as Partial<O>);
   }
@@ -432,6 +434,8 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
    * @param key The key of the property to get
    */
   get<TKey extends keyof O>(key: TKey): O[TKey] {
+    key = typeof key === "string" ? key : (String(key) as TKey); // For non-TS users
+
     return this._map.get(key as string) as O[TKey];
   }
 
@@ -440,6 +444,8 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
    * @param key The key of the property to delete
    */
   delete(key: keyof O): void {
+    key = typeof key === "string" ? key : (String(key) as keyof O); // For non-TS users
+
     const keyAsString = key as string;
     const oldValue = this._map.get(keyAsString);
 


### PR DESCRIPTION
Fixes https://github.com/liveblocks/liveblocks/pull/337#discussion_r897511528.

As mentioned in the https://github.com/liveblocks/liveblocks/pull/337#discussion_r897511528 thread already, this only fixes this at the surface of a much deeper rabbit hole, which warrants a separate quality pass of its own later.

This is not the only case that we need to address. The class fix for this would be to make sure that all public APIs always perform runtime type checking on their arguments. (We wouldn't have to do this for internal APIs; we have TypeScript for that.)

This would be very maintenance unfriendly and error prone to be enforcing manually, so I'd suggest to enforce this using some kind of build step or (custom) rollup plugin.

Made a ticket for this larger task, see #340.
