### PR TITLE
Exploration: canUndo/canRedo

### DIFF
--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -889,6 +889,22 @@ describe("room", () => {
       });
     });
 
+    test("batch history", () => {
+      const { machine } = setupStateMachine({});
+
+      const callback = jest.fn();
+
+      machine.subscribe("history", callback);
+
+      machine.batch(() => {
+        machine.updatePresence({ x: 0 }, { addToHistory: true });
+        machine.updatePresence({ y: 1 }, { addToHistory: true });
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({ canUndo: true, canRedo: false });
+    });
+
     test("my-presence", () => {
       const { machine } = setupStateMachine({});
 
@@ -974,6 +990,34 @@ describe("room", () => {
           type: "MY_EVENT",
         },
       });
+    });
+
+    test("history", () => {
+      const { machine } = setupStateMachine({});
+
+      const callback = jest.fn();
+
+      const unsubscribe = machine.subscribe("history", callback);
+
+      machine.updatePresence({ x: 0 }, { addToHistory: true });
+
+      expect(callback).toHaveBeenCalledWith({ canUndo: true, canRedo: false });
+
+      machine.undo();
+
+      expect(callback).toHaveBeenCalledWith({ canUndo: false, canRedo: true });
+
+      machine.redo();
+
+      expect(callback).toHaveBeenCalledWith({ canUndo: true, canRedo: false });
+
+      machine.updatePresence({ x: 1 });
+
+      unsubscribe();
+
+      machine.updatePresence({ x: 2 }, { addToHistory: true });
+
+      expect(callback).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/liveblocks-client/src/room.test.ts
+++ b/packages/liveblocks-client/src/room.test.ts
@@ -688,6 +688,23 @@ describe("room", () => {
     expect(storage.root.toObject()).toEqual({ x: 1 });
   });
 
+  test("canUndo / canRedo", async () => {
+    const { storage, undo, canUndo, canRedo } = await prepareStorageTest<{
+      a: number;
+    }>([createSerializedObject("0:0", { a: 1 })], 1);
+
+    expect(canUndo()).toBeFalsy();
+    expect(canRedo()).toBeFalsy();
+
+    storage.root.set("a", 2);
+
+    expect(canUndo()).toBeTruthy();
+
+    undo();
+
+    expect(canRedo()).toBeTruthy();
+  });
+
   describe("subscription", () => {
     test("batch my-presence", () => {
       const { machine } = setupStateMachine({});

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -120,6 +120,8 @@ export type Machine<
   batch(callback: () => void): void;
   undo(): void;
   redo(): void;
+  canUndo(): void;
+  canRedo(): void;
   pauseHistory(): void;
   resumeHistory(): void;
 
@@ -1423,6 +1425,10 @@ export function makeStateMachine<
     tryFlushing();
   }
 
+  function canUndo() {
+    return state.undoStack.length > 0;
+  }
+
   function redo() {
     if (state.isBatching) {
       throw new Error("redo is not allowed during a batch");
@@ -1445,6 +1451,10 @@ export function makeStateMachine<
       }
     }
     tryFlushing();
+  }
+
+  function canRedo() {
+    return state.redoStack.length > 0;
   }
 
   function batch(callback: () => void) {
@@ -1540,6 +1550,8 @@ export function makeStateMachine<
     batch,
     undo,
     redo,
+    canUndo,
+    canRedo,
     pauseHistory,
     resumeHistory,
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -120,8 +120,8 @@ export type Machine<
   batch(callback: () => void): void;
   undo(): void;
   redo(): void;
-  canUndo(): void;
-  canRedo(): void;
+  canUndo(): boolean;
+  canRedo(): boolean;
   pauseHistory(): void;
   resumeHistory(): void;
 
@@ -1698,6 +1698,8 @@ export function createRoom<
     history: {
       undo: machine.undo,
       redo: machine.redo,
+      canUndo: machine.canUndo,
+      canRedo: machine.canRedo,
       pause: machine.pauseHistory,
       resume: machine.resumeHistory,
     },

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -429,6 +429,29 @@ export interface History {
   redo: () => void;
 
   /**
+   * Returns whether there are any operations to undo.
+   *
+   * @example
+   * room.updatePresence({ selectedId: "xx" }, { addToHistory: true });
+   * // room.history.canUndo() is true
+   * room.history.undo();
+   * // room.history.canUndo() is false
+   */
+  canUndo: () => boolean;
+
+  /**
+   * Returns whether there are any operations to redo.
+   *
+   * @example
+   * room.updatePresence({ selectedId: "xx" }, { addToHistory: true });
+   * room.history.undo();
+   * // room.history.canRedo() is true
+   * room.history.redo();
+   * // room.history.canRedo() is false
+   */
+  canRedo: () => boolean;
+
+  /**
    * All future modifications made on the Room will be merged together to create a single history item until resume is called.
    *
    * @example

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -55,6 +55,8 @@ export type ErrorCallback = (error: Error) => void;
 
 export type ConnectionCallback = (state: ConnectionState) => void;
 
+export type HistoryCallback = (event: HistoryEvent) => void;
+
 type RoomEventCallbackMap<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
@@ -65,6 +67,7 @@ type RoomEventCallbackMap<
   event: EventCallback<TRoomEvent>;
   error: ErrorCallback;
   connection: ConnectionCallback;
+  history: HistoryCallback;
 };
 
 export type RoomEventName = Extract<
@@ -92,7 +95,8 @@ export function isRoomEventName(value: string): value is RoomEventName {
     value === "others" ||
     value === "event" ||
     value === "error" ||
-    value === "connection"
+    value === "connection" ||
+    value === "history"
   );
 }
 
@@ -480,6 +484,11 @@ export interface History {
   resume: () => void;
 }
 
+export interface HistoryEvent {
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
 export type Room<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
@@ -497,6 +506,8 @@ export type Room<
      *
      * @param listener the callback that is called every time the current user presence is updated with {@link Room.updatePresence}.
      *
+     * @returns Unsubscribe function.
+     *
      * @example
      * room.subscribe("my-presence", (presence) => {
      *   // Do something
@@ -508,6 +519,8 @@ export type Room<
      * Subscribe to the other users updates.
      *
      * @param listener the callback that is called when a user enters or leaves the room or when a user update its presence.
+     *
+     * @returns Unsubscribe function.
      *
      * @example
      * room.subscribe("others", (others) => {
@@ -524,6 +537,8 @@ export type Room<
      *
      * @param listener the callback that is called when a user calls {@link Room.broadcastEvent}
      *
+     * @returns Unsubscribe function.
+     *
      * @example
      * room.subscribe("event", ({ event, connectionId }) => {
      *   // Do something
@@ -533,11 +548,15 @@ export type Room<
 
     /**
      * Subscribe to errors thrown in the room.
+     *
+     * @returns Unsubscribe function.
      */
     (type: "error", listener: ErrorCallback): () => void;
 
     /**
      * Subscribe to connection state updates.
+     *
+     * @returns Unsubscribe function.
      */
     (type: "connection", listener: ConnectionCallback): () => void;
 
@@ -579,6 +598,18 @@ export type Room<
       callback: StorageCallback,
       options: { isDeep: true }
     ): () => void;
+
+    /**
+     * Subscribe to the current user's history changes.
+     *
+     * @returns Unsubscribe function.
+     *
+     * @example
+     * room.subscribe("history", ({canUndo, canRedo}) => {
+     *   // Do something
+     * });
+     */
+    (type: "history", listener: HistoryCallback): () => void;
   };
 
   /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -605,7 +605,7 @@ export type Room<
      * @returns Unsubscribe function.
      *
      * @example
-     * room.subscribe("history", ({canUndo, canRedo}) => {
+     * room.subscribe("history", ({ canUndo, canRedo }) => {
      *   // Do something
      * });
      */

--- a/packages/liveblocks-client/test/utils.ts
+++ b/packages/liveblocks-client/test/utils.ts
@@ -366,6 +366,8 @@ export async function prepareStorageTest<
     batch: machine.batch,
     undo: machine.undo,
     redo: machine.redo,
+    canUndo: machine.canUndo,
+    canRedo: machine.canRedo,
     applyRemoteOperations: (ops: Op[]) =>
       machine.onMessage(
         serverMessage({

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -74,6 +74,30 @@ export function useBroadcastEvent<TRoomEvent extends Json>(): (
 
 /**
  * @deprecated Please use `createRoomContext()` instead of importing
+ * `useCanRedo` from `@liveblocks/react` directly. See
+ * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
+ */
+export function useCanRedo(): boolean {
+  deprecate(
+    "Please use `createRoomContext()` instead of importing `useCanRedo` from `@liveblocks/react` directly. See https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details."
+  );
+  return _hooks.useCanRedo();
+}
+
+/**
+ * @deprecated Please use `createRoomContext()` instead of importing
+ * `useCanUndo` from `@liveblocks/react` directly. See
+ * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
+ */
+export function useCanUndo(): boolean {
+  deprecate(
+    "Please use `createRoomContext()` instead of importing `useCanUndo` from `@liveblocks/react` directly. See https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details."
+  );
+  return _hooks.useCanUndo();
+}
+
+/**
+ * @deprecated Please use `createRoomContext()` instead of importing
  * `useErrorListener` from `@liveblocks/react` directly. See
  * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
  */

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -791,7 +791,7 @@ Please see https://bit.ly/3Niy5aP for details.`
 
   function useCanUndo(): boolean {
     const room = useRoom();
-    const [canUndo, setCanUndo] = React.useState(false);
+    const [canUndo, setCanUndo] = React.useState(room.history.canUndo);
 
     React.useEffect(() => {
       const unsubscribe = room.subscribe("history", ({ canUndo }) =>
@@ -807,7 +807,7 @@ Please see https://bit.ly/3Niy5aP for details.`
 
   function useCanRedo(): boolean {
     const room = useRoom();
-    const [canRedo, setCanRedo] = React.useState(false);
+    const [canRedo, setCanRedo] = React.useState(room.history.canRedo);
 
     React.useEffect(() => {
       const unsubscribe = room.subscribe("history", ({ canRedo }) =>

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -122,6 +122,16 @@ type RoomContextBundle<
   useRedo(): () => void;
 
   /**
+   * Returns whether there are any operations to undo.
+   */
+  useCanUndo(): boolean;
+
+  /**
+   * Returns whether there are any operations to redo.
+   */
+  useCanRedo(): boolean;
+
+  /**
    * Returns the LiveList associated with the provided key.
    * The hook triggers a re-render if the LiveList is updated, however it does not triggers a re-render if a nested CRDT is updated.
    *
@@ -779,6 +789,38 @@ Please see https://bit.ly/3Niy5aP for details.`
     return useHistory().redo;
   }
 
+  function useCanUndo(): boolean {
+    const room = useRoom();
+    const [canUndo, setCanUndo] = React.useState(false);
+
+    React.useEffect(() => {
+      const unsubscribe = room.subscribe("history", ({ canUndo }) =>
+        setCanUndo(canUndo)
+      );
+      return () => {
+        unsubscribe();
+      };
+    }, [room]);
+
+    return canUndo;
+  }
+
+  function useCanRedo(): boolean {
+    const room = useRoom();
+    const [canRedo, setCanRedo] = React.useState(false);
+
+    React.useEffect(() => {
+      const unsubscribe = room.subscribe("history", ({ canRedo }) =>
+        setCanRedo(canRedo)
+      );
+      return () => {
+        unsubscribe();
+      };
+    }, [room]);
+
+    return canRedo;
+  }
+
   function useBatch(): (callback: () => void) => void {
     return useRoom().batch;
   }
@@ -856,6 +898,8 @@ Please see https://bit.ly/3Niy5aP for details.`
     RoomProvider,
     useBatch,
     useBroadcastEvent,
+    useCanRedo,
+    useCanUndo,
     useErrorListener,
     useEventListener,
     useHistory,


### PR DESCRIPTION
This PR explores exposing whether `undo` and `redo` will do anything. It's mostly an idea, the API is to be considered as part of the discussion and not set in stone _at all_. ~(e.g. without subscribing, it's currently mostly useless since the main use-case is to update a UI state)~

~I briefly tried to think about how it could be made reactive in `@liveblocks/react` as `useCanUndo` and `useCanRedo` but I'm not sure what to subscribe to (it will only ever change after an undo/redo action) to rerender. I thought `useUndo` and `useRedo` could maybe handle callbacks but that would ignore any change made with `useHistory().undo` or to client directly.~

**Update:** I implemented subscribing as an overload to the existing `subscribe()` (as @GuillaumeSalles suggested), using a single `"history"` event type.