### PR TITLE
Detect accidental duplication in production bundles

### DIFF
--- a/packages/liveblocks-client/rollup.config.js
+++ b/packages/liveblocks-client/rollup.config.js
@@ -85,6 +85,7 @@ function buildESM(srcFiles, external = []) {
     external,
     plugins: [
       replaceText({
+        __PACKAGE_FORMAT__: "ESM",
         __PACKAGE_VERSION__: packageJson.version,
         preventAssignment: true,
       }),
@@ -109,6 +110,7 @@ function buildCJS(srcFiles, external = []) {
     plugins: [
       resolve({ extensions }),
       replaceText({
+        __PACKAGE_FORMAT__: "CJS",
         __PACKAGE_VERSION__: packageJson.version,
         preventAssignment: true,
       }),

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -1,3 +1,21 @@
+if (process.env.NODE_ENV !== "production") {
+  const pkg = "@liveblocks/client";
+  const format =
+    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+      ? "ESM"
+      : "__PACKAGE_FORMAT__";
+  const g = globalThis as typeof globalThis & { [key: string]: string };
+  if (g && g[pkg] !== format) {
+    if (g[pkg] === undefined) {
+      g[pkg] = format;
+    } else {
+      console.warn(
+        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+      );
+    }
+  }
+}
+
 export { createClient } from "./client";
 export { LiveList } from "./LiveList";
 export { LiveMap } from "./LiveMap";

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -1,18 +1,17 @@
-if (process.env.NODE_ENV !== "production") {
-  const pkg = "@liveblocks/client";
-  const format =
-    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
-      ? "ESM"
-      : "__PACKAGE_FORMAT__";
-  const g = globalThis as typeof globalThis & { [key: string]: string };
-  if (g && g[pkg] !== format) {
-    if (g[pkg] === undefined) {
-      g[pkg] = format;
-    } else {
-      console.warn(
-        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
-      );
-    }
+const pkg = "@liveblocks/client";
+const format =
+  "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+    ? "ESM"
+    : "__PACKAGE_FORMAT__";
+const g = globalThis as typeof globalThis & { [key: string]: string };
+if (g && g[pkg] !== format) {
+  if (g[pkg] === undefined) {
+    g[pkg] = format;
+  } else {
+    console.warn(
+      // XXX Link to documentation with more details/debugging instructions
+      `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+    );
   }
 }
 

--- a/packages/liveblocks-node/rollup.config.js
+++ b/packages/liveblocks-node/rollup.config.js
@@ -9,6 +9,7 @@ import { terser as terserPlugin } from "rollup-plugin-terser";
 import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
 const babelConfig = require("./babel.config");
+const packageJson = require("./package.json");
 
 function makeExternalFn() {
   // NOTE: Make sure this list always matches the names of all dependencies and
@@ -82,7 +83,16 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments(), prettier()],
+    plugins: [
+      replaceText({
+        __PACKAGE_FORMAT__: "ESM",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
+      typescriptCompile(),
+      stripComments(),
+      prettier(),
+    ],
   };
 }
 
@@ -99,6 +109,11 @@ function buildCJS(srcFiles, external = []) {
     external,
     plugins: [
       resolve({ extensions }),
+      replaceText({
+        __PACKAGE_FORMAT__: "CJS",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
       prettier(),

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -1,5 +1,23 @@
 import fetch from "node-fetch";
 
+if (process.env.NODE_ENV !== "production") {
+  const pkg = "@liveblocks/node";
+  const format =
+    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+      ? "ESM"
+      : "__PACKAGE_FORMAT__";
+  const g = globalThis as typeof globalThis & { [key: string]: string };
+  if (g && g[pkg] !== format) {
+    if (g[pkg] === undefined) {
+      g[pkg] = format;
+    } else {
+      console.warn(
+        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+      );
+    }
+  }
+}
+
 type AuthorizeOptions = {
   /**
    * The secret api provided at https://liveblocks.io/dashboard/apikeys

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -1,20 +1,19 @@
 import fetch from "node-fetch";
 
-if (process.env.NODE_ENV !== "production") {
-  const pkg = "@liveblocks/node";
-  const format =
-    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
-      ? "ESM"
-      : "__PACKAGE_FORMAT__";
-  const g = globalThis as typeof globalThis & { [key: string]: string };
-  if (g && g[pkg] !== format) {
-    if (g[pkg] === undefined) {
-      g[pkg] = format;
-    } else {
-      console.warn(
-        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
-      );
-    }
+const pkg = "@liveblocks/node";
+const format =
+  "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+    ? "ESM"
+    : "__PACKAGE_FORMAT__";
+const g = globalThis as typeof globalThis & { [key: string]: string };
+if (g && g[pkg] !== format) {
+  if (g[pkg] === undefined) {
+    g[pkg] = format;
+  } else {
+    // XXX Link to documentation with more details/debugging instructions
+    console.warn(
+      `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+    );
   }
 }
 

--- a/packages/liveblocks-react/rollup.config.js
+++ b/packages/liveblocks-react/rollup.config.js
@@ -8,6 +8,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
 import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
+const packageJson = require("./package.json");
 const createBabelConfig = require("./babel.config");
 
 function makeExternalFn() {
@@ -81,7 +82,16 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments(), prettier()],
+    plugins: [
+      replaceText({
+        __PACKAGE_FORMAT__: "ESM",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
+      typescriptCompile(),
+      stripComments(),
+      prettier(),
+    ],
   };
 }
 
@@ -98,6 +108,11 @@ function buildCJS(srcFiles, external = []) {
     external,
     plugins: [
       resolve({ extensions }),
+      replaceText({
+        __PACKAGE_FORMAT__: "CJS",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
       prettier(),

--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -1,18 +1,17 @@
-if (process.env.NODE_ENV !== "production") {
-  const pkg = "@liveblocks/react";
-  const format =
-    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
-      ? "ESM"
-      : "__PACKAGE_FORMAT__";
-  const g = globalThis as typeof globalThis & { [key: string]: string };
-  if (g && g[pkg] !== format) {
-    if (g[pkg] === undefined) {
-      g[pkg] = format;
-    } else {
-      console.warn(
-        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
-      );
-    }
+const pkg = "@liveblocks/react";
+const format =
+  "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+    ? "ESM"
+    : "__PACKAGE_FORMAT__";
+const g = globalThis as typeof globalThis & { [key: string]: string };
+if (g && g[pkg] !== format) {
+  if (g[pkg] === undefined) {
+    g[pkg] = format;
+  } else {
+    // XXX Link to documentation with more details/debugging instructions
+    console.warn(
+      `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+    );
   }
 }
 

--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -1,3 +1,21 @@
+if (process.env.NODE_ENV !== "production") {
+  const pkg = "@liveblocks/react";
+  const format =
+    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+      ? "ESM"
+      : "__PACKAGE_FORMAT__";
+  const g = globalThis as typeof globalThis & { [key: string]: string };
+  if (g && g[pkg] !== format) {
+    if (g[pkg] === undefined) {
+      g[pkg] = format;
+    } else {
+      console.warn(
+        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+      );
+    }
+  }
+}
+
 export { LiveblocksProvider, useClient } from "./client";
 
 export { createRoomContext } from "./factory";

--- a/packages/liveblocks-redux/rollup.config.js
+++ b/packages/liveblocks-redux/rollup.config.js
@@ -8,6 +8,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
 import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
+const packageJson = require("./package.json");
 const createBabelConfig = require("./babel.config");
 
 function makeExternalFn() {
@@ -82,7 +83,16 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments(), prettier()],
+    plugins: [
+      replaceText({
+        __PACKAGE_FORMAT__: "ESM",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
+      typescriptCompile(),
+      stripComments(),
+      prettier(),
+    ],
   };
 }
 
@@ -99,6 +109,11 @@ function buildCJS(srcFiles, external = []) {
     external,
     plugins: [
       resolve({ extensions }),
+      replaceText({
+        __PACKAGE_FORMAT__: "CJS",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
       prettier(),

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -1,18 +1,17 @@
-if (process.env.NODE_ENV !== "production") {
-  const pkg = "@liveblocks/redux";
-  const format =
-    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
-      ? "ESM"
-      : "__PACKAGE_FORMAT__";
-  const g = globalThis as typeof globalThis & { [key: string]: string };
-  if (g && g[pkg] !== format) {
-    if (g[pkg] === undefined) {
-      g[pkg] = format;
-    } else {
-      console.warn(
-        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
-      );
-    }
+const pkg = "@liveblocks/redux";
+const format =
+  "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+    ? "ESM"
+    : "__PACKAGE_FORMAT__";
+const g = globalThis as typeof globalThis & { [key: string]: string };
+if (g && g[pkg] !== format) {
+  if (g[pkg] === undefined) {
+    g[pkg] = format;
+  } else {
+    // XXX Link to documentation with more details/debugging instructions
+    console.warn(
+      `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+    );
   }
 }
 

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -1,3 +1,21 @@
+if (process.env.NODE_ENV !== "production") {
+  const pkg = "@liveblocks/redux";
+  const format =
+    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+      ? "ESM"
+      : "__PACKAGE_FORMAT__";
+  const g = globalThis as typeof globalThis & { [key: string]: string };
+  if (g && g[pkg] !== format) {
+    if (g[pkg] === undefined) {
+      g[pkg] = format;
+    } else {
+      console.warn(
+        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+      );
+    }
+  }
+}
+
 import type {
   BaseUserMeta,
   Client,

--- a/packages/liveblocks-zustand/rollup.config.js
+++ b/packages/liveblocks-zustand/rollup.config.js
@@ -8,6 +8,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import { terser as terserPlugin } from "rollup-plugin-terser";
 import typescriptPlugin from "@rollup/plugin-typescript";
 import { promises } from "fs";
+const packageJson = require("./package.json");
 const createBabelConfig = require("./babel.config");
 
 function makeExternalFn() {
@@ -82,7 +83,16 @@ function buildESM(srcFiles, external = []) {
       chunkFileNames: "shared.mjs",
     },
     external,
-    plugins: [typescriptCompile(), stripComments(), prettier()],
+    plugins: [
+      replaceText({
+        __PACKAGE_FORMAT__: "ESM",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
+      typescriptCompile(),
+      stripComments(),
+      prettier(),
+    ],
   };
 }
 
@@ -99,6 +109,11 @@ function buildCJS(srcFiles, external = []) {
     external,
     plugins: [
       resolve({ extensions }),
+      replaceText({
+        __PACKAGE_FORMAT__: "CJS",
+        __PACKAGE_VERSION__: packageJson.version,
+        preventAssignment: true,
+      }),
       babelPlugin(getBabelOptions(extensions, { ie: 11 })),
       stripComments(),
       prettier(),

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -24,21 +24,20 @@ import {
   missingMapping,
 } from "./errors";
 
-if (process.env.NODE_ENV !== "production") {
-  const pkg = "@liveblocks/zustand";
-  const format =
-    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
-      ? "ESM"
-      : "__PACKAGE_FORMAT__";
-  const g = globalThis as typeof globalThis & { [key: string]: string };
-  if (g && g[pkg] !== format) {
-    if (g[pkg] === undefined) {
-      g[pkg] = format;
-    } else {
-      console.warn(
-        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
-      );
-    }
+const pkg = "@liveblocks/zustand";
+const format =
+  "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+    ? "ESM"
+    : "__PACKAGE_FORMAT__";
+const g = globalThis as typeof globalThis & { [key: string]: string };
+if (g && g[pkg] !== format) {
+  if (g[pkg] === undefined) {
+    g[pkg] = format;
+  } else {
+    // XXX Link to documentation with more details/debugging instructions
+    console.warn(
+      `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+    );
   }
 }
 

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -24,6 +24,24 @@ import {
   missingMapping,
 } from "./errors";
 
+if (process.env.NODE_ENV !== "production") {
+  const pkg = "@liveblocks/zustand";
+  const format =
+    "__PACKAGE_FORMAT__" === "__PACKAGE" + /* don't join */ "_FORMAT__"
+      ? "ESM"
+      : "__PACKAGE_FORMAT__";
+  const g = globalThis as typeof globalThis & { [key: string]: string };
+  if (g && g[pkg] !== format) {
+    if (g[pkg] === undefined) {
+      g[pkg] = format;
+    } else {
+      console.warn(
+        `${pkg} appears twice in your bundle (as ${g[pkg]} and ${format}). This can lead to hard-to-debug problems. Please see XXX for details.`
+      );
+    }
+  }
+}
+
 function isJson(value: unknown): value is Json {
   return (
     value === null ||


### PR DESCRIPTION
This adds a code snippet to detect cases where complex bundle setups or certain monorepo setups lead to duplicated inclusion of both the CJS and ESM versions of our library in the final production bundle. The problem with that is that object instances generated with one "runtime copy" of the library end up being sent to APIs from the other "runtime copy", which leads to various bugs.

This is a proposed fix for #432.

Not sure if I actually like this solution. Would love to get everyone's opinion on this? Good idea? Terrible idea? A different approach?
