### PR TITLE
Make @liveblocks/zustand middleware generic types optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,77 @@
+# v0.17.7
+
+In **@liveblocks/zustand**:
+
+Simplify zustand middleware integration with Typescript. `TPresence`, `TStorage`, `TUserMeta`, and `TRoomEvent` are now optional.
+
+Note that `@liveblocks/zustand` does not work with zustand > v4 because v3 and v4 have completely different type definitions. As soon as zustand v4 is out of the RC phase, we will consider updating our middleware to work with the latest version.
+
+### Example
+
+Let's take a look at our [To-do list](https://github.com/liveblocks/liveblocks/tree/main/examples/zustand-todo-list) example. Without our middleware, the store would look like this:
+
+```ts
+import create from "zustand";
+
+type State = {
+  draft: string;
+  isTyping: boolean;
+  todos: Todo[];
+  setDraft: (draft: string) => void;
+  addTodo: () => void;
+  deleteTodo: (index: number) => void;
+};
+
+create<State>(/* ... */)
+```
+
+With our middleware, you simply need to move the `State` param at the middleware level:
+
+```ts
+import create from "zustand";
+import { createClient } from "@liveblocks/client";
+import { middleware } from "@liveblocks/zustand";
+
+const client = createClient({ /*...*/ });
+
+type State = {
+  draft: string;
+  isTyping: boolean;
+  todos: Todo[];
+  setDraft: (draft: string) => void;
+  addTodo: () => void;
+  deleteTodo: (index: number) => void;
+};
+
+create(
+  middleware<State>(/* ... */, {
+    client,
+    presenceMapping: { isTyping: true },
+    storageMapping: { todos: true }
+  })
+);
+```
+
+If you want to type `others` presence, you can use the `TPresence` generic argument on the middleware.
+
+```ts
+
+type Presence = {
+  isTyping: true;
+}
+
+const useStore = create(
+  middleware<State, Presence>(/* ... */, {
+    client,
+    presenceMapping: { isTyping: true },
+    storageMapping: { todos: true }
+  })
+);
+
+// In your component
+useStore(state => state.liveblocks.others[0].presence?.isTyping)
+```
+
 # v0.17.6
 
 In **@liveblocks/react**:

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -41,10 +41,10 @@ export type ZustandState =
 
 export type LiveblocksState<
   TState extends ZustandState,
