### PR TITLE
Fix: remove a leftover from refactoring

### DIFF
--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -681,13 +681,7 @@ export type Room<
    * @example
    * const { root } = await room.getStorage();
    */
-  getStorage: <
-    /**
-     * @deprecated This type argument is ignored. If you want to annotate this
-     * type manually, please annotate the Room instance instead.
-     */
-    _ = unknown
-  >() => Promise<{
+  getStorage: () => Promise<{
     root: LiveObject<TStorage>;
   }>;
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -343,7 +343,7 @@ export function createRoomContext<
       let didCancel = false;
 
       async function fetchStorage() {
-        const storage = await room.getStorage<TStorage>();
+        const storage = await room.getStorage();
         if (!didCancel) {
           setState(storage.root);
         }

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -222,7 +222,7 @@ const internalEnhancer = <T>(options: {
           type: ACTION_TYPES.START_LOADING_STORAGE,
         });
 
-        room.getStorage<any>().then(({ root }) => {
+        room.getStorage().then(({ root }) => {
           const updates: any = {};
 
           room!.batch(() => {

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -229,7 +229,7 @@ export function middleware<
         })
       );
 
-      room.getStorage<any>().then(({ root }) => {
+      room.getStorage().then(({ root }) => {
         const updates: any = {};
 
         room!.batch(() => {


### PR DESCRIPTION
Removes an old type param position that I forgot to remove after refactoring. Found this by inspecting [the outer API diff output](https://gist.github.com/nvie/c4d8ca61648bff584ddb2701d19acf36#file-v0-16-17-vs-v0-17-diff-L547-L555) :)
