### PR TITLE
Remove deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [Upgrade Guide for 0.17](https://liveblocks.io/docs/guides/upgrading/0.17) for
   instructions.
 - Remove second argument to `useMap()`, `useList()`, and `useObject()`.
+- Remove `new LiveMap(null)` support. (Just use `new LiveMap()` or
+  `new LiveMap([])`.)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Remove support for directly importing hooks from **@liveblocks/client** (e.g.
   `import { useMyPresence } from '@liveblocks/react'`). If you’re still using
   these imports, see the
-  [Upgrade Guide for 0.17](https://liveblocks.io/docs/guides/upgrading/0.17)
-  for instructions.
+  [Upgrade Guide for 0.17](https://liveblocks.io/docs/guides/upgrading/0.17) for
+  instructions.
+- Remove second argument to `useMap()`, `useList()`, and `useObject()`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   these imports, see the
   [Upgrade Guide for 0.17](https://liveblocks.io/docs/guides/upgrading/0.17) for
   instructions.
+- Remove `defaultPresence` and `defaultStorageRoot` arguments. (Just use
+  `initialPresence` and `initialStorage` arguments now.)
 - Remove second argument to `useMap()`, `useList()`, and `useObject()`.
 - Remove `new LiveMap(null)` support. (Just use `new LiveMap()` or
   `new LiveMap([])`.)

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -1,7 +1,6 @@
 import type { ApplyResult, Doc } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
 import { nn } from "./assert";
-import { errorIf } from "./deprecation";
 import type {
   CreateChildOp,
   CreateMapOp,
@@ -36,20 +35,8 @@ export class LiveMap<
   /** @internal */
   private unacknowledgedSet: Map<TKey, string>;
 
-  constructor(entries?: readonly (readonly [TKey, TValue])[] | undefined);
-  /**
-   * @deprecated Please call as `new LiveMap()` or `new LiveMap([])` instead.
-   */
-  constructor(entries: null);
-  constructor(
-    entries?: readonly (readonly [TKey, TValue])[] | undefined | null
-  ) {
+  constructor(entries?: readonly (readonly [TKey, TValue])[] | undefined) {
     super();
-    errorIf(
-      entries === null,
-      "Support for calling `new LiveMap(null)` will be removed in @liveblocks/client 0.18. Please call as `new LiveMap()`, or `new LiveMap([])`."
-    );
-
     this.unacknowledgedSet = new Map<TKey, string>();
 
     if (entries) {

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,4 +1,3 @@
-import { errorIf } from "./deprecation";
 import type { InternalRoom } from "./room";
 import { createRoom } from "./room";
 import type {
@@ -101,21 +100,10 @@ export function createClient(options: ClientOptions): Client {
       >;
     }
 
-    errorIf(
-      options.defaultPresence,
-      "Argument `defaultPresence` will be removed in @liveblocks/client 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP"
-    );
-    errorIf(
-      options.defaultStorageRoot,
-      "Argument `defaultStorageRoot` will be removed in @liveblocks/client 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP"
-    );
-
     internalRoom = createRoom<TPresence, TStorage, TUserMeta, TRoomEvent>(
       {
         initialPresence: options.initialPresence,
         initialStorage: options.initialStorage,
-        defaultPresence: options.defaultPresence, // Will get removed in 0.18
-        defaultStorageRoot: options.defaultStorageRoot, // Will get removed in 0.18
       },
       {
         roomId,

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -13,7 +13,6 @@ export type {
   Lson,
   LsonObject,
   Others,
-  Presence, // Deprecated! Will get removed in 0.18
   Room,
   StorageUpdate,
   User,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1646,8 +1646,7 @@ export function createRoom<
   options: RoomInitializers<TPresence, TStorage>,
   context: Context
 ): InternalRoom<TPresence, TStorage, TUserMeta, TRoomEvent> {
-  const initialPresence = options.initialPresence ?? options.defaultPresence;
-  const initialStorage = options.initialStorage ?? options.defaultStorageRoot;
+  const { initialPresence, initialStorage } = options;
 
   const state = defaultState<TPresence, TStorage, TUserMeta, TRoomEvent>(
     typeof initialPresence === "function"

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1287,11 +1287,7 @@ export function makeStateMachine<
     if (state.buffer.presence) {
       messages.push({
         type: ClientMsgCode.UPDATE_PRESENCE,
-        data: state.buffer.presence as unknown as TPresence,
-        //                          ^^^^^^^^^^^^^^^^^^^^^^^
-        //                          TODO: In 0.18, state.buffer.presence will
-        //                          become a TPresence and this force-cast will
-        //                          no longer be necessary.
+        data: state.buffer.presence,
       });
     }
     for (const event of state.buffer.messages) {

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -289,23 +289,6 @@ export type User<
   _hasReceivedInitialPresence?: boolean;
 };
 
-/**
- * @deprecated Whatever you want to store as presence is app-specific. Please
- * define your own Presence type instead of importing it from
- * `@liveblocks/client`, for example:
- *
- *    type Presence = {
- *      name: string,
- *      cursor: {
- *        x: number,
- *        y: number,
- *      } | null,
- *    }
- *
- * As long as it only contains JSON-serializable values, you're good!
- */
-export type Presence = JsonObject;
-
 type AuthEndpointCallback = (room: string) => Promise<{ token: string }>;
 
 export type AuthEndpoint = string | AuthEndpointCallback;

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -197,16 +197,6 @@ export type RoomInitializers<
    * The initial Storage to use when entering a new Room.
    */
   initialStorage?: TStorage | ((roomId: string) => TStorage);
-  /**
-   * @deprecated Please use `initialPresence` instead. This property is
-   * scheduled for removal in 0.18.
-   */
-  defaultPresence?: () => TPresence;
-  /**
-   * @deprecated Please use `initialStorage` instead. This property is
-   * scheduled for removal in 0.18.
-   */
-  defaultStorageRoot?: TStorage;
 }>;
 
 export type Client = {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -236,75 +236,6 @@ type RoomContext<
     overrides: Partial<TPresence>,
     options?: { addToHistory: boolean }
   ) => void;
-
-  // ....................................................................................
-
-  /**
-   * Returns the LiveList associated with the provided key.
-   * The hook triggers a re-render if the LiveList is updated, however it does not triggers a re-render if a nested CRDT is updated.
-   *
-   * @param key The storage key associated with the LiveList
-   * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
-   *
-   * @example
-   * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
-   */
-  useList_deprecated<TValue extends Lson>(key: string): LiveList<TValue> | null;
-
-  /**
-   * @deprecated We no longer recommend initializing the
-   * items from the useList() hook. For details, see https://bit.ly/3Niy5aP.
-   */
-  useList_deprecated<TValue extends Lson>(
-    key: string,
-    items: TValue[]
-  ): LiveList<TValue> | null;
-
-  /**
-   * Returns the LiveMap associated with the provided key. If the LiveMap does not exist, a new empty LiveMap will be created.
-   * The hook triggers a re-render if the LiveMap is updated, however it does not triggers a re-render if a nested CRDT is updated.
-   *
-   * @param key The storage key associated with the LiveMap
-   * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
-   *
-   * @example
-   * const shapesById = useMap("shapes");
-   */
-  useMap_deprecated<TKey extends string, TValue extends Lson>(
-    key: string
-  ): LiveMap<TKey, TValue> | null;
-
-  /**
-   * @deprecated We no longer recommend initializing the
-   * entries from the useMap() hook. For details, see https://bit.ly/3Niy5aP.
-   */
-  useMap_deprecated<TKey extends string, TValue extends Lson>(
-    key: string,
-    entries: readonly (readonly [TKey, TValue])[] | null
-  ): LiveMap<TKey, TValue> | null;
-
-  /**
-   * Returns the LiveObject associated with the provided key.
-   * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
-   *
-   * @param key The storage key associated with the LiveObject
-   * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
-   *
-   * @example
-   * const object = useObject("obj");
-   */
-  useObject_deprecated<TData extends LsonObject>(
-    key: string
-  ): LiveObject<TData> | null;
-
-  /**
-   * @deprecated We no longer recommend initializing the fields from the
-   * useObject() hook. For details, see https://bit.ly/3Niy5aP.
-   */
-  useObject_deprecated<TData extends LsonObject>(
-    key: string,
-    initialData: TData
-  ): LiveObject<TData> | null;
 };
 
 type LookupResult<T> =
@@ -866,9 +797,5 @@ Please see https://bit.ly/3Niy5aP for details.`
     useStorage,
     useUndo,
     useUpdateMyPresence,
-
-    useList_deprecated,
-    useMap_deprecated,
-    useObject_deprecated,
   };
 }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -12,7 +12,6 @@ import type {
   User,
 } from "@liveblocks/client";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
-import { errorIf } from "@liveblocks/client/internal";
 import * as React from "react";
 
 import { useClient as _useClient } from "./client";
@@ -258,13 +257,7 @@ export function createRoomContext<
   > | null>(null);
 
   function RoomProvider(props: RoomProviderProps<TPresence, TStorage>) {
-    const {
-      id: roomId,
-      initialPresence,
-      initialStorage,
-      defaultPresence, // Will get removed in 0.18
-      defaultStorageRoot, // Will get removed in 0.18
-    } = props;
+    const { id: roomId, initialPresence, initialStorage } = props;
 
     if (process.env.NODE_ENV !== "production") {
       if (roomId == null) {
@@ -277,15 +270,6 @@ export function createRoomContext<
       }
     }
 
-    errorIf(
-      defaultPresence,
-      "RoomProvider's `defaultPresence` prop will be removed in @liveblocks/react 0.18. Please use `initialPresence` instead. For more info, see https://bit.ly/3Niy5aP"
-    );
-    errorIf(
-      defaultStorageRoot,
-      "RoomProvider's `defaultStorageRoot` prop will be removed in @liveblocks/react 0.18. Please use `initialStorage` instead. For more info, see https://bit.ly/3Niy5aP"
-    );
-
     const _client = useClient();
 
     // NOTE: Boxing deliberately avoids this value from triggering effects
@@ -293,8 +277,6 @@ export function createRoomContext<
     const box = useBox({
       initialPresence,
       initialStorage,
-      defaultPresence, // Will get removed in 0.18
-      defaultStorageRoot, // Will get removed in 0.18
     });
 
     const [room, setRoom] = React.useState<
@@ -303,8 +285,6 @@ export function createRoomContext<
       _client.enter(roomId, {
         initialPresence,
         initialStorage,
-        defaultPresence, // Will get removed in 0.18
-        defaultStorageRoot, // Will get removed in 0.18
         DO_NOT_USE_withoutConnecting: typeof window === "undefined",
       } as RoomInitializers<TPresence, TStorage>)
     );
@@ -314,8 +294,6 @@ export function createRoomContext<
         _client.enter(roomId, {
           initialPresence: box.current.initialPresence,
           initialStorage: box.current.initialStorage,
-          defaultPresence: box.current.defaultPresence, // Will get removed in 0.18
-          defaultStorageRoot: box.current.defaultStorageRoot, // Will get removed in 0.18
           DO_NOT_USE_withoutConnecting: typeof window === "undefined",
         } as RoomInitializers<TPresence, TStorage>)
       );

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -489,24 +489,6 @@ export function createRoomContext<
     return [root];
   }
 
-  function useList<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey
-  ): TStorage[TKey] | null {
-    return useStorageValue(key);
-  }
-
-  function useMap<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey
-  ): TStorage[TKey] | null {
-    return useStorageValue(key);
-  }
-
-  function useObject<TKey extends Extract<keyof TStorage, string>>(
-    key: TKey
-  ): TStorage[TKey] | null {
-    return useStorageValue(key);
-  }
-
   function useHistory(): History {
     return useRoom().history;
   }
@@ -581,10 +563,7 @@ export function createRoomContext<
     useErrorListener,
     useEventListener,
     useHistory,
-    useList,
-    useMap,
     useMyPresence,
-    useObject,
     useOthers,
     useRedo,
     useRoom,
@@ -592,5 +571,10 @@ export function createRoomContext<
     useStorage,
     useUndo,
     useUpdateMyPresence,
+
+    // These are just aliases. The passed-in key will define their return values.
+    useList: useStorageValue,
+    useMap: useStorageValue,
+    useObject: useStorageValue,
   };
 }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -5,13 +5,12 @@ import type {
   History,
   Json,
   JsonObject,
-  Lson,
+  LiveObject,
   LsonObject,
   Others,
   Room,
   User,
 } from "@liveblocks/client";
-import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
 import { errorIf } from "@liveblocks/client/internal";
 import * as React from "react";
@@ -237,11 +236,6 @@ type RoomContext<
     options?: { addToHistory: boolean }
   ) => void;
 };
-
-type LookupResult<T> =
-  | { status: "ok"; value: T }
-  | { status: "loading" }
-  | { status: "notfound" };
 
 export function createRoomContext<
   TPresence extends JsonObject,
@@ -495,203 +489,22 @@ export function createRoomContext<
     return [root];
   }
 
