### PR TITLE
Move test helper to another module

### DIFF
--- a/packages/liveblocks-client/src/immutable.test.ts
+++ b/packages/liveblocks-client/src/immutable.test.ts
@@ -4,18 +4,120 @@ import {
   createSerializedRegister,
   FIRST_POSITION,
   FOURTH_POSITION,
-  prepareStorageImmutableTest,
+  prepareRoomWithStorage,
   SECOND_POSITION,
+  serverMessage,
   THIRD_POSITION,
 } from "../test/utils";
 import { LiveList, LiveMap } from ".";
 import {
+  lsonToJson,
   patchImmutableObject,
   patchLiveObject,
   patchLiveObjectKey,
 } from "./immutable";
 import { LiveObject } from "./LiveObject";
-import type { JsonObject, StorageUpdate } from "./types";
+import type {
+  BaseUserMeta,
+  ClientMsg,
+  IdTuple,
+  Json,
+  JsonObject,
+  LsonObject,
+  SerializedCrdt,
+  StorageUpdate,
+  ToJson,
+} from "./types";
+import { ClientMsgCode, ServerMsgCode } from "./types";
+
+async function prepareStorageImmutableTest<
+  TStorage extends LsonObject,
+  TPresence extends JsonObject = never,
+  TUserMeta extends BaseUserMeta = never,
+  TRoomEvent extends Json = never
+>(items: IdTuple<SerializedCrdt>[], actor: number = 0) {
+  let state = {} as ToJson<TStorage>;
+  let refState = {} as ToJson<TStorage>;
+
+  let totalStorageOps = 0;
+
+  const { machine: refMachine, storage: refStorage } =
+    await prepareRoomWithStorage<TPresence, TStorage, TUserMeta, TRoomEvent>(
+      items,
+      -1
+    );
+
+  const { machine, storage } = await prepareRoomWithStorage<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TRoomEvent
+  >(items, actor, (messages: ClientMsg<TPresence, TRoomEvent>[]) => {
+    for (const message of messages) {
+      if (message.type === ClientMsgCode.UPDATE_STORAGE) {
+        totalStorageOps += message.ops.length;
+        refMachine.onMessage(
+          serverMessage({
+            type: ServerMsgCode.UPDATE_STORAGE,
+            ops: message.ops,
+          })
+        );
+        machine.onMessage(
+          serverMessage({
+            type: ServerMsgCode.UPDATE_STORAGE,
+            ops: message.ops,
+          })
+        );
+      }
+    }
+  });
+
+  state = lsonToJson(storage.root) as ToJson<TStorage>;
+  refState = lsonToJson(refStorage.root) as ToJson<TStorage>;
+
+  const root = refStorage.root;
+  refMachine.subscribe(
+    root,
+    () => {
+      refState = lsonToJson(refStorage.root) as ToJson<TStorage>;
+    },
+    { isDeep: true }
+  );
+
+  function assert(
+    data: ToJson<TStorage>,
+    itemsCount?: number,
+    storageOpsCount?: number
+  ) {
+    assertStorage(data);
+
+    if (itemsCount) {
+      expect(machine.getItemsCount()).toBe(itemsCount);
+    }
+    expect(state).toEqual(refState);
+    expect(state).toEqual(data);
+
+    if (storageOpsCount) {
+      expect(totalStorageOps).toEqual(storageOpsCount);
+    }
+  }
+
+  function assertStorage(data: ToJson<TStorage>) {
+    const json = lsonToJson(storage.root);
+    expect(json).toEqual(data);
+    expect(lsonToJson(refStorage.root)).toEqual(data);
+  }
+
+  return {
+    storage,
+    refStorage,
+    assert,
+    assertStorage,
+    subscribe: machine.subscribe,
+    refSubscribe: refMachine.subscribe,
+    state,
+  };
+}
 
 function applyStateChanges<T extends JsonObject>(
   state: T,

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -153,7 +153,7 @@ const defaultContext = {
   },
 };
 
-async function prepareRoomWithStorage<
+export async function prepareRoomWithStorage<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -466,95 +466,6 @@ export async function reconnect<
       items: newItems,
     })
   );
-}
-
-export async function prepareStorageImmutableTest<
-  TStorage extends LsonObject,
-  TPresence extends JsonObject = never,
-  TUserMeta extends BaseUserMeta = never,
-  TRoomEvent extends Json = never
->(items: IdTuple<SerializedCrdt>[], actor: number = 0) {
-  let state = {} as ToJson<TStorage>;
-  let refState = {} as ToJson<TStorage>;
-
-  let totalStorageOps = 0;
-
-  const { machine: refMachine, storage: refStorage } =
-    await prepareRoomWithStorage<TPresence, TStorage, TUserMeta, TRoomEvent>(
-      items,
-      -1
-    );
-
-  const { machine, storage } = await prepareRoomWithStorage<
-    TPresence,
-    TStorage,
-    TUserMeta,
-    TRoomEvent
-  >(items, actor, (messages: ClientMsg<TPresence, TRoomEvent>[]) => {
-    for (const message of messages) {
-      if (message.type === ClientMsgCode.UPDATE_STORAGE) {
-        totalStorageOps += message.ops.length;
-        refMachine.onMessage(
-          serverMessage({
-            type: ServerMsgCode.UPDATE_STORAGE,
-            ops: message.ops,
-          })
-        );
-        machine.onMessage(
-          serverMessage({
-            type: ServerMsgCode.UPDATE_STORAGE,
-            ops: message.ops,
-          })
-        );
-      }
-    }
-  });
-
-  state = lsonToJson(storage.root) as ToJson<TStorage>;
-  refState = lsonToJson(refStorage.root) as ToJson<TStorage>;
-
-  const root = refStorage.root;
-  refMachine.subscribe(
-    root,
-    (updates) => {
-      refState = patchImmutableObject(refState, updates);
-    },
-    { isDeep: true }
-  );
-
-  function assert(
-    data: ToJson<TStorage>,
-    itemsCount?: number,
-    storageOpsCount?: number
-  ) {
-    assertStorage(data);
-
-    if (itemsCount) {
-      expect(machine.getItemsCount()).toBe(itemsCount);
-    }
-    expect(state).toEqual(refState);
-    expect(state).toEqual(data);
-
-    if (storageOpsCount) {
-      expect(totalStorageOps).toEqual(storageOpsCount);
-    }
-  }
-
-  function assertStorage(data: ToJson<TStorage>) {
-    const json = lsonToJson(storage.root);
-    expect(json).toEqual(data);
-    expect(lsonToJson(refStorage.root)).toEqual(data);
-  }
-
-  return {
-    storage,
-    refStorage,
-    assert,
-    assertStorage,
-    subscribe: machine.subscribe,
-    refSubscribe: refMachine.subscribe,
-    state,
-  };
 }
 
 export function createSerializedObject(


### PR DESCRIPTION
This just moves the `prepareStorageImmutableTest` test helper from the generic `test/utils.ts` module into the only test module that uses it, to keep it local there. Committing this to `main` now to help shave off uninteresting diff noise from [the `useSelector` PR](https://github.com/liveblocks/liveblocks/pull/404) by rebasing it.
