### PR TITLE
No need to generate `useCanUndo` wrapper in compat module

### DIFF
--- a/packages/liveblocks-react/scripts/generate-compat.ts
+++ b/packages/liveblocks-react/scripts/generate-compat.ts
@@ -14,6 +14,29 @@ import {
   isTypeNode,
 } from "typescript";
 
+const GENERATE_FOR_HOOKS = [
+  "RoomProvider",
+  "useBatch",
+  "useBroadcastEvent",
+  "useErrorListener",
+  "useEventListener",
+  "useHistory",
+  "useList",
+  "useList_deprecated",
+  "useMap",
+  "useMap_deprecated",
+  "useMyPresence",
+  "useObject",
+  "useObject_deprecated",
+  "useOthers",
+  "useRedo",
+  "useRoom",
+  "useSelf",
+  "useStorage",
+  "useUndo",
+  "useUpdateMyPresence",
+];
+
 const migrationGuideLink =
   "https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17";
 
@@ -107,7 +130,7 @@ function getLiveblocksHookDefintions() {
   for (const name of exportedNames) {
     const found = decls.filter(
       (d): d is FunctionDeclaration & { name: Identifier } =>
-        d.name?.text === name
+        d.name?.text === name && GENERATE_FOR_HOOKS.includes(d.name?.text)
     );
     if (found.length === 0) {
       continue;

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -74,30 +74,6 @@ export function useBroadcastEvent<TRoomEvent extends Json>(): (
 
 /**
  * @deprecated Please use `createRoomContext()` instead of importing
- * `useCanRedo` from `@liveblocks/react` directly. See
- * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
- */
-export function useCanRedo(): boolean {
-  deprecate(
-    "Please use `createRoomContext()` instead of importing `useCanRedo` from `@liveblocks/react` directly. See https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details."
-  );
-  return _hooks.useCanRedo();
-}
-
-/**
- * @deprecated Please use `createRoomContext()` instead of importing
- * `useCanUndo` from `@liveblocks/react` directly. See
- * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
- */
-export function useCanUndo(): boolean {
-  deprecate(
-    "Please use `createRoomContext()` instead of importing `useCanUndo` from `@liveblocks/react` directly. See https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details."
-  );
-  return _hooks.useCanUndo();
-}
-
-/**
- * @deprecated Please use `createRoomContext()` instead of importing
  * `useErrorListener` from `@liveblocks/react` directly. See
  * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
  */


### PR DESCRIPTION
Small cleanup after #430. This generated layer is only needed for _old_ APIs. New hooks (like `useCanUndo`, etc) shouldn't have an entry in there. I'm enforcing that in this PR by hardcoding the list of APIs to generate for now.

With 0.18, this whole module (and the code generation script) will get removed anyway, since it's no longer needed.
