### PR TITLE
Test suite improvement for `@liveblocks/react`

### DIFF
--- a/packages/liveblocks-react/jest.config.js
+++ b/packages/liveblocks-react/jest.config.js
@@ -1,5 +1,6 @@
 // jest.config.js
 module.exports = {
   modulePathIgnorePatterns: ["<rootDir>/lib/"],
+  testPathIgnorePatterns: ["__tests__/_.*"],
   setupFiles: ["./jest.setup.js"],
 };

--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -1,0 +1,19 @@
+import type { LiveObject } from "@liveblocks/client";
+import { createClient } from "@liveblocks/client";
+
+import { createRoomContext } from "../factory";
+
+type Presence = {
+  x: number;
+};
+
+type Storage = {
+  obj: LiveObject<{
+    a: number;
+  }>;
+};
+
+const client = createClient({ authEndpoint: "/api/auth" });
+
+export const { RoomProvider, useMyPresence, useObject, useOthers } =
+  createRoomContext<Presence, Storage>(client);

--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -15,5 +15,5 @@ type Storage = {
 
 const client = createClient({ authEndpoint: "/api/auth" });
 
-export const { RoomProvider, useMyPresence, useObject, useOthers } =
+export const { RoomProvider, useMyPresence, useObject, useOthers, useRoom } =
   createRoomContext<Presence, Storage>(client);

--- a/packages/liveblocks-react/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react/src/__tests__/_utils.tsx
@@ -1,6 +1,6 @@
 import { LiveObject } from "@liveblocks/client";
-import type { RenderOptions } from "@testing-library/react";
-import { render } from "@testing-library/react";
+import type { RenderHookResult, RenderOptions } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
 import type { ReactElement } from "react";
 import * as React from "react";
 
@@ -30,5 +30,19 @@ function customRender(ui: ReactElement, options?: RenderOptions) {
   return render(ui, { wrapper: AllTheProviders, ...options });
 }
 
+/**
+ * Wrapper for rendering hooks that are wrapped in a pre set up
+ * <RoomProvider> context.
+ */
+function customRenderHook<Result, Props>(
+  render: (initialProps: Props) => Result,
+  options?: {
+    initialProps?: Props;
+    wrapper?: React.JSXElementConstructor<{ children: React.ReactElement }>;
+  }
+): RenderHookResult<Result, Props> {
+  return renderHook(render, { wrapper: AllTheProviders, ...options });
+}
+
 export * from "@testing-library/react";
-export { customRender as render };
+export { customRender as render, customRenderHook as renderHook };

--- a/packages/liveblocks-react/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react/src/__tests__/_utils.tsx
@@ -1,0 +1,34 @@
+import { LiveObject } from "@liveblocks/client";
+import type { RenderOptions } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import * as React from "react";
+
+import { RoomProvider } from "./_liveblocks.config";
+
+/**
+ * Testing context for all tests. Sets up a default RoomProvider to wrap all
+ * tests with.
+ */
+export function AllTheProviders(props: { children: React.ReactNode }) {
+  return (
+    <RoomProvider
+      id="room"
+      initialPresence={() => ({ x: 1 })}
+      initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
+    >
+      {props.children}
+    </RoomProvider>
+  );
+}
+
+/**
+ * Wrapper for rendering components that are wrapped in a pre set up
+ * <RoomProvider> context.
+ */
+function customRender(ui: ReactElement, options?: RenderOptions) {
+  return render(ui, { wrapper: AllTheProviders, ...options });
+}
+
+export * from "@testing-library/react";
+export { customRender as render };

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -5,7 +5,6 @@ import {
 } from "@liveblocks/client/internal";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import * as React from "react";
 
 import {
   useMyPresence,
@@ -13,17 +12,7 @@ import {
   useOthers,
   useRoom,
 } from "./_liveblocks.config";
-import { act, fireEvent, render, renderHook, screen, waitFor } from "./_utils"; // Basically re-exports from @testing-library/react
-
-type TestID = "me-x" | "increment" | "othersJson" | "liveObject" | "unmount";
-
-function testId(testId: TestID) {
-  return testId;
-}
-
-function element(testId: TestID) {
-  return screen.getByTestId(testId);
-}
+import { act, renderHook, waitFor } from "./_utils"; // Basically re-exports from @testing-library/react
 
 /**
  * https://github.com/Luka967/websocket-close-codes

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -1,21 +1,14 @@
-import { createClient, LiveObject } from "@liveblocks/client";
 import {
   ClientMsgCode,
   CrdtType,
   ServerMsgCode,
 } from "@liveblocks/client/internal";
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import * as React from "react";
 
-import { createRoomContext } from "./factory";
+import { useMyPresence, useObject, useOthers } from "./_liveblocks.config";
+import { act, fireEvent, render, screen, waitFor } from "./_utils"; // Basically re-exports from @testing-library/react
 
 type TestID = "me-x" | "increment" | "othersJson" | "liveObject" | "unmount";
 
@@ -33,23 +26,6 @@ function element(testId: TestID) {
 enum WebSocketErrorCodes {
   CLOSE_ABNORMAL = 1006,
 }
-
-type Presence = {
-  x: number;
-};
-
-type Storage = {
-  obj: LiveObject<{
-    a: number;
-  }>;
-};
-
-const client = createClient({ authEndpoint: "/api/auth" });
-
-const { RoomProvider, useObject, useOthers, useMyPresence } = createRoomContext<
-  Presence,
-  Storage
->(client);
 
 function remove<T>(array: T[], item: T) {
   for (let i = 0; i < array.length; i++) {
@@ -177,11 +153,7 @@ async function waitForSocketToBeConnected() {
 
 describe("presence", () => {
   test("initial presence should be set on state immediately", async () => {
-    render(
-      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-        <PresenceComponent />
-      </RoomProvider>
-    );
+    render(<PresenceComponent />);
 
     expect(element("me-x").textContent).toBe("1");
 
@@ -215,11 +187,7 @@ describe("presence", () => {
   // });
 
   test("initial presence should be sent to other users when socket is connected", async () => {
-    render(
-      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-        <PresenceComponent />
-      </RoomProvider>
-    );
+    render(<PresenceComponent />);
 
     const socket = await waitForSocketToBeConnected();
 
@@ -236,11 +204,7 @@ describe("presence", () => {
   });
 
   test("set presence should replace current presence", async () => {
-    render(
-      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-        <PresenceComponent />
-      </RoomProvider>
-    );
+    render(<PresenceComponent />);
 
     await waitForSocketToBeConnected();
 
@@ -254,11 +218,7 @@ describe("presence", () => {
   });
 
   test("others presence should be set on update", async () => {
-    render(
-      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-        <PresenceComponent />
-      </RoomProvider>
-    );
+    render(<PresenceComponent />);
 
     const socket = await waitForSocketToBeConnected();
 
@@ -287,11 +247,7 @@ describe("presence", () => {
   });
 
   test("others presence should be merged on update", async () => {
-    render(
-      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-        <PresenceComponent />
-      </RoomProvider>
-    );
+    render(<PresenceComponent />);
 
     const socket = await waitForSocketToBeConnected();
 
@@ -377,11 +333,7 @@ describe("presence", () => {
   // });
 
   test("others presence should be cleared on close", async () => {
-    render(
-      <RoomProvider id="room" initialPresence={() => ({ x: 1 })}>
-        <PresenceComponent />
-      </RoomProvider>
-    );
+    render(<PresenceComponent />);
 
     const socket = await waitForSocketToBeConnected();
 
@@ -449,14 +401,7 @@ function UnmountContainer({ children }: { children: React.ReactElement }) {
 
 describe("Storage", () => {
   test("useObject initialization", async () => {
-    render(
-      <RoomProvider
-        id="room"
-        initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
-      >
-        <ObjectComponent />
-      </RoomProvider>
-    );
+    render(<ObjectComponent />);
 
     expect(element("liveObject").textContent).toEqual("Loading");
 
@@ -482,14 +427,9 @@ describe("Storage", () => {
 
   test("unmounting useObject while storage is loading should not cause a memory leak", async () => {
     render(
-      <RoomProvider
-        id="room"
-        initialStorage={() => ({ obj: new LiveObject({ a: 0 }) })}
-      >
-        <UnmountContainer>
-          <ObjectComponent />
-        </UnmountContainer>
-      </RoomProvider>
+      <UnmountContainer>
+        <ObjectComponent />
+      </UnmountContainer>
     );
 
     expect(element("liveObject").textContent).toEqual("Loading");

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -161,13 +161,7 @@ async function websocketSimulator() {
   };
 }
 
-describe("presence", () => {
-  test("initial presence should be set on state immediately", () => {
-    const { result } = renderHook(() => useMyPresence());
-    const [me] = result.current;
-    expect(me.x).toBe(1);
-  });
-
+describe("useRoom", () => {
   test("initial presence should be sent to other users when socket is connected", async () => {
     renderHook(() => useRoom()); // Ignore return value here, this hook triggers the initialization side effect
 
@@ -180,6 +174,14 @@ describe("presence", () => {
         },
       ])
     );
+  });
+});
+
+describe("useMyPresence", () => {
+  test("initial presence should be readable immediately", () => {
+    const { result } = renderHook(() => useMyPresence());
+    const [me] = result.current;
+    expect(me.x).toBe(1);
   });
 
   test("set presence should replace current presence", () => {
@@ -194,7 +196,9 @@ describe("presence", () => {
     me = result.current[0];
     expect(me).toEqual({ x: 2 });
   });
+});
 
+describe("useOthers", () => {
   test("others presence should be set on update", async () => {
     const { result } = renderHook(() => useOthers());
 
@@ -264,8 +268,8 @@ describe("presence", () => {
   });
 });
 
-describe("Storage", () => {
-  test("useObject initialization", async () => {
+describe("useObject", () => {
+  test("initialization happens asynchronously", async () => {
     const { result, rerender } = renderHook(() => useObject("obj"));
 
     // On the initial render, this hook will return `null`

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -17,7 +17,7 @@ import {
 import { act, renderHook, waitFor } from "./_utils"; // Basically re-exports from @testing-library/react
 
 /**
- * https://github.com/Luka967/websocket-close-codes
+ * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
  */
 enum WebSocketErrorCodes {
   CLOSE_ABNORMAL = 1006,

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -143,32 +143,6 @@ describe("presence", () => {
     expect(me.x).toBe(1);
   });
 
-  // test("updating room should disconnect and reconnect and replace initial presence", async () => {
-  //   const client = createClient({ authEndpoint: "/api/auth" });
-
-  //   const { rerender } = render(
-  //     <LiveblocksProvider client={client}>
-  //       <PresenceComponent room="room" initialPresence={{ x: 1 }} />
-  //     </LiveblocksProvider>
-  //   );
-
-  //   expect(element("me-x").textContent).toBe("1");
-
-  //   await waitForSocketToBeConnected();
-
-  //   MockWebSocket.instances = [];
-
-  //   rerender(
-  //     <LiveblocksProvider client={client}>
-  //       <PresenceComponent room="room-b" initialPresence={{ x: 2 }} />
-  //     </LiveblocksProvider>
-  //   );
-
-  //   expect(element("me-x").textContent).toBe("1");
-
-  //   await waitForSocketToBeConnected();
-  // });
-
   test("initial presence should be sent to other users when socket is connected", async () => {
     renderHook(() => useRoom()); // Ignore return value here, this hook triggers the initialization side effect
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -184,8 +184,9 @@ describe("presence", () => {
 
   test("set presence should replace current presence", () => {
     const { result } = renderHook(() => useMyPresence());
-    let [me, setPresence] = result.current;
+    const [, setPresence] = result.current;
 
+    let me = result.current[0];
     expect(me).toEqual({ x: 1 });
 
     act(() => setPresence({ x: me.x + 1 }));

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -270,16 +270,12 @@ describe("useOthers", () => {
 
 describe("useObject", () => {
   test("initialization happens asynchronously", async () => {
-    const { result, rerender } = renderHook(() => useObject("obj"));
+    const { result } = renderHook(() => useObject("obj"));
 
     // On the initial render, this hook will return `null`
     expect(result.current).toBeNull();
 
     const sim = await websocketSimulator();
-
-    rerender();
-    expect(result.current).toBeNull();
-
     act(() =>
       sim.simulateIncomingMessage({
         type: ServerMsgCode.INITIAL_STORAGE_STATE,


### PR DESCRIPTION
This PR reorganizes the test suite for `@liveblocks/react` a bit, so that writing new tests is a lot easier. (I wanted to add a few tests for the upcoming `useSelector()` hook, but found this to be very difficult in the current setup.)

Improvements include:

1. All test code is now moved into `src/__tests__` (relates to #233)
2. The `src/__tests__/_utils.tsx` file wraps the `@testing-library/react` package, to have all tests automatically be wrapped in a `RoomProvider` context (following their own [docs/recommendations](https://testing-library.com/docs/react-testing-library/setup#custom-render))
3. The tests are rewritten to no longer have all these manual testing components that were necessary to test hooks. For example, previously we had to define [an `ObjectComponent`](https://github.com/liveblocks/liveblocks/blob/0d8943d33bb54c90426d4739a7e7a02615272518/packages/liveblocks-react/src/index.test.tsx#L423-L430), which [needed to be wrapped in a `RoomProvider`](https://github.com/liveblocks/liveblocks/blob/0d8943d33bb54c90426d4739a7e7a02615272518/packages/liveblocks-react/src/index.test.tsx#L453-L458), only to be able [to call `useObject()`](https://github.com/liveblocks/liveblocks/blob/0d8943d33bb54c90426d4739a7e7a02615272518/packages/liveblocks-react/src/index.test.tsx#L424), and then we needed [extra constructs to generate test IDs for divs](https://github.com/liveblocks/liveblocks/blob/0d8943d33bb54c90426d4739a7e7a02615272518/packages/liveblocks-react/src/index.test.tsx#L20-L28) for [event handlers](https://github.com/liveblocks/liveblocks/blob/0d8943d33bb54c90426d4739a7e7a02615272518/packages/liveblocks-react/src/index.test.tsx#L250) and [text serialization](https://github.com/liveblocks/liveblocks/blob/0d8943d33bb54c90426d4739a7e7a02615272518/packages/liveblocks-react/src/index.test.tsx#L253), only so that we could `expect()` on the output. I've rewritten all of that using [`renderHook()`](https://github.com/liveblocks/liveblocks/blob/c0eb2c1555594e49606f5599e2a1ce361279313d/packages/liveblocks-react/src/__tests__/index.test.tsx#L199), and [directly `expect()`'ing its results](https://github.com/liveblocks/liveblocks/blob/c0eb2c1555594e49606f5599e2a1ce361279313d/packages/liveblocks-react/src/__tests__/index.test.tsx#L210-L212). Much less noise!
4. Lastly, I've cleaned out the manual mutations done to the mocked websocket to simulate server events, and instead I've abstracted those into a small "Websocket simulator" API, which makes the tests a bit more readable/succinct.

There were no fundamental changes made to the test suite yet. The same stuff is still being tested.
