### PR TITLE
Also upgrade `@liveblocks/node` in all examples from now on

### DIFF
--- a/e2e/next-sandbox/package-lock.json
+++ b/e2e/next-sandbox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "0.3.0",
+        "@liveblocks/node": "^0.17.1",
         "@liveblocks/react": "^0.17.1",
         "@liveblocks/redux": "^0.17.1",
         "@liveblocks/zustand": "^0.17.1",
@@ -1818,9 +1818,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -9017,9 +9017,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/e2e/next-sandbox/package.json
+++ b/e2e/next-sandbox/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "0.3.0",
+    "@liveblocks/node": "^0.17.1",
     "@liveblocks/react": "^0.17.1",
     "@liveblocks/redux": "^0.17.1",
     "@liveblocks/zustand": "^0.17.1",

--- a/examples/nextjs-live-avatars/package-lock.json
+++ b/examples/nextjs-live-avatars/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "0.3.0",
+        "@liveblocks/node": "^0.17.1",
         "@liveblocks/react": "^0.17.1",
         "next": "^12.1.6",
         "react": "^18.1.0",
@@ -56,10 +56,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
-      "license": "MIT",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -1963,9 +1962,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/nextjs-live-avatars/package.json
+++ b/examples/nextjs-live-avatars/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "0.3.0",
+    "@liveblocks/node": "^0.17.1",
     "@liveblocks/react": "^0.17.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/nextjs-logo-builder/package-lock.json
+++ b/examples/nextjs-logo-builder/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "^0.3.0",
+        "@liveblocks/node": "^0.17.1",
         "@liveblocks/react": "^0.17.1",
         "next": "^12.1.6",
         "react": "^18.1.0",
@@ -27,9 +27,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -478,9 +478,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/nextjs-logo-builder/package.json
+++ b/examples/nextjs-logo-builder/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "^0.3.0",
+    "@liveblocks/node": "^0.17.1",
     "@liveblocks/react": "^0.17.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/nextjs-whiteboard-advanced/package-lock.json
+++ b/examples/nextjs-whiteboard-advanced/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "0.3.0",
+        "@liveblocks/node": "^0.17.1",
         "@liveblocks/react": "^0.17.1",
         "nanoid": "^3.1.25",
         "next": "^12.1.6",
@@ -58,10 +58,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
-      "license": "MIT",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -2140,9 +2139,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "0.3.0",
+    "@liveblocks/node": "^0.17.1",
     "@liveblocks/react": "^0.17.1",
     "nanoid": "^3.1.25",
     "next": "^12.1.6",

--- a/examples/nuxtjs-live-avatars/package-lock.json
+++ b/examples/nuxtjs-live-avatars/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "^0.3.0",
+        "@liveblocks/node": "^0.17.1",
         "core-js": "^3.9.1",
         "express": "^4.17.1",
         "nuxt": "^2.15.3"
@@ -1604,9 +1604,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -18883,9 +18883,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/nuxtjs-live-avatars/package.json
+++ b/examples/nuxtjs-live-avatars/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "^0.3.0",
+    "@liveblocks/node": "^0.17.1",
     "core-js": "^3.9.1",
     "express": "^4.17.1",
     "nuxt": "^2.15.3"

--- a/examples/sveltekit-live-avatars/package-lock.json
+++ b/examples/sveltekit-live-avatars/package-lock.json
@@ -7,7 +7,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "^0.3.0"
+        "@liveblocks/node": "^0.17.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "next",
@@ -59,9 +59,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -2751,9 +2751,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/sveltekit-live-avatars/package.json
+++ b/examples/sveltekit-live-avatars/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "^0.3.0"
+    "@liveblocks/node": "^0.17.1"
   }
 }

--- a/examples/sveltekit-live-cursors/package-lock.json
+++ b/examples/sveltekit-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "^0.17.1",
-        "@liveblocks/node": "^0.3.0"
+        "@liveblocks/node": "^0.17.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "next",
@@ -59,9 +59,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -2751,9 +2751,9 @@
       "integrity": "sha512-brK8+sOmolPy64nyx2bGGe5+TSZIeprNGc2VV3tTulubzb1EaYzSzjdlAit8bAqP/pz4yew2VsmhNUm7gYM5oQ=="
     },
     "@liveblocks/node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.3.0.tgz",
-      "integrity": "sha512-3IJ6uN3QU71z6WXiDM97wW17fVVvrG9zMy4G4PY3zYzmeRfMnA+KBSBT1uPvlfgWm2D3d6/HNIXWxhwyv7bkfw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.1.tgz",
+      "integrity": "sha512-sHFFM0VkGJVNStmSuh7ABfBtgxfbspDhjiY21XlyapwwKucYtThDR9l4btkVLTbOm1c+elhb+Qm9l4hH4UOvzQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/sveltekit-live-cursors/package.json
+++ b/examples/sveltekit-live-cursors/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@liveblocks/client": "^0.17.1",
-    "@liveblocks/node": "^0.3.0"
+    "@liveblocks/node": "^0.17.1"
   }
 }

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -44,8 +44,7 @@ list_all_projects () {
 
 list_liveblocks_deps () {
     jq -r '(.dependencies // {})|keys[]' package.json \
-        | grep -Ee '^@liveblocks' \
-        | grep -vEe '@liveblocks/node'
+        | grep -Ee '^@liveblocks'
 }
 
 list_install_args () {


### PR DESCRIPTION
Previously, we didn't version `@liveblocks/node` alongside the other packages, but since 0.17, we do. This reflects that in the helper `upgrade-examples.sh` script, and updates all examples we have that rely on `@liveblocks/node`.