### PR TITLE
Ship our own `shallow` helper

### DIFF
--- a/packages/liveblocks-client/package-lock.json
+++ b/packages/liveblocks-client/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^8.12.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
+        "fast-check": "^3.0.1",
         "jest": "^28.0.3",
         "jest-each": "^27.5.1",
         "jest-environment-jsdom": "^28.1.0",
@@ -5838,6 +5839,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.0.1.tgz",
+      "integrity": "sha512-AriFDYpYVOBynpPZq/quxSLumFOo2hPB2H5Nz2vc1QlNfjOaA62zX8USNXcOY5nwKHEq7lZ84dG9M1W+LAND1g==",
+      "dev": true,
+      "dependencies": {
+        "pure-rand": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11201,6 +11218,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.1.tgz",
+      "integrity": "sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/fast-check"
       }
     },
     "node_modules/queue-microtask": {
@@ -16961,6 +16988,15 @@
         "tmp": "^0.0.33"
       }
     },
+    "fast-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.0.1.tgz",
+      "integrity": "sha512-AriFDYpYVOBynpPZq/quxSLumFOo2hPB2H5Nz2vc1QlNfjOaA62zX8USNXcOY5nwKHEq7lZ84dG9M1W+LAND1g==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^5.0.1"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -21043,6 +21079,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.1.tgz",
+      "integrity": "sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==",
       "dev": true
     },
     "queue-microtask": {

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -55,6 +55,7 @@
     "eslint": "^8.12.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "fast-check": "^3.0.1",
     "jest": "^28.0.3",
     "jest-each": "^27.5.1",
     "jest-environment-jsdom": "^28.1.0",

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -2,6 +2,7 @@ export { createClient } from "./client";
 export { LiveList } from "./LiveList";
 export { LiveMap } from "./LiveMap";
 export { LiveObject } from "./LiveObject";
+export { shallow } from "./shallow";
 export type {
   BaseUserMeta,
   BroadcastOptions,

--- a/packages/liveblocks-client/src/shallow.test.ts
+++ b/packages/liveblocks-client/src/shallow.test.ts
@@ -80,10 +80,12 @@ describe("shallow", () => {
 
   it("sparse arrays", () => {
     // Sparse arrays should not break
+    /* eslint-disable no-sparse-arrays */
     expect(shallow([,], ["oops", 1])).toBe(false);
     expect(shallow(["oops", 1], [,])).toBe(false);
     expect(shallow([, , ,], [, , ,])).toBe(true);
     expect(shallow([, , , "hi"], [, , , "hi"])).toBe(true);
+    /* eslint-enable no-sparse-arrays */
   });
 });
 

--- a/packages/liveblocks-client/src/shallow.test.ts
+++ b/packages/liveblocks-client/src/shallow.test.ts
@@ -1,0 +1,150 @@
+import fc from "fast-check";
+
+import shallow from "./shallow";
+
+const scalar = () => fc.jsonValue({ maxDepth: 0 });
+
+const complex = () =>
+  fc.anything().filter((value) => value !== null && typeof value === "object");
+
+describe("shallow", () => {
+  it("scalar values", () => {
+    expect(shallow(0, 0)).toBe(true);
+    expect(shallow("", "")).toBe(true);
+    expect(shallow("hi", "hi")).toBe(true);
+    expect(shallow(false, false)).toBe(true);
+    expect(shallow(true, true)).toBe(true);
+
+    expect(shallow(0, 1)).toBe(false);
+    expect(shallow(false, true)).toBe(false);
+    expect(shallow(true, false)).toBe(false);
+
+    // Weird exceptions
+    expect(shallow(NaN, NaN)).toBe(true);
+    expect(shallow(-0, +0)).toBe(false);
+  });
+
+  it("scalar values wrapped in list", () => {
+    expect(shallow([0], [0])).toBe(true);
+    expect(shallow([""], [""])).toBe(true);
+    expect(shallow(["hi"], ["hi"])).toBe(true);
+    expect(shallow([false], [false])).toBe(true);
+    expect(shallow([true], [true])).toBe(true);
+
+    expect(shallow([0], [1])).toBe(false);
+    expect(shallow([false], [true])).toBe(false);
+    expect(shallow([true], [false])).toBe(false);
+
+    // Weird exceptions   ],[
+    expect(shallow([NaN], [NaN])).toBe(true);
+    expect(shallow([-0], [+0])).toBe(false);
+  });
+
+  it("scalar values wrapped in objs", () => {
+    expect(shallow({ k: 0 }, { k: 0 })).toBe(true);
+    expect(shallow({ k: "" }, { k: "" })).toBe(true);
+    expect(shallow({ k: "hi" }, { k: "hi" })).toBe(true);
+    expect(shallow({ k: false }, { k: false })).toBe(true);
+    expect(shallow({ k: true }, { k: true })).toBe(true);
+
+    expect(shallow({ k: 0 }, { k: 1 })).toBe(false);
+    expect(shallow({ k: false }, { k: true })).toBe(false);
+    expect(shallow({ k: true }, { k: false })).toBe(false);
+
+    // Weird exceptions
+    expect(shallow({ k: NaN }, { k: NaN })).toBe(true);
+    expect(shallow({ k: -0 }, { k: +0 })).toBe(false);
+  });
+});
+
+describe("shallow (properties)", () => {
+  it("all equal scalars are shallowly equal", () => {
+    fc.assert(
+      fc.property(
+        // Inputs
+        fc.clone(scalar(), 2),
+
+        // Unit test
+        ([scalar1, scalar2]) => {
+          expect(shallow(scalar1, scalar2)).toBe(true);
+
+          // If two values are shallowly equal, then those values wrapped in an
+          // array (one level) should _also_ be considered shallowly equal
+          expect(shallow([scalar1], [scalar2])).toBe(true);
+          expect(shallow([scalar1, scalar1], [scalar2, scalar2])).toBe(true);
+
+          // Ditto for objects
+          expect(shallow({ a: scalar1 }, { a: scalar2 })).toBe(true);
+          expect(
+            shallow({ a: scalar1, b: scalar1 }, { a: scalar2, b: scalar2 })
+          ).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("different scalars are not shallowly equal", () => {
+    fc.assert(
+      fc.property(
+        // Inputs
+        fc.tuple(scalar(), scalar()).filter(([x, y]) => x !== y),
+
+        // Unit test
+        ([scalar1, scalar2]) => {
+          expect(shallow(scalar1, scalar2)).toBe(false);
+
+          // If two values are shallowly unequal, then wrapping those in an
+          // array (one level) should also always be shallowly unequal
+          expect(shallow([scalar1], [scalar2])).toBe(false);
+
+          // Ditto for objects
+          expect(shallow({ k: scalar1 }, { k: scalar2 })).toBe(false);
+        }
+      )
+    );
+  });
+
+  it("equal composite values", () => {
+    fc.assert(
+      fc.property(
+        // Inputs
+        fc.clone(complex(), 2),
+
+        // Unit test
+        ([complex1, complex2]) => {
+          // Property: _if_ two complex values are considered shallowly equal,
+          // then wrapping them in an array (one level) will guarantee they're
+          // not shallowly equal
+          expect(
+            // Read as: if complex1 = complex2, then also [complex1] != [complex2]
+            !shallow(complex1, complex2) || !shallow([complex1], [complex2])
+          ).toBe(true);
+
+          // Ditto for objects
+          expect(
+            // Read as: if complex1 = complex2, then also [complex1] != [complex2]
+            !shallow(complex1, complex2) ||
+              !shallow({ k: complex1 }, { k: complex2 })
+          ).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("dates are always considered unequal", () => {
+    fc.assert(
+      fc.property(
+        // Inputs
+        fc.date(),
+        fc.date(),
+
+        // Unit test
+        (date1, date2) => {
+          expect(shallow(date1, date2)).toBe(false);
+          expect(shallow([date1], [date2])).toBe(false);
+          expect(shallow({ k: date1 }, { k: date2 })).toBe(false);
+        }
+      )
+    );
+  });
+});

--- a/packages/liveblocks-client/src/shallow.test.ts
+++ b/packages/liveblocks-client/src/shallow.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 
-import shallow from "./shallow";
+import { shallow } from "./shallow";
 
 const anything = () =>
   fc.anything({

--- a/packages/liveblocks-client/src/shallow.test.ts
+++ b/packages/liveblocks-client/src/shallow.test.ts
@@ -73,11 +73,19 @@ describe("shallow (properties)", () => {
           expect(shallow([scalar1], [scalar2])).toBe(true);
           expect(shallow([scalar1, scalar1], [scalar2, scalar2])).toBe(true);
 
+          // ...but wrapping twice is _never_ going to be equal
+          expect(shallow([[scalar1]], [[scalar2]])).toBe(false);
+
           // Ditto for objects
           expect(shallow({ a: scalar1 }, { a: scalar2 })).toBe(true);
           expect(
             shallow({ a: scalar1, b: scalar1 }, { a: scalar2, b: scalar2 })
           ).toBe(true);
+
+          // ...but nesting twice is _never_ going to be equal
+          expect(shallow({ a: { b: scalar1 } }, { a: { b: scalar2 } })).toBe(
+            false
+          );
         }
       )
     );

--- a/packages/liveblocks-client/src/shallow.test.ts
+++ b/packages/liveblocks-client/src/shallow.test.ts
@@ -5,7 +5,19 @@ import shallow from "./shallow";
 const scalar = () => fc.jsonValue({ maxDepth: 0 });
 
 const complex = () =>
-  fc.anything().filter((value) => value !== null && typeof value === "object");
+  fc
+    .anything({
+      withBigInt: true,
+      withBoxedValues: true,
+      withDate: true,
+      withMap: true,
+      withNullPrototype: true,
+      withObjectString: true,
+      withSet: true,
+      withTypedArray: true,
+      withSparseArray: true,
+    })
+    .filter((value) => value !== null && typeof value === "object");
 
 describe("shallow", () => {
   it("scalar values", () => {

--- a/packages/liveblocks-client/src/shallow.test.ts
+++ b/packages/liveblocks-client/src/shallow.test.ts
@@ -77,6 +77,14 @@ describe("shallow", () => {
     expect(shallow(new Date(), [])).toBe(false);
     expect(shallow({}, new Date())).toBe(false);
   });
+
+  it("sparse arrays", () => {
+    // Sparse arrays should not break
+    expect(shallow([,], ["oops", 1])).toBe(false);
+    expect(shallow(["oops", 1], [,])).toBe(false);
+    expect(shallow([, , ,], [, , ,])).toBe(true);
+    expect(shallow([, , , "hi"], [, , , "hi"])).toBe(true);
+  });
 });
 
 describe("shallow (properties)", () => {

--- a/packages/liveblocks-client/src/shallow.ts
+++ b/packages/liveblocks-client/src/shallow.ts
@@ -12,7 +12,7 @@ function shallowArray(xs: unknown[], ys: unknown[]): boolean {
   return true;
 }
 
-function shallowObj<T>(objA: T, objB: T): boolean {
+function shallowObj<T, U>(objA: T, objB: U): boolean {
   if (
     typeof objA !== "object" ||
     objA === null ||
@@ -38,7 +38,7 @@ function shallowObj<T>(objA: T, objB: T): boolean {
   return keysA.every(
     (key) =>
       Object.prototype.hasOwnProperty.call(objB, key) &&
-      Object.is(objA[key as keyof T], objB[key as keyof T])
+      Object.is(objA[key as keyof T], objB[key as keyof U])
   );
 }
 
@@ -51,7 +51,7 @@ function shallowObj<T>(objA: T, objB: T): boolean {
  *
  * Testing goes one level deep.
  */
-export function shallow<T>(a: T, b: T): boolean {
+export function shallow(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) {
     return true;
   }

--- a/packages/liveblocks-client/src/shallow.ts
+++ b/packages/liveblocks-client/src/shallow.ts
@@ -41,7 +41,7 @@ function shallowObj<T>(objA: T, objB: T): boolean {
  *
  * Testing goes one level deep.
  */
-export default function shallow<T>(a: T, b: T): boolean {
+export function shallow<T>(a: T, b: T): boolean {
   if (Object.is(a, b)) {
     return true;
   }

--- a/packages/liveblocks-client/src/shallow.ts
+++ b/packages/liveblocks-client/src/shallow.ts
@@ -1,5 +1,15 @@
 function shallowArray(xs: unknown[], ys: unknown[]): boolean {
-  return xs.length === ys.length && xs.every((x, idx) => Object.is(x, ys[idx]));
+  if (xs.length !== ys.length) {
+    return false;
+  }
+
+  for (let i = 0; i < xs.length; i++) {
+    if (!Object.is(xs[i], ys[i])) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function shallowObj<T>(objA: T, objB: T): boolean {

--- a/packages/liveblocks-client/src/shallow.ts
+++ b/packages/liveblocks-client/src/shallow.ts
@@ -1,0 +1,51 @@
+function shallowArray(xs: unknown, ys: unknown): boolean {
+  return (
+    Array.isArray(xs) &&
+    Array.isArray(ys) &&
+    xs.length === ys.length &&
+    xs.every((x, idx) => Object.is(x, ys[idx]))
+  );
+}
+
+function shallowObj<T>(objA: T, objB: T): boolean {
+  if (
+    typeof objA !== "object" ||
+    objA === null ||
+    typeof objB !== "object" ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  // Specific exception for dates
+  if (
+    Object.prototype.toString.call(objA) === "[object Date]" ||
+    Object.prototype.toString.call(objB) === "[object Date]"
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  if (keysA.length !== Object.keys(objB).length) {
+    return false;
+  }
+
+  return keysA.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(objB, key) &&
+      Object.is(objA[key as keyof T], objB[key as keyof T])
+  );
+}
+
+/**
+ * Shallowly compares two given values.
+ *
+ * - Two simple values are considered equal if they're strictly equal
+ * - Two arrays are considered equal if their members are strictly equal
+ * - Two objects are considered equal if their values are strictly equal
+ *
+ * Testing goes one level deep.
+ */
+export default function shallow<T>(a: T, b: T): boolean {
+  return Object.is(a, b) || shallowArray(a, b) || shallowObj(a, b);
+}

--- a/packages/liveblocks-client/src/shallow.ts
+++ b/packages/liveblocks-client/src/shallow.ts
@@ -1,10 +1,5 @@
-function shallowArray(xs: unknown, ys: unknown): boolean {
-  return (
-    Array.isArray(xs) &&
-    Array.isArray(ys) &&
-    xs.length === ys.length &&
-    xs.every((x, idx) => Object.is(x, ys[idx]))
-  );
+function shallowArray(xs: unknown[], ys: unknown[]): boolean {
+  return xs.length === ys.length && xs.every((x, idx) => Object.is(x, ys[idx]));
 }
 
 function shallowObj<T>(objA: T, objB: T): boolean {
@@ -47,5 +42,19 @@ function shallowObj<T>(objA: T, objB: T): boolean {
  * Testing goes one level deep.
  */
 export default function shallow<T>(a: T, b: T): boolean {
-  return Object.is(a, b) || shallowArray(a, b) || shallowObj(a, b);
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  const isArrayA = Array.isArray(a);
+  const isArrayB = Array.isArray(b);
+  if (isArrayA || isArrayB) {
+    if (!isArrayA || !isArrayB) {
+      return false;
+    }
+
+    return shallowArray(a, b);
+  }
+
+  return shallowObj(a, b);
 }

--- a/packages/liveblocks-client/src/shallow.ts
+++ b/packages/liveblocks-client/src/shallow.ts
@@ -13,19 +13,15 @@ function shallowArray(xs: unknown[], ys: unknown[]): boolean {
 }
 
 function shallowObj<T, U>(objA: T, objB: U): boolean {
+  // Only try to compare keys/values if these objects are both "pojos" (plain
+  // old JavaScript objects)
   if (
     typeof objA !== "object" ||
     objA === null ||
     typeof objB !== "object" ||
-    objB === null
-  ) {
-    return false;
-  }
-
-  // Specific exception for dates
-  if (
-    Object.prototype.toString.call(objA) === "[object Date]" ||
-    Object.prototype.toString.call(objB) === "[object Date]"
+    objB === null ||
+    Object.prototype.toString.call(objA) !== "[object Object]" ||
+    Object.prototype.toString.call(objB) !== "[object Object]"
   ) {
     return false;
   }


### PR DESCRIPTION
> **Warning** This PR's target branch is **release-0.18**, not **main**.

This PR adds a `shallow` function, which can compare two values shallowly. This will soon be needed for the `useSelector()` API that's currently in progress.

Also this PR adds our first property-based unit tests using a testing library called `fast-check`.

The following comparisons will be true:

```tsx
shallow(0, 0)
shallow('hi', 'hi')
shallow([0, 1, 2], [0, 1, 2])
shallow({ a: 1 }, { a: 1 })
```

These will be false:

```tsx
shallow(true, false)
shallow(0, 1)
shallow('hi', 'there')
shallow([['hi']], [['hi']])
shallow([{ a: 1 }], [{ a: 1 }])
```
