### PR TITLE
Mark some APIs as `@internal` that were missing it

### DIFF
--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -106,9 +106,7 @@ export abstract class AbstractCrdt {
 
   private _parent: ParentInfo = NoParent;
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _getParentKeyOrThrow(): string {
     switch (this.parent.type) {
       case "HasParent":
@@ -125,9 +123,7 @@ export abstract class AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   protected get _doc(): Doc | undefined {
     return this.__doc;
   }
@@ -136,23 +132,17 @@ export abstract class AbstractCrdt {
     return this.__doc ? this.__doc.roomId : null;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   get _id(): string | undefined {
     return this.__id;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   get parent(): ParentInfo {
     return this._parent;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   get _parentNode(): LiveNode | null {
     switch (this.parent.type) {
       case "HasParent":
@@ -169,9 +159,7 @@ export abstract class AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   get _parentKey(): string | null {
     switch (this.parent.type) {
       case "HasParent":
@@ -188,9 +176,7 @@ export abstract class AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _apply(op: Op, _isLocal: boolean): ApplyResult {
     switch (op.type) {
       case OpCode.DELETE_CRDT: {
@@ -205,9 +191,7 @@ export abstract class AbstractCrdt {
     return { modified: false };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _setParentLink(newParentNode: LiveNode, newParentKey: string): void {
     switch (this.parent.type) {
       case "HasParent":
@@ -230,9 +214,7 @@ export abstract class AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _attach(id: string, doc: Doc): void {
     if (this.__id || this.__doc) {
       throw new Error("Cannot attach if CRDT is already attached");
@@ -244,14 +226,10 @@ export abstract class AbstractCrdt {
     this.__doc = doc;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   abstract _attachChild(op: CreateChildOp, source: OpSource): ApplyResult;
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _detach(): void {
     if (this.__doc && this.__id) {
       this.__doc.deleteItem(this.__id);
@@ -282,21 +260,15 @@ export abstract class AbstractCrdt {
     this.__doc = undefined;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   abstract _detachChild(crdt: LiveNode): ApplyResult;
-  /**
-   * @internal
-   */
+  /** @internal */
   abstract _serialize(
     parentId: string,
     parentKey: string,
     doc?: Doc
   ): CreateChildOp[];
 
-  /**
-   * @internal
-   */
+  /** @internal */
   abstract _toSerializedCrdt(): SerializedCrdt;
 }

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -101,9 +101,12 @@ type ParentInfo =
 
 export abstract class AbstractCrdt {
   //                  ^^^^^^^^^^^^ TODO: Make this an interface
+  /** @internal */
   private __doc?: Doc;
+  /** @internal */
   private __id?: string;
 
+  /** @internal */
   private _parent: ParentInfo = NoParent;
 
   /** @internal */

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -29,9 +29,13 @@ import {
  */
 export class LiveList<TItem extends Lson> extends AbstractCrdt {
   // TODO: Naive array at first, find a better data structure. Maybe an Order statistics tree?
+  /** @internal */
   private _items: Array<LiveNode>;
 
+  /** @internal */
   private _implicitlyDeletedItems: Set<LiveNode>;
+
+  /** @internal */
   private _unacknowledgedSets: Map<string, string>;
 
   constructor(items: TItem[] = []) {
@@ -50,9 +54,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   static _deserialize(
     [id]: IdTuple<SerializedList>,
     parentToChildren: ParentToChildNodeMap,
@@ -78,9 +80,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return list;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _serialize(parentId: string, parentKey: string, doc?: Doc): CreateChildOp[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
@@ -104,18 +104,14 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return ops;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _indexOfPosition(position: string): number {
     return this._items.findIndex(
       (item) => item._getParentKeyOrThrow() === position
     );
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _attach(id: string, doc: Doc): void {
     super._attach(id, doc);
 
@@ -124,9 +120,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _detach(): void {
     super._detach();
 
@@ -135,9 +129,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applySetRemote(op: CreateChildOp): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
@@ -219,9 +211,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applySetAck(op: CreateChildOp): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
@@ -361,9 +351,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return result.modified.updates[0];
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applyRemoteInsert(op: CreateChildOp): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
@@ -387,9 +375,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applyInsertAck(op: CreateChildOp): ApplyResult {
     const existingItem = this._items.find((item) => item._id === op.id);
     const key = op.parentKey;
@@ -456,9 +442,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applyInsertUndoRedo(op: CreateChildOp): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
@@ -497,9 +481,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applySetUndoRedo(op: CreateChildOp): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
@@ -556,9 +538,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _attachChild(op: CreateChildOp, source: OpSource): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
@@ -588,9 +568,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _detachChild(
     child: LiveNode
   ): { reverse: Op[]; modified: LiveListUpdates<TItem> } | { modified: false } {
@@ -613,9 +591,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return { modified: false };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applySetChildKeyRemote(
     newKey: string,
     child: LiveNode
@@ -692,9 +668,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applySetChildKeyAck(newKey: string, child: LiveNode): ApplyResult {
     const previousKey = nn(child._parentKey);
 
@@ -766,9 +740,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _applySetChildKeyUndoRedo(
     newKey: string,
     child: LiveNode
@@ -813,9 +785,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _setChildKey(newKey: string, child: LiveNode, source: OpSource): ApplyResult {
     if (source === OpSource.REMOTE) {
       return this._applySetChildKeyRemote(newKey, child);
@@ -826,16 +796,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _apply(op: Op, isLocal: boolean): ApplyResult {
     return super._apply(op, isLocal);
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _toSerializedCrdt(): SerializedList {
     if (this.parent.type !== "HasParent") {
       throw new Error("Cannot serialize LiveList if parent is missing");
@@ -1214,9 +1180,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return new LiveListIterator(this._items);
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _createAttachItemAndSort(
     op: CreateOp,
     key: string
@@ -1237,9 +1201,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return { newItem, newIndex };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   private _shiftItemPosition(index: number, key: string) {
     const shiftedPosition = makePosition(
       key,

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -31,6 +31,7 @@ export class LiveMap<
   TKey extends string,
   TValue extends Lson
 > extends AbstractCrdt {
+  /** @internal */
   private _map: Map<TKey, LiveNode>;
 
   constructor(entries?: readonly (readonly [TKey, TValue])[] | undefined);

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -36,7 +36,10 @@ import {
  * If multiple clients update the same property simultaneously, the last modification received by the Liveblocks servers is the winner.
  */
 export class LiveObject<O extends LsonObject> extends AbstractCrdt {
+  /** @internal */
   private _map: Map<string, Lson>;
+
+  /** @internal */
   private _propToLastUpdate: Map<string, string>;
 
   constructor(obj: O = {} as O) {
@@ -56,15 +59,15 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     this._map = new Map(Object.entries(obj)) as Map<string, Lson>;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _serialize(parentId: string, parentKey: string, doc?: Doc): CreateChildOp[];
+  /** @internal */
   _serialize(
     parentId?: undefined,
     parentKey?: undefined,
     doc?: Doc
   ): CreateOp[];
+  /** @internal */
   _serialize(parentId?: string, parentKey?: string, doc?: Doc): CreateOp[] {
     if (this._id == null) {
       throw new Error("Cannot serialize item is not attached");
@@ -99,9 +102,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     return ops;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   static _deserialize(
     [id, item]: IdTuple<SerializedObject | SerializedRootObject>,
     parentToChildren: ParentToChildNodeMap,
@@ -112,9 +113,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     return this._deserializeChildren(liveObj, parentToChildren, doc);
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   static _deserializeChildren(
     liveObj: LiveObject<JsonObject>,
     parentToChildren: ParentToChildNodeMap,
@@ -137,9 +136,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     return liveObj;
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _attach(id: string, doc: Doc): void {
     super._attach(id, doc);
 
@@ -150,9 +147,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _attachChild(op: CreateChildOp, source: OpSource): ApplyResult {
     if (this._doc == null) {
       throw new Error("Can't attach child if doc is not present");
@@ -218,9 +213,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     };
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _detachChild(child: LiveNode): ApplyResult {
     if (child) {
       const id = nn(this._id);
@@ -262,9 +255,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     }
   }
 
-  /**
-   * @internal
-   */
+  /** @internal */
   _apply(op: Op, isLocal: boolean): ApplyResult {
     if (op.type === OpCode.UPDATE_OBJECT) {
       return this._applyUpdate(op, isLocal);
@@ -304,6 +295,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     }
   }
 
+  /** @internal */
   private _applyUpdate(op: UpdateObjectOp, isLocal: boolean): ApplyResult {
     let isModified = false;
     const id = nn(this._id);
@@ -375,6 +367,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       : { modified: false };
   }
 
+  /** @internal */
   private _applyDeleteObjectKey(op: DeleteObjectKeyOp): ApplyResult {
     const key = op.key;
 

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -17,6 +17,7 @@ import { CrdtType, OpCode } from "./types";
  * INTERNAL
  */
 export class LiveRegister<TValue extends Json> extends AbstractCrdt {
+  /** @internal */
   _data: TValue;
 
   constructor(data: TValue) {
@@ -28,9 +29,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     return this._data;
   }
 
-  /**
-   * INTERNAL
-   */
+  /** @internal */
   static _deserialize(
     [id, item]: IdTuple<SerializedRegister>,
     _parentToChildren: ParentToChildNodeMap,
@@ -41,9 +40,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     return register;
   }
 
-  /**
-   * INTERNAL
-   */
+  /** @internal */
   _serialize(
     parentId: string,
     parentKey: string,
@@ -67,9 +64,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     ];
   }
 
-  /**
-   * INTERNAL
-   */
+  /** @internal */
   _toSerializedCrdt(): SerializedRegister {
     if (this.parent.type !== "HasParent") {
       throw new Error("Cannot serialize LiveRegister if parent is missing");
@@ -83,14 +78,17 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     };
   }
 
+  /** @internal */
   _attachChild(_op: CreateChildOp): ApplyResult {
     throw new Error("Method not implemented.");
   }
 
+  /** @internal */
   _detachChild(_crdt: LiveNode): ApplyResult {
     throw new Error("Method not implemented.");
   }
 
+  /** @internal */
   _apply(op: Op, isLocal: boolean): ApplyResult {
     return super._apply(op, isLocal);
   }

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -268,9 +268,7 @@ export type User<
    * The user presence.
    */
   readonly presence?: TPresence;
-  /**
-   * @internal
-   */
+  /** @internal */
   _hasReceivedInitialPresence?: boolean;
 };
 


### PR DESCRIPTION
This adds some missing `@internals`. The effects on the outer observable API are pretty significant.

Compare:
- The API diff we would (accidentally) ship if we [were to release `main` as 0.17 today](https://gist.github.com/nvie/0ddda98cee4e0d2242b2648c462b5b31)
- The API diff [with this PR applied](https://gist.github.com/nvie/c4d8ca61648bff584ddb2701d19acf36)