-  function useMap_deprecated<TKey extends string, TValue extends Lson>(
-    key: string
-  ): LiveMap<TKey, TValue> | null;
-  function useMap_deprecated<TKey extends string, TValue extends Lson>(
-    key: string,
-    entries: readonly (readonly [TKey, TValue])[] | null
-  ): LiveMap<TKey, TValue> | null;
-  function useMap_deprecated<TKey extends string, TValue extends Lson>(
-    key: string,
-    entries?: readonly (readonly [TKey, TValue])[] | null | undefined
-  ): LiveMap<TKey, TValue> | null {
-    errorIf(
-      entries,
-      `Support for initializing entries in useMap() directly will be removed in @liveblocks/react 0.18.
-
-Instead, please initialize this data where you set up your RoomProvider:
-
-    const initialStorage = () => ({
-      ${JSON.stringify(key)}: new LiveMap(...),
-      ...
-    });
-
-    <RoomProvider initialStorage={initialStorage}>
-      ...
-    </RoomProvider>
-
-Please see https://bit.ly/3Niy5aP for details.`
-    );
-    const value = useStorageValue(key, new LiveMap(entries ?? undefined));
-    //                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    //                                 NOTE: This param is scheduled for removal in 0.18
-    if (value.status === "ok") {
-      return value.value;
-    } else {
-      errorIf(
-        value.status === "notfound",
-        `Key ${JSON.stringify(
-          key
-        )} was not found in Storage. Starting with 0.18, useMap() will no longer automatically create this key.
-
-Instead, please initialize your storage where you set up your RoomProvider:
-
-    import { LiveMap } from "@liveblocks/client";
-
-    const initialStorage = () => ({
-      ${JSON.stringify(key)}: new LiveMap(...),
-      ...
-    });
-
-    <RoomProvider initialStorage={initialStorage}>
-      ...
-    </RoomProvider>
-
-Please see https://bit.ly/3Niy5aP for details.`
-      );
-      return null;
-    }
-  }
-
-  function useList_deprecated<TValue extends Lson>(
-    key: string
-  ): LiveList<TValue> | null;
-  function useList_deprecated<TValue extends Lson>(
-    key: string,
-    items: TValue[]
-  ): LiveList<TValue> | null;
-  function useList_deprecated<TValue extends Lson>(
-    key: string,
-    items?: TValue[] | undefined
-  ): LiveList<TValue> | null {
-    errorIf(
-      items,
-      `Support for initializing items in useList() directly will be removed in @liveblocks/react 0.18.
-
-Instead, please initialize this data where you set up your RoomProvider:
-
-    import { LiveList } from "@liveblocks/client";
-
-    const initialStorage = () => ({
-      ${JSON.stringify(key)}: new LiveList(...),
-      ...
-    });
-
-    <RoomProvider initialStorage={initialStorage}>
-      ...
-    </RoomProvider>
-
-Please see https://bit.ly/3Niy5aP for details.`
-    );
-    const value = useStorageValue<LiveList<TValue>>(key, new LiveList(items));
-    //                                                   ^^^^^^^^^^^^^^^^^^^
-    //                                                   NOTE: This param is scheduled for removal in 0.18
-    if (value.status === "ok") {
-      return value.value;
-    } else {
-      errorIf(
-        value.status === "notfound",
-        `Key ${JSON.stringify(
-          key
-        )} was not found in Storage. Starting with 0.18, useList() will no longer automatically create this key.
-
-Instead, please initialize your storage where you set up your RoomProvider:
-
-    import { LiveList } from "@liveblocks/client";
-
-    const initialStorage = () => ({
-      ${JSON.stringify(key)}: new LiveList(...),
-      ...
-    });
-
-    <RoomProvider initialStorage={initialStorage}>
-      ...
-    </RoomProvider>
-
-Please see https://bit.ly/3Niy5aP for details.`
-      );
-      return null;
-    }
-  }
-
-  function useObject_deprecated<TData extends LsonObject>(
-    key: string
-  ): LiveObject<TData> | null;
-  function useObject_deprecated<TData extends LsonObject>(
-    key: string,
-    initialData: TData
-  ): LiveObject<TData> | null;
-  function useObject_deprecated<TData extends LsonObject>(
-    key: string,
-    initialData?: TData
-  ): LiveObject<TData> | null {
-    errorIf(
-      initialData,
-      `Support for initializing data in useObject() directly will be removed in @liveblocks/react 0.18.
-
-Instead, please initialize this data where you set up your RoomProvider:
-
-    import { LiveObject } from "@liveblocks/client";
-
-    const initialStorage = () => ({
-      ${JSON.stringify(key)}: new LiveObject(...),
-      ...
-    });
-
-    <RoomProvider initialStorage={initialStorage}>
-      ...
-    </RoomProvider>
-
-Please see https://bit.ly/3Niy5aP for details.`
-    );
-    const value = useStorageValue(key, new LiveObject(initialData));
-    //                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    //                                 NOTE: This param is scheduled for removal in 0.18
-    if (value.status === "ok") {
-      return value.value;
-    } else {
-      errorIf(
-        value.status === "notfound",
-        `Key ${JSON.stringify(
-          key
-        )} was not found in Storage. Starting with 0.18, useObject() will no longer automatically create this key.
-
-Instead, please initialize your storage where you set up your RoomProvider:
-
-    import { LiveObject } from "@liveblocks/client";
-
-    const initialStorage = () => ({
-      ${JSON.stringify(key)}: new LiveObject(...),
-      ...
-    });
-
-    <RoomProvider initialStorage={initialStorage}>
-      ...
-    </RoomProvider>
-
-Please see https://bit.ly/3Niy5aP for details.`
-      );
-      return null;
-    }
-  }
-
   function useList<TKey extends Extract<keyof TStorage, string>>(
     key: TKey
   ): TStorage[TKey] | null {
-    return useList_deprecated(key) as unknown as TStorage[TKey];
+    return useStorageValue(key);
   }
 
   function useMap<TKey extends Extract<keyof TStorage, string>>(
     key: TKey
   ): TStorage[TKey] | null {
-    return useMap_deprecated(key) as unknown as TStorage[TKey];
+    return useStorageValue(key);
   }
 
   function useObject<TKey extends Extract<keyof TStorage, string>>(
     key: TKey
   ): TStorage[TKey] | null {
-    return useObject_deprecated(key) as unknown as TStorage[TKey];
+    return useStorageValue(key);
   }
 
   function useHistory(): History {
@@ -710,35 +523,22 @@ Please see https://bit.ly/3Niy5aP for details.`
     return useRoom().batch;
   }
 
