### PR TITLE
Cleanup TypeScript definitions for `subscribe` overloads

### DIFF
--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -901,7 +901,7 @@ describe("room", () => {
 
       let others: Others<P, never> | undefined;
 
-      const unsubscribe = machine.subscribe<P>("others", (o) => (others = o));
+      const unsubscribe = machine.subscribe("others", (o) => (others = o));
 
       machine.onMessage(
         serverMessage({
@@ -1172,7 +1172,7 @@ describe("room", () => {
 
       let others: Others<P, M> | undefined;
 
-      machine.subscribe<P>("others", (o) => (others = o));
+      machine.subscribe("others", (o) => (others = o));
 
       machine.onMessage(
         serverMessage({

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -3,8 +3,6 @@ import { OpSource } from "./AbstractCrdt";
 import { nn } from "./assert";
 import type { RoomAuthToken } from "./AuthToken";
 import { isTokenExpired, parseRoomAuthToken } from "./AuthToken";
-import type { LiveList } from "./LiveList";
-import type { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";
 import type {
   Authentication,
@@ -24,7 +22,6 @@ import type {
   JsonObject,
   LiveNode,
   LiveStructure,
-  Lson,
   LsonObject,
   MyPresenceCallback,
   NodeMap,
@@ -35,7 +32,8 @@ import type {
   ParentToChildNodeMap,
   Polyfills,
   Room,
-  RoomEventCallbackMap,
+  RoomEventCallback,
+  RoomEventCallbackFor,
   RoomEventName,
   RoomInitializers,
   RoomStateServerMsg,
@@ -103,37 +101,22 @@ export type Machine<
   disconnect(): void;
 
   subscribe(callback: StorageCallback): () => void;
-  subscribe<TKey extends string, TValue extends Lson>(
-    liveMap: LiveMap<TKey, TValue>,
-    callback: (liveMap: LiveMap<TKey, TValue>) => void
+  subscribe<L extends LiveStructure>(
+    liveStructure: L,
+    callback: (node: L) => void
   ): () => void;
-  subscribe<TData extends LsonObject>(
-    liveObject: LiveObject<TData>,
-    callback: (liveObject: LiveObject<TData>) => void
-  ): () => void;
-  subscribe<TItem extends Lson>(
-    liveList: LiveList<TItem>,
-    callback: (liveList: LiveList<TItem>) => void
-  ): () => void;
-  subscribe<TItem extends LiveStructure>(
-    node: TItem,
-    callback: (updates: StorageUpdate[]) => void,
+  subscribe(
+    node: LiveStructure,
+    callback: StorageCallback,
     options: { isDeep: true }
   ): () => void;
-  subscribe<TPresence extends JsonObject>(
-    type: "my-presence",
-    listener: MyPresenceCallback<TPresence>
+  subscribe<E extends RoomEventName>(
+    type: E,
+    listener: RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>
   ): () => void;
-  subscribe<TPresence extends JsonObject>(
-    type: "others",
-    listener: OthersEventCallback<TPresence, TUserMeta>
-  ): () => void;
-  subscribe(type: "event", listener: EventCallback<TEvent>): () => void;
-  subscribe(type: "error", listener: ErrorCallback): () => void;
-  subscribe(type: "connection", listener: ConnectionCallback): () => void;
-  subscribe<K extends RoomEventName>(
-    firstParam: K | LiveStructure | ((updates: StorageUpdate[]) => void),
-    listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K],
+  subscribe<L extends LiveStructure, E extends RoomEventName>(
+    first: StorageCallback | L | E,
+    second?: ((node: L) => void) | StorageCallback | RoomEventCallback,
     options?: { isDeep: boolean }
   ): () => void;
 
@@ -381,27 +364,31 @@ export function makeStateMachine<
     return () => remove(state.listeners.storage, callback);
   }
 
-  function subscribeToLiveStructure(
-    liveValue: LiveStructure,
-    innerCallback: (updates: StorageUpdate[] | LiveStructure) => void,
-    options?: { isDeep: boolean }
-  ) {
-    const cb = (updates: StorageUpdate[]) => {
-      const relatedUpdates: StorageUpdate[] = [];
+  function subscribeToLiveStructureDeeply<L extends LiveStructure>(
+    node: L,
+    callback: (updates: StorageUpdate[]) => void
+  ): () => void {
+    return genericSubscribe((updates) => {
+      const relatedUpdates = updates.filter((update) =>
+        isSameNodeOrChildOf(update.node, node)
+      );
+      if (relatedUpdates.length > 0) {
+        callback(relatedUpdates);
+      }
+    });
+  }
+
+  function subscribeToLiveStructureShallowly<L extends LiveStructure>(
+    node: L,
+    callback: (node: L) => void
+  ): () => void {
+    return genericSubscribe((updates) => {
       for (const update of updates) {
-        if (options?.isDeep && isSameNodeOrChildOf(update.node, liveValue)) {
-          relatedUpdates.push(update);
-        } else if (update.node._id === liveValue._id) {
-          innerCallback(update.node);
+        if (update.node._id === node._id) {
+          callback(update.node as L);
         }
       }
-
-      if (options?.isDeep && relatedUpdates.length > 0) {
-        innerCallback(relatedUpdates);
-      }
-    };
-
-    return genericSubscribe(cb);
+    });
   }
 
   function createOrUpdateRootFromMessage(
@@ -730,69 +717,60 @@ export function makeStateMachine<
     }
   }
 
+  // Generic storage callbacks -----------------------------------------------------------------------
+  // prettier-ignore
   function subscribe(callback: StorageCallback): () => void;
-  function subscribe<TKey extends string, TValue extends Lson>(
-    liveMap: LiveMap<TKey, TValue>,
-    callback: (liveMap: LiveMap<TKey, TValue>) => void
-  ): () => void;
-  function subscribe<TData extends LsonObject>(
-    liveObject: LiveObject<TData>,
-    callback: (liveObject: LiveObject<TData>) => void
-  ): () => void;
-  function subscribe<TItem extends Lson>(
-    liveList: LiveList<TItem>,
-    callback: (liveList: LiveList<TItem>) => void
-  ): () => void;
-  function subscribe(
-    node: LiveStructure,
-    callback: (updates: StorageUpdate[]) => void,
-    options: { isDeep: true }
-  ): () => void;
-  function subscribe<TPresence extends JsonObject>(
-    type: "my-presence",
-    listener: MyPresenceCallback<TPresence>
-  ): () => void;
-  function subscribe<TPresence extends JsonObject>(
-    type: "others",
-    listener: OthersEventCallback<TPresence, TUserMeta>
-  ): () => void;
-  function subscribe(
-    type: "event",
-    listener: EventCallback<TEvent>
-  ): () => void;
-  function subscribe(type: "error", listener: ErrorCallback): () => void;
-  function subscribe(
-    type: "connection",
-    listener: ConnectionCallback
-  ): () => void;
-  function subscribe<K extends RoomEventName>(
-    firstParam: StorageCallback | K | LiveStructure,
-    listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K],
+
+  // Storage callbacks filtered by Live structure ----------------------------------------------------
+  // prettier-ignore
+  function subscribe<L extends LiveStructure>(liveStructure: L, callback: (node: L) => void): () => void;
+  // prettier-ignore
+  function subscribe(node: LiveStructure, callback: StorageCallback, options: { isDeep: true }): () => void;
+
+  // RoomEventCallbacks ------------------------------------------------------------------------------
+  // prettier-ignore
+  function subscribe<E extends RoomEventName>(type: E, listener: RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>): () => void;
+
+  function subscribe<L extends LiveStructure, E extends RoomEventName>(
+    first: StorageCallback | L | E,
+    second?: ((node: L) => void) | StorageCallback | RoomEventCallback,
     options?: { isDeep: boolean }
   ): () => void {
-    if (isLiveNode(firstParam)) {
-      return subscribeToLiveStructure(firstParam, listener, options);
-    } else if (typeof firstParam === "function") {
-      return genericSubscribe(firstParam);
-    } else if (!isRoomEventName(firstParam)) {
-      throw new Error(`"${firstParam}" is not a valid event name`);
+    if (second === undefined || typeof first === "function") {
+      if (typeof first === "function") {
+        const storageCallback = first;
+        return genericSubscribe(storageCallback);
+      } else {
+        throw new Error("Please specify a listener callback");
+      }
     }
 
-    (
-      state.listeners[firstParam] as RoomEventCallbackMap<
-        TPresence,
-        TUserMeta,
-        TEvent
-      >[K][]
-    ).push(listener);
+    if (isLiveNode(first)) {
+      const node = first;
+      if (options?.isDeep) {
+        const storageCallback = second as StorageCallback;
+        return subscribeToLiveStructureDeeply(node, storageCallback);
+      } else {
+        const nodeCallback = second as (node: L) => void;
+        return subscribeToLiveStructureShallowly(node, nodeCallback);
+      }
+    }
+
+    if (!isRoomEventName(first)) {
+      throw new Error(`"${first}" is not a valid event name`);
+    }
+
+    type EventListener = RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>;
+    type EventQueue = EventListener[];
+
+    const eventName = first;
+    const eventListener = second as EventListener;
+
+    (state.listeners[eventName] as EventQueue).push(eventListener);
 
     return () => {
-      const callbacks = state.listeners[firstParam] as RoomEventCallbackMap<
-        TPresence,
-        TUserMeta,
-        TEvent
-      >[K][];
-      remove(callbacks, listener);
+      const callbacks = state.listeners[eventName] as EventQueue;
+      remove(callbacks, eventListener);
     };
   }
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -100,25 +100,15 @@ export type Machine<
   connect(): null | undefined;
   disconnect(): void;
 
+  // Generic storage callbacks
   subscribe(callback: StorageCallback): () => void;
-  subscribe<L extends LiveStructure>(
-    liveStructure: L,
-    callback: (node: L) => void
-  ): () => void;
-  subscribe(
-    node: LiveStructure,
-    callback: StorageCallback,
-    options: { isDeep: true }
-  ): () => void;
-  subscribe<E extends RoomEventName>(
-    type: E,
-    listener: RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>
-  ): () => void;
-  subscribe<L extends LiveStructure, E extends RoomEventName>(
-    first: StorageCallback | L | E,
-    second?: ((node: L) => void) | StorageCallback | RoomEventCallback,
-    options?: { isDeep: boolean }
-  ): () => void;
+
+  // Storage callbacks filtered by Live structure
+  subscribe<L extends LiveStructure>(liveStructure: L, callback: (node: L) => void): () => void; // prettier-ignore
+  subscribe(node: LiveStructure, callback: StorageCallback, options: { isDeep: true }): () => void; // prettier-ignore
+
+  // Room event callbacks
+  subscribe<E extends RoomEventName>(type: E, listener: RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>): () => void; // prettier-ignore
 
   // Presence
   updatePresence(
@@ -717,19 +707,13 @@ export function makeStateMachine<
     }
   }
 
-  // Generic storage callbacks -----------------------------------------------------------------------
-  // prettier-ignore
-  function subscribe(callback: StorageCallback): () => void;
-
-  // Storage callbacks filtered by Live structure ----------------------------------------------------
-  // prettier-ignore
-  function subscribe<L extends LiveStructure>(liveStructure: L, callback: (node: L) => void): () => void;
-  // prettier-ignore
-  function subscribe(node: LiveStructure, callback: StorageCallback, options: { isDeep: true }): () => void;
-
-  // RoomEventCallbacks ------------------------------------------------------------------------------
-  // prettier-ignore
-  function subscribe<E extends RoomEventName>(type: E, listener: RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>): () => void;
+  // Generic storage callbacks
+  function subscribe(callback: StorageCallback): () => void; // prettier-ignore
+  // Storage callbacks filtered by Live structure
+  function subscribe<L extends LiveStructure>(liveStructure: L, callback: (node: L) => void): () => void; // prettier-ignore
+  function subscribe(node: LiveStructure, callback: StorageCallback, options: { isDeep: true }): () => void; // prettier-ignore
+  // Room event callbacks
+  function subscribe<E extends RoomEventName>(type: E, listener: RoomEventCallbackFor<E, TPresence, TUserMeta, TEvent>): () => void; // prettier-ignore
 
   function subscribe<L extends LiveStructure, E extends RoomEventName>(
     first: StorageCallback | L | E,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -767,7 +767,7 @@ export function makeStateMachine<
   ): () => void;
   function subscribe<K extends RoomEventName>(
     firstParam: StorageCallback | K | LiveStructure,
-    listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K] | any,
+    listener?: RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[K],
     options?: { isDeep: boolean }
   ): () => void {
     if (isLiveNode(firstParam)) {

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -3,7 +3,7 @@ import type { LiveMap } from "../LiveMap";
 import type { LiveObject } from "../LiveObject";
 import type { BaseUserMeta } from "./BaseUserMeta";
 import type { Json, JsonObject } from "./Json";
-import type { Lson, LsonObject } from "./Lson";
+import type { LiveStructure, Lson, LsonObject } from "./Lson";
 
 /**
  * This helper type is effectively a no-op, but will force TypeScript to
@@ -522,7 +522,7 @@ export type Room<
      * Subscribes to changes made on a {@link LiveMap}. Returns an unsubscribe function.
      * In a future version, we will also expose what exactly changed in the {@link LiveMap}.
      *
-     * @param listener the callback this called when the {@link LiveMap} changes.
+     * @param callback The callback this called when the {@link LiveMap} changes.
      *
      * @returns Unsubscribe function.
      *
@@ -531,9 +531,9 @@ export type Room<
      * const unsubscribe = room.subscribe(liveMap, (liveMap) => { });
      * unsubscribe();
      */
-    <TKey extends string, TValue extends Lson>(
-      liveMap: LiveMap<TKey, TValue>,
-      listener: (liveMap: LiveMap<TKey, TValue>) => void
+    <L extends LiveMap<string, Lson>>(
+      liveMap: L,
+      callback: (node: L) => void
     ): () => void;
 
     /**
@@ -549,9 +549,9 @@ export type Room<
      * const unsubscribe = room.subscribe(liveObject, (liveObject) => { });
      * unsubscribe();
      */
-    <TData extends JsonObject>(
-      liveObject: LiveObject<TData>,
-      callback: (liveObject: LiveObject<TData>) => void
+    <L extends LiveObject<JsonObject>>(
+      liveObject: L,
+      callback: (node: L) => void
     ): () => void;
 
     /**
@@ -567,65 +567,29 @@ export type Room<
      * const unsubscribe = room.subscribe(liveList, (liveList) => { });
      * unsubscribe();
      */
-    <TItem extends Lson>(
-      liveList: LiveList<TItem>,
-      callback: (liveList: LiveList<TItem>) => void
+    <L extends LiveList<Lson>>(
+      liveList: L,
+      callback: (node: L) => void
     ): () => void;
 
     /**
-     * Subscribes to changes made on a {@link LiveMap} and all the nested data structures. Returns an unsubscribe function.
-     * In a future version, we will also expose what exactly changed in the {@link LiveMap}.
+     * Subscribes to changes made on a Live structure and all the nested data
+     * structures. Returns an unsubscribe function. In a future version, we
+     * will also expose what exactly changed in the Live structure.
      *
-     * @param callback the callback this called when the {@link LiveMap} changes.
+     * @param callback The callback this called when the Live structure, or any
+     * of its nested values, changes.
      *
      * @returns Unsubscribe function.
      *
      * @example
      * const liveMap = new LiveMap();
-     * const unsubscribe = room.subscribe(liveMap, (liveMap) => { }, { isDeep: true });
+     * const unsubscribe = room.subscribe(liveMap, (updates) => { }, { isDeep: true });
      * unsubscribe();
      */
-    <TKey extends string, TValue extends Lson>(
-      liveMap: LiveMap<TKey, TValue>,
-      callback: (updates: LiveMapUpdates<TKey, TValue>[]) => void,
-      options: { isDeep: true }
-    ): () => void;
-
-    /**
-     * Subscribes to changes made on a {@link LiveObject} and all the nested data structures. Returns an unsubscribe function.
-     * In a future version, we will also expose what exactly changed in the {@link LiveObject}.
-     *
-     * @param callback the callback this called when the {@link LiveObject} changes.
-     *
-     * @returns Unsubscribe function.
-     *
-     * @example
-     * const liveObject = new LiveObject();
-     * const unsubscribe = room.subscribe(liveObject, (liveObject) => { }, { isDeep: true });
-     * unsubscribe();
-     */
-    <TData extends LsonObject>(
-      liveObject: LiveObject<TData>,
-      callback: (updates: LiveObjectUpdates<TData>[]) => void,
-      options: { isDeep: true }
-    ): () => void;
-
-    /**
-     * Subscribes to changes made on a {@link LiveList} and all the nested data structures. Returns an unsubscribe function.
-     * In a future version, we will also expose what exactly changed in the {@link LiveList}.
-     *
-     * @param callback the callback this called when the {@link LiveList} changes.
-     *
-     * @returns Unsubscribe function.
-     *
-     * @example
-     * const liveList = new LiveList();
-     * const unsubscribe = room.subscribe(liveList, (liveList) => { }, { isDeep: true });
-     * unsubscribe();
-     */
-    <TItem extends Lson>(
-      liveList: LiveList<TItem>,
-      callback: (updates: LiveListUpdates<TItem>[]) => void,
+    <L extends LiveStructure>(
+      liveStructure: L,
+      callback: StorageCallback,
       options: { isDeep: true }
     ): () => void;
   };

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -519,56 +519,20 @@ export type Room<
     (type: "connection", listener: ConnectionCallback): () => void;
 
     /**
-     * Subscribes to changes made on a {@link LiveMap}. Returns an unsubscribe function.
-     * In a future version, we will also expose what exactly changed in the {@link LiveMap}.
+     * Subscribes to changes made on a Live structure. Returns an unsubscribe function.
+     * In a future version, we will also expose what exactly changed in the Live structure.
      *
-     * @param callback The callback this called when the {@link LiveMap} changes.
+     * @param callback The callback this called when the Live structure changes.
      *
      * @returns Unsubscribe function.
      *
      * @example
-     * const liveMap = new LiveMap();
+     * const liveMap = new LiveMap();  // Could also be LiveList or LiveObject
      * const unsubscribe = room.subscribe(liveMap, (liveMap) => { });
      * unsubscribe();
      */
-    <L extends LiveMap<string, Lson>>(
-      liveMap: L,
-      callback: (node: L) => void
-    ): () => void;
-
-    /**
-     * Subscribes to changes made on a {@link LiveObject}. Returns an unsubscribe function.
-     * In a future version, we will also expose what exactly changed in the {@link LiveObject}.
-     *
-     * @param callback the callback this called when the {@link LiveObject} changes.
-     *
-     * @returns Unsubscribe function.
-     *
-     * @example
-     * const liveObject = new LiveObject();
-     * const unsubscribe = room.subscribe(liveObject, (liveObject) => { });
-     * unsubscribe();
-     */
-    <L extends LiveObject<JsonObject>>(
-      liveObject: L,
-      callback: (node: L) => void
-    ): () => void;
-
-    /**
-     * Subscribes to changes made on a {@link LiveList}. Returns an unsubscribe function.
-     * In a future version, we will also expose what exactly changed in the {@link LiveList}.
-     *
-     * @param callback the callback this called when the {@link LiveList} changes.
-     *
-     * @returns Unsubscribe function.
-     *
-     * @example
-     * const liveList = new LiveList();
-     * const unsubscribe = room.subscribe(liveList, (liveList) => { });
-     * unsubscribe();
-     */
-    <L extends LiveList<Lson>>(
-      liveList: L,
+    <L extends LiveStructure>(
+      liveStructure: L,
       callback: (node: L) => void
     ): () => void;
 
@@ -583,7 +547,7 @@ export type Room<
      * @returns Unsubscribe function.
      *
      * @example
-     * const liveMap = new LiveMap();
+     * const liveMap = new LiveMap();  // Could also be LiveList or LiveObject
      * const unsubscribe = room.subscribe(liveMap, (updates) => { }, { isDeep: true });
      * unsubscribe();
      */

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -55,7 +55,7 @@ export type ErrorCallback = (error: Error) => void;
 
 export type ConnectionCallback = (state: ConnectionState) => void;
 
-export type RoomEventCallbackMap<
+type RoomEventCallbackMap<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
   TEvent extends Json
@@ -70,6 +70,20 @@ export type RoomEventCallbackMap<
 export type RoomEventName = Extract<
   keyof RoomEventCallbackMap<never, never, never>,
   string
+>;
+
+export type RoomEventCallbackFor<
+  E extends RoomEventName,
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+  TEvent extends Json
+> = RoomEventCallbackMap<TPresence, TUserMeta, TEvent>[E];
+
+export type RoomEventCallback = RoomEventCallbackFor<
+  RoomEventName,
+  JsonObject,
+  BaseUserMeta,
+  Json
 >;
 
 export function isRoomEventName(value: string): value is RoomEventName {


### PR DESCRIPTION
Fixes #343 , correcting the type bug that previously were hidden by the `any` in one of the overloads, and restructures the internals to be a bit simpler to follow. Does not contain any functional changes.