### PR TITLE
Fix: send `initialPresence` as a Full Presence™ message

### DIFF
--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -232,7 +232,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 } },
+      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 }, targetActor: -1 },
     ]);
   });
 
@@ -246,7 +246,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 } },
+      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 }, targetActor: -1 },
     ]);
   });
 
@@ -259,7 +259,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: {} },
+      { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
     ]);
   });
 
@@ -280,9 +280,9 @@ describe("room", () => {
       defaultContext.throttleDelay - 30
     );
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 } },
+      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 }, targetActor: -1 },
     ]);
-    expect(state.buffer.presence).toEqual({ x: 1 });
+    expect(state.buffer.presence?.data).toEqual({ x: 1 });
   });
 
   test("should replace current presence and set flushData presence when connection is closed", () => {
@@ -291,7 +291,7 @@ describe("room", () => {
     machine.updatePresence({ x: 0 });
 
     expect(state.me).toEqual({ x: 0 });
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
   });
 
   test("should merge current presence and set flushData presence when connection is closed", () => {
@@ -300,11 +300,11 @@ describe("room", () => {
     machine.updatePresence({ x: 0 });
 
     expect(state.me).toEqual({ x: 0 });
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
 
     machine.updatePresence({ y: 0 });
     expect(state.me).toEqual({ x: 0, y: 0 });
-    expect(state.buffer.presence).toEqual({ x: 0, y: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0, y: 0 });
   });
 
   test("others should be iterable", () => {
@@ -374,7 +374,7 @@ describe("room", () => {
       withDateNow(now, () => ws.open());
 
       expect(effects.send).nthCalledWith(1, [
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {} },
+        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
       ]);
 
       // Event payload can be any JSON value
@@ -411,7 +411,7 @@ describe("room", () => {
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {} },
+        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
       ]);
     });
 
@@ -432,7 +432,7 @@ describe("room", () => {
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {} },
+        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
         { type: ClientMsgCode.BROADCAST_EVENT, event: { type: "EVENT" } },
       ]);
     });
@@ -470,18 +470,18 @@ describe("room", () => {
 
     expect(state.buffer.presence).toEqual(null);
     room.updatePresence({ x: 0 }, { addToHistory: true });
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
     room.updatePresence({ x: 1 }, { addToHistory: true });
-    expect(state.buffer.presence).toEqual({ x: 1 });
+    expect(state.buffer.presence?.data).toEqual({ x: 1 });
 
     room.undo();
 
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
     expect(room.selectors.getPresence()).toEqual({ x: 0 });
 
     room.redo();
 
-    expect(state.buffer.presence).toEqual({ x: 1 });
+    expect(state.buffer.presence?.data).toEqual({ x: 1 });
     expect(room.selectors.getPresence()).toEqual({ x: 1 });
   });
 
@@ -529,14 +529,14 @@ describe("room", () => {
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
     room.updatePresence({ x: 1 }, { addToHistory: true });
-    expect(state.buffer.presence).toEqual({ x: 1 });
+    expect(state.buffer.presence?.data).toEqual({ x: 1 });
 
     room.pauseHistory();
     room.resumeHistory();
 
     room.undo();
 
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
     expect(room.selectors.getPresence()).toEqual({ x: 0 });
   });
 
@@ -565,28 +565,28 @@ describe("room", () => {
     ws.open();
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
 
     room.pauseHistory();
 
     for (let i = 1; i <= 10; i++) {
       room.updatePresence({ x: i }, { addToHistory: true });
-      expect(state.buffer.presence).toEqual({ x: i });
+      expect(state.buffer.presence?.data).toEqual({ x: i });
     }
 
     expect(room.selectors.getPresence()).toEqual({ x: 10 });
-    expect(state.buffer.presence).toEqual({ x: 10 });
+    expect(state.buffer.presence?.data).toEqual({ x: 10 });
 
     room.resumeHistory();
 
     room.undo();
 
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
     expect(room.selectors.getPresence()).toEqual({ x: 0 });
 
     room.redo();
 
-    expect(state.buffer.presence).toEqual({ x: 10 });
+    expect(state.buffer.presence?.data).toEqual({ x: 10 });
     expect(room.selectors.getPresence()).toEqual({ x: 10 });
   });
 
@@ -612,7 +612,7 @@ describe("room", () => {
 
     expect(room.selectors.getPresence()).toEqual({ x: 0 });
 
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
   });
 
   test("undo redo with presence + storage", async () => {
@@ -641,17 +641,17 @@ describe("room", () => {
       storage.root.set("x", 1);
     });
 
-    expect(state.buffer.presence).toEqual({ x: 1 });
+    expect(state.buffer.presence?.data).toEqual({ x: 1 });
 
     room.undo();
 
-    expect(state.buffer.presence).toEqual({ x: 0 });
+    expect(state.buffer.presence?.data).toEqual({ x: 0 });
     expect(room.selectors.getPresence()).toEqual({ x: 0 });
     expect(storage.root.toObject()).toEqual({ x: 0 });
 
     room.redo();
 
-    expect(state.buffer.presence).toEqual({ x: 1 });
+    expect(state.buffer.presence?.data).toEqual({ x: 1 });
     expect(storage.root.toObject()).toEqual({ x: 1 });
     expect(room.selectors.getPresence()).toEqual({ x: 1 });
   });
@@ -1289,7 +1289,7 @@ describe("room", () => {
       });
 
       assertMessagesSent([
-        { data: {}, type: ClientMsgCode.UPDATE_PRESENCE },
+        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
         { type: ClientMsgCode.FETCH_STORAGE },
         {
           type: ClientMsgCode.UPDATE_STORAGE,

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -232,7 +232,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 }, targetActor: -1 },
+      { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },
     ]);
   });
 