-  TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TPresence extends JsonObject = JsonObject,
+  TStorage extends LsonObject = LsonObject,
+  TUserMeta extends BaseUserMeta = BaseUserMeta,
+  TRoomEvent extends Json = Json
 > = TState & {
   /**
    * Liveblocks extra state attached by the middleware
@@ -68,7 +68,7 @@ export type LiveblocksState<
     /**
      * Other users in the room. Empty no room is currently synced
      */
-    readonly others: Array<User<TPresence, TStorage>>;
+    readonly others: Array<User<TPresence, TUserMeta>>;
     /**
      * Whether or not the room storage is currently loading
      */
@@ -385,10 +385,10 @@ function updatePresence<
 function patchLiveblocksStorage<
   O extends LsonObject,
   TState extends ZustandState,
-  TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TPresence extends JsonObject = JsonObject,
+  TStorage extends LsonObject = LsonObject,
+  TUserMeta extends BaseUserMeta = BaseUserMeta,
+  TRoomEvent extends Json = Json
 >(
   root: LiveObject<O>,
   oldState: LiveblocksState<TState, TPresence, TStorage, TUserMeta, TRoomEvent>,

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -107,10 +107,10 @@ type Options<T> = {
 
 export function middleware<
   T extends ZustandState,
-  TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TPresence extends JsonObject = JsonObject,
+  TStorage extends LsonObject = LsonObject,
+  TUserMeta extends BaseUserMeta = BaseUserMeta,
+  TRoomEvent extends Json = Json
 >(
   config: StateCreator<
     T,
@@ -385,10 +385,10 @@ function updatePresence<
 function patchLiveblocksStorage<
   O extends LsonObject,
   TState extends ZustandState,
-  TPresence extends JsonObject = JsonObject,
-  TStorage extends LsonObject = LsonObject,
-  TUserMeta extends BaseUserMeta = BaseUserMeta,
-  TRoomEvent extends Json = Json
+  TPresence extends JsonObject,
+  TStorage extends LsonObject,
+  TUserMeta extends BaseUserMeta,
+  TRoomEvent extends Json
 >(
   root: LiveObject<O>,
   oldState: LiveblocksState<TState, TPresence, TStorage, TUserMeta, TRoomEvent>,

--- a/packages/liveblocks-zustand/types/fake-app.ts
+++ b/packages/liveblocks-zustand/types/fake-app.ts
@@ -1,0 +1,112 @@
+// This file is used to test our types definition with dtslint
+
+import { createClient, LiveList } from "@liveblocks/client";
+import create from "zustand";
+import { middleware } from "@liveblocks/zustand";
+import { persist } from "zustand/middleware";
+
+type BasicStore = {
+  value: number;
+  setValue: (newValue: number) => void;
+};
+
+type Presence = {
+  cursor: { x: number; y: number };
+};
+
+type Storage = {
+  todos: LiveList<{ text: string }>;
+};
+
+type BaseUser = {
+  info: {
+    name: string;
+  };
+};
+
+type RoomEvent = {
+  type: "MESSAGE";
+  value: string;
+};
+
+const client = createClient({ authEndpoint: "/api/auth" });
+
+const useStore = create(
+  persist(
+    middleware<BasicStore, Presence, Storage, BaseUser, RoomEvent>(
+      (set, get, api) => ({
+        value: 0,
+        setValue: (newValue: number) => {
+          // Liveblocks state should be available here
+          const {
+            others,
+            connection,
+            enterRoom,
+            leaveRoom,
+            isStorageLoading,
+            room,
+          } = get().liveblocks;
+
+          // $ExpectError
+          get().liveblocks = {}; // Readonly
+
+          const liveblocksState = get().liveblocks;
+
+          // $ExpectError
+          liveblocksState.room = {} as any; // Readonly
+
+          // $ExpectError
+          liveblocksState.others = {} as any; // Readonly
+
+          liveblocksState.others[0].presence?.cursor;
+
+          // $ExpectError
+          liveblocksState.others[0].presence?.unknownPresenceProperty;
+
+          liveblocksState.others[0].info.name;
+
+          // $ExpectError
+          liveblocksState.others[0].info.unknownUserProperty;
+
+          liveblocksState.room?.broadcastEvent({
+            type: "MESSAGE",
+            value: "string",
+          });
+
+          liveblocksState.room?.broadcastEvent({
+            // $ExpectError
+            type: "INVALID_MESSAGE",
+          });
+
+          liveblocksState.room?.getStorage().then((storage) => {
+            storage.root.get("todos");
+
+            // $ExpectError
+            storage.root.get("unknown_key");
+          });
+
+          return set({ value: get().value });
+        },
+      }),
+      { client, storageMapping: {}, presenceMapping: {} }
+    ),
+    {
+      name: "persist-name",
+    }
+  )
+);
+
+const { value, liveblocks } = useStore.getState();
+
+// $ExpectError
+liveblocks.enterRoom = () => {}; // Readonly
+// $ExpectError
+liveblocks.leaveRoom = () => {}; // Readonly
+// $ExpectError
+liveblocks.connection = "open"; // Readonly
+// $ExpectError
+liveblocks.others = []; // Readonly
+// $ExpectError
+liveblocks.isStorageLoading = false; // Readonly
+// $ExpectError
+liveblocks.room = {}; // Readonly

--- a/packages/liveblocks-zustand/types/tsconfig.json
+++ b/packages/liveblocks-zustand/types/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2015",
     "module": "es2020",
     "moduleResolution": "node",
-    "lib": ["es2015"],
+    "lib": ["es2015", "DOM"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictFunctionTypes": true,
@@ -12,6 +12,6 @@
     "noEmit": true,
     "forceConsistentCasingInFileNames": true,
 
-    "paths": { "@liveblocks/zustand": [".."] }
+    "paths": { "@liveblocks/zustand": ["../lib"] }
   }
 }


### PR DESCRIPTION
Simplify zustand middleware integration with Typescript. `TPresence`, `TStorage`, `TUserMeta`, and `TRoomEvent` are now optional.

Note that `@liveblocks/zustand` does not work with zustand > v4 because v3 and v4 have completely different type definitions. As soon as zustand v4 is out of the RC phase, we will consider updating our middleware to work with the latest version.

### Example

Let's take a look at our [To-do list](https://github.com/liveblocks/liveblocks/tree/main/examples/zustand-todo-list) example. Without our middleware, the store would look like this:

```ts
import create from "zustand";

type State = {
  draft: string;
  isTyping: boolean;
  todos: Todo[];
  setDraft: (draft: string) => void;
  addTodo: () => void;
  deleteTodo: (index: number) => void;
};

create<State>(/* ... */)
```

With our middleware, you simply need to move the `State` param at the middleware level:

```ts
import create from "zustand";
import { createClient } from "@liveblocks/client";
import { middleware } from "@liveblocks/zustand";

const client = createClient({ /*...*/ });

type State = {
  draft: string;
  isTyping: boolean;
  todos: Todo[];
  setDraft: (draft: string) => void;
  addTodo: () => void;
  deleteTodo: (index: number) => void;
};

create(
  middleware<State>(/* ... */, {
    client,
    presenceMapping: { isTyping: true },
    storageMapping: { todos: true }
  })
);
```