### PR TITLE
feat(secretKey): handle error

### DIFF
--- a/packages/liveblocks-client/.gitignore
+++ b/packages/liveblocks-client/.gitignore
@@ -17,3 +17,6 @@ npm-debug.log*
 *.tgz
 
 .env
+
+# testing
+/coverage

--- a/packages/liveblocks-node/src/index.test.ts
+++ b/packages/liveblocks-node/src/index.test.ts
@@ -9,19 +9,23 @@ describe("authorize", () => {
 
     expect(response.status).toBe(403);
     expect(response.error && response.error.message).toBe(
-      "Invalid key. You are using the public key which is not supported. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+      'We expect a secret key ("sk_") here, but we found a public key ("pk_") instead. Hint: You can find your secret key at https://liveblocks.io/dashboard/apikeys. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize'
     );
   });
 
-  test("should error if unknown key is used", async () => {
-    const response = await authorize({
-      secret: "unknown",
-      room: "room",
-    });
+  test.each(["unknown", undefined, null, "", {}])(
+    "should error if unknown key is used",
+    async (secret) => {
+      const response = await authorize({
+        // @ts-expect-error: we want to test for anything passed as secret
+        secret,
+        room: "room",
+      });
 
-    expect(response.status).toBe(403);
-    expect(response.error && response.error.message).toBe(
-      "Invalid key. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
-    );
-  });
+      expect(response.status).toBe(403);
+      expect(response.error && response.error.message).toBe(
+        'We expect a secret key ("sk_") here, but we found an unknown key instead. Hint: You can find your secret key at https://liveblocks.io/dashboard/apikeys. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize'
+      );
+    }
+  );
 });

--- a/packages/liveblocks-node/src/index.test.ts
+++ b/packages/liveblocks-node/src/index.test.ts
@@ -8,7 +8,7 @@ describe("authorize", () => {
     });
 
     expect(response.status).toBe(403);
-    expect(response.error.message).toBe(
+    expect(response.error && response.error.message).toBe(
       "Invalid key. You are using the public key which is not supported. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
     );
   });
@@ -20,7 +20,7 @@ describe("authorize", () => {
     });
 
     expect(response.status).toBe(403);
-    expect(response.error.message).toBe(
+    expect(response.error && response.error.message).toBe(
       "Invalid key. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
     );
   });

--- a/packages/liveblocks-node/src/index.test.ts
+++ b/packages/liveblocks-node/src/index.test.ts
@@ -1,0 +1,27 @@
+import { authorize } from ".";
+
+describe("authorize", () => {
+  test("should error if public api key is used", async () => {
+    const response = await authorize({
+      secret: "pk_xxx",
+      room: "room",
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.error.message).toBe(
+      "Invalid key. You are using the public key which is not supported. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+    );
+  });
+
+  test("should error if unknown key is used", async () => {
+    const response = await authorize({
+      secret: "unknown",
+      room: "room",
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.error.message).toBe(
+      "Invalid key. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+    );
+  });
+});

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -33,6 +33,18 @@ export async function authorize(
   options: AuthorizeOptions
 ): Promise<AuthorizeResponse> {
   try {
+    const { room, userId, userInfo, secret } = options;
+
+    if (secret.startsWith("pk_")) {
+      throw new Error(
+        "Invalid key. You are using the public key which is not supported. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+      );
+    } else if (!secret.startsWith("sk_")) {
+      throw new Error(
+        "Invalid key. Please use the secret key instead. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+      );
+    }
+
     const result = await fetch(
       (options as AllAuthorizeOptions).liveblocksAuthorizeEndpoint ||
         "https://liveblocks.io/api/authorize",
@@ -43,9 +55,9 @@ export async function authorize(
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          room: options.room,
-          userId: options.userId,
-          userInfo: options.userInfo,
+          room,
+          userId,
+          userInfo,
         }),
       }
     );
@@ -61,11 +73,11 @@ export async function authorize(
       status: 200,
       body: await result.text(),
     };
-  } catch (er) {
+  } catch (error) {
     return {
       status: 403,
       body: 'Call to "https://liveblocks.io/api/authorize" failed. See "error" for more information.',
-      error: er,
+      error,
     };
   }
 }


### PR DESCRIPTION
Ensures that only the secret key should be used in the node client