### PR TITLE
Make tests more stable

### DIFF
--- a/e2e/next-sandbox/test/presence/index.test.ts
+++ b/e2e/next-sandbox/test/presence/index.test.ts
@@ -4,6 +4,7 @@ import {
   preparePage,
   delay,
   getJsonContent,
+  waitForTextContent,
   // getTextContent,
   // preparePages,
   assertContainText,
@@ -167,8 +168,8 @@ test.describe("Broadcast", () => {
       secondPage.waitForSelector("#events"),
     ]);
 
-    // Give other clients some time to properly connect to the room
-    await delay(500);
+    // Wait until the other client is connected
+    await waitForTextContent(firstPage, "#othersCount", "1");
 
     await firstPage.click("#broadcast-emoji");
     await delay(500);


### PR DESCRIPTION
This tweaks a unit test that is failing more often. Instead of waiting an arbitrary delay (500ms), occasionally this test will fail because the clients haven't established a connection within this timeout. I've expressed this test to wait until a certain text content change happens.

There are likely more places we could make similar updates, but I intend to take a deeper look at the e2e test suite and see if we can speed it up a bit and/or stabilize it a bit more soon. (Once 0.18 is out.)