### PR TITLE
Fix bug with exported docstrings

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -50,7 +50,7 @@ export function createRoomContext<
     useClient = _useClient;
   }
 
-  const RoomContext = React.createContext<Room<
+  const RoomCtx = React.createContext<Room<
     TPresence,
     TStorage,
     TUserMeta,
@@ -121,9 +121,7 @@ export function createRoomContext<
       };
     }, [_client, roomId]);
 
-    return (
-      <RoomContext.Provider value={room}>{props.children}</RoomContext.Provider>
-    );
+    return <RoomCtx.Provider value={room}>{props.children}</RoomCtx.Provider>;
   }
 
   /**
@@ -131,7 +129,7 @@ export function createRoomContext<
    * tree.
    */
   function useRoom(): Room<TPresence, TStorage, TUserMeta, TRoomEvent> {
-    const room = React.useContext(RoomContext);
+    const room = React.useContext(RoomCtx);
     if (room == null) {
       throw new Error("RoomProvider is missing from the react tree");
     }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -32,6 +32,264 @@ export type RoomProviderProps<
   } & RoomInitializers<TPresence, TStorage>
 >;
 
+type RoomContext<
+  TPresence extends JsonObject,
+  TStorage extends LsonObject,
+  TUserMeta extends BaseUserMeta,
+  TRoomEvent extends Json
+> = {
+  /**
+   * Makes a Room available in the component hierarchy below.
+   * When this component is unmounted, the current user leave the room.
+   * That means that you can't have 2 RoomProvider with the same room id in your react tree.
+   */
+  RoomProvider(props: RoomProviderProps<TPresence, TStorage>): JSX.Element;
+
+  /**
+   * Returns a function that batches modifications made during the given function.
+   * All the modifications are sent to other clients in a single message.
+   * All the modifications are merged in a single history item (undo/redo).
+   * All the subscribers are called only after the batch is over.
+   */
+  useBatch(): (callback: () => void) => void;
+
+  /**
+   * Returns a callback that lets you broadcast custom events to other users in the room
+   *
+   * @example
+   * const broadcast = useBroadcastEvent();
+   *
+   * broadcast({ type: "CUSTOM_EVENT", data: { x: 0, y: 0 } });
+   */
+  useBroadcastEvent(): (event: TRoomEvent, options?: BroadcastOptions) => void;
+
+  /**
+   * useErrorListener is a react hook that lets you react to potential room connection errors.
+   *
+   * @example
+   * useErrorListener(er => {
+   *   console.error(er);
+   * })
+   */
+  useErrorListener(callback: (err: Error) => void): void;
+
+  /**
+   * useEventListener is a react hook that lets you react to event broadcasted by other users in the room.
+   *
+   * @example
+   * useEventListener(({ connectionId, event }) => {
+   *   if (event.type === "CUSTOM_EVENT") {
+   *     // Do something
+   *   }
+   * });
+   */
+  useEventListener(
+    callback: (eventData: { connectionId: number; event: TRoomEvent }) => void
+  ): void;
+
+  /**
+   * Returns the room.history
+   */
+  useHistory(): History;
+
+  /**
+   * Returns a function that undoes the last operation executed by the current client.
+   * It does not impact operations made by other clients.
+   */
+  useUndo(): () => void;
+
+  /**
+   * Returns a function that redoes the last operation executed by the current client.
+   * It does not impact operations made by other clients.
+   */
+  useRedo(): () => void;
+
+  /**
+   * Returns the LiveList associated with the provided key.
+   * The hook triggers a re-render if the LiveList is updated, however it does not triggers a re-render if a nested CRDT is updated.
+   *
+   * @param key The storage key associated with the LiveList
+   * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
+   *
+   * @example
+   * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
+   */
+  useList<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null;
+
+  /**
+   * Returns the LiveMap associated with the provided key. If the LiveMap does not exist, a new empty LiveMap will be created.
+   * The hook triggers a re-render if the LiveMap is updated, however it does not triggers a re-render if a nested CRDT is updated.
+   *
+   * @param key The storage key associated with the LiveMap
+   * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
+   *
+   * @example
+   * const shapesById = useMap<string, Shape>("shapes");
+   */
+  useMap<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null;
+
+  /**
+   * Returns the LiveObject associated with the provided key.
+   * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
+   *
+   * @param key The storage key associated with the LiveObject
+   * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
+   *
+   * @example
+   * const object = useObject("obj");
+   */
+  useObject<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null;
+
+  /**
+   * Returns the presence of the current user of the current room, and a function to update it.
+   * It is different from the setState function returned by the useState hook from React.
+   * You don't need to pass the full presence object to update it.
+   *
+   * @example
+   * const [myPresence, updateMyPresence] = useMyPresence();
+   * updateMyPresence({ x: 0 });
+   * updateMyPresence({ y: 0 });
+   *
+   * // At the next render, "myPresence" will be equal to "{ x: 0, y: 0 }"
+   */
+  useMyPresence(): [
+    TPresence,
+    (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) => void
+  ];
+
+  /**
+   * Returns an object that lets you get information about all the the users currently connected in the room.
+   *
+   * @example
+   * const others = useOthers();
+   *
+   * // Example to map all cursors in jsx
+   * {
+   *   others.map(({ connectionId, presence }) => {
+   *     if(presence == null || presence.cursor == null) {
+   *       return null;
+   *     }
+   *     return <Cursor key={connectionId} cursor={presence.cursor} />
+   *   })
+   * }
+   */
+  useOthers(): Others<TPresence, TUserMeta>;
+
+  /**
+   * Returns the Room of the nearest RoomProvider above in the React component
+   * tree.
+   */
+  useRoom(): Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
+
+  /**
+   * Gets the current user once it is connected to the room.
+   *
+   * @example
+   * const user = useSelf();
+   */
+  useSelf(): User<TPresence, TUserMeta> | null;
+
+  /**
+   * Returns the LiveObject instance that is the root of your entire Liveblocks
+   * Storage.
+   *
+   * @example
+   * const [root] = useStorage();
+   */
+  useStorage(): [root: LiveObject<TStorage> | null];
+
+  /**
+   * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.
+   * If you don't use the current user presence in your component, but you need to update it (e.g. live cursor), it's better to use useUpdateMyPresence to avoid unnecessary renders.
+   *
+   * @example
+   * const updateMyPresence = useUpdateMyPresence();
+   * updateMyPresence({ x: 0 });
+   * updateMyPresence({ y: 0 });
+   *
+   * // At the next render, the presence of the current user will be equal to "{ x: 0, y: 0 }"
+   */
+  useUpdateMyPresence(): (
+    overrides: Partial<TPresence>,
+    options?: { addToHistory: boolean }
+  ) => void;
+
+  // ....................................................................................
+
+  /**
+   * Returns the LiveList associated with the provided key.
+   * The hook triggers a re-render if the LiveList is updated, however it does not triggers a re-render if a nested CRDT is updated.
+   *
+   * @param key The storage key associated with the LiveList
+   * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
+   *
+   * @example
+   * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
+   */
+  deprecated_useList<TValue extends Lson>(key: string): LiveList<TValue> | null;
+
+  /**
+   * @deprecated We no longer recommend initializing the
+   * items from the useList() hook. For details, see https://bit.ly/3Niy5aP.
+   */
+  deprecated_useList<TValue extends Lson>(
+    key: string,
+    items: TValue[]
+  ): LiveList<TValue> | null;
+
+  /**
+   * Returns the LiveMap associated with the provided key. If the LiveMap does not exist, a new empty LiveMap will be created.
+   * The hook triggers a re-render if the LiveMap is updated, however it does not triggers a re-render if a nested CRDT is updated.
+   *
+   * @param key The storage key associated with the LiveMap
+   * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
+   *
+   * @example
+   * const shapesById = useMap<string, Shape>("shapes");
+   */
+  deprecated_useMap<TKey extends string, TValue extends Lson>(
+    key: string
+  ): LiveMap<TKey, TValue> | null;
+
+  /**
+   * @deprecated We no longer recommend initializing the
+   * entries from the useMap() hook. For details, see https://bit.ly/3Niy5aP.
+   */
+  deprecated_useMap<TKey extends string, TValue extends Lson>(
+    key: string,
+    entries: readonly (readonly [TKey, TValue])[] | null
+  ): LiveMap<TKey, TValue> | null;
+
+  /**
+   * Returns the LiveObject associated with the provided key.
+   * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
+   *
+   * @param key The storage key associated with the LiveObject
+   * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
+   *
+   * @example
+   * const object = useObject("obj");
+   */
+  deprecated_useObject<TData extends LsonObject>(
+    key: string
+  ): LiveObject<TData> | null;
+
+  /**
+   * @deprecated We no longer recommend initializing the fields from the
+   * useObject() hook. For details, see https://bit.ly/3Niy5aP.
+   */
+  deprecated_useObject<TData extends LsonObject>(
+    key: string,
+    initialData: TData
+  ): LiveObject<TData> | null;
+};
+
 type LookupResult<T> =
   | { status: "ok"; value: T }
   | { status: "loading" }
