### PR TITLE
Minor type fixes

### DIFF
--- a/packages/liveblocks-redux/src/index.test.ts
+++ b/packages/liveblocks-redux/src/index.test.ts
@@ -76,7 +76,7 @@ function prepareClientAndStore<T>(
   >({
     reducer: reducer as any,
     enhancers: [enhancer({ client, ...options })],
-    preloadedState,
+    preloadedState: preloadedState as any,
   });
   return { client, store };
 }

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -420,7 +420,7 @@ function patchPresenceState<T>(presence: any, mapping: Mapping<T>) {
   return partialState;
 }
 
-function patchState<T>(
+function patchState<T extends JsonObject>(
   state: T,
   updates: any[], // StorageUpdate
   mapping: Mapping<T>


### PR DESCRIPTION
This fixes two type annotations in the Redux library that will become issues when users upgrade to the latest TypeScript 4.8 beta, which catches a few more corner cases than 4.7 did.