### PR TITLE
Lift `TUserMeta` and `TEvent` up to the `createRoomContext()` level

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -16,6 +16,7 @@ export type {
   Room,
   StorageUpdate,
   User,
+  UserMetadata,
 } from "./types";
 
 /**

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -76,7 +76,6 @@ export type {
   UpdateStorageServerMsg,
   UserJoinServerMsg,
   UserLeftServerMsg,
-  UserMetadata,
 } from "./types";
 export {
   ClientMsgCode,

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -76,6 +76,7 @@ export type {
   UpdateStorageServerMsg,
   UserJoinServerMsg,
   UserLeftServerMsg,
+  UserMetadata,
 } from "./types";
 export {
   ClientMsgCode,

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -26,8 +26,9 @@ import {
   ServerMsgCode,
   WebsocketCloseCodes,
 } from "./types";
-import type { JsonObject } from "./types/Json";
+import type { Json, JsonObject } from "./types/Json";
 import type { LsonObject } from "./types/Lson";
+import type { UserMetadata } from "./types/UserMetadata";
 
 const defaultContext = {
   roomId: "room-id",
@@ -48,11 +49,15 @@ const defaultRoomToken: RoomAuthToken = {
 
 function setupStateMachine<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(initialPresence?: TPresence) {
-  const effects = mockEffects<TPresence>();
-  const state = defaultState<TPresence, TStorage>(initialPresence);
-  const machine = makeStateMachine<TPresence, TStorage>(
+  const effects = mockEffects<TPresence, TEvent>();
+  const state = defaultState<TPresence, TStorage, TUserMeta, TEvent>(
+    initialPresence
+  );
+  const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TEvent>(
     state,
     defaultContext,
     effects
@@ -771,6 +776,8 @@ describe("room", () => {
     test("batch storage and presence with changes from server", async () => {
       type P = { x?: number };
       type S = { items: LiveList<string> };
+      type M = never;
+      type E = never;
 
       const {
         storage,
@@ -781,7 +788,7 @@ describe("room", () => {
         subscribe,
         refSubscribe,
         updatePresence,
-      } = await prepareStorageTest<S, P>(
+      } = await prepareStorageTest<S, P, M, E>(
         [
           createSerializedObject("0:0", {}),
           createSerializedList("0:1", "0:0", "items"),
@@ -794,8 +801,8 @@ describe("room", () => {
 
       const itemsSubscriber = jest.fn();
       const refItemsSubscriber = jest.fn();
-      let refOthers: Others<P> | undefined;
-      const refPresenceSubscriber = (o: Others<P>) => (refOthers = o);
+      let refOthers: Others<P, M> | undefined;
+      const refPresenceSubscriber = (o: Others<P, M>) => (refOthers = o);
 
       subscribe(items, itemsSubscriber);
       refSubscribe(refItems, refItemsSubscriber);
@@ -855,14 +862,14 @@ describe("room", () => {
     test("others", () => {
       type P = { x?: number };
 
-      const { machine } = setupStateMachine<P, never>({});
+      const { machine } = setupStateMachine<P, never, never, never>({});
 
       const ws = new MockWebSocket("");
       machine.connect();
       machine.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
 
-      let others: Others<P> | undefined;
+      let others: Others<P, never> | undefined;
 
       const unsubscribe = machine.subscribe<P>("others", (o) => (others = o));
 
@@ -1123,15 +1130,17 @@ describe("room", () => {
     test("skip UpdatePresence from other when initial full presence has not been received", () => {
       type P = { x?: number };
       type S = never;
+      type M = never;
+      type E = never;
 
-      const { machine } = setupStateMachine<P, S>({});
+      const { machine } = setupStateMachine<P, S, M, E>({});
 
       const ws = new MockWebSocket("");
       machine.connect();
       machine.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
 
-      let others: Others<P> | undefined;
+      let others: Others<P, M> | undefined;
 
       machine.subscribe<P>("others", (o) => (others = o));
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -47,6 +47,7 @@ import type {
   User,
   UserJoinServerMsg,
   UserLeftServerMsg,
+  UserMetadata,
 } from "./types";
 import {
   ClientMsgCode,
@@ -71,7 +72,9 @@ import {
 
 export type Machine<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 > = {
   // Internal
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
@@ -121,14 +124,14 @@ export type Machine<
   ): () => void;
   subscribe<TPresence extends JsonObject>(
     type: "others",
-    listener: OthersEventCallback<TPresence>
+    listener: OthersEventCallback<TPresence, TUserMeta>
   ): () => void;
-  subscribe(type: "event", listener: EventCallback): () => void;
+  subscribe(type: "event", listener: EventCallback<TEvent>): () => void;
   subscribe(type: "error", listener: ErrorCallback): () => void;
   subscribe(type: "connection", listener: ConnectionCallback): () => void;
   subscribe<K extends RoomEventName>(
     firstParam: K | LiveStructure | ((updates: StorageUpdate[]) => void),
-    listener?: RoomEventCallbackMap<TPresence>[K],
+    listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K],
     options?: { isDeep: boolean }
   ): () => void;
 
@@ -137,7 +140,7 @@ export type Machine<
     overrides: Partial<TPresence>,
     options?: { addToHistory: boolean }
   ): void;
-  broadcastEvent(event: Json, options?: BroadcastOptions): void;
+  broadcastEvent(event: TEvent, options?: BroadcastOptions): void;
 
   batch(callback: () => void): void;
   undo(): void;
@@ -152,11 +155,11 @@ export type Machine<
   selectors: {
     // Core
     getConnectionState(): ConnectionState;
-    getSelf(): User<TPresence> | null;
+    getSelf(): User<TPresence, TUserMeta> | null;
 
     // Presence
     getPresence(): TPresence;
-    getOthers(): Others<TPresence>;
+    getOthers(): Others<TPresence, TUserMeta>;
   };
 };
 
@@ -182,9 +185,12 @@ function makeIdFactory(connectionId: number): IdFactory {
   return () => `${connectionId}:${count++}`;
 }
 
-function makeOthers<TPresence extends JsonObject>(userMap: {
-  [key: number]: User<TPresence>;
-}): Others<TPresence> {
+function makeOthers<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+>(userMap: {
+  [key: number]: User<TPresence, TUserMeta>;
+}): Others<TPresence, TUserMeta> {
   const users = Object.values(userMap).map((user) => {
     const { _hasReceivedInitialPresence, ...publicKeys } = user;
     return publicKeys;
@@ -221,7 +227,12 @@ type HistoryItem<TPresence extends JsonObject> = Array<
 
 type IdFactory = () => string;
 
-export type State<TPresence extends JsonObject, TStorage extends LsonObject> = {
+export type State<
+  TPresence extends JsonObject,
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
+> = {
   connection: Connection;
   token: string | null;
   lastConnectionId: number | null;
@@ -229,7 +240,7 @@ export type State<TPresence extends JsonObject, TStorage extends LsonObject> = {
   lastFlushTime: number;
   buffer: {
     presence: TPresence | null;
-    messages: ClientMsg<TPresence>[];
+    messages: ClientMsg<TPresence, TEvent>[];
     storageOperations: Op[];
   };
   timeoutHandles: {
@@ -241,17 +252,17 @@ export type State<TPresence extends JsonObject, TStorage extends LsonObject> = {
     heartbeat: number;
   };
   listeners: {
-    event: EventCallback[];
-    others: OthersEventCallback<TPresence>[];
+    event: EventCallback<TEvent>[];
+    others: OthersEventCallback<TPresence, TUserMeta>[];
     "my-presence": MyPresenceCallback<TPresence>[];
     error: ErrorCallback[];
     connection: ConnectionCallback[];
     storage: StorageCallback[];
   };
   me: TPresence;
-  others: Others<TPresence>;
+  others: Others<TPresence, TUserMeta>;
   users: {
-    [connectionId: number]: User<TPresence>;
+    [connectionId: number]: User<TPresence, TUserMeta>;
   };
   idFactory: IdFactory | null;
   numberOfRetry: number;
@@ -280,12 +291,12 @@ export type State<TPresence extends JsonObject, TStorage extends LsonObject> = {
   offlineOperations: Map<string, Op>;
 };
 
-export type Effects<TPresence extends JsonObject> = {
+export type Effects<TPresence extends JsonObject, TEvent extends Json> = {
   authenticate(
     auth: (room: string) => Promise<AuthorizeResponse>,
     createWebSocket: (token: string) => WebSocket
   ): void;
-  send(messages: ClientMsg<TPresence>[]): void;
+  send(messages: ClientMsg<TPresence, TEvent>[]): void;
   delayFlush(delay: number): number;
   startHeartbeatInterval(): number;
   schedulePongTimeout(): number;
@@ -303,13 +314,15 @@ type Context = {
 
 export function makeStateMachine<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(
-  state: State<TPresence, TStorage>,
+  state: State<TPresence, TStorage, TUserMeta, TEvent>,
   context: Context,
-  mockedEffects?: Effects<TPresence>
-): Machine<TPresence, TStorage> {
-  const effects: Effects<TPresence> = mockedEffects || {
+  mockedEffects?: Effects<TPresence, TEvent>
+): Machine<TPresence, TStorage, TUserMeta, TEvent> {
+  const effects: Effects<TPresence, TEvent> = mockedEffects || {
     authenticate(
       auth: (room: string) => Promise<AuthorizeResponse>,
       createWebSocket: (token: string) => WebSocket
@@ -337,7 +350,11 @@ export function makeStateMachine<
           );
       }
     },
-    send(messageOrMessages: ClientMsg<TPresence> | ClientMsg<TPresence>[]) {
+    send(
+      messageOrMessages:
+        | ClientMsg<TPresence, TEvent>
+        | ClientMsg<TPresence, TEvent>[]
+    ) {
       if (state.socket == null) {
         throw new Error("Can't send message if socket is null");
       }
@@ -524,7 +541,7 @@ export function makeStateMachine<
   }: {
     storageUpdates?: Map<string, StorageUpdate>;
     presence?: boolean;
-    others?: OthersEvent<TPresence>[];
+    others?: OthersEvent<TPresence, TUserMeta>[];
   }) {
     if (otherEvents.length > 0) {
       state.others = makeOthers(state.users);
@@ -735,9 +752,12 @@ export function makeStateMachine<
   ): () => void;
   function subscribe<TPresence extends JsonObject>(
     type: "others",
-    listener: OthersEventCallback<TPresence>
+    listener: OthersEventCallback<TPresence, TUserMeta>
   ): () => void;
-  function subscribe(type: "event", listener: EventCallback): () => void;
+  function subscribe(
+    type: "event",
+    listener: EventCallback<TEvent>
+  ): () => void;
   function subscribe(type: "error", listener: ErrorCallback): () => void;
   function subscribe(
     type: "connection",
@@ -745,7 +765,7 @@ export function makeStateMachine<
   ): () => void;
   function subscribe<K extends RoomEventName>(
     firstParam: K | LiveStructure | ((updates: StorageUpdate[]) => void),
-    listener?: RoomEventCallbackMap<TPresence>[K] | any,
+    listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K] | any,
     options?: { isDeep: boolean }
   ): () => void {
     if (isLiveNode(firstParam)) {
@@ -756,14 +776,20 @@ export function makeStateMachine<
       throw new Error(`"${firstParam}" is not a valid event name`);
     }
 
-    (state.listeners[firstParam] as RoomEventCallbackMap<TPresence>[K][]).push(
-      listener
-    );
+    (
+      state.listeners[firstParam] as RoomEventCallbackMap<
+        TPresence,
+        TUserMeta,
+        TEvent
+      >[K][]
+    ).push(listener);
 
     return () => {
-      const callbacks = state.listeners[
-        firstParam
-      ] as RoomEventCallbackMap<TPresence>[K][];
+      const callbacks = state.listeners[firstParam] as RoomEventCallbackMap<
+        TPresence,
+        TUserMeta,
+        TEvent
+      >[K][];
       remove(callbacks, listener);
     };
   }
@@ -772,7 +798,7 @@ export function makeStateMachine<
     return state.connection.state;
   }
 
-  function getSelf(): User<TPresence> | null {
+  function getSelf(): User<TPresence, TUserMeta> | null {
     return state.connection.state === "open" ||
       state.connection.state === "connecting"
       ? {
@@ -876,7 +902,7 @@ export function makeStateMachine<
 
   function onUpdatePresenceMessage(
     message: UpdatePresenceServerMsg<TPresence>
-  ): OthersEvent<TPresence> | undefined {
+  ): OthersEvent<TPresence, TUserMeta> | undefined {
     const user = state.users[message.actor];
     // If the other user initial presence hasn't been received yet, we discard the presence update.
     // The initial presence update message contains the property "targetActor".
@@ -892,6 +918,8 @@ export function makeStateMachine<
       state.users[message.actor] = {
         connectionId: message.actor,
         presence: message.data,
+        id: undefined,
+        info: undefined,
         _hasReceivedInitialPresence: true,
       };
     } else {
@@ -916,7 +944,7 @@ export function makeStateMachine<
 
   function onUserLeftMessage(
     message: UserLeftServerMsg
-  ): OthersEvent<TPresence> | null {
+  ): OthersEvent<TPresence, TUserMeta> | null {
     const userLeftMessage: UserLeftServerMsg = message;
     const user = state.users[userLeftMessage.actor];
     if (user) {
@@ -927,9 +955,9 @@ export function makeStateMachine<
   }
 
   function onRoomStateMessage(
-    message: RoomStateServerMsg
-  ): OthersEvent<TPresence> {
-    const newUsers: { [connectionId: number]: User<TPresence> } = {};
+    message: RoomStateServerMsg<TUserMeta>
+  ): OthersEvent<TPresence, TUserMeta> {
+    const newUsers: { [connectionId: number]: User<TPresence, TUserMeta> } = {};
     for (const key in message.users) {
       const connectionId = Number.parseInt(key);
       const user = message.users[key];
@@ -950,15 +978,15 @@ export function makeStateMachine<
     }
   }
 
-  function onEvent(message: BroadcastedEventServerMsg) {
+  function onEvent(message: BroadcastedEventServerMsg<TEvent>) {
     for (const listener of state.listeners.event) {
       listener({ connectionId: message.actor, event: message.event });
     }
   }
 
   function onUserJoinedMessage(
-    message: UserJoinServerMsg
-  ): OthersEvent<TPresence> {
+    message: UserJoinServerMsg<TUserMeta>
+  ): OthersEvent<TPresence, TUserMeta> {
     state.users[message.actor] = {
       connectionId: message.actor,
       info: message.info,
@@ -984,16 +1012,20 @@ export function makeStateMachine<
     return { type: "enter", user: state.users[message.actor] };
   }
 
-  function parseServerMessage(data: Json): ServerMsg<TPresence> | null {
+  function parseServerMessage(
+    data: Json
+  ): ServerMsg<TPresence, TUserMeta, TEvent> | null {
     if (!isJsonObject(data)) {
       return null;
     }
 
-    return data as ServerMsg<TPresence>;
-    //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ FIXME: Properly validate incoming external data instead!
+    return data as ServerMsg<TPresence, TUserMeta, TEvent>;
+    //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FIXME: Properly validate incoming external data instead!
   }
 
-  function parseServerMessages(text: string): ServerMsg<TPresence>[] | null {
+  function parseServerMessages(
+    text: string
+  ): ServerMsg<TPresence, TUserMeta, TEvent>[] | null {
     const data: Json | undefined = tryParseJson(text);
     if (data === undefined) {
       return null;
@@ -1018,7 +1050,7 @@ export function makeStateMachine<
 
     const updates = {
       storageUpdates: new Map<string, StorageUpdate>(),
-      others: [] as OthersEvent<TPresence>[],
+      others: [] as OthersEvent<TPresence, TUserMeta>[],
     };
 
     for (const message of messages) {
@@ -1221,7 +1253,7 @@ export function makeStateMachine<
       return;
     }
 
-    const messages: ClientMsg<TPresence>[] = [];
+    const messages: ClientMsg<TPresence, TEvent>[] = [];
 
     const ops = Array.from(offlineOps.values());
 
@@ -1279,8 +1311,10 @@ export function makeStateMachine<
     }
   }
 
-  function flushDataToMessages(state: State<TPresence, TStorage>) {
-    const messages: ClientMsg<TPresence>[] = [];
+  function flushDataToMessages(
+    state: State<TPresence, TStorage, TUserMeta, TEvent>
+  ) {
+    const messages: ClientMsg<TPresence, TEvent>[] = [];
     if (state.buffer.presence) {
       messages.push({
         type: ClientMsgCode.UPDATE_PRESENCE,
@@ -1326,8 +1360,9 @@ export function makeStateMachine<
 
   function clearListeners() {
     for (const key in state.listeners) {
-      state.listeners[key as keyof State<TPresence, TStorage>["listeners"]] =
-        [];
+      state.listeners[
+        key as keyof State<TPresence, TStorage, TUserMeta, TEvent>["listeners"]
+      ] = [];
     }
   }
 
@@ -1335,12 +1370,12 @@ export function makeStateMachine<
     return state.me as TPresence;
   }
 
-  function getOthers(): Others<TPresence> {
-    return state.others as Others<TPresence>;
+  function getOthers(): Others<TPresence, TUserMeta> {
+    return state.others as Others<TPresence, TUserMeta>;
   }
 
   function broadcastEvent(
-    event: Json,
+    event: TEvent,
     options: BroadcastOptions = {
       shouldQueueEventIfNotReady: false,
     }
@@ -1550,11 +1585,13 @@ export function makeStateMachine<
 
 export function defaultState<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(
   initialPresence?: TPresence,
   initialStorage?: TStorage
-): State<TPresence, TStorage> {
+): State<TPresence, TStorage, TUserMeta, TEvent> {
   return {
     connection: { state: "closed" },
     token: null,
@@ -1615,9 +1652,11 @@ export function defaultState<
 
 export type InternalRoom<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 > = {
-  room: Room<TPresence, TStorage>;
+  room: Room<TPresence, TStorage, TUserMeta, TEvent>;
   connect: () => void;
   disconnect: () => void;
   onNavigatorOnline: () => void;
@@ -1626,15 +1665,17 @@ export type InternalRoom<
 
 export function createRoom<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(
   options: RoomInitializers<TPresence, TStorage>,
   context: Context
-): InternalRoom<TPresence, TStorage> {
+): InternalRoom<TPresence, TStorage, TUserMeta, TEvent> {
   const initialPresence = options.initialPresence ?? options.defaultPresence;
   const initialStorage = options.initialStorage ?? options.defaultStorageRoot;
 
-  const state = defaultState<TPresence, TStorage>(
+  const state = defaultState<TPresence, TStorage, TUserMeta, TEvent>(
     typeof initialPresence === "function"
       ? initialPresence(context.roomId)
       : initialPresence,
@@ -1643,9 +1684,12 @@ export function createRoom<
       : initialStorage
   );
 
-  const machine = makeStateMachine<TPresence, TStorage>(state, context);
+  const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TEvent>(
+    state,
+    context
+  );
 
-  const room: Room<TPresence, TStorage> = {
+  const room: Room<TPresence, TStorage, TUserMeta, TEvent> = {
     id: context.roomId,
     /////////////
     // Core    //

--- a/packages/liveblocks-client/src/types/ClientMsg.ts
+++ b/packages/liveblocks-client/src/types/ClientMsg.ts
@@ -14,18 +14,18 @@ export enum ClientMsgCode {
 /**
  * Messages that can be sent from the client to the server.
  */
