### PR TITLE
Correct return type of `useStorage()` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Remove support for directly importing hooks from **@liveblocks/client** (e.g.
   `import { useMyPresence } from '@liveblocks/react'`). If you’re still using
   these imports, see the
-  [Upgrade Guide for 0.17](https://liveblocks.io/docs/guides/upgrading/0.17)
-  for instructions.
+  [Upgrade Guide for 0.17](https://liveblocks.io/docs/guides/upgrading/0.17) for
+  instructions.
+- `useStorage()` now returns `root` directory, no longer wrapped in `[root]`
 
 ---
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -217,9 +217,9 @@ type RoomContext<
    * Storage.
    *
    * @example
-   * const [root] = useStorage();
+   * const root = useStorage();
    */
-  useStorage(): [root: LiveObject<TStorage> | null];
+  useStorage(): LiveObject<TStorage> | null;
 
   /**
    * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.
@@ -540,7 +540,7 @@ export function createRoomContext<
     return room.getSelf();
   }
 
-  function useStorage(): [root: LiveObject<TStorage> | null] {
+  function useStorage(): LiveObject<TStorage> | null {
     const room = useRoom();
     const [root, setState] = React.useState<LiveObject<TStorage> | null>(null);
 
@@ -561,7 +561,7 @@ export function createRoomContext<
       };
     }, [room]);
 
-    return [root];
+    return root;
   }
 
   function useMap_deprecated<TKey extends string, TValue extends Lson>(
@@ -786,7 +786,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     initialValue: T
   ): LookupResult<T> {
     const room = useRoom();
-    const [root] = useStorage();
+    const root = useStorage();
     const rerender = useRerender();
 
     // NOTE: Boxing deliberately avoids this value from triggering effects


### PR DESCRIPTION
> **Warning** This PR's target branch is **release-0.18**, not **main**.

This PR fixes the return type of the `useStorage()` API by having it return `root` instead of `[root]`, so no more unpacking needed there. This will also make it closer to a potential Suspense API.
