### PR TITLE
Update tests to make it easier to work with test IDs

### DIFF
--- a/packages/liveblocks-react/src/index.test.tsx
+++ b/packages/liveblocks-react/src/index.test.tsx
@@ -17,6 +17,16 @@ import * as React from "react";
 
 import { createRoomContext } from "./factory";
 
+type TestID = "me-x" | "increment" | "othersJson" | "liveObject" | "unmount";
+
+function testId(testId: TestID) {
+  return testId;
+}
+
+function element(testId: TestID) {
+  return screen.getByTestId(testId);
+}
+
 /**
  * https://github.com/Luka967/websocket-close-codes
  */
@@ -136,16 +146,6 @@ beforeEach(() => {
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-const testIds = {
-  meX: "me-x",
-  incrementButton: "increment",
-  errorMessage: "error-message",
-  errorConstructorName: "error-constructor-name",
-  othersJson: "othersJson",
-  liveObject: "liveObject",
-  unmount: "unmount",
-};
-
 function PresenceComponent() {
   const [me, setPresence] = useMyPresence();
   const others = useOthers();
@@ -153,13 +153,13 @@ function PresenceComponent() {
   return (
     <div>
       <button
-        data-testid={testIds.incrementButton}
+        data-testid={testId("increment")}
         onClick={() => setPresence({ x: me.x + 1 })}
       >
         Increment
       </button>
-      <div data-testid={testIds.meX}>{me.x}</div>
-      <div data-testid={testIds.othersJson}>
+      <div data-testid={testId("me-x")}>{me.x}</div>
+      <div data-testid={testId("othersJson")}>
         {JSON.stringify(others.toArray())}
       </div>
     </div>
@@ -183,7 +183,7 @@ describe("presence", () => {
       </RoomProvider>
     );
 
-    expect(screen.getByTestId(testIds.meX).textContent).toBe("1");
+    expect(element("me-x").textContent).toBe("1");
 
     await waitForSocketToBeConnected();
   });
@@ -197,7 +197,7 @@ describe("presence", () => {
   //     </LiveblocksProvider>
   //   );
 
-  //   expect(screen.getByTestId(testIds.meX).textContent).toBe("1");
+  //   expect(element("me-x").textContent).toBe("1");
 
   //   await waitForSocketToBeConnected();
 
@@ -209,7 +209,7 @@ describe("presence", () => {
   //     </LiveblocksProvider>
   //   );
 
-  //   expect(screen.getByTestId(testIds.meX).textContent).toBe("1");
+  //   expect(element("me-x").textContent).toBe("1");
 
   //   await waitForSocketToBeConnected();
   // });
@@ -244,13 +244,13 @@ describe("presence", () => {
 
     await waitForSocketToBeConnected();
 
-    expect(screen.getByTestId(testIds.meX).textContent).toBe("1");
+    expect(element("me-x").textContent).toBe("1");
 
     act(() => {
-      fireEvent.click(screen.getByTestId(testIds.incrementButton));
+      fireEvent.click(element("increment"));
     });
 
-    expect(screen.getByTestId(testIds.meX).textContent).toBe("2");
+    expect(element("me-x").textContent).toBe("2");
   });
 
   test("others presence should be set on update", async () => {
@@ -274,7 +274,7 @@ describe("presence", () => {
       } as MessageEvent);
     });
 
-    expect(screen.getByTestId(testIds.othersJson).textContent).toEqual(
+    expect(element("othersJson").textContent).toEqual(
       JSON.stringify([
         {
           connectionId: 1,
@@ -307,7 +307,7 @@ describe("presence", () => {
       } as MessageEvent);
     });
 
-    expect(screen.getByTestId(testIds.othersJson).textContent).toEqual(
+    expect(element("othersJson").textContent).toEqual(
       JSON.stringify([
         {
           connectionId: 1,
@@ -328,7 +328,7 @@ describe("presence", () => {
       } as MessageEvent);
     });
 
-    expect(screen.getByTestId(testIds.othersJson).textContent).toEqual(
+    expect(element("othersJson").textContent).toEqual(
       JSON.stringify([
         {
           connectionId: 1,
@@ -397,7 +397,7 @@ describe("presence", () => {
       } as MessageEvent);
     });
 
-    expect(screen.getByTestId(testIds.othersJson).textContent).toEqual(
+    expect(element("othersJson").textContent).toEqual(
       JSON.stringify([
         {
           connectionId: 1,
@@ -416,16 +416,14 @@ describe("presence", () => {
       } as CloseEvent);
     });
 
-    expect(screen.getByTestId(testIds.othersJson).textContent).toEqual(
-      JSON.stringify([])
-    );
+    expect(element("othersJson").textContent).toEqual(JSON.stringify([]));
   });
 });
 
 function ObjectComponent() {
   const obj = useObject("obj");
   return (
-    <div data-testid={testIds.liveObject}>
+    <div data-testid={testId("liveObject")}>
       {obj == null ? "Loading" : JSON.stringify(obj.toObject())}
     </div>
   );
@@ -437,7 +435,7 @@ function UnmountContainer({ children }: { children: React.ReactElement }) {
   return (
     <div>
       <button
-        data-testid={testIds.unmount}
+        data-testid={testId("unmount")}
         onClick={() => {
           setIsVisible(!isVisible);
         }}
@@ -460,17 +458,13 @@ describe("Storage", () => {
       </RoomProvider>
     );
 
-    expect(screen.getByTestId(testIds.liveObject).textContent).toEqual(
-      "Loading"
-    );
+    expect(element("liveObject").textContent).toEqual("Loading");
 
     const socket = await waitForSocketToBeConnected();
 
     socket.callbacks.open[0]();
 
-    expect(screen.getByTestId(testIds.liveObject).textContent).toEqual(
-      "Loading"
-    );
+    expect(element("liveObject").textContent).toEqual("Loading");
 
     act(() => {
       socket.callbacks.message[0]({
@@ -482,9 +476,7 @@ describe("Storage", () => {
     });
 
     await waitFor(() =>
-      expect(screen.getByTestId(testIds.liveObject).textContent).toBe(
-        JSON.stringify({ a: 0 })
-      )
+      expect(element("liveObject").textContent).toBe(JSON.stringify({ a: 0 }))
     );
   });
 
@@ -500,20 +492,16 @@ describe("Storage", () => {
       </RoomProvider>
     );
 
-    expect(screen.getByTestId(testIds.liveObject).textContent).toEqual(
-      "Loading"
-    );
+    expect(element("liveObject").textContent).toEqual("Loading");
 
     const socket = await waitForSocketToBeConnected();
 
     socket.callbacks.open[0]();
 
-    expect(screen.getByTestId(testIds.liveObject).textContent).toEqual(
-      "Loading"
-    );
+    expect(element("liveObject").textContent).toEqual("Loading");
 
     act(() => {
-      fireEvent.click(screen.getByTestId(testIds.unmount));
+      fireEvent.click(element("unmount"));
     });
 
     act(() => {


### PR DESCRIPTION
This restructures the "test ID" helpers a bit, so we're able to use plain string literals (which I think are easier to read and debug), and structure it so that TypeScript will prevent us from making typos.