### PR TITLE
Suspense support in Storage APIs

### DIFF
--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -94,7 +94,19 @@ export default function Room() {
       }}
     >
       <div className={styles.container}>
-        <ClientSideSuspense fallback={<h1>hahaha</h1>}>
+        {
+          //
+          // XXX Not sure what is the best way to make Suspense and SSR best
+          // friends. The new NextJS and React 18 might have a better way to
+          // offer this.
+          //
+          // This client-side-only Suspense trick works.
+          //
+          // Either way, it's important to realize that this is not related to
+          // Liveblocks at all. All Suspense-aware components have this issue.
+          //
+        }
+        <ClientSideSuspense fallback={<Loading />}>
           {
             /* This component tree will only run on the client, never during SSR */
             () => <Canvas />

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -43,6 +43,16 @@ import ToolsBar from "./components/ToolsBar";
 
 const MAX_LAYERS = 100;
 
+function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.loading}>
+        <img src="https://liveblocks.io/loading.svg" alt="Loading" />
+      </div>
+    </div>
+  );
+}
+
 export default function Room() {
   const roomId = useOverrideRoomId("nextjs-whiteboard-advanced");
 
@@ -74,13 +84,7 @@ function WhiteboardTool() {
   const layerIds = useList("layerIds");
 
   if (layerIds == null || layers == null) {
-    return (
-      <div className={styles.container}>
-        <div className={styles.loading}>
-          <img src="https://liveblocks.io/loading.svg" alt="Loading" />
-        </div>
-      </div>
-    );
+    return <Loading />;
   }
 
   return <Canvas layers={layers} layerIds={layerIds} />;

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -197,13 +197,33 @@ export function useSelf<
  * `useStorage` from `@liveblocks/react` directly. See
  * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
  */
-export function useStorage<TStorage extends LsonObject>(): [
-  root: LiveObject<TStorage> | null
-] {
+export function useStorage<TStorage extends LsonObject>(options: {
+  suspense: true;
+}): LiveObject<TStorage>;
+
+/**
+ * @deprecated Please use `createRoomContext()` instead of importing
+ * `useStorage` from `@liveblocks/react` directly. See
+ * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
+ */
+export function useStorage<TStorage extends LsonObject>(options?: {
+  suspense: false;
+}): [root: LiveObject<TStorage> | null];
+
+/**
+ * @deprecated Please use `createRoomContext()` instead of importing
+ * `useStorage` from `@liveblocks/react` directly. See
+ * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
+ */
+export function useStorage<TStorage extends LsonObject>(options?: {
+  suspense?: boolean;
+}): LiveObject<TStorage> | [root: LiveObject<TStorage> | null] {
   deprecate(
     "Please use `createRoomContext()` instead of importing `useStorage` from `@liveblocks/react` directly. See https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details."
   );
-  return _hooks.useStorage() as unknown as [root: LiveObject<TStorage> | null];
+  return _hooks.useStorage(options as any) as unknown as
+    | LiveObject<TStorage>
+    | [root: LiveObject<TStorage> | null];
 }
 
 /**

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -806,6 +806,14 @@ Please see https://bit.ly/3Niy5aP for details.`
   //
   function useList<TKey extends Extract<keyof TStorage, string>>(
     key: TKey,
+    options: { suspense: true }
+  ): TStorage[TKey];
+  function useList<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey,
+    options?: { suspense: boolean }
+  ): TStorage[TKey] | null;
+  function useList<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey,
     options?: { suspense: boolean }
   ): TStorage[TKey] | null {
     if (options?.suspense) {
@@ -825,6 +833,14 @@ Please see https://bit.ly/3Niy5aP for details.`
   //
   function useMap<TKey extends Extract<keyof TStorage, string>>(
     key: TKey,
+    options: { suspense: true }
+  ): TStorage[TKey];
+  function useMap<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey,
+    options?: { suspense: boolean }
+  ): TStorage[TKey] | null;
+  function useMap<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey,
     options?: { suspense: boolean }
   ): TStorage[TKey] | null {
     if (options?.suspense) {
@@ -842,6 +858,14 @@ Please see https://bit.ly/3Niy5aP for details.`
   // 2. export const { useObject } = createRoomContext(client, { suspense: true });
   // 3. import { createRoomContext } from '@liveblocks/react/suspense'
   //
+  function useObject<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey,
+    options: { suspense: true }
+  ): TStorage[TKey];
+  function useObject<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey,
+    options?: { suspense: boolean }
+  ): TStorage[TKey] | null;
   function useObject<TKey extends Extract<keyof TStorage, string>>(
     key: TKey,
     options?: { suspense: boolean }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -797,14 +797,13 @@ Please see https://bit.ly/3Niy5aP for details.`
     }
   }
 
-  function useList<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey,
-    options: { suspense: true }
-  ): TStorage[TKey];
-  function useList<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey,
-    options?: { suspense: boolean }
-  ): TStorage[TKey] | null;
+  // XXX Think about how to expose these APIs:
+  //
+  // Some alternatives:
+  // 1. useList('xxx', { suspense: true })
+  // 2. export const { useList } = createRoomContext(client, { suspense: true });
+  // 3. import { createRoomContext } from '@liveblocks/react/suspense'
+  //
   function useList<TKey extends Extract<keyof TStorage, string>>(
     key: TKey,
     options?: { suspense: boolean }
@@ -817,14 +816,13 @@ Please see https://bit.ly/3Niy5aP for details.`
     }
   }
 
-  function useMap<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey,
-    options: { suspense: true }
-  ): TStorage[TKey];
-  function useMap<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey,
-    options?: { suspense: boolean }
-  ): TStorage[TKey] | null;
+  // XXX Think about how to expose these APIs:
+  //
+  // Some alternatives:
+  // 1. useMap('xxx', { suspense: true })
+  // 2. export const { useMap } = createRoomContext(client, { suspense: true });
+  // 3. import { createRoomContext } from '@liveblocks/react/suspense'
+  //
   function useMap<TKey extends Extract<keyof TStorage, string>>(
     key: TKey,
     options?: { suspense: boolean }
@@ -837,14 +835,13 @@ Please see https://bit.ly/3Niy5aP for details.`
     }
   }
 
-  function useObject<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey,
-    options: { suspense: true }
-  ): TStorage[TKey];
-  function useObject<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey,
-    options?: { suspense: boolean }
-  ): TStorage[TKey] | null;
+  // XXX Think about how to expose these APIs:
+  //
+  // Some alternatives:
+  // 1. useObject('xxx', { suspense: true })
+  // 2. export const { useObject } = createRoomContext(client, { suspense: true });
+  // 3. import { createRoomContext } from '@liveblocks/react/suspense'
+  //
   function useObject<TKey extends Extract<keyof TStorage, string>>(
     key: TKey,
     options?: { suspense: boolean }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -569,7 +569,7 @@ export function createRoomContext<
     let inflight = _storagePromisesInflight.get(room.id);
     if (!inflight) {
       // Fire off the fetch right now, and keep the promise in cache
-      const inflight = room.getStorage().then((resp) => {
+      inflight = room.getStorage().then((resp) => {
         _storageCache.set(room.id, resp.root);
       });
       _storagePromisesInflight.set(room.id, inflight);

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -514,7 +514,7 @@ export function createRoomContext<
     return room.getSelf();
   }
 
-  function useStorage(): [root: LiveObject<TStorage> | null] {
+  function useStorage_classic(): [root: LiveObject<TStorage> | null] {
     const room = useRoom();
     const [root, setState] = React.useState<LiveObject<TStorage> | null>(null);
 
@@ -536,6 +536,10 @@ export function createRoomContext<
     }, [room]);
 
     return [root];
+  }
+
+  function useStorage(): [root: LiveObject<TStorage> | null] {
+    return useStorage_classic();
   }
 
   function deprecated_useMap<TKey extends string, TValue extends Lson>(

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -14,6 +14,7 @@ import {
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import * as React from "react";
+
 import { createRoomContext } from "./factory";
 
 /**

--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -14,14 +14,7 @@ import {
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import * as React from "react";
-
-import {
-  LiveblocksProvider,
-  RoomProvider,
-  useMyPresence,
-  useObject,
-  useOthers,
-} from ".";
+import { createRoomContext } from "./factory";
 
 /**
  * https://github.com/Luka967/websocket-close-codes
@@ -29,6 +22,23 @@ import {
 enum WebSocketErrorCodes {
   CLOSE_ABNORMAL = 1006,
 }
+
+type Presence = {
+  x: number;
+};
+
+type Storage = {
+  obj: LiveObject<{
+    a: number;
+  }>;
+};
+
+const client = createClient({ authEndpoint: "/api/auth" });
+
+const { RoomProvider, useObject, useOthers, useMyPresence } = createRoomContext<
+  Presence,
+  Storage
+>(client);
 
 function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {
@@ -136,7 +146,7 @@ const testIds = {
 };
 
 function PresenceComponent() {
-  const [me, setPresence] = useMyPresence<{ x: number }>();
+  const [me, setPresence] = useMyPresence();
   const others = useOthers();
 
   return (
@@ -166,14 +176,10 @@ async function waitForSocketToBeConnected() {
 
 describe("presence", () => {
   test("initial presence should be set on state immediately", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-          <PresenceComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
+        <PresenceComponent />
+      </RoomProvider>
     );
 
     expect(screen.getByTestId(testIds.meX).textContent).toBe("1");
@@ -208,14 +214,10 @@ describe("presence", () => {
   // });
 
   test("initial presence should be sent to other users when socket is connected", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-          <PresenceComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
+        <PresenceComponent />
+      </RoomProvider>
     );
 
     const socket = await waitForSocketToBeConnected();
@@ -233,14 +235,10 @@ describe("presence", () => {
   });
 
   test("set presence should replace current presence", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-          <PresenceComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
+        <PresenceComponent />
+      </RoomProvider>
     );
 
     await waitForSocketToBeConnected();
@@ -255,14 +253,10 @@ describe("presence", () => {
   });
 
   test("others presence should be set on update", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-          <PresenceComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
+        <PresenceComponent />
+      </RoomProvider>
     );
 
     const socket = await waitForSocketToBeConnected();
@@ -292,14 +286,10 @@ describe("presence", () => {
   });
 
   test("others presence should be merged on update", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-          <PresenceComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
+        <PresenceComponent />
+      </RoomProvider>
     );
 
     const socket = await waitForSocketToBeConnected();
@@ -386,14 +376,10 @@ describe("presence", () => {
   // });
 
   test("others presence should be cleared on close", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-          <PresenceComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
+        <PresenceComponent />
+      </RoomProvider>
     );
 
     const socket = await waitForSocketToBeConnected();
@@ -464,17 +450,13 @@ function UnmountContainer({ children }: { children: React.ReactElement }) {
 
 describe("Storage", () => {
   test("useObject initialization", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
-
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider
-          id="room"
-          initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
-        >
-          <ObjectComponent />
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider
+        id="room"
+        initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
+      >
+        <ObjectComponent />
+      </RoomProvider>
     );
 
     expect(screen.getByTestId(testIds.liveObject).textContent).toEqual(
@@ -506,18 +488,15 @@ describe("Storage", () => {
   });
 
   test("unmounting useObject while storage is loading should not cause a memory leak", async () => {
-    const client = createClient({ authEndpoint: "/api/auth" });
     render(
-      <LiveblocksProvider client={client}>
-        <RoomProvider
-          id="room"
-          initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
-        >
-          <UnmountContainer>
-            <ObjectComponent />
-          </UnmountContainer>
-        </RoomProvider>
-      </LiveblocksProvider>
+      <RoomProvider
+        id="room"
+        initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
+      >
+        <UnmountContainer>
+          <ObjectComponent />
+        </UnmountContainer>
+      </RoomProvider>
     );
 
     expect(screen.getByTestId(testIds.liveObject).textContent).toEqual(


### PR DESCRIPTION
This PR is a minimal proof of concept to add Suspense support to our Storage APIs:

- `useStorage()`
- `useMap()`
- `useList()`
- `useObject()`

Each of these now have an overload on this branch that will allow you to pass in a `useMap('mykey', { suspense: true })` config option to use the function overload that will never return `null`. Instead, these hooks _suspend_ instead of returning `null`.

A quick refresher on how Suspense works with custom hooks. Such hooks will throw a promise (instead of an error) up the call stack. Then the `<Suspense>` boundary component will catch that thrown promise and render the fallback instead. Then, much later, once the thrown promise resolves, Suspense will rerender the component tree, by which time it should be able to resolve synchronously without suspending.

Ultimately, we add this in preparation for better/simpler Storage hooks. I'm not proposing per se to include these APIs as such in the `useMap` & friends hooks. Perhaps we'll decide that only a new `useSelector()` API will have support for Suspense. All the existing `useMap` & friends overloads are already pretty overwhelming to maintain. I just added them in here for now, because these are the ones we have today.