-export type ClientMsg<TPresence extends JsonObject> =
+export type ClientMsg<TPresence extends JsonObject, TEvent extends Json> =
   // For Presence
-  | BroadcastEventClientMsg
+  | BroadcastEventClientMsg<TEvent>
   | UpdatePresenceClientMsg<TPresence>
 
   // For Storage
   | UpdateStorageClientMsg
   | FetchStorageClientMsg;
 
-export type BroadcastEventClientMsg = {
+export type BroadcastEventClientMsg<TEvent extends Json> = {
   type: ClientMsgCode.BROADCAST_EVENT;
-  event: Json;
+  event: TEvent;
 };
 
 export type UpdatePresenceClientMsg<TPresence extends JsonObject> = {

--- a/packages/liveblocks-client/src/types/UserMetadata.ts
+++ b/packages/liveblocks-client/src/types/UserMetadata.ts
@@ -1,0 +1,14 @@
+import type { Json } from "./Json";
+
+export type UserMetadata = {
+  /**
+   * The id of the user that has been set in the authentication endpoint.
+   * Useful to get additional information about the connected user.
+   */
+  id?: string;
+
+  /**
+   * Additional user information that has been set in the authentication endpoint.
+   */
+  info?: Json;
+};

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -3,6 +3,7 @@ import type { LiveMap } from "../LiveMap";
 import type { LiveObject } from "../LiveObject";
 import type { Json, JsonObject } from "./Json";
 import type { Lson, LsonObject } from "./Lson";
+import type { UserMetadata } from "./UserMetadata";
 
 /**
  * This helper type is effectively a no-op, but will force TypeScript to
@@ -34,32 +35,39 @@ export type MyPresenceCallback<TPresence extends JsonObject> = (
   me: TPresence
 ) => void;
 
-export type OthersEventCallback<TPresence extends JsonObject> = (
-  others: Others<TPresence>,
-  event: OthersEvent<TPresence>
+export type OthersEventCallback<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+> = (
+  others: Others<TPresence, TUserMeta>,
+  event: OthersEvent<TPresence, TUserMeta>
 ) => void;
 
-export type EventCallback = ({
+export type EventCallback<TEvent extends Json> = ({
   connectionId,
   event,
 }: {
   connectionId: number;
-  event: Json;
+  event: TEvent;
 }) => void;
 
 export type ErrorCallback = (error: Error) => void;
 
 export type ConnectionCallback = (state: ConnectionState) => void;
 
-export type RoomEventCallbackMap<TPresence extends JsonObject> = {
+export type RoomEventCallbackMap<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
+> = {
   "my-presence": MyPresenceCallback<TPresence>;
-  others: OthersEventCallback<TPresence>;
-  event: EventCallback;
+  others: OthersEventCallback<TPresence, TUserMeta>;
+  event: EventCallback<TEvent>;
   error: ErrorCallback;
   connection: ConnectionCallback;
 };
 
-export type RoomEventName = keyof RoomEventCallbackMap<never>;
+export type RoomEventName = keyof RoomEventCallbackMap<never, never, never>;
 
 export type UpdateDelta =
   | {
@@ -180,19 +188,29 @@ export type Client = {
    *
    * @param roomId The id of the room
    */
-  getRoom<TPresence extends JsonObject, TStorage extends LsonObject>(
+  getRoom<
+    TPresence extends JsonObject,
+    TStorage extends LsonObject,
+    TUserMeta extends UserMetadata,
+    TEvent extends Json
+  >(
     roomId: string
-  ): Room<TPresence, TStorage> | null;
+  ): Room<TPresence, TStorage, TUserMeta, TEvent> | null;
 
   /**
    * Enters a room and returns it.
    * @param roomId The id of the room
    * @param options Optional. You can provide initializers for the Presence or Storage when entering the Room.
    */
-  enter<TPresence extends JsonObject, TStorage extends LsonObject>(
+  enter<
+    TPresence extends JsonObject,
+    TStorage extends LsonObject,
+    TUserMeta extends UserMetadata,
+    TEvent extends Json
+  >(
     roomId: string,
     options?: RoomInitializers<TPresence, TStorage>
-  ): Room<TPresence, TStorage>;
+  ): Room<TPresence, TStorage, TUserMeta, TEvent>;
 
   /**
    * Leaves a room.
@@ -204,7 +222,10 @@ export type Client = {
 /**
  * Represents all the other users connected in the room. Treated as immutable.
  */
-export interface Others<TPresence extends JsonObject> {
+export interface Others<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+> {
   /**
    * Number of other users in the room.
    */
@@ -212,21 +233,24 @@ export interface Others<TPresence extends JsonObject> {
   /**
    * Returns a new Iterator object that contains the users.
    */
-  [Symbol.iterator](): IterableIterator<User<TPresence>>;
+  [Symbol.iterator](): IterableIterator<User<TPresence, TUserMeta>>;
   /**
    * Returns the array of connected users in room.
    */
-  toArray(): User<TPresence>[];
+  toArray(): User<TPresence, TUserMeta>[];
   /**
    * This function let you map over the connected users in the room.
    */
-  map<U>(callback: (user: User<TPresence>) => U): U[];
+  map<U>(callback: (user: User<TPresence, TUserMeta>) => U): U[];
 }
 
 /**
  * Represents a user connected in a room. Treated as immutable.
  */
-export type User<TPresence extends JsonObject> = {
+export type User<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+> = {
   /**
    * The connection id of the user. It is unique and increment at every new connection.
    */
@@ -235,16 +259,15 @@ export type User<TPresence extends JsonObject> = {
    * The id of the user that has been set in the authentication endpoint.
    * Useful to get additional information about the connected user.
    */
-  readonly id?: string;
+  readonly id: TUserMeta["id"];
   /**
    * Additional user information that has been set in the authentication endpoint.
    */
-  readonly info?: any;
+  readonly info: TUserMeta["info"];
   /**
    * The user presence.
    */
   readonly presence?: TPresence;
-
   /**
    * @internal
    */
@@ -318,18 +341,21 @@ export type Connection =
 
 export type ConnectionState = Connection["state"];
 
-export type OthersEvent<TPresence extends JsonObject> =
+export type OthersEvent<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+> =
   | {
       type: "leave";
-      user: User<TPresence>;
+      user: User<TPresence, TUserMeta>;
     }
   | {
       type: "enter";
-      user: User<TPresence>;
+      user: User<TPresence, TUserMeta>;
     }
   | {
       type: "update";
-      user: User<TPresence>;
+      user: User<TPresence, TUserMeta>;
       updates: Partial<TPresence>;
     }
   | {
@@ -392,7 +418,12 @@ export interface History {
   resume: () => void;
 }
 
-export type Room<TPresence extends JsonObject, TStorage extends LsonObject> = {
+export type Room<
+  TPresence extends JsonObject,
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
+> = {
   /**
    * The id of the room.
    */
@@ -421,7 +452,10 @@ export type Room<TPresence extends JsonObject, TStorage extends LsonObject> = {
      *   // Do something
      * });
      */
-    (type: "others", listener: OthersEventCallback<TPresence>): () => void;
+    (
+      type: "others",
+      listener: OthersEventCallback<TPresence, TUserMeta>
+    ): () => void;
 
     /**
      * Subscribe to events broadcasted by {@link Room.broadcastEvent}
@@ -433,7 +467,7 @@ export type Room<TPresence extends JsonObject, TStorage extends LsonObject> = {
      *   // Do something
      * });
      */
-    (type: "event", listener: EventCallback): () => void;
+    (type: "event", listener: EventCallback<TEvent>): () => void;
 
     /**
      * Subscribe to errors thrown in the room.
@@ -569,7 +603,7 @@ export type Room<TPresence extends JsonObject, TStorage extends LsonObject> = {
    * @example
    * const user = room.getSelf();
    */
-  getSelf(): User<TPresence> | null;
+  getSelf(): User<TPresence, TUserMeta> | null;
 
   /**
    * Gets the presence of the current user.
@@ -585,7 +619,7 @@ export type Room<TPresence extends JsonObject, TStorage extends LsonObject> = {
    * @example
    * const others = room.getOthers();
    */
-  getOthers: () => Others<TPresence>;
+  getOthers: () => Others<TPresence, TUserMeta>;
 
   /**
    * Updates the presence of the current user. Only pass the properties you want to update. No need to send the full presence.
@@ -624,7 +658,7 @@ export type Room<TPresence extends JsonObject, TStorage extends LsonObject> = {
    *   }
    * });
    */
-  broadcastEvent: (event: Json, options?: BroadcastOptions) => void;
+  broadcastEvent: (event: TEvent, options?: BroadcastOptions) => void;
 
   /**
    * Get the room's storage asynchronously.
@@ -731,3 +765,4 @@ export type {
   UserLeftServerMsg,
 } from "./ServerMsg";
 export { ServerMsgCode } from "./ServerMsg";
+export type { UserMetadata } from "./UserMetadata";

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -20,6 +20,7 @@ import type {
   SerializedRootObject,
   ServerMsg,
   ToJson,
+  UserMetadata,
 } from "../src/types";
 import { ClientMsgCode, CrdtType, ServerMsgCode } from "../src/types";
 import { remove } from "../src/utils";
@@ -152,21 +153,23 @@ const defaultContext = {
 
 async function prepareRoomWithStorage<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(
   items: IdTuple<SerializedCrdt>[],
   actor: number = 0,
-  onSend: (messages: ClientMsg<TPresence>[]) => void = () => {},
+  onSend: (messages: ClientMsg<TPresence, TEvent>[]) => void = () => {},
   defaultStorage?: TStorage
 ) {
   const effects = mockEffects();
   (effects.send as jest.MockedFunction<any>).mockImplementation(onSend);
 
-  const state = defaultState<TPresence, TStorage>(
+  const state = defaultState<TPresence, TStorage, TUserMeta, TEvent>(
     {} as TPresence,
     defaultStorage || ({} as TStorage)
   );
-  const machine = makeStateMachine<TPresence, TStorage>(
+  const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TEvent>(
     state,
     defaultContext,
     effects
@@ -201,15 +204,17 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
   actor: number = 0,
   defaultStorage?: TStorage
 ) {
-  const messagesSent: ClientMsg<never>[] = [];
+  const messagesSent: ClientMsg<never, never>[] = [];
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
     never,
-    TStorage
+    TStorage,
+    never,
+    never
   >(
     items,
     actor,
-    (messages: ClientMsg<never>[]) => {
+    (messages: ClientMsg<never, never>[]) => {
       messagesSent.push(...messages);
     },
     defaultStorage || ({} as TStorage)
@@ -224,7 +229,7 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
     ws,
     assert: (data: ToJson<TStorage>) =>
       expect(lsonToJson(storage.root)).toEqual(data),
-    assertMessagesSent: (messages: ClientMsg<JsonObject>[]) => {
+    assertMessagesSent: (messages: ClientMsg<JsonObject, Json>[]) => {
       expect(messagesSent).toEqual(messages);
     },
     applyRemoteOperations: (ops: Op[]) =>
@@ -244,18 +249,25 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
  */
 export async function prepareStorageTest<
   TStorage extends LsonObject,
-  TPresence extends JsonObject = never
+  TPresence extends JsonObject = never,
+  TUserMeta extends UserMetadata = never,
+  TEvent extends Json = never
 >(items: IdTuple<SerializedCrdt>[], actor: number = 0) {
   let currentActor = actor;
   const operations: Op[] = [];
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TPresence, TStorage>(items, -1);
+    await prepareRoomWithStorage<TPresence, TStorage, TUserMeta, TEvent>(
+      items,
+      -1
+    );
 
   const { machine, storage, ws } = await prepareRoomWithStorage<
     TPresence,
-    TStorage
-  >(items, currentActor, (messages: ClientMsg<TPresence>[]) => {
+    TStorage,
+    TUserMeta,
+    TEvent
+  >(items, currentActor, (messages: ClientMsg<TPresence, TEvent>[]) => {
     for (const message of messages) {
       if (message.type === ClientMsgCode.UPDATE_STORAGE) {
         operations.push(...message.ops);
@@ -369,12 +381,14 @@ export async function prepareStorageTest<
  */
 export function prepareStorageUpdateTest<
   TStorage extends LsonObject,
-  TPresence extends JsonObject = never
+  TPresence extends JsonObject = never,
+  TUserMeta extends UserMetadata = never,
+  TEvent extends Json = never
 >(
   items: IdTuple<SerializedCrdt>[],
   callback: (args: {
     root: LiveObject<TStorage>;
-    machine: Machine<TPresence, TStorage>;
+    machine: Machine<TPresence, TStorage, TUserMeta, TEvent>;
     assert: (updates: JsonStorageUpdate[][]) => void;
   }) => Promise<void>
 ): () => Promise<void> {
@@ -384,7 +398,9 @@ export function prepareStorageUpdateTest<
 
     const { storage, machine } = await prepareRoomWithStorage<
       TPresence,
-      TStorage
+      TStorage,
+      TUserMeta,
+      TEvent
     >(items, 0, (messages) => {
       for (const message of messages) {
         if (message.type === ClientMsgCode.UPDATE_STORAGE) {
@@ -429,9 +445,11 @@ export function prepareStorageUpdateTest<
 
 export async function reconnect<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(
-  machine: Machine<TPresence, TStorage>,
+  machine: Machine<TPresence, TStorage, TUserMeta, TEvent>,
   actor: number,
   newItems: IdTuple<SerializedCrdt>[]
 ) {
@@ -450,7 +468,9 @@ export async function reconnect<
 
 export async function prepareStorageImmutableTest<
   TStorage extends LsonObject,
-  TPresence extends JsonObject = never
+  TPresence extends JsonObject = never,
+  TUserMeta extends UserMetadata = never,
+  TEvent extends Json = never
 >(items: IdTuple<SerializedCrdt>[], actor: number = 0) {
   let state = {} as ToJson<TStorage>;
   let refState = {} as ToJson<TStorage>;
@@ -458,12 +478,17 @@ export async function prepareStorageImmutableTest<
   let totalStorageOps = 0;
 
   const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TPresence, TStorage>(items, -1);
+    await prepareRoomWithStorage<TPresence, TStorage, TUserMeta, TEvent>(
+      items,
+      -1
+    );
 
   const { machine, storage } = await prepareRoomWithStorage<
     TPresence,
-    TStorage
-  >(items, actor, (messages: ClientMsg<TPresence>[]) => {
+    TStorage,
+    TUserMeta,
+    TEvent
+  >(items, actor, (messages: ClientMsg<TPresence, TEvent>[]) => {
     for (const message of messages) {
       if (message.type === ClientMsgCode.UPDATE_STORAGE) {
         totalStorageOps += message.ops.length;
@@ -582,8 +607,9 @@ export function createSerializedRegister(
 }
 
 export function mockEffects<
-  TPresence extends JsonObject
->(): Effects<TPresence> {
+  TPresence extends JsonObject,
+  TEvent extends Json
+>(): Effects<TPresence, TEvent> {
   return {
     authenticate: jest.fn(),
     delayFlush: jest.fn(),
@@ -594,7 +620,9 @@ export function mockEffects<
   };
 }
 
-export function serverMessage(message: ServerMsg<JsonObject>) {
+export function serverMessage(
+  message: ServerMsg<JsonObject, UserMetadata, Json>
+) {
   return new MessageEvent("message", {
     data: JSON.stringify(message),
   });

--- a/packages/liveblocks-react/scripts/generate-compat.ts
+++ b/packages/liveblocks-react/scripts/generate-compat.ts
@@ -207,7 +207,18 @@ function wrapHookDeclaration(
   if (!isOverload) {
     const args = paramDecls
       .map(({ name }) => name.text)
-      .map((arg) => (hasOverloads ? `${arg} as any` : arg))
+      .map((arg) =>
+        hasOverloads ||
+        // This condition should not be checking the name of the hook, of
+        // course! Really it should be checking whether the injected type
+        // argument is used in a contravariant type position (for example,
+        // a function argument to a callback function). Currently, that's only
+        // the case in the `useEventListener` callback, though. So YOLO.
+        // (This script only has to live one release anyway.)
+        name === "useEventListener"
+          ? `${arg} as any`
+          : arg
+      )
       .join(", ");
 
     const optionalCast =

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -18,6 +18,7 @@ import type {
   Others,
   Room,
   User,
+  UserMetadata,
 } from "@liveblocks/client";
 import { deprecate } from "@liveblocks/client/internal";
 
@@ -61,14 +62,17 @@ export function useBatch(): (callback: () => void) => void {
  * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
  * details.
  */
-export function useBroadcastEvent(): (
-  event: Json,
+export function useBroadcastEvent<TEvent extends Json>(): (
+  event: TEvent,
   options?: BroadcastOptions
 ) => void {
   deprecate(
     "Please use `createRoomContext()` instead of importing `useBroadcastEvent` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
   );
-  return _hooks.useBroadcastEvent();
+  return _hooks.useBroadcastEvent() as unknown as (
+    event: TEvent,
+    options?: BroadcastOptions
+  ) => void;
 }
 
 /**
@@ -90,13 +94,13 @@ export function useErrorListener(callback: (err: Error) => void): void {
  * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
  * details.
  */
-export function useEventListener(
-  callback: (eventData: { connectionId: number; event: Json }) => void
+export function useEventListener<TEvent extends Json>(
+  callback: (eventData: { connectionId: number; event: TEvent }) => void
 ): void {
   deprecate(
     "Please use `createRoomContext()` instead of importing `useEventListener` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
   );
-  return _hooks.useEventListener(callback);
+  return _hooks.useEventListener(callback as any);
 }
 
 /**
@@ -137,11 +141,14 @@ export function useMyPresence<TPresence extends JsonObject>(): [
  * https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for
  * details.
  */
-export function useOthers<TPresence extends JsonObject>(): Others<TPresence> {
+export function useOthers<
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+>(): Others<TPresence, TUserMeta> {
   deprecate(
     "Please use `createRoomContext()` instead of importing `useOthers` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
   );
-  return _hooks.useOthers() as unknown as Others<TPresence>;
+  return _hooks.useOthers() as unknown as Others<TPresence, TUserMeta>;
 }
 
 /**
@@ -165,12 +172,19 @@ export function useRedo(): () => void {
  */
 export function useRoom<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
->(): Room<TPresence, TStorage> {
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
+>(): Room<TPresence, TStorage, TUserMeta, TEvent> {
   deprecate(
     "Please use `createRoomContext()` instead of importing `useRoom` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
   );
-  return _hooks.useRoom() as unknown as Room<TPresence, TStorage>;
+  return _hooks.useRoom() as unknown as Room<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TEvent
+  >;
 }
 
 /**
@@ -180,12 +194,13 @@ export function useRoom<
  * details.
  */
 export function useSelf<
-  TPresence extends JsonObject
->(): User<TPresence> | null {
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+>(): User<TPresence, TUserMeta> | null {
   deprecate(
     "Please use `createRoomContext()` instead of importing `useSelf` from `@liveblocks/react` directly. See https://gist.github.com/nvie/5e718902c51ea7dad93cd6952fe1af03 for details."
   );
-  return _hooks.useSelf() as unknown as User<TPresence> | null;
+  return _hooks.useSelf() as unknown as User<TPresence, TUserMeta> | null;
 }
 
 /**

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -39,9 +39,9 @@ type LookupResult<T> =
 
 export function createRoomContext<
   TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends UserMetadata,
-  TEvent extends Json
+  TStorage extends LsonObject = {},
+  TUserMeta extends UserMetadata = UserMetadata,
+  TEvent extends Json = never
 >(client: Client) {
   let useClient: () => Client;
   if ((client as unknown) !== "__legacy") {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -9,6 +9,7 @@ import type {
   Others,
   Room,
   User,
+  UserMetadata,
 } from "@liveblocks/client";
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
@@ -38,7 +39,9 @@ type LookupResult<T> =
 
 export function createRoomContext<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends UserMetadata,
+  TEvent extends Json
 >(client: Client) {
   let useClient: () => Client;
   if ((client as unknown) !== "__legacy") {
@@ -47,9 +50,12 @@ export function createRoomContext<
     useClient = _useClient;
   }
 
-  const RoomContext = React.createContext<Room<TPresence, TStorage> | null>(
-    null
-  );
+  const RoomContext = React.createContext<Room<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TEvent
+  > | null>(null);
 
   /**
    * Makes a Room available in the component hierarchy below.
@@ -87,7 +93,9 @@ export function createRoomContext<
 
     const _client = useClient();
 
-    const [room, setRoom] = React.useState(() =>
+    const [room, setRoom] = React.useState<
+      Room<TPresence, TStorage, TUserMeta, TEvent>
+    >(() =>
       _client.enter(roomId, {
         initialPresence,
         initialStorage,
@@ -122,7 +130,7 @@ export function createRoomContext<
    * Returns the Room of the nearest RoomProvider above in the React component
    * tree.
    */
-  function useRoom(): Room<TPresence, TStorage> {
+  function useRoom(): Room<TPresence, TStorage, TUserMeta, TEvent> {
     const room = React.useContext(RoomContext);
     if (room == null) {
       throw new Error("RoomProvider is missing from the react tree");
@@ -207,7 +215,7 @@ export function createRoomContext<
    *   })
    * }
    */
-  function useOthers(): Others<TPresence> {
+  function useOthers(): Others<TPresence, TUserMeta> {
     const room = useRoom();
     const rerender = useRerender();
 
@@ -230,14 +238,14 @@ export function createRoomContext<
    * broadcast({ type: "CUSTOM_EVENT", data: { x: 0, y: 0 } });
    */
   function useBroadcastEvent(): (
-    event: Json,
+    event: TEvent,
     options?: BroadcastOptions
   ) => void {
     const room = useRoom();
 
     return React.useCallback(
       (
-        event: any,
+        event: TEvent,
         options: BroadcastOptions = { shouldQueueEventIfNotReady: false }
       ) => {
         room.broadcastEvent(event, options);
@@ -283,7 +291,7 @@ export function createRoomContext<
    * });
    */
   function useEventListener(
-    callback: (eventData: { connectionId: number; event: Json }) => void
+    callback: (eventData: { connectionId: number; event: TEvent }) => void
   ): void {
     const room = useRoom();
     const savedCallback = React.useRef(callback);
@@ -293,7 +301,7 @@ export function createRoomContext<
     });
 
     React.useEffect(() => {
-      const listener = (eventData: { connectionId: number; event: Json }) => {
+      const listener = (eventData: { connectionId: number; event: TEvent }) => {
         savedCallback.current(eventData);
       };
 
@@ -310,7 +318,7 @@ export function createRoomContext<
    * @example
    * const user = useSelf();
    */
-  function useSelf(): User<TPresence> | null {
+  function useSelf(): User<TPresence, TUserMeta> | null {
     const room = useRoom();
     const rerender = useRerender();
 

--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from "@liveblocks/client";
+import type { Json, JsonObject, UserMetadata } from "@liveblocks/client";
 import { createClient } from "@liveblocks/client";
 import type {
   IdTuple,
@@ -71,7 +71,9 @@ function prepareClientAndStore<T>(
   preloadedState?: T
 ) {
   const client = createClient({ authEndpoint: "/api/auth" });
-  const store = configureStore<LiveblocksState<BasicState, BasicPresence>>({
+  const store = configureStore<
+    LiveblocksState<BasicState, BasicPresence, never>
+  >({
     reducer: reducer as any,
     enhancers: [enhancer({ client, ...options })],
     preloadedState,
@@ -172,7 +174,9 @@ async function prepareWithStorage<T extends Record<string, unknown>>(
     }),
   } as MessageEvent);
 
-  function sendMessage(serverMessage: ServerMsg<JsonObject>) {
+  function sendMessage(
+    serverMessage: ServerMsg<JsonObject, UserMetadata, Json>
+  ) {
     socket.callbacks.message[0]!({
       data: JSON.stringify(serverMessage),
     } as MessageEvent);
@@ -383,7 +387,7 @@ describe("middleware", () => {
               info: { name: "Testy McTester" },
             },
           },
-        } as RoomStateServerMsg),
+        } as RoomStateServerMsg<UserMetadata>),
       } as MessageEvent);
 
       expect(store.getState().liveblocks.others).toEqual([

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -5,6 +5,7 @@ import type {
   LsonObject,
   Room,
   User,
+  UserMetadata,
 } from "@liveblocks/client";
 import {
   lsonToJson,
@@ -35,7 +36,11 @@ const ACTION_TYPES = {
   UPDATE_OTHERS: "@@LIVEBLOCKS/UPDATE_OTHERS",
 };
 
-export type LiveblocksState<TState, TPresence extends JsonObject> = TState & {
+export type LiveblocksState<
+  TState,
+  TPresence extends JsonObject,
+  TUserMeta extends UserMetadata
+> = TState & {
   /**
    * Liveblocks extra state attached by the enhancer
    */
@@ -43,7 +48,7 @@ export type LiveblocksState<TState, TPresence extends JsonObject> = TState & {
     /**
      * Other users in the room. Empty no room is currently synced
      */
-    readonly others: Array<User<TPresence>>;
+    readonly others: Array<User<TPresence, TUserMeta>>;
     /**
      * Whether or not the room storage is currently loading
      */
@@ -84,7 +89,7 @@ const internalEnhancer = <T>(options: {
 
   return (createStore: any) =>
     (reducer: any, initialState: any, enhancer: any) => {
-      let room: Room<any, any> | null = null;
+      let room: Room<any, any, any, any> | null = null;
       let isPatching: boolean = false;
       let storageRoot: LiveObject<any> | null = null;
       let unsubscribeCallbacks: Array<() => void> = [];
@@ -364,7 +369,7 @@ function patchLiveblocksStorage<O extends LsonObject>(
 }
 
 function broadcastInitialPresence<T>(
-  room: Room<any, any>,
+  room: Room<any, any, any, any>,
   state: T,
   mapping: Mapping<T>
 ) {
@@ -374,7 +379,7 @@ function broadcastInitialPresence<T>(
 }
 
 function updatePresence<TPresence extends JsonObject>(
-  room: Room<TPresence, any>,
+  room: Room<TPresence, any, any, any>,
   oldState: TPresence,
   newState: TPresence,
   presenceMapping: Mapping<TPresence>


### PR DESCRIPTION
This PR also lifts the `TUserMeta` and `TEvent` type arguments to the highest level, like we discussed. Fixes #342.
