### PR TITLE
Presence internals refactoring

### DIFF
--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -17,6 +17,7 @@ import type { ToImmutable } from "./types/Immutable";
 import {
   creationOpToLiveNode,
   deserialize,
+  freeze,
   isLiveNode,
   liveNodeToLson,
   lsonToLiveNode,
@@ -447,8 +448,6 @@ export class LiveMap<
     for (const [key, value] of this._map) {
       result.set(key, value.toImmutable() as ToImmutable<TValue>);
     }
-    return process.env.NODE_ENV === "production"
-      ? result
-      : Object.freeze(result);
+    return freeze(result);
   }
 }

--- a/packages/liveblocks-client/src/Presence.ts
+++ b/packages/liveblocks-client/src/Presence.ts
@@ -45,6 +45,13 @@ function merge<T>(target: T, patch: Partial<T>): T {
   return updated ? newValue : target;
 }
 
+function makeUser<TPresence extends JsonObject, TUserMeta extends BaseUserMeta>(
+  conn: Connection<TUserMeta>,
+  presence: TPresence
+): User<TPresence, TUserMeta> {
+  return freeze(compactObject({ ...conn, presence }));
+}
+
 export class Presence<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta
@@ -103,8 +110,7 @@ export class Presence<
     const conn = this._connections[connectionId];
     const presence = this._presences[connectionId];
     if (conn !== undefined && presence !== undefined) {
-      const user: User<TPresence, TUserMeta> = { ...conn, presence };
-      return freeze(user);
+      return makeUser(conn, presence);
     }
 
     return undefined;

--- a/packages/liveblocks-client/src/Presence.ts
+++ b/packages/liveblocks-client/src/Presence.ts
@@ -51,7 +51,12 @@ export class Presence<
   /** @internal */
   _presences: { [connectionId: number]: TPresence };
 
-  // Derived/cached data. Never set these directly.
+  //
+  // --------------------------------------------------------------
+  //
+  // CACHES
+  // All of these are derived/cached data. Never set these directly.
+  //
   /** @internal */
   _users: { [connectionId: number]: User<TPresence, TUserMeta> };
   /** @internal */
@@ -60,6 +65,9 @@ export class Presence<
   _othersProxy: Others<TPresence, TUserMeta> | undefined;
   /** @internal */
   _snapshot: { me: TPresence; others: TPresence[] } | undefined;
+  //
+  // --------------------------------------------------------------
+  //
 
   constructor(initialPresence: TPresence) {
     // Me
@@ -82,6 +90,7 @@ export class Presence<
     return this._me;
   }
 
