### PR TITLE
Publish NPM packages more atomically

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -29,10 +29,6 @@ is_valid_version () {
     echo "$1" | grep -qEe "^[0-9]+[.][0-9]+[.][0-9]+(-[[:alnum:].]+)?$"
 }
 
-is_valid_otp_token () {
-    echo "$1" | grep -qEe "^[0-9]{6}$"
-}
-
 usage () {
     err "usage: publish.sh [-V <version>] [-t <tag>] [-h]"
     err
@@ -253,13 +249,19 @@ npm_pkg_exists () {
 
 # This global variable will store the pasted OTP token
 OTP=""
+OTP_TMPFILE="$(mktemp)"
+
+is_valid_otp_token () {
+    echo "$OTP" | grep -qEe "^[0-9]{6}$"
+}
 
 #
 # Does all the interactive prompting to get a legal OTP token, and writes it
 # into the OTP variable, so you can reuse it for multiple commands in a row.
 #
 collect_otp_token () {
-    while ! is_valid_otp_token "$OTP"; do
+    OTP="$(cat "$OTP_TMPFILE")"
+    while ! is_valid_otp_token; do
         if [ -n "$OTP" ]; then
             err "Invalid OTP token: $OTP"
             err "Please try again."
@@ -268,6 +270,7 @@ collect_otp_token () {
             err "To enable writes to the NPM registry, you'll need a One-Time Password (OTP) token."
         fi
         read -p "OTP token? " OTP
+        echo "$OTP" > "$OTP_TMPFILE"
     done
 }
 


### PR DESCRIPTION
This updates the `publish.sh` script with two features.

### Make publishing closer to atomic
Never publish to the `'latest'` tag directly (to avoid [NPM snafus](https://liveblocks.slack.com/archives/C02PZL7QAAW/p1656658565896589) like we saw last night). This will instead always publish to a `'private'` tag on NPM, and only once all the packages have been successfully published (and successfully readable!), it will assign the final tag to those versions (i.e. the given tag, or `latest`). Lastly, when all of that succeeded, it will clean up the `'private'` tag from those packages. Hopefully this makes publishing the family of packages a bit more atomic.

Also, this means that if somehow during the build of, say, `@liveblocks/zustand` (or another secondary pkg) something fails and the `publish.sh` script terminates, the `latest` tags on NPM for all our packages remain intact still. (Previously, this would mean that `@liveblocks/client` was already published and we'd have to hurry to fix things quickly. Now we can have peace of mind.)

Btw, this new `'private'` tag setup does mean that we cannot—and should not—run multiple `publish.sh` scripts simultaneously. If we really want to enable that, we could generate a `'private-<random>'` string though.

### Reduce OTP prompts
Secondly, while I was at it, I realized that these steps will require many extra moments where we'd have to paste in the OTP token. (One for `npm publish`, one for `npm dist-tag add`, and one for `npm dist-tag rm`) × 5 packages = 15 OTP tokens to paste 😬

That's why I changed the OTP prompting set-up a bit to only ask for the OTP once, and to keep it in memory to use everywhere.