@@ -246,7 +246,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 }, targetActor: -1 },
+      { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },
     ]);
   });
 
@@ -259,7 +259,7 @@ describe("room", () => {
     ws.open();
 
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
+      { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
     ]);
   });
 
@@ -280,7 +280,7 @@ describe("room", () => {
       defaultContext.throttleDelay - 30
     );
     expect(effects.send).toHaveBeenCalledWith([
-      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 0 }, targetActor: -1 },
+      { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },
     ]);
     expect(state.buffer.presence?.data).toEqual({ x: 1 });
   });
@@ -374,7 +374,7 @@ describe("room", () => {
       withDateNow(now, () => ws.open());
 
       expect(effects.send).nthCalledWith(1, [
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
+        { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
       ]);
 
       // Event payload can be any JSON value
@@ -411,7 +411,7 @@ describe("room", () => {
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
+        { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
       ]);
     });
 
@@ -432,7 +432,7 @@ describe("room", () => {
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
+        { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
         { type: ClientMsgCode.BROADCAST_EVENT, event: { type: "EVENT" } },
       ]);
     });
@@ -1289,7 +1289,7 @@ describe("room", () => {
       });
 
       assertMessagesSent([
-        { type: ClientMsgCode.UPDATE_PRESENCE, data: {}, targetActor: -1 },
+        { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
         { type: ClientMsgCode.FETCH_STORAGE },
         {
           type: ClientMsgCode.UPDATE_STORAGE,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1312,11 +1312,11 @@ export function makeStateMachine<
         state.buffer.presence.type === "full"
           ? {
               type: ClientMsgCode.UPDATE_PRESENCE,
-              data: state.buffer.presence.data,
-
-              // HACK to express that this message is a Full Presence™ message,
-              // which will get interpreted by other clients as such
+              // Populating the `targetActor` field turns this message into
+              // a Full Presence™ update message (not a patch), which will get
+              // interpreted by other clients as such.
               targetActor: -1,
+              data: state.buffer.presence.data,
             }
           : {
               type: ClientMsgCode.UPDATE_PRESENCE,

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -207,7 +207,11 @@ export type State<
   socket: WebSocket | null;
   lastFlushTime: number;
   buffer: {
-    presence: TPresence | null;
+    // Queued-up Presence updates to be flushed at the earliest convenience
+    presence:
+      | { type: "partial"; data: Partial<TPresence> }
+      | { type: "full"; data: TPresence }
+      | null;
     messages: ClientMsg<TPresence, TRoomEvent>[];
     storageOperations: Op[];
   };
@@ -607,10 +611,12 @@ export function makeStateMachine<
         state.me = { ...state.me, ...op.data };
 
         if (state.buffer.presence == null) {
-          state.buffer.presence = op.data;
+          state.buffer.presence = { type: "partial", data: op.data };
         } else {
+          // Merge the new fields with whatever is already queued up (doesn't
+          // matter whether its a partial or full update)
           for (const key in op.data) {
-            state.buffer.presence[key] = op.data[key];
+            state.buffer.presence.data[key] = op.data[key];
           }
         }
 
@@ -812,7 +818,10 @@ export function makeStateMachine<
     const oldValues = {} as TPresence;
 
     if (state.buffer.presence == null) {
-      state.buffer.presence = {} as TPresence;
+      state.buffer.presence = {
+        type: "partial",
+        data: {},
+      };
     }
 
     for (const key in overrides) {
@@ -821,7 +830,7 @@ export function makeStateMachine<
       if (overrideValue === undefined) {
         continue;
       }
-      state.buffer.presence[key] = overrideValue;
+      state.buffer.presence.data[key] = overrideValue;
       oldValues[key] = state.me[key];
     }
 
@@ -1173,7 +1182,10 @@ export function makeStateMachine<
 
       // Re-broadcast the user presence during a reconnect.
       if (state.lastConnectionId !== undefined) {
-        state.buffer.presence = state.me;
+        state.buffer.presence = {
+          type: "full",
+          data: state.me,
+        };
         tryFlushing();
       }
 
@@ -1296,14 +1308,21 @@ export function makeStateMachine<
   ) {
     const messages: ClientMsg<TPresence, TRoomEvent>[] = [];
     if (state.buffer.presence) {
-      messages.push({
-        type: ClientMsgCode.UPDATE_PRESENCE,
-        data: state.buffer.presence as unknown as TPresence,
-        //                          ^^^^^^^^^^^^^^^^^^^^^^^
-        //                          TODO: In 0.18, state.buffer.presence will
-        //                          become a TPresence and this force-cast will
-        //                          no longer be necessary.
-      });
+      messages.push(
+        state.buffer.presence.type === "full"
+          ? {
+              type: ClientMsgCode.UPDATE_PRESENCE,
+              data: state.buffer.presence.data,
+
+              // HACK to express that this message is a Full Presence™ message,
+              // which will get interpreted by other clients as such
+              targetActor: -1,
+            }
+          : {
+              type: ClientMsgCode.UPDATE_PRESENCE,
+              data: state.buffer.presence.data,
+            }
+      );
     }
     for (const event of state.buffer.messages) {
       messages.push(event);
@@ -1611,7 +1630,12 @@ export function defaultState<
       pongTimeout: 0,
     },
     buffer: {
-      presence: initialPresence == null ? ({} as TPresence) : initialPresence,
+      presence:
+        // Queue up the initial presence message as a Full Presence™ update
+        {
+          type: "full",
+          data: initialPresence == null ? ({} as TPresence) : initialPresence,
+        },
       messages: [],
       storageOperations: [],
     },

--- a/packages/liveblocks-client/src/types/ClientMsg.ts
+++ b/packages/liveblocks-client/src/types/ClientMsg.ts
@@ -32,14 +32,31 @@ export type UpdatePresenceClientMsg<TPresence extends JsonObject> =
   // Full Presence™ message
   | {
       type: ClientMsgCode.UPDATE_PRESENCE;
-      data: TPresence;
+      /**
+       * Set this to any number to signify that this is a Full Presence™
+       * update, not a patch.
+       *
+       * The numeric value itself no longer has specific meaning. Historically,
+       * this field was intended so that clients could ignore these broadcasted
+       * full presence messages, but it turned out that getting a full presence
+       * "keyframe" from time to time was useful.
+       *
+       * So nowadays, the presence (pun intended) of this `targetActor` field
+       * is a backward-compatible way of expressing that the `data` contains
+       * all presence fields, and isn't a partial "patch".
+       */
       targetActor: number;
+      data: TPresence;
     }
   // Partial Presence™ message
   | {
       type: ClientMsgCode.UPDATE_PRESENCE;
-      data: Partial<TPresence>;
+      /**
+       * Absence of the `targetActor` field signifies that this is a Partial
+       * Presence™ "patch".
+       */
       targetActor?: undefined;
+      data: Partial<TPresence>;
     };
 
 export type UpdateStorageClientMsg = {

--- a/packages/liveblocks-client/src/types/ClientMsg.ts
+++ b/packages/liveblocks-client/src/types/ClientMsg.ts
@@ -28,11 +28,19 @@ export type BroadcastEventClientMsg<TRoomEvent extends Json> = {
   event: TRoomEvent;
 };
 
-export type UpdatePresenceClientMsg<TPresence extends JsonObject> = {
-  type: ClientMsgCode.UPDATE_PRESENCE;
-  data: TPresence;
-  targetActor?: number;
-};
+export type UpdatePresenceClientMsg<TPresence extends JsonObject> =
+  // Full Presence™ message
+  | {
+      type: ClientMsgCode.UPDATE_PRESENCE;
+      data: TPresence;
+      targetActor: number;
+    }
+  // Partial Presence™ message
+  | {
+      type: ClientMsgCode.UPDATE_PRESENCE;
+      data: Partial<TPresence>;
+      targetActor?: undefined;
+    };
 
 export type UpdateStorageClientMsg = {
   type: ClientMsgCode.UPDATE_STORAGE;

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -183,6 +183,7 @@ describe("useRoom", () => {
       JSON.stringify([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { x: 1 },
         },
       ])

--- a/packages/liveblocks-redux/src/__tests__/index.test.ts
+++ b/packages/liveblocks-redux/src/__tests__/index.test.ts
@@ -276,6 +276,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {
@@ -305,6 +306,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {
@@ -325,6 +327,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {
@@ -356,6 +359,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {

--- a/packages/liveblocks-zustand/src/__tests__/index.test.ts
+++ b/packages/liveblocks-zustand/src/__tests__/index.test.ts
@@ -259,6 +259,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {
@@ -290,6 +291,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {
@@ -312,6 +314,7 @@ describe("middleware", () => {
       expect(JSON.parse(socket.sentMessages[0]!)).toEqual([
         {
           type: ClientMsgCode.UPDATE_PRESENCE,
+          targetActor: -1,
           data: { cursor: { x: 0, y: 0 } },
         },
         {


### PR DESCRIPTION
Originally, this patch was introduced as part of #443, but this slight change in protocol is now backported to be included in a 0.17.x patch release. The only observable effect is that the initial client message that sends the `initialPresence` to the server now includes a `targetActor` field.

As documented in the comment, the meaning of this field originally was to target a specific actor in broadcasted messages, but this wasn't how this field was used in practice anyway. Instead, such updates were treated as full presence updates (rather than patches).

This fix in a way just reflects that reality.

In 0.18, we're going to need to rely on this behavior more explicitly, to overcome the issue where there is a moment during app's initialization where some "others" may not yet have a known presence for a brief moment. Hence this backport to 0.17.x.