+  /** @internal */
   _getUser(connectionId: number): User<TPresence, TUserMeta> | undefined {
     const conn = this._connections[connectionId];
     const presence = this._presences[connectionId];

--- a/packages/liveblocks-client/src/Presence.ts
+++ b/packages/liveblocks-client/src/Presence.ts
@@ -37,7 +37,8 @@ function merge<T>(target: T, patch: Partial<T>): T {
   return updated ? newValue : target;
 }
 
-export function makeOthers<
+// XXX Refactor this helper away!
+function makeOthers<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta
 >(userMap: {

--- a/packages/liveblocks-client/src/Presence.ts
+++ b/packages/liveblocks-client/src/Presence.ts
@@ -1,9 +1,12 @@
 import type { BaseUserMeta, JsonObject, Others, User } from "./types";
 import { compact, compactObject, freeze } from "./utils";
 
-export type PresenceSnapshot<TPresence> = {
+export type PresenceSnapshot<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta
+> = {
   readonly me: TPresence;
-  readonly others: TPresence[];
+  readonly others: readonly User<TPresence, TUserMeta>[];
 };
 
 type Connection<TUserMeta extends BaseUserMeta> = {
@@ -69,7 +72,7 @@ export class Presence<
   /** @internal */
   _othersProxy: Others<TPresence, TUserMeta> | undefined;
   /** @internal */
-  _snapshot: { me: TPresence; others: TPresence[] } | undefined;
+  _snapshot: PresenceSnapshot<TPresence, TUserMeta> | undefined;
   //
   // --------------------------------------------------------------
   //
@@ -187,12 +190,12 @@ export class Presence<
     this._snapshot = undefined;
   }
 
-  toImmutable(): PresenceSnapshot<TPresence> {
+  toImmutable(): PresenceSnapshot<TPresence, TUserMeta> {
     return (
       this._snapshot ??
       (this._snapshot = freeze({
         me: this.me,
-        others: this.others.map((other) => other.presence),
+        others: this.others,
       }))
     );
   }

--- a/packages/liveblocks-client/src/Presence.ts
+++ b/packages/liveblocks-client/src/Presence.ts
@@ -79,7 +79,7 @@ export class Presence<
     this._users = {};
   }
 
-  clearOthers() {
+  clearOthers(): void {
     this._connections = {};
     this._presences = {};
     this._users = {};

--- a/packages/liveblocks-client/src/Presence.ts
+++ b/packages/liveblocks-client/src/Presence.ts
@@ -1,0 +1,225 @@
+import type { BaseUserMeta, JsonObject, Others, User } from "./types";
+import { compact, compactObject } from "./utils";
+
+type Connection<TUserMeta extends BaseUserMeta> = {
+  readonly connectionId: number;
+  readonly id: TUserMeta["id"];
+  readonly info: TUserMeta["info"];
+};
+
+/**
+ * Patches a target object by "merging in" the provided fields. Patch
+ * fields that are explicitly-undefined will delete keys from the target
+ * object. Will return a new object.
+ *
+ * Important guarantee:
+ * If the patch effectively did not mutate the target object because the
+ * patch fields have the same value as the original, then the original
+ * object reference will be returned.
+ */
+function merge<T>(target: T, patch: Partial<T>): T {
+  let updated = false;
+  const newValue = { ...target };
+
+  Object.keys(patch).forEach((k) => {
+    const key = k as keyof T;
+    const val = patch[key];
+    if (newValue[key] !== val) {
+      if (val === undefined) {
+        delete newValue[key];
+      } else {
+        newValue[key] = val as T[keyof T];
+      }
+      updated = true;
+    }
+  });
+
+  return updated ? newValue : target;
+}
+
+export function makeOthers<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta
+>(userMap: {
+  [key: number]: User<TPresence, TUserMeta>;
+}): Others<TPresence, TUserMeta> {
+  const users = Object.values(userMap).map((user) => {
+    const { _hasReceivedInitialPresence, ...publicKeys } = user;
+    return publicKeys;
+  });
+
+  return {
+    get count() {
+      return users.length;
+    },
+    [Symbol.iterator]() {
+      return users[Symbol.iterator]();
+    },
+    map(callback) {
+      return users.map(callback);
+    },
+    toArray() {
+      return users;
+    },
+  };
+}
+
+export class Presence<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta
+> {
+  // To track "me"
+  /** @internal */
+  _me: TPresence;
+
+  // To track "others"
+  /** @internal */
+  _connections: { [connectionId: number]: Connection<TUserMeta> };
+  /** @internal */
+  _presences: { [connectionId: number]: TPresence };
+
+  // Derived/cached data. Never set these directly.
+  /** @internal */
+  _others: Others<TPresence, TUserMeta> | undefined;
+  /** @internal */
+  _snapshot: { me: TPresence; others: TPresence[] } | undefined;
+
+  constructor(initialPresence: TPresence) {
+    // Me
+    this._me = compactObject(initialPresence);
+
+    // Others
+    this._connections = {};
+    this._presences = {};
+  }
+
+  clearOthers() {
+    this._connections = {};
+    this._presences = {};
+    this._users = {};
+    this._invalidateOthers();
+  }
+
+  get me(): TPresence {
+    return this._me;
+  }
+
+  getUser(connectionId: number): User<TPresence, TUserMeta> | undefined {
+    const conn = this._connections[connectionId];
+    const presence = this._presences[connectionId];
+    if (conn !== undefined && presence !== undefined) {
+      const user: User<TPresence, TUserMeta> = { ...conn, presence };
+      return user;
+    }
+
+    return undefined;
+  }
+
+  _getUsers(): User<TPresence, TUserMeta>[] {
+    return compact(
+      Object.keys(this._presences).map((connectionId) =>
+        this.getUser(Number(connectionId))
+      )
+    );
+  }
+
+  get others(): Others<TPresence, TUserMeta> {
+    return this._others ?? (this._others = makeOthers(this._getUsers()));
+  }
+
+  /** @internal */
+  _invalidateOthers(): void {
+    this._others = undefined;
+    this._invalidateSnapshot();
+  }
+
+  /** @internal */
+  _invalidateMe(): void {
+    this._invalidateSnapshot();
+  }
+
+  /** @internal */
+  _invalidateSnapshot(): void {
+    this._snapshot = undefined;
+  }
+
+  toImmutable(): { me: TPresence; others: TPresence[] } {
+    return (
+      this._snapshot ??
+      (this._snapshot = {
+        me: this.me,
+        others: compact(this.others.map((other) => other.presence)),
+      })
+    );
+  }
+
+  /**
+   * Patches the current "me" instance.
+   */
+  patchMe(patch: Partial<TPresence>): void {
+    const oldMe = this.me;
+    const newMe = merge(oldMe, patch);
+    if (oldMe !== newMe) {
+      this._me = newMe;
+      this._invalidateMe();
+    }
+  }
+
+  /**
+   * Records a known connection. This records the connection ID and the
+   * associated metadata.
+   */
+  setConnection(
+    connectionId: number,
+    metaUserId: TUserMeta["id"],
+    metaUserInfo: TUserMeta["info"]
+  ): void {
+    this._connections[connectionId] = {
+      connectionId,
+      id: metaUserId,
+      info: metaUserInfo,
+    };
+    if (this._presences[connectionId] !== undefined) {
+      this._invalidateOthers();
+    }
+  }
+
+  /**
+   * Removes a known connectionId. Removes both the connection's metadata and
+   * the presence information.
+   */
+  removeConnection(connectionId: number): void {
+    delete this._connections[connectionId];
+    delete this._presences[connectionId];
+    this._invalidateOthers();
+  }
+
+  /**
+   * Stores a new user from a full presence update. If the user already exists,
+   * its known presence data is overwritten.
+   */
+  setOther(connectionId: number, presence: TPresence): void {
+    this._presences[connectionId] = compactObject(presence);
+    if (this._connections[connectionId] !== undefined) {
+      this._invalidateOthers();
+    }
+  }
+
+  /**
+   * Patches the presence data for an existing "other". If we don't know the
+   * initial presence data for this user yet, discard this patch and await the
+   * full .setOther() call first.
+   */
+  patchOther(connectionId: number, patch: Partial<TPresence>): void {
+    const oldPresence = this._presences[connectionId];
+    if (oldPresence === undefined) {
+      return;
+    }
+
+    const newPresence = merge(oldPresence, patch);
+    if (oldPresence !== newPresence) {
+      this._presences[connectionId] = newPresence;
+      this._invalidateOthers();
+    }
+  }
+}

--- a/packages/liveblocks-client/src/__tests__/Presence.test.ts
+++ b/packages/liveblocks-client/src/__tests__/Presence.test.ts
@@ -146,36 +146,47 @@ describe("Presence", () => {
     });
   });
 
-  it("caches immutable results", () => {
-    const p = new Presence<P, M>({ x: 0, y: 0 });
-    p.setConnection(2, "user-123", undefined);
-    p.setOther(2, { x: 2, y: 2 });
+  describe("caching", () => {
+    it("caches immutable results", () => {
+      const p = new Presence<P, M>({ x: 0, y: 0 });
+      p.setConnection(2, "user-123", undefined);
+      p.setOther(2, { x: 2, y: 2 });
 
-    const imm1 = p.toImmutable();
-    const imm2 = p.toImmutable();
-    expect(imm1).toBe(imm2);
+      const imm1 = p.toImmutable();
+      const imm2 = p.toImmutable();
+      expect(imm1).toBe(imm2);
 
-    // These are effectively no-ops
-    p.patchMe({ x: 0 });
-    p.patchMe({ y: 0, z: undefined });
-    p.patchOther(2, { x: 2 });
-    p.patchOther(2, { y: 2, z: undefined });
+      // These are effectively no-ops
+      p.patchMe({ x: 0 });
+      p.patchMe({ y: 0, z: undefined });
+      p.patchOther(2, { x: 2 });
+      p.patchOther(2, { y: 2, z: undefined });
 
-    const imm3 = p.toImmutable();
-    expect(imm2).toBe(imm3); // No observable change!
+      const imm3 = p.toImmutable();
+      expect(imm2).toBe(imm3); // No observable change!
 
-    p.patchMe({ y: -1 });
+      p.patchMe({ y: -1 });
 
-    const imm4 = p.toImmutable();
-    const imm5 = p.toImmutable();
-    expect(imm3).not.toBe(imm4);
-    expect(imm4).toBe(imm5);
+      const imm4 = p.toImmutable();
+      const imm5 = p.toImmutable();
+      expect(imm3).not.toBe(imm4);
+      expect(imm4).toBe(imm5);
 
-    p.patchOther(2, { y: -2 });
+      p.patchOther(2, { y: -2 });
 
-    const imm6 = p.toImmutable();
-    const imm7 = p.toImmutable();
-    expect(imm5).not.toBe(imm6);
-    expect(imm6).toBe(imm7);
+      const imm6 = p.toImmutable();
+      const imm7 = p.toImmutable();
+      expect(imm5).not.toBe(imm6);
+      expect(imm6).toBe(imm7);
+    });
+
+    it("getUser() returns stable cache results", () => {
+      const p = new Presence<P, M>({ x: 0, y: 0 });
+      p.setConnection(2, "user-123", undefined);
+      p.setOther(2, { x: 2, y: 2 });
+
+      expect(p.me).toBe(p.me);
+      expect(p.getUser(2)).toBe(p.getUser(2));
+    });
   });
 });

--- a/packages/liveblocks-client/src/__tests__/Presence.test.ts
+++ b/packages/liveblocks-client/src/__tests__/Presence.test.ts
@@ -64,7 +64,7 @@ describe("Presence", () => {
       p.setConnection(2, "user-123", undefined);
       expect(p.toImmutable()).toStrictEqual({
         me: { x: 0, y: 0 },
-        others: [{ x: 1, y: 1 }],
+        others: [{ connectionId: 2, id: "user-123", presence: { x: 1, y: 1 } }],
       });
     });
 
@@ -80,8 +80,8 @@ describe("Presence", () => {
       expect(p.toImmutable()).toStrictEqual({
         me: { x: 0, y: 0 },
         others: [
-          { x: -2, y: -2 },
-          { x: 3, y: 3 },
+          { connectionId: 2, id: "user-123", presence: { x: -2, y: -2 } },
+          { connectionId: 3, id: "user-567", presence: { x: 3, y: 3 } },
         ],
       });
     });
@@ -94,8 +94,8 @@ describe("Presence", () => {
 
       expect(p.toImmutable()).toStrictEqual({
         me: { x: 0, y: 0 },
-        others: [{ x: 2, y: 2 }],
-        //                   ^ 🔑 (no explicit undefined here)
+        others: [{ connectionId: 2, id: "user-123", presence: { x: 2, y: 2 } }],
+        //                                                      ^ 🔑 (no explicit undefined here)
       });
     });
 
@@ -114,13 +114,19 @@ describe("Presence", () => {
       const p = new Presence<P, M>({ x: 1, y: 2 });
       p.setConnection(2, "user-123", undefined);
       p.setOther(2, { x: 2, y: 2 });
-      expect(p.toImmutable().others).toStrictEqual([{ x: 2, y: 2 }]);
+      expect(p.toImmutable().others).toStrictEqual([
+        { connectionId: 2, id: "user-123", presence: { x: 2, y: 2 } },
+      ]);
 
       p.patchOther(2, { y: -2, z: -2 });
-      expect(p.toImmutable().others).toStrictEqual([{ x: 2, y: -2, z: -2 }]);
+      expect(p.toImmutable().others).toStrictEqual([
+        { connectionId: 2, id: "user-123", presence: { x: 2, y: -2, z: -2 } },
+      ]);
 
       p.patchOther(2, { z: undefined });
-      expect(p.toImmutable().others).toStrictEqual([{ x: 2, y: -2 }]);
+      expect(p.toImmutable().others).toStrictEqual([
+        { connectionId: 2, id: "user-123", presence: { x: 2, y: -2 } },
+      ]);
     });
 
     it("removing connections", () => {
@@ -131,7 +137,6 @@ describe("Presence", () => {
       expect(p.getUser(2)).toStrictEqual({
         connectionId: 2,
         id: "user-123",
-        info: undefined,
         presence: { x: 2, y: 2 },
       });
       p.removeConnection(2);

--- a/packages/liveblocks-client/src/__tests__/Presence.test.ts
+++ b/packages/liveblocks-client/src/__tests__/Presence.test.ts
@@ -1,0 +1,181 @@
+import { Presence } from "../Presence";
+
+type P = {
+  x: number;
+  y: number;
+  z?: number;
+};
+
+type M = {
+  id: string;
+  info?: {
+    avatar: string;
+  };
+};
+
+describe("Presence", () => {
+  it("empty", () => {
+    const p = new Presence({ x: 0, y: 0, z: undefined });
+    expect(p.toImmutable()).toStrictEqual({
+      me: { x: 0, y: 0 },
+      others: [],
+    });
+  });
+
+  describe('Tracking "me"', () => {
+    it("patching me", () => {
+      const p = new Presence<P, never>({ x: 0, y: 0 });
+      p.patchMe({ y: 1, z: 2 });
+
+      expect(p.toImmutable()).toStrictEqual({
+        me: { x: 0, y: 1, z: 2 },
+        others: [],
+      });
+    });
+
+    it("patching me with undefineds deletes keys", () => {
+      const p = new Presence<P, never>({ x: 1, y: 2 });
+      p.patchMe({ x: undefined });
+      expect(p.me).toStrictEqual({ y: 2 });
+      p.patchMe({ y: undefined });
+      expect(p.me).toStrictEqual({});
+      p.patchMe({ z: undefined });
+      expect(p.me).toStrictEqual({});
+    });
+  });
+
+  describe('Tracking "others"', () => {
+    it("setting alone is not enough other", () => {
+      const p = new Presence<P, M>({
+        x: 0,
+        y: 0,
+      });
+      p.setOther(2, { x: 1, y: 1 });
+
+      expect(p.toImmutable()).toStrictEqual({
+        me: { x: 0, y: 0 },
+        others: [], // NOTE: Even though .setOther() is called, this is still empty!
+      });
+
+      // The "others" will only be populated if both connection and presence
+      // information is known for this user. Normally, this information is
+      // known before the .setOther() call is made, unlike how this test case
+      // is structured.
+      p.setConnection(2, "user-123", undefined);
+      expect(p.toImmutable()).toStrictEqual({
+        me: { x: 0, y: 0 },
+        others: [{ x: 1, y: 1 }],
+      });
+    });
+
+    it("setting other", () => {
+      const p = new Presence<P, M>({ x: 0, y: 0 });
+      p.setConnection(2, "user-123", undefined);
+      p.setConnection(3, "user-567", undefined);
+
+      p.setOther(2, { x: 2, y: 2 });
+      p.setOther(3, { x: 3, y: 3 });
+      p.setOther(2, { x: -2, y: -2 });
+
+      expect(p.toImmutable()).toStrictEqual({
+        me: { x: 0, y: 0 },
+        others: [
+          { x: -2, y: -2 },
+          { x: 3, y: 3 },
+        ],
+      });
+    });
+
+    it("setting others removes explicitly-undefined keys", () => {
+      const p = new Presence<P, M>({ x: 0, y: 0 });
+      p.setConnection(2, "user-123", undefined);
+      p.setOther(2, { x: 2, y: 2, z: undefined });
+      //                             ^^^^^^^^^ 🔑
+
+      expect(p.toImmutable()).toStrictEqual({
+        me: { x: 0, y: 0 },
+        others: [{ x: 2, y: 2 }],
+        //                   ^ 🔑 (no explicit undefined here)
+      });
+    });
+
+    it("patching others ignores patches for unknown users", () => {
+      const p = new Presence<P, M>({ x: 0, y: 0 });
+      p.setConnection(2, "user-123", undefined);
+      p.patchOther(2, { y: 1, z: 2 }); // .setOther() not called yet for actor 2
+
+      expect(p.toImmutable()).toStrictEqual({
+        me: { x: 0, y: 0 },
+        others: [],
+      });
+    });
+
+    it("patching others", () => {
+      const p = new Presence<P, M>({ x: 1, y: 2 });
+      p.setConnection(2, "user-123", undefined);
+      p.setOther(2, { x: 2, y: 2 });
+      expect(p.toImmutable().others).toStrictEqual([{ x: 2, y: 2 }]);
+
+      p.patchOther(2, { y: -2, z: -2 });
+      expect(p.toImmutable().others).toStrictEqual([{ x: 2, y: -2, z: -2 }]);
+
+      p.patchOther(2, { z: undefined });
+      expect(p.toImmutable().others).toStrictEqual([{ x: 2, y: -2 }]);
+    });
+
+    it("removing connections", () => {
+      const p = new Presence<P, M>({ x: 1, y: 2 });
+      p.setConnection(2, "user-123", undefined);
+      p.setOther(2, { x: 2, y: 2 });
+
+      expect(p.getUser(2)).toStrictEqual({
+        connectionId: 2,
+        id: "user-123",
+        info: undefined,
+        presence: { x: 2, y: 2 },
+      });
+      p.removeConnection(2);
+
+      expect(p.getUser(2)).toBeUndefined();
+      expect(p.toImmutable().others).toStrictEqual([]);
+
+      // Setting other without .setConnection() will have no effect
+      p.setOther(2, { x: 2, y: 2 });
+      expect(p.getUser(2)).toBeUndefined();
+      expect(p.toImmutable().others).toStrictEqual([]);
+    });
+  });
+
+  it("caches immutable results", () => {
+    const p = new Presence<P, M>({ x: 0, y: 0 });
+    p.setConnection(2, "user-123", undefined);
+    p.setOther(2, { x: 2, y: 2 });
+
+    const imm1 = p.toImmutable();
+    const imm2 = p.toImmutable();
+    expect(imm1).toBe(imm2);
+
+    // These are effectively no-ops
+    p.patchMe({ x: 0 });
+    p.patchMe({ y: 0, z: undefined });
+    p.patchOther(2, { x: 2 });
+    p.patchOther(2, { y: 2, z: undefined });
+
+    const imm3 = p.toImmutable();
+    expect(imm2).toBe(imm3); // No observable change!
+
+    p.patchMe({ y: -1 });
+
+    const imm4 = p.toImmutable();
+    const imm5 = p.toImmutable();
+    expect(imm3).not.toBe(imm4);
+    expect(imm4).toBe(imm5);
+
+    p.patchOther(2, { y: -2 });
+
+    const imm6 = p.toImmutable();
+    const imm7 = p.toImmutable();
+    expect(imm5).not.toBe(imm6);
+    expect(imm6).toBe(imm7);
+  });
+});

--- a/packages/liveblocks-client/src/__tests__/_utils.ts
+++ b/packages/liveblocks-client/src/__tests__/_utils.ts
@@ -304,6 +304,28 @@ export async function prepareStorageTest<
     }
   });
 
+  // Mock Server messages for Presence
+
+  // Machine is the first user connected to the room, it then receives a server message
+  // saying that the refMachine user joined the room.
+  machine.onMessage(
+    serverMessage({
+      type: ServerMsgCode.USER_JOINED,
+      actor: -1,
+      id: undefined,
+      info: undefined,
+    })
+  );
+
+  // RefMachine is the second user connected to the room, it receives a server message
+  // ROOM_STATE with the list of users in the room.
+  refMachine.onMessage(
+    serverMessage({
+      type: ServerMsgCode.ROOM_STATE,
+      users: { [currentActor]: {} },
+    })
+  );
+
   const states: ToImmutable<TStorage>[] = [];
 
   function assertState(data: ToImmutable<TStorage>) {
@@ -344,6 +366,17 @@ export async function prepareStorageTest<
     machine.connect();
     machine.authenticationSuccess(makeRoomToken(actor), ws as any);
     ws.open();
+
+    // Mock server messages for Presence.
+    // Other user in the room (refMachine) recieves a "USER_JOINED" message.
+    refMachine.onMessage(
+      serverMessage({
+        type: ServerMsgCode.USER_JOINED,
+        actor,
+        id: undefined,
+        info: undefined,
+      })
+    );
 
     if (newItems) {
       machine.onMessage(

--- a/packages/liveblocks-client/src/__tests__/_utils.ts
+++ b/packages/liveblocks-client/src/__tests__/_utils.ts
@@ -297,6 +297,7 @@ export async function prepareStorageTest<
             type: ServerMsgCode.UPDATE_PRESENCE,
             data: message.data,
             actor: currentActor,
+            targetActor: message.targetActor,
           })
         );
       }

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -338,7 +338,7 @@ describe("room", () => {
     );
 
     const users = [];
-    for (const user of machine.selectors.getOthers()) {
+    for (const user of machine.getOthers()) {
       users.push(user);
     }
 
@@ -371,7 +371,7 @@ describe("room", () => {
       })
     );
 
-    expect(machine.selectors.getOthers().toArray()).toEqual([
+    expect(machine.getOthers().toArray()).toEqual([
       { connectionId: 1, presence: { x: 2 } },
     ]);
 
@@ -382,7 +382,7 @@ describe("room", () => {
       })
     );
 
-    expect(machine.selectors.getOthers().toArray()).toEqual([]);
+    expect(machine.getOthers().toArray()).toEqual([]);
   });
 
   describe("broadcast", () => {
@@ -501,12 +501,12 @@ describe("room", () => {
     room.undo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 0 });
-    expect(room.selectors.getPresence()).toEqual({ x: 0 });
+    expect(room.getPresence()).toEqual({ x: 0 });
 
     room.redo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 1 });
-    expect(room.selectors.getPresence()).toEqual({ x: 1 });
+    expect(room.getPresence()).toEqual({ x: 1 });
   });
 
   test("if presence is not added to history during a batch, it should not impact the undo/stack", async () => {
@@ -537,7 +537,7 @@ describe("room", () => {
 
     room.undo();
 
-    expect(room.selectors.getPresence()).toEqual({ x: 1 });
+    expect(room.getPresence()).toEqual({ x: 1 });
     expect(storage.root.toObject()).toEqual({ x: 0 });
 
     room.redo();
@@ -561,7 +561,7 @@ describe("room", () => {
     room.undo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 0 });
-    expect(room.selectors.getPresence()).toEqual({ x: 0 });
+    expect(room.getPresence()).toEqual({ x: 0 });
   });
 
   test("undo redo with presence that do not impact presence", async () => {
@@ -577,7 +577,7 @@ describe("room", () => {
 
     room.undo();
 
-    expect(room.selectors.getPresence()).toEqual({ x: 1 });
+    expect(room.getPresence()).toEqual({ x: 1 });
   });
 
   test("pause / resume history", async () => {
@@ -598,7 +598,7 @@ describe("room", () => {
       expect(state.buffer.presence?.data).toEqual({ x: i });
     }
 
-    expect(room.selectors.getPresence()).toEqual({ x: 10 });
+    expect(room.getPresence()).toEqual({ x: 10 });
     expect(state.buffer.presence?.data).toEqual({ x: 10 });
 
     room.resumeHistory();
@@ -606,12 +606,12 @@ describe("room", () => {
     room.undo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 0 });
-    expect(room.selectors.getPresence()).toEqual({ x: 0 });
+    expect(room.getPresence()).toEqual({ x: 0 });
 
     room.redo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 10 });
-    expect(room.selectors.getPresence()).toEqual({ x: 10 });
+    expect(room.getPresence()).toEqual({ x: 10 });
   });
 
   test("undo while history is paused", async () => {
@@ -634,7 +634,7 @@ describe("room", () => {
 
     room.undo();
 
-    expect(room.selectors.getPresence()).toEqual({ x: 0 });
+    expect(room.getPresence()).toEqual({ x: 0 });
 
     expect(state.buffer.presence?.data).toEqual({ x: 0 });
   });
@@ -670,14 +670,14 @@ describe("room", () => {
     room.undo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 0 });
-    expect(room.selectors.getPresence()).toEqual({ x: 0 });
+    expect(room.getPresence()).toEqual({ x: 0 });
     expect(storage.root.toObject()).toEqual({ x: 0 });
 
     room.redo();
 
     expect(state.buffer.presence?.data).toEqual({ x: 1 });
     expect(storage.root.toObject()).toEqual({ x: 1 });
-    expect(room.selectors.getPresence()).toEqual({ x: 1 });
+    expect(room.getPresence()).toEqual({ x: 1 });
   });
 
   test("batch without changes should not erase redo stack", async () => {
@@ -1179,7 +1179,7 @@ describe("room", () => {
 
       reconnect(2);
 
-      const refMachineOthers = refMachine.selectors.getOthers().toArray();
+      const refMachineOthers = refMachine.getOthers().toArray();
 
       expect(refMachineOthers).toEqual([
         { connectionId: 1, id: undefined, info: undefined, presence: { x: 1 } }, // old user is not cleaned directly

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -321,9 +321,19 @@ describe("room", () => {
 
     machine.onMessage(
       serverMessage({
+        type: ServerMsgCode.ROOM_STATE,
+        users: {
+          "1": {},
+        },
+      })
+    );
+
+    machine.onMessage(
+      serverMessage({
         type: ServerMsgCode.UPDATE_PRESENCE,
         data: { x: 2 },
         actor: 1,
+        targetActor: 0, // Setting targetActor means this is a full presence update
       })
     );
 
@@ -345,9 +355,19 @@ describe("room", () => {
 
     machine.onMessage(
       serverMessage({
+        type: ServerMsgCode.ROOM_STATE,
+        users: {
+          "1": {},
+        },
+      })
+    );
+
+    machine.onMessage(
+      serverMessage({
         type: ServerMsgCode.UPDATE_PRESENCE,
         data: { x: 2 },
         actor: 1,
+        targetActor: 0, // Setting targetActor means this is a full presence update
       })
     );
 
@@ -942,9 +962,17 @@ describe("room", () => {
 
       machine.onMessage(
         serverMessage({
+          type: ServerMsgCode.ROOM_STATE,
+          users: { 1: {} },
+        })
+      );
+
+      machine.onMessage(
+        serverMessage({
           type: ServerMsgCode.UPDATE_PRESENCE,
           data: { x: 2 },
           actor: 1,
+          targetActor: 0, // Setting targetActor means this is a full presence update
         })
       );
 
@@ -1256,7 +1284,7 @@ describe("room", () => {
       );
 
       expect(others?.toArray()).toEqual([
-        { connectionId: 1, id: undefined, info: undefined },
+        // User not yet publicly visible
       ]);
 
       // Full UpdatePresence sent as an answer to "UserJoined" message

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -294,8 +294,8 @@ describe("room", () => {
 
     machine.updatePresence({ x: 0 });
 
-    expect(state.me).toEqual({ x: 0 });
-    expect(state.buffer.presence?.data).toEqual({ x: 0 });
+    expect(state.presence.me).toStrictEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toStrictEqual({ x: 0 });
   });
 
   test("should merge current presence and set flushData presence when connection is closed", () => {
@@ -303,12 +303,12 @@ describe("room", () => {
 
     machine.updatePresence({ x: 0 });
 
-    expect(state.me).toEqual({ x: 0 });
-    expect(state.buffer.presence?.data).toEqual({ x: 0 });
+    expect(state.presence.me).toStrictEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toStrictEqual({ x: 0 });
 
     machine.updatePresence({ y: 0 });
-    expect(state.me).toEqual({ x: 0, y: 0 });
-    expect(state.buffer.presence?.data).toEqual({ x: 0, y: 0 });
+    expect(state.presence.me).toStrictEqual({ x: 0, y: 0 });
+    expect(state.buffer.presence?.data).toStrictEqual({ x: 0, y: 0 });
   });
 
   test("others should be iterable", () => {

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -137,15 +137,13 @@ type Machine<
     storageHasLoaded: EventSource<void>;
   };
 
-  selectors: {
-    // Core
-    getConnectionState(): ConnectionState;
-    getSelf(): User<TPresence, TUserMeta> | null;
+  // Core
+  getConnectionState(): ConnectionState;
+  getSelf(): User<TPresence, TUserMeta> | null;
 
-    // Presence
-    getPresence(): TPresence;
-    getOthers(): Others<TPresence, TUserMeta>;
-  };
+  // Presence
+  getPresence(): TPresence;
+  getOthers(): Others<TPresence, TUserMeta>;
 };
 
 const BACKOFF_RETRY_DELAYS = [250, 500, 1000, 2000, 4000, 8000, 10000];
@@ -1574,15 +1572,13 @@ function makeStateMachine<
       storageHasLoaded,
     },
 
-    selectors: {
-      // Core
-      getConnectionState,
-      getSelf,
+    // Core
+    getConnectionState,
+    getSelf,
 
-      // Presence
-      getPresence,
-      getOthers,
-    },
+    // Presence
+    getPresence,
+    getOthers,
   };
 }
 
@@ -1704,17 +1700,17 @@ export function createRoom<
     /////////////
     // Core    //
     /////////////
-    getConnectionState: machine.selectors.getConnectionState,
-    getSelf: machine.selectors.getSelf,
+    getConnectionState: machine.getConnectionState,
+    getSelf: machine.getSelf,
 
     subscribe: machine.subscribe,
 
     //////////////
     // Presence //
     //////////////
-    getPresence: machine.selectors.getPresence,
+    getPresence: machine.getPresence,
     updatePresence: machine.updatePresence,
-    getOthers: machine.selectors.getOthers,
+    getOthers: machine.getOthers,
     broadcastEvent: machine.broadcastEvent,
 
     getStorage: machine.getStorage,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -512,7 +512,7 @@ function makeStateMachine<
     if (otherEvents.length > 0) {
       for (const event of otherEvents) {
         for (const listener of state.listeners.others) {
-          listener(state.presence.others, event);
+          listener(state.presence.getOthersProxy(), event);
         }
       }
     }
@@ -1334,7 +1334,7 @@ function makeStateMachine<
   }
 
   function getOthers(): Others<TPresence, TUserMeta> {
-    return state.presence.others;
+    return state.presence.getOthersProxy();
   }
 
   function broadcastEvent(

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -6,7 +6,7 @@ import { isTokenExpired, parseRoomAuthToken } from "./AuthToken";
 import type { EventSource } from "./EventSource";
 import { makeEventSource } from "./EventSource";
 import { LiveObject } from "./LiveObject";
-import { makeOthers } from "./Presence";
+import { Presence } from "./Presence";
 import type {
   Authentication,
   AuthorizeResponse,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -6,6 +6,7 @@ import { isTokenExpired, parseRoomAuthToken } from "./AuthToken";
 import type { EventSource } from "./EventSource";
 import { makeEventSource } from "./EventSource";
 import { LiveObject } from "./LiveObject";
+import { makeOthers } from "./Presence";
 import type {
   Authentication,
   AuthorizeResponse,
@@ -157,33 +158,6 @@ const PONG_TIMEOUT = 2000;
 function makeIdFactory(connectionId: number): IdFactory {
   let count = 0;
   return () => `${connectionId}:${count++}`;
-}
-
-function makeOthers<
-  TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
->(userMap: {
-  [key: number]: User<TPresence, TUserMeta>;
-}): Others<TPresence, TUserMeta> {
-  const users = Object.values(userMap).map((user) => {
-    const { _hasReceivedInitialPresence, ...publicKeys } = user;
-    return publicKeys;
-  });
-
-  return {
-    get count() {
-      return users.length;
-    },
-    [Symbol.iterator]() {
-      return users[Symbol.iterator]();
-    },
-    map(callback) {
-      return users.map(callback);
-    },
-    toArray() {
-      return users;
-    },
-  };
 }
 
 function log(..._params: unknown[]) {

--- a/packages/liveblocks-client/src/types/ClientMsg.ts
+++ b/packages/liveblocks-client/src/types/ClientMsg.ts
@@ -29,7 +29,9 @@ export type BroadcastEventClientMsg<TRoomEvent extends Json> = {
 };
 
 export type UpdatePresenceClientMsg<TPresence extends JsonObject> =
+  //
   // Full Presence™ message
+  //
   | {
       type: ClientMsgCode.UPDATE_PRESENCE;
       /**
@@ -48,7 +50,10 @@ export type UpdatePresenceClientMsg<TPresence extends JsonObject> =
       targetActor: number;
       data: TPresence;
     }
+
+  //
   // Partial Presence™ message
+  //
   | {
       type: ClientMsgCode.UPDATE_PRESENCE;
       /**

--- a/packages/liveblocks-client/src/types/ServerMsg.ts
+++ b/packages/liveblocks-client/src/types/ServerMsg.ts
@@ -46,24 +46,46 @@ export type ServerMsg<
  * those cases, the `targetActor` field indicates the newly connected client,
  * so all other existing clients can ignore this broadcasted message.
  */
-export type UpdatePresenceServerMsg<TPresence extends JsonObject> = {
+export type UpdatePresenceServerMsg<TPresence extends JsonObject> =
+  | FullUpdatePresenceServerMsg<TPresence>
+  | PartialUpdatePresenceServerMsg<TPresence>;
+
+export type FullUpdatePresenceServerMsg<TPresence extends JsonObject> = {
   type: ServerMsgCode.UPDATE_PRESENCE;
   /**
    * The User whose Presence has changed.
    */
   actor: number;
   /**
+   * If this message was sent in response to a newly joined user, this field
+   * indicates which client this message is for. Other existing clients may
+   * ignore this message if this message isn't targeted for them, but they
+   * don't have to.
+   */
+  targetActor: number;
+  /**
    * The partial or full Presence of a User. If the `targetActor` field is set,
    * this will be the full Presence, otherwise it only contain the fields that
    * have changed since the last broadcast.
    */
   data: TPresence;
+};
+
+export type PartialUpdatePresenceServerMsg<TPresence extends JsonObject> = {
+  type: ServerMsgCode.UPDATE_PRESENCE;
   /**
-   * If this message was sent in response to a newly joined user, this field
-   * indicates which client this message is for. Other existing clients may
-   * ignore this message if this message isn't targeted for them.
+   * The User whose Presence has changed.
    */
-  targetActor?: number;
+  actor: number;
+  /**
+   * Not set for partial presence updates.
+   */
+  targetActor?: undefined;
+  /**
+   * A partial Presence patch to apply to the User. It will only contain the
+   * fields that have changed since the last broadcast.
+   */
+  data: Partial<TPresence>;
 };
 
 /**

--- a/packages/liveblocks-client/src/types/ServerMsg.ts
+++ b/packages/liveblocks-client/src/types/ServerMsg.ts
@@ -47,46 +47,55 @@ export type ServerMsg<
  * so all other existing clients can ignore this broadcasted message.
  */
 export type UpdatePresenceServerMsg<TPresence extends JsonObject> =
-  | FullUpdatePresenceServerMsg<TPresence>
-  | PartialUpdatePresenceServerMsg<TPresence>;
+  //
+  // Full Presence™ message
+  //
+  | {
+      type: ServerMsgCode.UPDATE_PRESENCE;
+      /**
+       * The User whose Presence has changed.
+       */
+      actor: number;
+      /**
+       * When set, signifies that this is a Full Presence™ update, not a patch.
+       *
+       * The numeric value itself no longer has specific meaning. Historically,
+       * this field was intended so that clients could ignore these broadcasted
+       * full presence messages, but it turned out that getting a full presence
+       * "keyframe" from time to time was useful.
+       *
+       * So nowadays, the presence (pun intended) of this `targetActor` field
+       * is a backward-compatible way of expressing that the `data` contains
+       * all presence fields, and isn't a partial "patch".
+       */
+      targetActor: number;
+      /**
+       * The partial or full Presence of a User. If the `targetActor` field is set,
+       * this will be the full Presence, otherwise it only contain the fields that
+       * have changed since the last broadcast.
+       */
+      data: TPresence;
+    }
 
-export type FullUpdatePresenceServerMsg<TPresence extends JsonObject> = {
-  type: ServerMsgCode.UPDATE_PRESENCE;
-  /**
-   * The User whose Presence has changed.
-   */
-  actor: number;
-  /**
-   * If this message was sent in response to a newly joined user, this field
-   * indicates which client this message is for. Other existing clients may
-   * ignore this message if this message isn't targeted for them, but they
-   * don't have to.
-   */
-  targetActor: number;
-  /**
-   * The partial or full Presence of a User. If the `targetActor` field is set,
-   * this will be the full Presence, otherwise it only contain the fields that
-   * have changed since the last broadcast.
-   */
-  data: TPresence;
-};
-
-export type PartialUpdatePresenceServerMsg<TPresence extends JsonObject> = {
-  type: ServerMsgCode.UPDATE_PRESENCE;
-  /**
-   * The User whose Presence has changed.
-   */
-  actor: number;
-  /**
-   * Not set for partial presence updates.
-   */
-  targetActor?: undefined;
-  /**
-   * A partial Presence patch to apply to the User. It will only contain the
-   * fields that have changed since the last broadcast.
-   */
-  data: Partial<TPresence>;
-};
+  //
+  // Partial Presence™ message
+  //
+  | {
+      type: ServerMsgCode.UPDATE_PRESENCE;
+      /**
+       * The User whose Presence has changed.
+       */
+      actor: number;
+      /**
+       * Not set for partial presence updates.
+       */
+      targetActor?: undefined;
+      /**
+       * A partial Presence patch to apply to the User. It will only contain the
+       * fields that have changed since the last broadcast.
+       */
+      data: Partial<TPresence>;
+    };
 
 /**
  * Sent by the WebSocket server and broadcasted to all clients to announce that

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -259,7 +259,7 @@ export interface Others<
   /**
    * Returns the array of connected users in room.
    */
-  toArray(): User<TPresence, TUserMeta>[];
+  toArray(): readonly User<TPresence, TUserMeta>[];
   /**
    * This function let you map over the connected users in the room.
    */

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -289,9 +289,7 @@ export type User<
   /**
    * The user presence.
    */
-  readonly presence?: TPresence;
-  /** @internal */
-  _hasReceivedInitialPresence?: boolean;
+  readonly presence: TPresence;
 };
 
 type AuthEndpointCallback = (room: string) => Promise<{ token: string }>;

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -33,6 +33,15 @@ export function remove<T>(array: T[], item: T): void {
 }
 
 /**
+ * Freezes the given argument, but only in development builds. In production
+ * builds, this is a no-op for performance reasons.
+ */
+export const freeze: typeof Object.freeze =
+  process.env.NODE_ENV === "production"
+    ? (((x: unknown) => x) as typeof Object.freeze)
+    : Object.freeze;
+
+/**
  * Removes null and undefined values from the array, and reflects this in the
  * output type.
  */

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -40,6 +40,21 @@ export function compact<T>(items: readonly T[]): NonNullable<T>[] {
   return items.filter((item: T): item is NonNullable<T> => item != null);
 }
 
+/**
+ * Returns a new object instance where all explictly-undefined values are
+ * removed.
+ */
+export function compactObject<O>(obj: O): O {
+  const newObj = { ...obj };
+  Object.keys(obj).forEach((k) => {
+    const key = k as keyof O;
+    if (newObj[key] === undefined) {
+      delete newObj[key];
+    }
+  });
+  return newObj;
+}
+
 export function creationOpToLiveNode(op: CreateOp): LiveNode {
   return lsonToLiveNode(creationOpToLson(op));
 }

--- a/packages/liveblocks-redux/src/__tests__/index.test.ts
+++ b/packages/liveblocks-redux/src/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import type {
   RoomStateServerMsg,
   SerializedCrdt,
   ServerMsg,
+  UpdatePresenceServerMsg,
 } from "@liveblocks/client/internal";
 import {
   ClientMsgCode,
@@ -394,6 +395,15 @@ describe("middleware", () => {
         } as RoomStateServerMsg<BaseUserMeta>),
       } as MessageEvent);
 
+      socket.callbacks.message[0]!({
+        data: JSON.stringify({
+          type: ServerMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
+          actor: 1,
+          data: { x: 1 },
+        } as UpdatePresenceServerMsg<JsonObject>),
+      } as MessageEvent);
+
       expect(store.getState().liveblocks.others).toEqual([
         {
           connectionId: 1,
@@ -401,6 +411,7 @@ describe("middleware", () => {
           info: {
             name: "Testy McTester",
           },
+          presence: { x: 1 },
         },
       ]);
     });

--- a/packages/liveblocks-zustand/src/__tests__/index.test.ts
+++ b/packages/liveblocks-zustand/src/__tests__/index.test.ts
@@ -10,6 +10,7 @@ import type {
   RoomStateServerMsg,
   SerializedCrdt,
   ServerMsg,
+  UpdatePresenceServerMsg,
 } from "@liveblocks/client/internal";
 import {
   ClientMsgCode,
@@ -356,6 +357,15 @@ describe("middleware", () => {
         } as RoomStateServerMsg<BaseUserMeta>),
       } as MessageEvent);
 
+      socket.callbacks.message[0]!({
+        data: JSON.stringify({
+          type: ServerMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
+          actor: 1,
+          data: { x: 1 },
+        } as UpdatePresenceServerMsg<JsonObject>),
+      } as MessageEvent);
+
       expect(store.getState().liveblocks.others).toEqual([
         {
           connectionId: 1,
@@ -363,6 +373,7 @@ describe("middleware", () => {
           info: {
             name: "Testy McTester",
           },
+          presence: { x: 1 },
         },
       ]);
     });

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -68,7 +68,7 @@ export type LiveblocksState<
     /**
      * Other users in the room. Empty no room is currently synced
      */
-    readonly others: Array<User<TPresence, TUserMeta>>;
+    readonly others: readonly User<TPresence, TUserMeta>[];
     /**
      * Whether or not the room storage is currently loading
      */


### PR DESCRIPTION
This is a refactoring of the internals used to maintain our Presence state inside the room's machine. It replaces the `state.me`, `state.others`, and `state.users` fields, and encapsulates them all into a single `state.presence` field, which is a single `Presence` class instance. This way, we can "reason locally" about all updates to presence. More importantly, it enables us to start treating all presence internals as immutable/readonly data, just like we do since #404.

## Why this change?
This is an important change, because it's an enabler for implementing a `usePresenceSelector()` hook (which I'll tackle in a follow-up PR). Basically, this refactoring makes all presence data (`me` +`others`) readonly/immutable, just like we did for our Storage in #404. It means that if you have 3 connected users, and only one is updating their cursor, the other two user's presence data will stay referentially equal until they actually change.

Here's a recent ask for exactly such [from the community](https://discord.com/channels/913109211746009108/913157273046646795/1011337537702338581). We also [want this in 0.18](https://www.notion.so/liveblocks/Release-0-18-997d8dbd04d040598486e4f1c0cf5b1c#4d920ef0b12b4a818c25bb7291e274ca). And it may be the elegant/efficient way to reattempt #140.

## Important details
All Presence state management is now abstracted into the `Presence` class. This class is separately unit tested to provide the object reference guarantees that are important.

## Behavioral change
I've introduced one behavioral change here, compared to our current version (0.17.9). "Others" will only become visible in clients once that client knows both their metadata _and_ their initial presence data. This makes dealing with others data less cumbersome for users, since there will never be a case where metadata or presence data is unknown/undefined for a user. Either we know about the others and we know everything, or we don't know about them yet.

Observable difference in the UI:

### Before

![before](https://user-images.githubusercontent.com/83844/186652439-cdc3b821-fb32-45cc-a252-2cca372f9bee.png)

### After

![after](https://user-images.githubusercontent.com/83844/186652445-113b3d19-eeef-4327-880f-fb1a8758fa4e.png)
