### PR TITLE
Build package contents in the same way for all packages

### DIFF
--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/liveblocks/liveblocks/issues"
   },
   "scripts": {
-    "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "build": "rollup -c && ../../scripts/build.sh",
     "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
     "test": "jest --watch --silent --verbose --config=./jest.config.js",

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/liveblocks/liveblocks/issues"
   },
   "scripts": {
-    "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "build": "rollup -c && ../../scripts/build.sh",
     "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --watch --silent --verbose",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/liveblocks/liveblocks/issues"
   },
   "scripts": {
-    "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "build": "rollup -c && ../../scripts/build.sh",
     "start": "rollup -c -w",
     "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -17,7 +17,7 @@
     "collaborative"
   ],
   "scripts": {
-    "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "build": "rollup -c && ../../scripts/build.sh",
     "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
     "test": "jest --watch --silent --verbose",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -17,7 +17,7 @@
     "collaborative"
   ],
   "scripts": {
-    "build": "rollup -c && cp ./package.json ./README.md ./lib",
+    "build": "rollup -c && ../../scripts/build.sh",
     "format": "eslint --fix src/ test/ && prettier --write src/ test/",
     "lint": "eslint src/ test/",
     "test": "jest --watch --silent --verbose",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+# Ensure this script can assume it's run from the repo's
+# root directory, even if the current working directory is
+# different.
+ROOT="$(git rev-parse --show-toplevel)"
+if [ ! -f "./package.json" ]; then
+    echo "This script should be run from inside a package directory" >&2
+    exit 1
+fi
+
+# Target dir to place file into
+DIST="lib"
+
+check_jq_installed () {
+    if ! which -s jq; then
+        err ""
+        err "jq is not installed."
+        err ""
+        err "You can find it at:"
+        err "  https://stedolan.github.io/jq/"
+        err ""
+        err "Please run:"
+        err "  brew install jq"
+        err ""
+        exit 2
+    fi
+}
+
+main () {
+    check_jq_installed
+
+    # Copy these files into the distribution
+    cp "$ROOT/LICENSE" ./README.md "$DIST/"
+
+    # Strip keys from package.json and place the result in lib/
+    cat package.json                     | \
+        jq 'del(.type)'                    \
+        jq 'del(.private)'               | \
+        jq 'del(.scripts)'               | \
+        jq 'del(.files)'                 | \
+        jq 'del(.devDependencies)'       | \
+        jq 'del(.optionalDependencies)'  | \
+        jq 'del(.jest)'                  | \
+        jq 'del(.prettier)'              | \
+            > "$DIST/package.json"
+
+    prettier --write "$DIST/package.json"
+}
+
+main

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,13 +5,13 @@ set -eu
 # root directory, even if the current working directory is
 # different.
 ROOT="$(git rev-parse --show-toplevel)"
-if [ ! -f "./package.json" ]; then
-    echo "This script should be run from inside a package directory" >&2
-    exit 1
-fi
 
 # Target dir to place file into
 DIST="lib"
+
+err () {
+    echo "$@" >&2
+}
 
 check_jq_installed () {
     if ! which -s jq; then
@@ -48,5 +48,10 @@ main () {
 
     prettier --write "$DIST/package.json"
 }
+
+if [ ! -f "./package.json" ]; then
+    err "This script should be run from inside a package directory"
+    exit 1
+fi
 
 main

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,38 +13,25 @@ err () {
     echo "$@" >&2
 }
 
-check_jq_installed () {
-    if ! which -s jq; then
-        err ""
-        err "jq is not installed."
-        err ""
-        err "You can find it at:"
-        err "  https://stedolan.github.io/jq/"
-        err ""
-        err "Please run:"
-        err "  brew install jq"
-        err ""
-        exit 2
-    fi
-}
-
 main () {
-    check_jq_installed
-
     # Copy these files into the distribution
     cp "$ROOT/LICENSE" ./README.md "$DIST/"
 
     # Strip keys from package.json and place the result in lib/
-    cat package.json                     | \
-        jq 'del(.type)'                    \
-        jq 'del(.private)'               | \
-        jq 'del(.scripts)'               | \
-        jq 'del(.files)'                 | \
-        jq 'del(.devDependencies)'       | \
-        jq 'del(.optionalDependencies)'  | \
-        jq 'del(.jest)'                  | \
-        jq 'del(.prettier)'              | \
-            > "$DIST/package.json"
+    echo '
+    const data = require("./package.json");
+
+    data.type = undefined;
+    data.private = undefined;
+    data.scripts = undefined;
+    data.files = undefined;
+    data.devDependencies = undefined;
+    data.optionalDependencies = undefined;
+    data.jest = undefined;
+    data.prettier = undefined;
+
+    console.log(JSON.stringify(data));
+    ' | node - > "$DIST/package.json"
 
     prettier --write "$DIST/package.json"
 }


### PR DESCRIPTION
This PR makes our NPM builds a bit cleaner, by stripping off unneeded keys from the `package.json` files when we produce the contents of the `lib/` folder.

The most important key stripped off here is the `devDependencies` key, but there are more keys that are being stripped, like `scripts`.

Also, while I was at it, I've included the `LICENSE` file in each produced build.

Fixes #399.
