### PR TITLE
Fix auto-detection of external packages in Rollup configs

### DIFF
--- a/packages/liveblocks-node/rollup.config.js
+++ b/packages/liveblocks-node/rollup.config.js
@@ -10,6 +10,22 @@ import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
 const babelConfig = require("./babel.config");
 
+function makeExternalFn() {
+  // NOTE: Make sure this list always matches the names of all dependencies and
+  // peerDependencies from package.json
+  const pkgJson = require("./package.json");
+
+  const EXTERNAL_PKGS = [
+    ...Object.keys(pkgJson?.dependencies ?? {}),
+    ...Object.keys(pkgJson?.peerDependencies ?? {}),
+  ];
+
+  return (importPath) =>
+    EXTERNAL_PKGS.some(
+      (ext) => importPath === ext || importPath.startsWith(ext + "/")
+    );
+}
+
 function execute(cmd, wait = true) {
   return commandPlugin(cmd, { exitOnFail: true, wait });
 }
@@ -192,17 +208,7 @@ export default async () => {
 
   // Files relative to `src/`
   const srcFiles = ["index.ts"];
-
-  // NOTE: Make sure this list always matches the names of all dependencies and
-  // peerDependencies from package.json
-  const pkgJson = require("./package.json");
-  const external = [
-    ...Object.keys(pkgJson?.dependencies ?? {}),
-    ...Object.keys(pkgJson?.peerDependencies ?? {}),
-  ].flatMap((dep) =>
-    // Also include `@liveblocks/.../internal` as an external reference, by convention
-    dep.startsWith("@liveblocks/") ? [dep, dep + "/internal"] : [dep]
-  );
+  const external = makeExternalFn();
 
   return [
     // Build modern ES modules (*.mjs)

--- a/packages/liveblocks-redux/rollup.config.js
+++ b/packages/liveblocks-redux/rollup.config.js
@@ -10,6 +10,22 @@ import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
 const createBabelConfig = require("./babel.config");
 
+function makeExternalFn() {
+  // NOTE: Make sure this list always matches the names of all dependencies and
+  // peerDependencies from package.json
+  const pkgJson = require("./package.json");
+
+  const EXTERNAL_PKGS = [
+    ...Object.keys(pkgJson?.dependencies ?? {}),
+    ...Object.keys(pkgJson?.peerDependencies ?? {}),
+  ];
+
+  return (importPath) =>
+    EXTERNAL_PKGS.some(
+      (ext) => importPath === ext || importPath.startsWith(ext + "/")
+    );
+}
+
 function execute(cmd, wait = true) {
   return commandPlugin(cmd, { exitOnFail: true, wait });
 }
@@ -192,17 +208,7 @@ export default async () => {
 
   // Files relative to `src/`
   const srcFiles = ["index.ts"];
-
-  // NOTE: Make sure this list always matches the names of all dependencies and
-  // peerDependencies from package.json
-  const pkgJson = require("./package.json");
-  const external = [
-    ...Object.keys(pkgJson?.dependencies ?? {}),
-    ...Object.keys(pkgJson?.peerDependencies ?? {}),
-  ].flatMap((dep) =>
-    // Also include `@liveblocks/.../internal` as an external reference, by convention
-    dep.startsWith("@liveblocks/") ? [dep, dep + "/internal"] : [dep]
-  );
+  const external = makeExternalFn();
 
   return [
     // Build modern ES modules (*.mjs)

--- a/packages/liveblocks-zustand/rollup.config.js
+++ b/packages/liveblocks-zustand/rollup.config.js
@@ -10,6 +10,22 @@ import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
 const createBabelConfig = require("./babel.config");
 
+function makeExternalFn() {
+  // NOTE: Make sure this list always matches the names of all dependencies and
+  // peerDependencies from package.json
+  const pkgJson = require("./package.json");
+
+  const EXTERNAL_PKGS = [
+    ...Object.keys(pkgJson?.dependencies ?? {}),
+    ...Object.keys(pkgJson?.peerDependencies ?? {}),
+  ];
+
+  return (importPath) =>
+    EXTERNAL_PKGS.some(
+      (ext) => importPath === ext || importPath.startsWith(ext + "/")
+    );
+}
+
 function execute(cmd, wait = true) {
   return commandPlugin(cmd, { exitOnFail: true, wait });
 }
@@ -192,17 +208,7 @@ export default async () => {
 
   // Files relative to `src/`
   const srcFiles = ["index.ts"];
-
-  // NOTE: Make sure this list always matches the names of all dependencies and
-  // peerDependencies from package.json
-  const pkgJson = require("./package.json");
-  const external = [
-    ...Object.keys(pkgJson?.dependencies ?? {}),
-    ...Object.keys(pkgJson?.peerDependencies ?? {}),
-  ].flatMap((dep) =>
-    // Also include `@liveblocks/.../internal` as an external reference, by convention
-    dep.startsWith("@liveblocks/") ? [dep, dep + "/internal"] : [dep]
-  );
+  const external = makeExternalFn();
 
   return [
     // Build modern ES modules (*.mjs)


### PR DESCRIPTION
This fixes an issue where, if you had `some-pkg` declared in your dependencies, but then imported from `"some-pkg/sub/module"`, then Rollup would not consider that an external dependency, because it was not an exact match.

The fix made by this PR is to not codify the externals as a static list but to make `external` a callback function that can do a prefix-match.

This fix also allows us to get rid of the custom `@liveblocks/client/internal` hack we had in there to support a similar case.

I am making this fix proactively here (on `main`), because I needed to add `use-sync-external-store` soon on #404 , which made me run into this problem.