### PR TITLE
use v2 api endpoints

### DIFF
--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -269,5 +269,7 @@ function buildLiveblocksPublicAuthorizeEndpoint(
     return options.publicAuthorizeEndpoint.replace("{roomId}", roomId);
   }
 
-  return `https://api.liveblocks.io/v2/rooms/${roomId}/public/authorize`;
+  return `https://api.liveblocks.io/v2/rooms/${encodeURIComponent(
+    roomId
+  )}/public/authorize`;
 }

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -11,12 +11,17 @@ type AuthorizeOptions = {
   room: string;
   /**
    * The id of the user that try to connect. It should be used to get information about the connected users in the room (name, avatar, etc).
+   * It can also be used to generate a token that gives access to a private room where the userId is configured in the room accessesl
    */
   userId?: string;
   /**
    * The info associated to the user. Can be used to store the name or the profile picture to implement avatar for example. Can't exceed 1KB when serialized as JSON
    */
   userInfo?: unknown; // must be Json
+  /**
+   * The ids of the groups to which the user belongs. It should be used to generate a token that gives access to a private room and at least one of the group is configured in the room accesses.
+   */
+  groupIds?: string[];
 };
 
 type AllAuthorizeOptions = AuthorizeOptions & {
@@ -42,7 +47,8 @@ type AuthorizeResponse = {
  *   userId: "123", // Optional
  *   userInfo: {    // Optional
  *     name: "Ada Lovelace"
- *   }
+ *   },
+ *   groupIds: ["group1"] // Optional
  * });
  * return res.status(response.status).end(response.body);
  * }
@@ -51,7 +57,7 @@ export async function authorize(
   options: AuthorizeOptions
 ): Promise<AuthorizeResponse> {
   try {
-    const { room, secret, userId, userInfo } = options;
+    const { room, secret, userId, userInfo, groupIds } = options;
 
     if (!(typeof room === "string" && room.length > 0)) {
       throw new Error(
@@ -60,18 +66,17 @@ export async function authorize(
     }
 
     const result = await fetch(
-      (options as AllAuthorizeOptions).liveblocksAuthorizeEndpoint ||
-        "https://liveblocks.io/api/authorize",
+      buildLiveblocksAuthorizeEndpoint(options as AllAuthorizeOptions, room),
       {
         method: "POST",
         headers: {
-          Authorization: `Bearer: ${secret}`,
+          Authorization: `Bearer ${secret}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          room,
           userId,
           userInfo,
+          groupIds,
         }),
       }
     );
@@ -90,8 +95,20 @@ export async function authorize(
   } catch (er) {
     return {
       status: 403,
-      body: 'Call to "https://liveblocks.io/api/authorize" failed. See "error" for more information.',
+      body: 'Call to "https://api.liveblocks.io/v2/rooms/{roomId}/authorize" failed. See "error" for more information.',
       error: er,
     };
   }
+}
+
+function buildLiveblocksAuthorizeEndpoint(
+  options: AllAuthorizeOptions,
+  room: string
+): string {
+  // INTERNAL override for testing purpose.
+  if (options.liveblocksAuthorizeEndpoint) {
+    return options.liveblocksAuthorizeEndpoint.replace("{roomId}", room);
+  }
+
+  return `https://api.liveblocks.io/v2/rooms/${room}/authorize`;
 }

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -11,7 +11,7 @@ type AuthorizeOptions = {
   room: string;
   /**
    * The id of the user that try to connect. It should be used to get information about the connected users in the room (name, avatar, etc).
-   * It can also be used to generate a token that gives access to a private room where the userId is configured in the room accessesl
+   * It can also be used to generate a token that gives access to a private room where the userId is configured in the room accesses
    */
   userId?: string;
   /**
@@ -95,7 +95,7 @@ export async function authorize(
   } catch (er) {
     return {
       status: 403,
-      body: 'Call to "https://api.liveblocks.io/v2/rooms/{roomId}/authorize" failed. See "error" for more information.',
+      body: 'Call to "https://api.liveblocks.io/v2/rooms/:roomId/authorize" failed. See "error" for more information.',
       error: er,
     };
   }
@@ -103,12 +103,14 @@ export async function authorize(
 
 function buildLiveblocksAuthorizeEndpoint(
   options: AllAuthorizeOptions,
-  room: string
+  roomId: string
 ): string {
   // INTERNAL override for testing purpose.
   if (options.liveblocksAuthorizeEndpoint) {
-    return options.liveblocksAuthorizeEndpoint.replace("{roomId}", room);
+    return options.liveblocksAuthorizeEndpoint.replace("{roomId}", roomId);
   }
 
-  return `https://api.liveblocks.io/v2/rooms/${room}/authorize`;
+  return `https://api.liveblocks.io/v2/rooms/${encodeURIComponent(
+    roomId
+  )}/authorize`;
 }


### PR DESCRIPTION
Use new API v2 server for authorize endpoints and websocket server.

This is not a breaking change.
Both tokens generated by the legacy and new auth endpoints can be used to enter the same room.


To be released in version 0.18

TODO:
- [x] CI e2e tests:  update Github actions env variable `E2E_TEST_LIVEBLOCKS_AUTHORIZE_ENDPOINT` and `E2E_TEST_LIVEBLOCKS_SERVER`.