@@ -42,7 +300,7 @@ export function createRoomContext<
   TStorage extends LsonObject = LsonObject,
   TUserMeta extends BaseUserMeta = BaseUserMeta,
   TRoomEvent extends Json = never
->(client: Client) {
+>(client: Client): RoomContext<TPresence, TStorage, TUserMeta, TRoomEvent> {
   let useClient: () => Client;
   if ((client as unknown) !== "__legacy") {
     useClient = () => client;
@@ -57,11 +315,6 @@ export function createRoomContext<
     TRoomEvent
   > | null>(null);
 
-  /**
-   * Makes a Room available in the component hierarchy below.
-   * When this component is unmounted, the current user leave the room.
-   * That means that you can't have 2 RoomProvider with the same room id in your react tree.
-   */
   function RoomProvider(props: RoomProviderProps<TPresence, TStorage>) {
     const {
       id: roomId,
@@ -124,10 +377,6 @@ export function createRoomContext<
     return <RoomCtx.Provider value={room}>{props.children}</RoomCtx.Provider>;
   }
 
-  /**
-   * Returns the Room of the nearest RoomProvider above in the React component
-   * tree.
-   */
   function useRoom(): Room<TPresence, TStorage, TUserMeta, TRoomEvent> {
     const room = React.useContext(RoomCtx);
     if (room == null) {
@@ -136,18 +385,6 @@ export function createRoomContext<
     return room;
   }
 
-  /**
-   * Returns the presence of the current user of the current room, and a function to update it.
-   * It is different from the setState function returned by the useState hook from React.
-   * You don't need to pass the full presence object to update it.
-   *
-   * @example
-   * const [myPresence, updateMyPresence] = useMyPresence();
-   * updateMyPresence({ x: 0 });
-   * updateMyPresence({ y: 0 });
-   *
-   * // At the next render, "myPresence" will be equal to "{ x: 0, y: 0 }"
-   */
   function useMyPresence(): [
     TPresence,
     (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) => void
@@ -172,17 +409,6 @@ export function createRoomContext<
     return [presence, setPresence];
   }
 
-  /**
-   * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.
-   * If you don't use the current user presence in your component, but you need to update it (e.g. live cursor), it's better to use useUpdateMyPresence to avoid unnecessary renders.
-   *
-   * @example
-   * const updateMyPresence = useUpdateMyPresence();
-   * updateMyPresence({ x: 0 });
-   * updateMyPresence({ y: 0 });
-   *
-   * // At the next render, the presence of the current user will be equal to "{ x: 0, y: 0 }"
-   */
   function useUpdateMyPresence(): (
     overrides: Partial<TPresence>,
     options?: { addToHistory: boolean }
@@ -197,22 +423,6 @@ export function createRoomContext<
     );
   }
 
-  /**
-   * Returns an object that lets you get information about all the the users currently connected in the room.
-   *
-   * @example
-   * const others = useOthers();
-   *
-   * // Example to map all cursors in jsx
-   * {
-   *   others.map(({ connectionId, presence }) => {
-   *     if(presence == null || presence.cursor == null) {
-   *       return null;
-   *     }
-   *     return <Cursor key={connectionId} cursor={presence.cursor} />
-   *   })
-   * }
-   */
   function useOthers(): Others<TPresence, TUserMeta> {
     const room = useRoom();
     const rerender = useRerender();
@@ -227,14 +437,6 @@ export function createRoomContext<
     return room.getOthers();
   }
 
-  /**
-   * Returns a callback that lets you broadcast custom events to other users in the room
-   *
-   * @example
-   * const broadcast = useBroadcastEvent();
-   *
-   * broadcast({ type: "CUSTOM_EVENT", data: { x: 0, y: 0 } });
-   */
   function useBroadcastEvent(): (
     event: TRoomEvent,
     options?: BroadcastOptions
@@ -252,14 +454,6 @@ export function createRoomContext<
     );
   }
 
-  /**
-   * useErrorListener is a react hook that lets you react to potential room connection errors.
-   *
-   * @example
-   * useErrorListener(er => {
-   *   console.error(er);
-   * })
-   */
   function useErrorListener(callback: (err: Error) => void): void {
     const room = useRoom();
     const savedCallback = React.useRef(callback);
@@ -278,16 +472,6 @@ export function createRoomContext<
     }, [room]);
   }
 
-  /**
-   * useEventListener is a react hook that lets you react to event broadcasted by other users in the room.
-   *
-   * @example
-   * useEventListener(({ connectionId, event }) => {
-   *   if (event.type === "CUSTOM_EVENT") {
-   *     // Do something
-   *   }
-   * });
-   */
   function useEventListener(
     callback: (eventData: { connectionId: number; event: TRoomEvent }) => void
   ): void {
@@ -313,12 +497,6 @@ export function createRoomContext<
     }, [room]);
   }
 
