### PR TITLE
Cleanup subscribe APIs

### DIFF
--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -52,6 +52,7 @@ import type {
 } from "./types";
 import {
   ClientMsgCode,
+  isRoomEventName,
   OpCode,
   ServerMsgCode,
   WebsocketCloseCodes,
@@ -170,16 +171,6 @@ const BACKOFF_RETRY_DELAYS_SLOW = [2000, 30000, 60000, 300000];
 const HEARTBEAT_INTERVAL = 30000;
 // const WAKE_UP_CHECK_INTERVAL = 2000;
 const PONG_TIMEOUT = 2000;
-
-function isValidRoomEventType(value: string) {
-  return (
-    value === "my-presence" ||
-    value === "others" ||
-    value === "event" ||
-    value === "error" ||
-    value === "connection"
-  );
-}
 
 function makeIdFactory(connectionId: number): IdFactory {
   let count = 0;
@@ -783,7 +774,7 @@ export function makeStateMachine<
       return subscribeToLiveStructure(firstParam, listener, options);
     } else if (typeof firstParam === "function") {
       return genericSubscribe(firstParam);
-    } else if (!isValidRoomEventType(firstParam)) {
+    } else if (!isRoomEventName(firstParam)) {
       throw new Error(`"${firstParam}" is not a valid event name`);
     }
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -102,7 +102,7 @@ export type Machine<
   connect(): null | undefined;
   disconnect(): void;
 
-  subscribe(callback: (updates: StorageUpdate) => void): () => void;
+  subscribe(callback: StorageCallback): () => void;
   subscribe<TKey extends string, TValue extends Lson>(
     liveMap: LiveMap<TKey, TValue>,
     callback: (liveMap: LiveMap<TKey, TValue>) => void
@@ -730,7 +730,7 @@ export function makeStateMachine<
     }
   }
 
-  function subscribe(callback: (updates: StorageUpdate) => void): () => void;
+  function subscribe(callback: StorageCallback): () => void;
   function subscribe<TKey extends string, TValue extends Lson>(
     liveMap: LiveMap<TKey, TValue>,
     callback: (liveMap: LiveMap<TKey, TValue>) => void
@@ -766,7 +766,7 @@ export function makeStateMachine<
     listener: ConnectionCallback
   ): () => void;
   function subscribe<K extends RoomEventName>(
-    firstParam: K | LiveStructure | ((updates: StorageUpdate[]) => void),
+    firstParam: StorageCallback | K | LiveStructure,
     listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K] | any,
     options?: { isDeep: boolean }
   ): () => void {

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -67,7 +67,20 @@ export type RoomEventCallbackMap<
   connection: ConnectionCallback;
 };
 
-export type RoomEventName = keyof RoomEventCallbackMap<never, never, never>;
+export type RoomEventName = Extract<
+  keyof RoomEventCallbackMap<never, never, never>,
+  string
+>;
+
+export function isRoomEventName(value: string): value is RoomEventName {
+  return (
+    value === "my-presence" ||
+    value === "others" ||
+    value === "event" ||
+    value === "error" ||
+    value === "connection"
+  );
+}
 
 export type UpdateDelta =
   | {


### PR DESCRIPTION
Tried to tackle #343, but it's more complicated that I initially thought. This fixes at least a superficial bug, and cleans/DRYs up a few params. Should not introduce any functional changes.