-  function useStorageValue<T extends Lson>(
-    key: string,
-    //   ^^^^^^
-    //   FIXME: Generalize to `keyof TStorage`?
-    initialValue: T
-  ): LookupResult<T> {
+  function useStorageValue<TKey extends Extract<keyof TStorage, string>>(
+    key: TKey
+  ): TStorage[TKey] | null {
     const room = useRoom();
     const [root] = useStorage();
     const rerender = useRerender();
-
-    // NOTE: Boxing deliberately avoids this value from triggering effects
-    // through the exhaustive-deps array.
-    const boxedInitialValue = useBox(initialValue);
 
     React.useEffect(() => {
       if (root == null) {
         return;
       }
 
-      let liveValue: T | undefined = root.get(key) as T | undefined;
-
-      if (liveValue == null) {
-        liveValue = boxedInitialValue.current;
-        root.set(key, liveValue as unknown as TStorage[string]);
-        //                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FIXME
-      }
+      let liveValue = root.get(key);
 
       function onRootChange() {
-        const newCrdt = root!.get(key) as T | undefined;
+        const newCrdt = root!.get(key);
         if (newCrdt !== liveValue) {
           unsubscribeCrdt();
           liveValue = newCrdt;
@@ -765,17 +565,12 @@ Please see https://bit.ly/3Niy5aP for details.`
         unsubscribeRoot();
         unsubscribeCrdt();
       };
-    }, [root, room, key, boxedInitialValue, rerender]);
+    }, [root, room, key, rerender]);
 
     if (root == null) {
-      return { status: "loading" };
+      return null;
     } else {
-      const value = root.get(key) as T | undefined;
-      if (value == null) {
-        return { status: "notfound" };
-      } else {
-        return { status: "ok", value };
-      }
+      return root.get(key);
     }
   }
 


### PR DESCRIPTION
This PR does a huge cleanup by removing the APIs we've been deprecating since 0.16.5 and 0.17. This much cleaner API surface will make adding new features a lot easier.