-  /**
-   * Gets the current user once it is connected to the room.
-   *
-   * @example
-   * const user = useSelf();
-   */
   function useSelf(): User<TPresence, TUserMeta> | null {
     const room = useRoom();
     const rerender = useRerender();
@@ -360,23 +538,9 @@ export function createRoomContext<
     return [root];
   }
 
-  /**
-   * Returns the LiveMap associated with the provided key. If the LiveMap does not exist, a new empty LiveMap will be created.
-   * The hook triggers a re-render if the LiveMap is updated, however it does not triggers a re-render if a nested CRDT is updated.
-   *
-   * @param key The storage key associated with the LiveMap
-   * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
-   *
-   * @example
-   * const shapesById = useMap<string, Shape>("shapes");
-   */
   function deprecated_useMap<TKey extends string, TValue extends Lson>(
     key: string
   ): LiveMap<TKey, TValue> | null;
-  /**
-   * @deprecated We no longer recommend initializing the
-   * entries from the useMap() hook. For details, see https://bit.ly/3Niy5aP.
-   */
   function deprecated_useMap<TKey extends string, TValue extends Lson>(
     key: string,
     entries: readonly (readonly [TKey, TValue])[] | null
@@ -433,23 +597,9 @@ Please see https://bit.ly/3Niy5aP for details.`
     }
   }
 
