### PR TITLE
feat(authorize): provide meaningful error when room is missing

### DIFF
--- a/packages/liveblocks-node/src/index.test.ts
+++ b/packages/liveblocks-node/src/index.test.ts
@@ -1,0 +1,17 @@
+import { authorize } from ".";
+
+describe("authorize", () => {
+  test.each([null, "", undefined, {}])(
+    "should check that room is a non-empty string",
+    async (room) => {
+      await authorize({
+        room,
+        secret: "sk_xxx",
+      }).then((response) => {
+        expect(response.error && response.error.message).toBe(
+          "Invalid room. Please provide a non-empty string as the room. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+        );
+      });
+    }
+  );
+});

--- a/packages/liveblocks-node/src/index.test.ts
+++ b/packages/liveblocks-node/src/index.test.ts
@@ -5,6 +5,7 @@ describe("authorize", () => {
     "should check that room is a non-empty string",
     async (room) => {
       await authorize({
+        // @ts-expect-error: we want to test for anything passed as room
         room,
         secret: "sk_xxx",
       }).then((response) => {

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -33,19 +33,27 @@ export async function authorize(
   options: AuthorizeOptions
 ): Promise<AuthorizeResponse> {
   try {
+    const { room, secret, userId, userInfo } = options;
+
+    if (!(typeof room === "string" && room.length > 0)) {
+      throw new Error(
+        "Invalid room. Please provide a non-empty string as the room. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize"
+      );
+    }
+
     const result = await fetch(
       (options as AllAuthorizeOptions).liveblocksAuthorizeEndpoint ||
         "https://liveblocks.io/api/authorize",
       {
         method: "POST",
         headers: {
-          Authorization: `Bearer: ${options.secret}`,
+          Authorization: `Bearer: ${secret}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          room: options.room,
-          userId: options.userId,
-          userInfo: options.userInfo,
+          room,
+          userId,
+          userInfo,
         }),
       }
     );

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -29,6 +29,24 @@ type AuthorizeResponse = {
   error?: Error;
 };
 
+/**
+ * @example
+ * export default async function auth(req, res) {
+ *
+ * // Implement your own security here.
+ *
+ * const room = req.body.room;
+ * const response = await authorize({
+ *   room,
+ *   secret,
+ *   userId: "123", // Optional
+ *   userInfo: {    // Optional
+ *     name: "Ada Lovelace"
+ *   }
+ * });
+ * return res.status(response.status).end(response.body);
+ * }
+ */
 export async function authorize(
   options: AuthorizeOptions
 ): Promise<AuthorizeResponse> {


### PR DESCRIPTION
Solves part of https://github.com/liveblocks/liveblocks/issues/331

Next step: throw a meaningful error when result of auth in `createClient` is missing `{token: "xxx"}`
