### PR TITLE
Simplify internal event source implementation

### DIFF
--- a/packages/liveblocks-client/src/EventSource.ts
+++ b/packages/liveblocks-client/src/EventSource.ts
@@ -1,4 +1,4 @@
-type Callback<T> = (event: T) => void;
+export type Callback<T> = (event: T) => void;
 type UnsubscribeCallback = () => void;
 
 export type Observable<T> = {
@@ -10,6 +10,9 @@ export type EventSource<T> = {
    * Private/controlled notification of events.
    */
   notify(event: T): void;
+  subscribe(callback: Callback<T>): UnsubscribeCallback;
+  clear(): void;
+
   /**
    * Observable instance, which can be used to subscribe to this event source
    * in a readonly fashion. Safe to publicly expose.
@@ -25,8 +28,8 @@ export type EventEmitter<T> = (event: T) => void;
  *
  * The events are anonymous, so you can use it to define events, like so:
  *
- *   const [event1, emitEvent1] = makeEventSource();
- *   const [event2, emitEvent2] = makeEventSource();
+ *   const event1 = makeEventSource();
+ *   const event2 = makeEventSource();
  *
  *   event1.subscribe(foo);
  *   event1.subscribe(bar);
@@ -36,8 +39,8 @@ export type EventEmitter<T> = (event: T) => void;
  *   const unsub = event2.subscribe(foo);
  *   unsub();
  *
- *   emitEvent1();  // Now foo and bar will get called
- *   emitEvent2();  // Now qux will get called (but foo will not, since it's unsubscribed)
+ *   event1.notify();  // Now foo and bar will get called
+ *   event2.notify();  // Now qux will get called (but foo will not, since it's unsubscribed)
  *
  */
 export function makeEventSource<T>(): EventSource<T> {
@@ -52,9 +55,15 @@ export function makeEventSource<T>(): EventSource<T> {
     _observers.forEach((callback) => callback(event));
   }
 
+  function clear() {
+    _observers.clear();
+  }
+
   return {
     // Private/internal control over event emission
     notify,
+    subscribe,
+    clear,
 
     // Publicly exposable subscription API
     observable: {

--- a/packages/liveblocks-client/src/EventSource.ts
+++ b/packages/liveblocks-client/src/EventSource.ts
@@ -1,5 +1,5 @@
 export type Callback<T> = (event: T) => void;
-type UnsubscribeCallback = () => void;
+export type UnsubscribeCallback = () => void;
 
 export type Observable<T> = {
   subscribe(callback: Callback<T>): UnsubscribeCallback;

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -141,8 +141,7 @@ type Machine<
     connection: Observable<ConnectionState>;
     storage: Observable<StorageUpdate[]>;
     history: Observable<HistoryEvent>;
-    storageHasLoaded: // TODO: Rename to `storageDidLoad`?
-    Observable<void>;
+    storageDidLoad: Observable<void>;
   };
 
   // Core
@@ -291,7 +290,7 @@ function makeStateMachine<
     connection: makeEventSource<ConnectionState>(),
     storage: makeEventSource<StorageUpdate[]>(),
     history: makeEventSource<HistoryEvent>(),
-    storageHasLoaded: makeEventSource<void>(),
+    storageDidLoad: makeEventSource<void>(),
   };
 
   const effects: Effects<TPresence, TRoomEvent> = mockedEffects || {
@@ -1063,7 +1062,7 @@ function makeStateMachine<
           createOrUpdateRootFromMessage(message);
           applyAndSendOfflineOps(offlineOps);
           _getInitialStateResolver?.();
-          eventHub.storageHasLoaded.notify();
+          eventHub.storageDidLoad.notify();
           break;
         }
         case ServerMsgCode.UPDATE_STORAGE: {
@@ -1592,7 +1591,7 @@ function makeStateMachine<
       connection: eventHub.connection.observable,
       storage: eventHub.storage.observable,
       history: eventHub.history.observable,
-      storageHasLoaded: eventHub.storageHasLoaded.observable,
+      storageDidLoad: eventHub.storageDidLoad.observable,
     },
 
     // Core

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -341,33 +341,6 @@ function makeStateMachine<
     },
   };
 
-  function subscribeToLiveStructureDeeply<L extends LiveStructure>(
-    node: L,
-    callback: (updates: StorageUpdate[]) => void
-  ): () => void {
-    return eventHub.storage.subscribe((updates) => {
-      const relatedUpdates = updates.filter((update) =>
-        isSameNodeOrChildOf(update.node, node)
-      );
-      if (relatedUpdates.length > 0) {
-        callback(relatedUpdates);
-      }
-    });
-  }
-
-  function subscribeToLiveStructureShallowly<L extends LiveStructure>(
-    node: L,
-    callback: (node: L) => void
-  ): () => void {
-    return eventHub.storage.subscribe((updates) => {
-      for (const update of updates) {
-        if (update.node._id === node._id) {
-          callback(update.node as L);
-        }
-      }
-    });
-  }
-
   function createOrUpdateRootFromMessage(
     message: InitialDocumentStateServerMsg
   ) {
@@ -689,6 +662,33 @@ function makeStateMachine<
         return parent._attachChild(op, source);
       }
     }
+  }
+
+  function subscribeToLiveStructureDeeply<L extends LiveStructure>(
+    node: L,
+    callback: (updates: StorageUpdate[]) => void
+  ): () => void {
+    return eventHub.storage.subscribe((updates) => {
+      const relatedUpdates = updates.filter((update) =>
+        isSameNodeOrChildOf(update.node, node)
+      );
+      if (relatedUpdates.length > 0) {
+        callback(relatedUpdates);
+      }
+    });
+  }
+
+  function subscribeToLiveStructureShallowly<L extends LiveStructure>(
+    node: L,
+    callback: (node: L) => void
+  ): () => void {
+    return eventHub.storage.subscribe((updates) => {
+      for (const update of updates) {
+        if (update.node._id === node._id) {
+          callback(update.node as L);
+        }
+      }
+    });
   }
 
   // Generic storage callbacks

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -15,6 +15,7 @@ import type {
   ClientMsg,
   Connection,
   ConnectionState,
+  CustomEvent,
   HistoryEvent,
   IdTuple,
   InitialDocumentStateServerMsg,
@@ -127,7 +128,7 @@ type Machine<
   }>;
   getStorageSnapshot(): LiveObject<TStorage> | null;
   events: {
-    customEvent: Observable<{ connectionId: number; event: TRoomEvent }>;
+    customEvent: Observable<CustomEvent<TRoomEvent>>;
     me: Observable<TPresence>;
     others: Observable<{
       others: Others<TPresence, TUserMeta>;
@@ -276,7 +277,7 @@ function makeStateMachine<
   mockedEffects?: Effects<TPresence, TRoomEvent>
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const eventHub = {
-    customEvent: makeEventSource<{ connectionId: number; event: TRoomEvent }>(),
+    customEvent: makeEventSource<CustomEvent<TRoomEvent>>(),
     me: makeEventSource<TPresence>(),
     others: makeEventSource<{
       others: Others<TPresence, TUserMeta>;
@@ -712,7 +713,7 @@ function makeStateMachine<
       switch (first) {
         case "event":
           return eventHub.customEvent.subscribe(
-            callback as Callback<{ connectionId: number; event: TRoomEvent }>
+            callback as Callback<CustomEvent<TRoomEvent>>
           );
 
         case "my-presence":

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -128,9 +128,7 @@ type Machine<
   }>;
   getStorageSnapshot(): LiveObject<TStorage> | null;
   events: {
-    event: // TODO: Rename to `custom`?
-    Observable<{ connectionId: number; event: TRoomEvent }>;
-
+    customEvent: Observable<{ connectionId: number; event: TRoomEvent }>;
     "my-presence": // TODO: Rename to `me`?
     Observable<TPresence>;
     others: Observable<{
@@ -280,7 +278,7 @@ function makeStateMachine<
   mockedEffects?: Effects<TPresence, TRoomEvent>
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const eventHub = {
-    event: makeEventSource<{ connectionId: number; event: TRoomEvent }>(),
+    customEvent: makeEventSource<{ connectionId: number; event: TRoomEvent }>(),
     others: makeEventSource<{
       others: Others<TPresence, TUserMeta>;
       event: OthersEvent<TPresence, TUserMeta>;
@@ -719,7 +717,7 @@ function makeStateMachine<
       const callback = second;
       switch (first) {
         case "event":
-          return eventHub.event.subscribe(
+          return eventHub.customEvent.subscribe(
             callback as Callback<{ connectionId: number; event: TRoomEvent }>
           );
 
@@ -1038,7 +1036,7 @@ function makeStateMachine<
           break;
         }
         case ServerMsgCode.BROADCASTED_EVENT: {
-          eventHub.event.notify({
+          eventHub.customEvent.notify({
             connectionId: message.actor,
             event: message.event,
           });
@@ -1584,7 +1582,7 @@ function makeStateMachine<
     getStorage,
     getStorageSnapshot,
     events: {
-      event: eventHub.event.observable,
+      customEvent: eventHub.customEvent.observable,
       others: eventHub.others.observable,
       "my-presence": eventHub["my-presence"].observable,
       error: eventHub.error.observable,

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -32,16 +32,6 @@ export type Resolve<T> = T extends (...args: unknown[]) => unknown
   ? T
   : { [K in keyof T]: T[K] };
 
-export type MyPresenceCallback<TPresence extends JsonObject> =
-  Callback<TPresence>;
-export type ErrorCallback = Callback<Error>;
-export type ConnectionCallback = Callback<ConnectionState>;
-export type HistoryCallback = Callback<HistoryEvent>;
-export type EventCallback<TRoomEvent extends Json> = Callback<{
-  connectionId: number;
-  event: TRoomEvent;
-}>;
-
 export type OthersEventCallback<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta
@@ -60,12 +50,16 @@ type RoomEventCallbackMap<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 > = {
-  "my-presence": MyPresenceCallback<TPresence>;
+  event: Callback<CustomEvent<TRoomEvent>>;
+  "my-presence": Callback<TPresence>;
+  //
+  // NOTE: OthersEventCallback is the only one not taking a Callback<T> shape,
+  // since this API historically has taken _two_ callback arguments instead of
+  // just one.
   others: OthersEventCallback<TPresence, TUserMeta>;
-  event: EventCallback<TRoomEvent>;
-  error: ErrorCallback;
-  connection: ConnectionCallback;
-  history: HistoryCallback;
+  error: Callback<Error>;
+  connection: Callback<ConnectionState>;
+  history: Callback<HistoryEvent>;
 };
 
 export type RoomEventName = Extract<
@@ -484,7 +478,7 @@ export type Room<
      *
      * @deprecated Please use `room.events.me.subscribe()` instead.
      */
-    (type: "my-presence", listener: MyPresenceCallback<TPresence>): () => void;
+    (type: "my-presence", listener: Callback<TPresence>): () => void;
 
     /**
      * Subscribe to the other users updates.
@@ -526,7 +520,7 @@ export type Room<
      * @deprecated Please use `room.events.custom.subscribe()` instead.
      *
      */
-    (type: "event", listener: EventCallback<TRoomEvent>): () => void;
+    (type: "event", listener: Callback<CustomEvent<TRoomEvent>>): () => void;
 
     /**
      * Subscribe to errors thrown in the room.
@@ -546,7 +540,7 @@ export type Room<
      * @deprecated Please use `room.events.connection.subscribe()` instead.
      *
      */
-    (type: "connection", listener: ConnectionCallback): () => void;
+    (type: "connection", listener: Callback<ConnectionState>): () => void;
 
     /**
      * Subscribes to changes made on a Live structure. Returns an unsubscribe function.
@@ -600,7 +594,7 @@ export type Room<
      * @deprecated Please use `room.events.history.subscribe()` instead.
      *
      */
-    (type: "history", listener: HistoryCallback): () => void;
+    (type: "history", listener: Callback<HistoryEvent>): () => void;
   };
 
   /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { Observable } from "../EventSource";
+import type { Callback, Observable } from "../EventSource";
 import type { LiveList } from "../LiveList";
 import type { LiveMap } from "../LiveMap";
 import type { LiveObject } from "../LiveObject";
@@ -32,11 +32,16 @@ export type Resolve<T> = T extends (...args: unknown[]) => unknown
   ? T
   : { [K in keyof T]: T[K] };
 
-export type MyPresenceCallback<TPresence extends JsonObject> = (
-  me: TPresence
-) => void;
+export type MyPresenceCallback<TPresence extends JsonObject> =
+  Callback<TPresence>;
+export type ErrorCallback = Callback<Error>;
+export type ConnectionCallback = Callback<ConnectionState>;
+export type HistoryCallback = Callback<HistoryEvent>;
+export type EventCallback<TRoomEvent extends Json> = Callback<{
+  connectionId: number;
+  event: TRoomEvent;
+}>;
 
-// TODO: Deprecate?
 export type OthersEventCallback<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta
@@ -44,21 +49,6 @@ export type OthersEventCallback<
   others: Others<TPresence, TUserMeta>,
   event: OthersEvent<TPresence, TUserMeta>
 ) => void;
-
-// TODO: Deprecate?
-export type EventCallback<TRoomEvent extends Json> = ({
-  connectionId,
-  event,
-}: {
-  connectionId: number;
-  event: TRoomEvent;
-}) => void;
-
-export type ErrorCallback = (error: Error) => void;
-
-export type ConnectionCallback = (state: ConnectionState) => void;
-
-export type HistoryCallback = (event: HistoryEvent) => void;
 
 type RoomEventCallbackMap<
   TPresence extends JsonObject,
@@ -699,11 +689,25 @@ export type Room<
   getStorageSnapshot(): LiveObject<TStorage> | null;
 
   events: {
+    event: // TODO: Rename to `custom`?
+    Observable<{ connectionId: number; event: TRoomEvent }>;
+
+    "my-presence": // TODO: Rename to `me`?
+    Observable<TPresence>;
+    others: Observable<{
+      others: Others<TPresence, TUserMeta>;
+      event: OthersEvent<TPresence, TUserMeta>;
+    }>;
+    error: Observable<Error>;
+    connection: Observable<ConnectionState>;
+    storage: Observable<StorageUpdate[]>;
+    history: Observable<HistoryEvent>;
     /**
      * Subscribe to the storage loaded event. Will fire at most once during the
      * lifetime of a Room.
      */
-    storageHasLoaded: Observable<void>;
+    storageHasLoaded: // TODO: Rename to `storageDidLoad`?
+    Observable<void>;
   };
 
   /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -476,6 +476,8 @@ export type Room<
      * room.subscribe("my-presence", (presence) => {
      *   // Do something
      * });
+     *
+     * @deprecated Please use `room.events.me.subscribe()` instead.
      */
     (type: "my-presence", listener: MyPresenceCallback<TPresence>): () => void;
 
@@ -490,6 +492,14 @@ export type Room<
      * room.subscribe("others", (others) => {
      *   // Do something
      * });
+     *
+     * @deprecated Please use `room.events.others.subscribe()` instead. Please
+     * note that this new API will only take a single callback argument:
+     *
+     *     room.subscribe('others', (others, event) => ...);
+     *       vs
+     *     room.events.others.subscribe(({ others, event }) => ...);
+     *
      */
     (
       type: "others",
@@ -507,6 +517,9 @@ export type Room<
      * room.subscribe("event", ({ event, connectionId }) => {
      *   // Do something
      * });
+     *
+     * @deprecated Please use `room.events.custom.subscribe()` instead.
+     *
      */
     (type: "event", listener: EventCallback<TRoomEvent>): () => void;
 
@@ -514,6 +527,9 @@ export type Room<
      * Subscribe to errors thrown in the room.
      *
      * @returns Unsubscribe function.
+     *
+     * @deprecated Please use `room.events.error.subscribe()` instead.
+     *
      */
     (type: "error", listener: ErrorCallback): () => void;
 
@@ -521,6 +537,9 @@ export type Room<
      * Subscribe to connection state updates.
      *
      * @returns Unsubscribe function.
+     *
+     * @deprecated Please use `room.events.connection.subscribe()` instead.
+     *
      */
     (type: "connection", listener: ConnectionCallback): () => void;
 
@@ -572,6 +591,9 @@ export type Room<
      * room.subscribe("history", ({ canUndo, canRedo }) => {
      *   // Do something
      * });
+     *
+     * @deprecated Please use `room.events.history.subscribe()` instead.
+     *
      */
     (type: "history", listener: HistoryCallback): () => void;
   };

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -470,8 +470,6 @@ export type Room<
      * room.subscribe("my-presence", (presence) => {
      *   // Do something
      * });
-     *
-     * @deprecated Please use `room.events.me.subscribe()` instead.
      */
     (type: "my-presence", listener: Callback<TPresence>): () => void;
 
@@ -486,13 +484,6 @@ export type Room<
      * room.subscribe("others", (others) => {
      *   // Do something
      * });
-     *
-     * @deprecated Please use `room.events.others.subscribe()` instead. Please
-     * note that this new API will only take a single callback argument:
-     *
-     *     room.subscribe('others', (others, event) => ...);
-     *       vs
-     *     room.events.others.subscribe(({ others, event }) => ...);
      *
      */
     (
@@ -515,8 +506,6 @@ export type Room<
      *   // Do something
      * });
      *
-     * @deprecated Please use `room.events.custom.subscribe()` instead.
-     *
      */
     (type: "event", listener: Callback<CustomEvent<TRoomEvent>>): () => void;
 
@@ -525,8 +514,6 @@ export type Room<
      *
      * @returns Unsubscribe function.
      *
-     * @deprecated Please use `room.events.error.subscribe()` instead.
-     *
      */
     (type: "error", listener: ErrorCallback): () => void;
 
@@ -534,8 +521,6 @@ export type Room<
      * Subscribe to connection state updates.
      *
      * @returns Unsubscribe function.
-     *
-     * @deprecated Please use `room.events.connection.subscribe()` instead.
      *
      */
     (type: "connection", listener: Callback<ConnectionState>): () => void;
@@ -588,8 +573,6 @@ export type Room<
      * room.subscribe("history", ({ canUndo, canRedo }) => {
      *   // Do something
      * });
-     *
-     * @deprecated Please use `room.events.history.subscribe()` instead.
      *
      */
     (type: "history", listener: Callback<HistoryEvent>): () => void;

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -36,6 +36,7 @@ export type MyPresenceCallback<TPresence extends JsonObject> = (
   me: TPresence
 ) => void;
 
+// TODO: Deprecate?
 export type OthersEventCallback<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta
@@ -44,6 +45,7 @@ export type OthersEventCallback<
   event: OthersEvent<TPresence, TUserMeta>
 ) => void;
 
+// TODO: Deprecate?
 export type EventCallback<TRoomEvent extends Json> = ({
   connectionId,
   event,
@@ -82,6 +84,29 @@ export type RoomEventCallbackFor<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 > = RoomEventCallbackMap<TPresence, TUserMeta, TRoomEvent>[E];
+
+type EventPayloadMapping<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+  TRoomEvent extends Json
+> = {
+  "my-presence": TPresence;
+  others: {
+    others: Others<TPresence, TUserMeta>;
+    event: OthersEvent<TPresence, TUserMeta>;
+  };
+  event: { connectionId: number; event: TRoomEvent };
+  error: Error;
+  connection: ConnectionState;
+  history: HistoryEvent;
+};
+
+export type PayloadFor<
+  E extends RoomEventName,
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+  TRoomEvent extends Json
+> = EventPayloadMapping<TPresence, TUserMeta, TRoomEvent>[E];
 
 export type RoomEventCallback = RoomEventCallbackFor<
   RoomEventName,

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -50,6 +50,11 @@ export type OthersEventCallback<
   event: OthersEvent<TPresence, TUserMeta>
 ) => void;
 
+export type CustomEvent<TRoomEvent extends Json> = {
+  connectionId: number;
+  event: TRoomEvent;
+};
+
 type RoomEventCallbackMap<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -689,9 +689,7 @@ export type Room<
   getStorageSnapshot(): LiveObject<TStorage> | null;
 
   events: {
-    event: // TODO: Rename to `custom`?
-    Observable<{ connectionId: number; event: TRoomEvent }>;
-
+    customEvent: Observable<{ connectionId: number; event: TRoomEvent }>;
     "my-presence": // TODO: Rename to `me`?
     Observable<TPresence>;
     others: Observable<{

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -32,14 +32,6 @@ export type Resolve<T> = T extends (...args: unknown[]) => unknown
   ? T
   : { [K in keyof T]: T[K] };
 
-export type OthersEventCallback<
-  TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
-> = (
-  others: Others<TPresence, TUserMeta>,
-  event: OthersEvent<TPresence, TUserMeta>
-) => void;
-
 export type CustomEvent<TRoomEvent extends Json> = {
   connectionId: number;
   event: TRoomEvent;
@@ -56,7 +48,10 @@ type RoomEventCallbackMap<
   // NOTE: OthersEventCallback is the only one not taking a Callback<T> shape,
   // since this API historically has taken _two_ callback arguments instead of
   // just one.
-  others: OthersEventCallback<TPresence, TUserMeta>;
+  others: (
+    others: Others<TPresence, TUserMeta>,
+    event: OthersEvent<TPresence, TUserMeta>
+  ) => void;
   error: Callback<Error>;
   connection: Callback<ConnectionState>;
   history: Callback<HistoryEvent>;
@@ -502,7 +497,10 @@ export type Room<
      */
     (
       type: "others",
-      listener: OthersEventCallback<TPresence, TUserMeta>
+      listener: (
+        others: Others<TPresence, TUserMeta>,
+        event: OthersEvent<TPresence, TUserMeta>
+      ) => void
     ): () => void;
 
     /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -706,8 +706,7 @@ export type Room<
      * Subscribe to the storage loaded event. Will fire at most once during the
      * lifetime of a Room.
      */
-    storageHasLoaded: // TODO: Rename to `storageDidLoad`?
-    Observable<void>;
+    storageDidLoad: Observable<void>;
   };
 
   /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { EventSource } from "../EventSource";
+import type { Observable } from "../EventSource";
 import type { LiveList } from "../LiveList";
 import type { LiveMap } from "../LiveMap";
 import type { LiveObject } from "../LiveObject";
@@ -678,7 +678,7 @@ export type Room<
      * Subscribe to the storage loaded event. Will fire at most once during the
      * lifetime of a Room.
      */
-    storageHasLoaded: EventSource<void>;
+    storageHasLoaded: Observable<void>;
   };
 
   /**

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -75,29 +75,6 @@ export type RoomEventCallbackFor<
   TRoomEvent extends Json
 > = RoomEventCallbackMap<TPresence, TUserMeta, TRoomEvent>[E];
 
-type EventPayloadMapping<
-  TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
-> = {
-  "my-presence": TPresence;
-  others: {
-    others: Others<TPresence, TUserMeta>;
-    event: OthersEvent<TPresence, TUserMeta>;
-  };
-  event: { connectionId: number; event: TRoomEvent };
-  error: Error;
-  connection: ConnectionState;
-  history: HistoryEvent;
-};
-
-export type PayloadFor<
-  E extends RoomEventName,
-  TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
-> = EventPayloadMapping<TPresence, TUserMeta, TRoomEvent>[E];
-
 export type RoomEventCallback = RoomEventCallbackFor<
   RoomEventName,
   JsonObject,
@@ -690,8 +667,7 @@ export type Room<
 
   events: {
     customEvent: Observable<{ connectionId: number; event: TRoomEvent }>;
-    "my-presence": // TODO: Rename to `me`?
-    Observable<TPresence>;
+    me: Observable<TPresence>;
     others: Observable<{
       others: Others<TPresence, TUserMeta>;
       event: OthersEvent<TPresence, TUserMeta>;

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -437,7 +437,7 @@ export function createRoomContext<
         savedCallback.current(eventData);
       };
 
-      return room.events.event.subscribe(listener);
+      return room.events.customEvent.subscribe(listener);
     }, [room]);
   }
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -348,12 +348,10 @@ export function createRoomContext<
     const presence = room.getPresence();
     const rerender = useRerender();
 
-    React.useEffect(() => {
-      const unsubscribe = room.subscribe("my-presence", rerender);
-      return () => {
-        unsubscribe();
-      };
-    }, [room, rerender]);
+    React.useEffect(
+      () => room.events["my-presence"].subscribe(rerender),
+      [room, rerender]
+    );
 
     const setPresence = React.useCallback(
       (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) =>
@@ -382,12 +380,10 @@ export function createRoomContext<
     const room = useRoom();
     const rerender = useRerender();
 
-    React.useEffect(() => {
-      const unsubscribe = room.subscribe("others", rerender);
-      return () => {
-        unsubscribe();
-      };
-    }, [room, rerender]);
+    React.useEffect(
+      () => room.events.others.subscribe(rerender),
+      [room, rerender]
+    );
 
     return room.getOthers();
   }
@@ -417,14 +413,10 @@ export function createRoomContext<
       savedCallback.current = callback;
     });
 
-    React.useEffect(() => {
-      const listener = (e: Error) => savedCallback.current(e);
-
-      const unsubscribe = room.subscribe("error", listener);
-      return () => {
-        unsubscribe();
-      };
-    }, [room]);
+    React.useEffect(
+      () => room.events.error.subscribe((e: Error) => savedCallback.current(e)),
+      [room]
+    );
   }
 
   function useEventListener(
@@ -445,10 +437,7 @@ export function createRoomContext<
         savedCallback.current(eventData);
       };
 
-      const unsubscribe = room.subscribe("event", listener);
-      return () => {
-        unsubscribe();
-      };
+      return room.events.event.subscribe(listener);
     }, [room]);
   }
 
@@ -457,8 +446,9 @@ export function createRoomContext<
     const rerender = useRerender();
 
     React.useEffect(() => {
-      const unsubscribePresence = room.subscribe("my-presence", rerender);
-      const unsubscribeConnection = room.subscribe("connection", rerender);
+      const unsubscribePresence =
+        room.events["my-presence"].subscribe(rerender);
+      const unsubscribeConnection = room.events.connection.subscribe(rerender);
 
       return () => {
         unsubscribePresence();
@@ -502,14 +492,10 @@ export function createRoomContext<
     const room = useRoom();
     const [canUndo, setCanUndo] = React.useState(room.history.canUndo);
 
-    React.useEffect(() => {
-      const unsubscribe = room.subscribe("history", ({ canUndo }) =>
-        setCanUndo(canUndo)
-      );
-      return () => {
-        unsubscribe();
-      };
-    }, [room]);
+    React.useEffect(
+      () => room.events.history.subscribe(({ canUndo }) => setCanUndo(canUndo)),
+      [room]
+    );
 
     return canUndo;
   }
@@ -518,14 +504,10 @@ export function createRoomContext<
     const room = useRoom();
     const [canRedo, setCanRedo] = React.useState(room.history.canRedo);
 
-    React.useEffect(() => {
-      const unsubscribe = room.subscribe("history", ({ canRedo }) =>
-        setCanRedo(canRedo)
-      );
-      return () => {
-        unsubscribe();
-      };
-    }, [room]);
+    React.useEffect(
+      () => room.events.history.subscribe(({ canRedo }) => setCanRedo(canRedo)),
+      [room]
+    );
 
     return canRedo;
   }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -464,7 +464,7 @@ export function createRoomContext<
 
     const room = useRoom();
 
-    const subscribe = room.events.storageHasLoaded.subscribe;
+    const subscribe = room.events.storageDidLoad.subscribe;
 
     const getSnapshot = React.useCallback(
       (): Snapshot => room.getStorageSnapshot(),

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -348,10 +348,7 @@ export function createRoomContext<
     const presence = room.getPresence();
     const rerender = useRerender();
 
-    React.useEffect(
-      () => room.events["my-presence"].subscribe(rerender),
-      [room, rerender]
-    );
+    React.useEffect(() => room.events.me.subscribe(rerender), [room, rerender]);
 
     const setPresence = React.useCallback(
       (overrides: Partial<TPresence>, options?: { addToHistory: boolean }) =>

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -443,8 +443,7 @@ export function createRoomContext<
     const rerender = useRerender();
 
     React.useEffect(() => {
-      const unsubscribePresence =
-        room.events["my-presence"].subscribe(rerender);
+      const unsubscribePresence = room.events.me.subscribe(rerender);
       const unsubscribeConnection = room.events.connection.subscribe(rerender);
 
       return () => {

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -187,7 +187,7 @@ const internalEnhancer = <T>(options: {
         broadcastInitialPresence(room, reduxState, presenceMapping as any);
 
         unsubscribeCallbacks.push(
-          room.subscribe("connection", () => {
+          room.events.connection.subscribe(() => {
             store.dispatch({
               type: ACTION_TYPES.UPDATE_CONNECTION,
               connection: room!.getConnectionState(),
@@ -196,7 +196,7 @@ const internalEnhancer = <T>(options: {
         );
 
         unsubscribeCallbacks.push(
-          room.subscribe("others", (others) => {
+          room.events.others.subscribe(({ others }) => {
             store.dispatch({
               type: ACTION_TYPES.UPDATE_OTHERS,
               others: others.toArray(),
@@ -205,7 +205,7 @@ const internalEnhancer = <T>(options: {
         );
 
         unsubscribeCallbacks.push(
-          room.subscribe("my-presence", () => {
+          room.events.me.subscribe(() => {
             if (isPatching === false) {
               store.dispatch({
                 type: ACTION_TYPES.PATCH_REDUX_STATE,

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -206,13 +206,13 @@ export function middleware<
       broadcastInitialPresence(room, state, presenceMapping as any);
 
       unsubscribeCallbacks.push(
-        room.subscribe("others", (others) => {
+        room.events.others.subscribe(({ others }) => {
           updateZustandLiveblocksState(set, { others: others.toArray() });
         })
       );
 
       unsubscribeCallbacks.push(
-        room.subscribe("connection", () => {
+        room.events.connection.subscribe(() => {
           updateZustandLiveblocksState(set, {
             connection: room!.getConnectionState(),
           });
@@ -220,7 +220,7 @@ export function middleware<
       );
 
       unsubscribeCallbacks.push(
-        room.subscribe("my-presence", () => {
+        room.events.me.subscribe(() => {
           if (isPatching === false) {
             set(
               patchPresenceState(room!.getPresence(), presenceMapping as any)


### PR DESCRIPTION
Fixes #411.

There currently is quite a bit of support code inside the Room's state machine to manage several event queue callbacks that can be subscribed to using a single exposed `room.subscribe()` API. This setup means many local variables exist in the state machine's scope, and there is lots of manual `.push()`'ing and looping-to-notify manually.

This PR simplifies the implementation by reusing the recently-introduced `EventSource` abstraction. This small helper abstracts out a simple event subscription/notification API. This way, those details don't have to be repeated internally everywhere.

The nice thing about the EventSource API is that it offers a standardized way to create both a "writable" (for private use) and a "readable" (for external use) part to these. So internally, we can emit events using `.notify()`, but externally, you can only `.subscribe()` to the events.

This change exposes the various event sources externally, making it possible to change:

```ts
room.subscribe('my-presence', ...);
room.subscribe('others', ...);
room.subscribe('connection', ...);
// etc
```

to

```ts
room.events.me.subscribe(...);
room.events.others.subscribe(...);
room.events.connection.subscribe(...);
// etc
```

Those events are all fully typed, and the type complexity there is a lot less than the complex type signature of `room.subscribe()`. It would be possible to officially deprecate the `room.subscribe('<string>', ...)` APIs now that we have these. (This PR doesn't officially do that yet.)

All other packages use these new APIs though, and only use the `room.subscribe()` to subscribe to Node instance changes.
