### PR TITLE
Bump to dev version after publish

### DIFF
--- a/packages/liveblocks-client/package-lock.json
+++ b/packages/liveblocks-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/client",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/client",
-      "version": "0.17.0-beta2",
+      "version": "0.17.0-beta2-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/client",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "description": "A client that lets you interact with Liveblocks servers.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/packages/liveblocks-node/package-lock.json
+++ b/packages/liveblocks-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/node",
-  "version": "0.17.0-test1",
+  "version": "0.17.0-beta2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/node",
-      "version": "0.17.0-test1",
+      "version": "0.17.0-beta2-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^2.6.1"

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/node",
-  "version": "0.17.0-test1",
+  "version": "0.17.0-beta2-dev",
   "description": "A server-side utility that lets you set up a Liveblocks authentication endpoint.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/packages/liveblocks-react/package-lock.json
+++ b/packages/liveblocks-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/react",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/react",
-      "version": "0.17.0-beta2",
+      "version": "0.17.0-beta2-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "description": "A set of React hooks and providers to use Liveblocks declaratively.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/packages/liveblocks-redux/package-lock.json
+++ b/packages/liveblocks-redux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/redux",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/redux",
-      "version": "0.17.0-beta2",
+      "version": "0.17.0-beta2-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/redux",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "description": "A store enhancer to integrate Liveblocks into Redux stores.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/packages/liveblocks-zustand/package-lock.json
+++ b/packages/liveblocks-zustand/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@liveblocks/zustand",
-      "version": "0.17.0-beta2",
+      "version": "0.17.0-beta2-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.17.10",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "0.17.0-beta2",
+  "version": "0.17.0-beta2-dev",
   "description": "A middleware to integrate Liveblocks into Zustand stores.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -279,11 +279,13 @@ publish_to_npm () {
 }
 
 commit_to_git () {
+    msg="$1"
+    shift 1
     ( cd "$ROOT" && (
         git reset --quiet HEAD
         git add "$@"
         if git is-dirty -i; then
-            git commit -m "Bump to $VERSION"
+            git commit -m "$msg"
         fi
     ) )
 }
@@ -292,10 +294,10 @@ commit_to_git () {
 ( cd "$PRIMARY_PKG" && (
     pkgname="$(npm_pkgname "$PRIMARY_PKG")"
     echo "==> Building and publishing $PRIMARY_PKG"
-     bump_version_in_pkg "$PRIMARY_PKG" "$VERSION"
-     build_pkg
-     publish_to_npm "$pkgname"
-     commit_to_git "$PRIMARY_PKG"
+    bump_version_in_pkg "$PRIMARY_PKG" "$VERSION"
+    build_pkg
+    publish_to_npm "$pkgname"
+    commit_to_git "Bump to $VERSION" "$PRIMARY_PKG"
 ) )
 
 # Then, build and publish all the other packages
@@ -308,7 +310,7 @@ for pkgdir in ${SECONDARY_PKGS[@]}; do
         publish_to_npm "$pkgname"
     ) )
 done
-commit_to_git ${SECONDARY_PKGS[@]}
+commit_to_git "Bump to $VERSION" ${SECONDARY_PKGS[@]}
 
 echo ""
 echo "All published!"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -338,6 +338,14 @@ else
     read
 fi
 
+echo "==> Bumping to next dev versions"
+bump_version_in_pkg "$PRIMARY_PKG" "$VERSION-dev"
+for pkgdir in ${SECONDARY_PKGS[@]}; do
+    bump_version_in_pkg "$pkgdir" "$VERSION-dev"
+done
+commit_to_git "Start new dev version $VERSION-dev" "$PRIMARY_PKG" ${SECONDARY_PKGS[@]}
+git push-current
+
 echo "==> Upgrade local examples?"
 echo "Now that you're all finished, you may want to also upgrade all our examples"
 echo "to the latest version. To do so, run:"


### PR DESCRIPTION
Bump all packages to `0.x.x-dev` dev versions after publishing. This follows up on https://github.com/liveblocks/liveblocks/pull/366#discussion_r907045527.