### PR TITLE
Expose `RoomContext` in `createRoomContext()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.17.6
+
+In **@liveblocks/react**:
+
+- Expose `RoomContext` in the return value of `createRoomContext()`
+
 # v0.17.5
 
 In **@liveblocks/react**:

--- a/packages/liveblocks-react/scripts/generate-compat.ts
+++ b/packages/liveblocks-react/scripts/generate-compat.ts
@@ -110,7 +110,7 @@ function getLiveblocksHookDefintions() {
         d.name?.text === name
     );
     if (found.length === 0) {
-      throw new Error("Declaration of " + name + " not found!");
+      continue;
     }
     fns.push(...found);
   }


### PR DESCRIPTION
This PR exposes `RoomContext` as another member in the object returned by `createRoomContext()`. It allows developers with advanced apps to set up context bridges between multiple React renderers, for example, to work with our React hooks inside of a React Three Fiber component (but where the RoomProvider is configured higher up the component tree, in a "normal" React DOM renderer). Here's an [example of such a context bridge](https://docs.pmnd.rs/react-three-fiber/advanced/gotchas#consuming-context-from-a-foreign-provider).