-  /**
-   * Returns the LiveList associated with the provided key.
-   * The hook triggers a re-render if the LiveList is updated, however it does not triggers a re-render if a nested CRDT is updated.
-   *
-   * @param key The storage key associated with the LiveList
-   * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
-   *
-   * @example
-   * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
-   */
   function deprecated_useList<TValue extends Lson>(
     key: string
   ): LiveList<TValue> | null;
-  /**
-   * @deprecated We no longer recommend initializing the
-   * items from the useList() hook. For details, see https://bit.ly/3Niy5aP.
-   */
   function deprecated_useList<TValue extends Lson>(
     key: string,
     items: TValue[]
@@ -508,23 +658,9 @@ Please see https://bit.ly/3Niy5aP for details.`
     }
   }
 
-  /**
-   * Returns the LiveObject associated with the provided key.
-   * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
-   *
-   * @param key The storage key associated with the LiveObject
-   * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
-   *
-   * @example
-   * const object = useObject("obj");
-   */
   function deprecated_useObject<TData extends LsonObject>(
     key: string
   ): LiveObject<TData> | null;
-  /**
-   * @deprecated We no longer recommend initializing the fields from the
-   * useObject() hook. For details, see https://bit.ly/3Niy5aP.
-   */
   function deprecated_useObject<TData extends LsonObject>(
     key: string,
     initialData: TData
@@ -601,35 +737,18 @@ Please see https://bit.ly/3Niy5aP for details.`
     return deprecated_useObject(key) as unknown as TStorage[TKey];
   }
 
-  /**
-   * Returns the room.history
-   */
   function useHistory(): History {
     return useRoom().history;
   }
 
-  /**
-   * Returns a function that undoes the last operation executed by the current client.
-   * It does not impact operations made by other clients.
-   */
   function useUndo(): () => void {
     return useHistory().undo;
   }
 
-  /**
-   * Returns a function that redoes the last operation executed by the current client.
-   * It does not impact operations made by other clients.
-   */
   function useRedo(): () => void {
     return useHistory().redo;
   }
 
-  /**
-   * Returns a function that batches modifications made during the given function.
-   * All the modifications are sent to other clients in a single message.
-   * All the modifications are merged in a single history item (undo/redo).
-   * All the subscribers are called only after the batch is over.
-   */
   function useBatch(): (callback: () => void) => void {
     return useRoom().batch;
   }


### PR DESCRIPTION
This PR restores TypeScript docstring exports for APIs constructed via `createRoomContext()`. Candidate for releasing as 0.17.2.

Fixes #376.

Before this PR:
![Screen Shot 2022-06-30 at 11 52 25@2x](https://user-images.githubusercontent.com/83844/176649074-cbaaa2b7-5132-4ace-8b3b-51978cef28d6.png)

After this PR:
![Screen Shot 2022-06-30 at 11 54 50@2x](https://user-images.githubusercontent.com/83844/176649097-f8f1a016-c5cd-4a27-9672-4567297e4a56.png)
