### PR TITLE
Refactor/rename doc internals

### DIFF
--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -22,9 +22,10 @@ export interface ManagedPool {
   roomId: string;
   generateId: () => string;
   generateOpId: () => string;
-  getItem: (id: string) => LiveNode | undefined;
-  addItem: (id: string, liveItem: LiveNode) => void;
-  deleteItem: (id: string) => void;
+
+  getNode: (id: string) => LiveNode | undefined;
+  addNode: (id: string, node: LiveNode) => void;
+  deleteNode: (id: string) => void;
 
   /**
    * Dispatching has three responsibilities:
@@ -227,7 +228,7 @@ export abstract class AbstractCrdt {
       throw new Error("Cannot attach if CRDT is already attached");
     }
 
-    pool.addItem(id, crdtAsLiveNode(this));
+    pool.addNode(id, crdtAsLiveNode(this));
 
     this.__id = id;
     this.__pool = pool;
@@ -239,7 +240,7 @@ export abstract class AbstractCrdt {
   /** @internal */
   _detach(): void {
     if (this.__pool && this.__id) {
-      this.__pool.deleteItem(this.__id);
+      this.__pool.deleteNode(this.__id);
     }
 
     switch (this.parent.type) {

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -204,7 +204,7 @@ export abstract class AbstractCrdt {
     switch (this.parent.type) {
       case "HasParent":
         if (this.parent.node !== newParentNode) {
-          throw new Error("Cannot attach parent if it already exist");
+          throw new Error("Cannot set parent: node already has a parent");
         } else {
           // Ignore
           this._parent = HasParent(newParentNode, newParentKey);
@@ -225,7 +225,7 @@ export abstract class AbstractCrdt {
   /** @internal */
   _attach(id: string, pool: ManagedPool): void {
     if (this.__id || this.__pool) {
-      throw new Error("Cannot attach if CRDT is already attached");
+      throw new Error("Cannot attach node: already attached");
     }
 
     pool.addNode(id, crdtAsLiveNode(this));

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -279,7 +279,7 @@ export abstract class AbstractCrdt {
   ): CreateChildOp[];
 
   /** @internal */
-  abstract _toSerializedCrdt(): SerializedCrdt;
+  abstract _serialize(): SerializedCrdt;
 
   /**
    * @internal

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -272,7 +272,7 @@ export abstract class AbstractCrdt {
   abstract _detachChild(crdt: LiveNode): ApplyResult;
 
   /** @internal */
-  abstract _serialize(
+  abstract _toOps(
     parentId: string,
     parentKey: string,
     pool?: ManagedPool

--- a/packages/liveblocks-client/src/AbstractCrdt.ts
+++ b/packages/liveblocks-client/src/AbstractCrdt.ts
@@ -13,6 +13,11 @@ export type ApplyResult =
   | { reverse: Op[]; modified: StorageUpdate }
   | { modified: false };
 
+/**
+ * The managed pool is a namespace registry (i.e. a context) that "owns" all
+ * the individual live nodes, ensuring each one has a unique ID, and holding on
+ * to live nodes before and after they are inter-connected.
+ */
 export interface ManagedPool {
   roomId: string;
   generateId: () => string;

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -41,7 +41,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   private _items: LiveNode[];
 
   /** @internal */
-  private _implicitlyDeletedItems: Set<LiveNode>;
+  private _implicitlyDeletedItems: WeakSet<LiveNode>;
 
   /** @internal */
   private _unacknowledgedSets: Map<string, string>;
@@ -49,7 +49,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   constructor(items: TItem[] = []) {
     super();
     this._items = [];
-    this._implicitlyDeletedItems = new Set();
+    this._implicitlyDeletedItems = new WeakSet();
     this._unacknowledgedSets = new Map();
 
     let position = undefined;

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -304,8 +304,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       };
     } else {
       // Item associated to the set ack does not exist either deleted localy or via remote undo/redo
-      const orphan = this._pool.getItem(op.id);
-
+      const orphan = this._pool.getNode(op.id);
       if (orphan && this._implicitlyDeletedItems.has(orphan)) {
         // Reattach orphan at the new position
         orphan._setParentLink(this, op.parentKey);
@@ -361,14 +360,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       return null;
     }
 
-    const deletedItem = this._pool.getItem(deletedId);
-
+    const deletedItem = this._pool.getNode(deletedId);
     if (deletedItem == null) {
       return null;
     }
 
     const result = this._detachChild(deletedItem);
-
     if (result.modified === false) {
       return null;
     }
@@ -436,8 +433,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         };
       }
     } else {
-      const orphan = nn(this._pool).getItem(op.id);
-
+      const orphan = nn(this._pool).getNode(op.id);
       if (orphan && this._implicitlyDeletedItems.has(orphan)) {
         // Implicit delete after set
         orphan._setParentLink(this, key);
@@ -471,7 +467,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
-    if (this._pool?.getItem(id) !== undefined) {
+    if (this._pool?.getNode(id) !== undefined) {
       return { modified: false };
     }
 
@@ -509,7 +505,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
-    if (this._pool?.getItem(id) !== undefined) {
+    if (this._pool?.getNode(id) !== undefined) {
       return { modified: false };
     }
 

--- a/packages/liveblocks-client/src/LiveList.ts
+++ b/packages/liveblocks-client/src/LiveList.ts
@@ -828,7 +828,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  _toSerializedCrdt(): SerializedList {
+  _serialize(): SerializedList {
     if (this.parent.type !== "HasParent") {
       throw new Error("Cannot serialize LiveList if parent is missing");
     }

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -226,7 +226,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _toSerializedCrdt(): SerializedMap {
+  _serialize(): SerializedMap {
     if (this.parent.type !== "HasParent") {
       throw new Error("Cannot serialize LiveMap if parent is missing");
     }

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -140,7 +140,7 @@ export class LiveMap<
 
     const child = creationOpToLiveNode(op);
 
-    if (this._pool.getItem(id) !== undefined) {
+    if (this._pool.getNode(id) !== undefined) {
       return { modified: false };
     }
 

--- a/packages/liveblocks-client/src/LiveMap.ts
+++ b/packages/liveblocks-client/src/LiveMap.ts
@@ -58,7 +58,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _serialize(
+  _toOps(
     parentId: string,
     parentKey: string,
     pool?: ManagedPool
@@ -79,7 +79,7 @@ export class LiveMap<
     ops.push(op);
 
     for (const [key, value] of this._map) {
-      ops.push(...value._serialize(this._id, key, pool));
+      ops.push(...value._toOps(this._id, key, pool));
     }
 
     return ops;
@@ -165,7 +165,7 @@ export class LiveMap<
     let reverse: Op[];
     if (previousValue) {
       const thisId = nn(this._id);
-      reverse = previousValue._serialize(thisId, key);
+      reverse = previousValue._toOps(thisId, key);
       previousValue._detach();
     } else {
       reverse = [{ type: OpCode.DELETE_CRDT, id }];
@@ -203,7 +203,7 @@ export class LiveMap<
   _detachChild(child: LiveNode): ApplyResult {
     const id = nn(this._id);
     const parentKey = nn(child._parentKey);
-    const reverse = child._serialize(id, parentKey, this._pool);
+    const reverse = child._toOps(id, parentKey, this._pool);
 
     for (const [key, value] of this._map) {
       if (value === child) {
@@ -282,14 +282,14 @@ export class LiveMap<
         updates: { [key]: { type: "update" } },
       });
 
-      const ops = item._serialize(this._id, key, this._pool);
+      const ops = item._toOps(this._id, key, this._pool);
 
       this.unacknowledgedSet.set(key, nn(ops[0].opId));
 
       this._pool.dispatch(
-        item._serialize(this._id, key, this._pool),
+        item._toOps(this._id, key, this._pool),
         oldValue
-          ? oldValue._serialize(this._id, key)
+          ? oldValue._toOps(this._id, key)
           : [{ type: OpCode.DELETE_CRDT, id }],
         storageUpdates
       );
@@ -343,7 +343,7 @@ export class LiveMap<
             opId: this._pool.generateOpId(),
           },
         ],
-        item._serialize(thisId, key),
+        item._toOps(thisId, key),
         storageUpdates
       );
     }

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -281,7 +281,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   /**
    * @internal
    */
-  _toSerializedCrdt(): SerializedObject | SerializedRootObject {
+  _serialize(): SerializedObject | SerializedRootObject {
     const data: JsonObject = {};
 
     // Add only the static Json data fields into the objects

--- a/packages/liveblocks-client/src/LiveObject.ts
+++ b/packages/liveblocks-client/src/LiveObject.ts
@@ -166,7 +166,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     const { id, opId, parentKey: key } = op;
     const child = creationOpToLson(op);
 
-    if (this._pool.getItem(id) !== undefined) {
+    if (this._pool.getNode(id) !== undefined) {
       if (this._propToLastUpdate.get(key) === opId) {
         // Acknowlegment from local operation
         this._propToLastUpdate.delete(key);

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -42,7 +42,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   }
 
   /** @internal */
-  _serialize(
+  _toOps(
     parentId: string,
     parentKey: string,
     pool?: ManagedPool

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -1,4 +1,4 @@
-import type { ApplyResult, Doc } from "./AbstractCrdt";
+import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
 import { nn } from "./assert";
 import type {
@@ -34,10 +34,10 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   static _deserialize(
     [id, item]: IdTuple<SerializedRegister>,
     _parentToChildren: ParentToChildNodeMap,
-    doc: Doc
+    pool: ManagedPool
   ): LiveRegister<Json> {
     const register = new LiveRegister(item.data);
-    register._attach(id, doc);
+    register._attach(id, pool);
     return register;
   }
 
@@ -45,7 +45,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   _serialize(
     parentId: string,
     parentKey: string,
-    doc?: Doc
+    pool?: ManagedPool
   ): CreateRegisterOp[] {
     if (this._id == null || parentId == null || parentKey == null) {
       throw new Error(
@@ -56,7 +56,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
     return [
       {
         type: OpCode.CREATE_REGISTER,
-        opId: doc?.generateOpId(),
+        opId: pool?.generateOpId(),
         id: this._id,
         parentId,
         parentKey,

--- a/packages/liveblocks-client/src/LiveRegister.ts
+++ b/packages/liveblocks-client/src/LiveRegister.ts
@@ -66,7 +66,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   }
 
   /** @internal */
-  _toSerializedCrdt(): SerializedRegister {
+  _serialize(): SerializedRegister {
     if (this.parent.type !== "HasParent") {
       throw new Error("Cannot serialize LiveRegister if parent is missing");
     }

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -435,7 +435,7 @@ function makeStateMachine<
 
     const currentItems: NodeMap = new Map();
     state.nodes.forEach((node, id) => {
-      currentItems.set(id, node._toSerializedCrdt());
+      currentItems.set(id, node._serialize());
     });
 
     // Get operations that represent the diff between 2 states.

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -447,7 +447,7 @@ function makeStateMachine<
   }
 
   function load(items: IdTuple<SerializedCrdt>[]): LiveObject<LsonObject> {
-    // XXX Abstract these details into a LiveObject._fromItems() helper
+    // TODO Abstract these details into a LiveObject._fromItems() helper?
     const [root, parentToChildren] = buildRootAndParentToChildren(items);
     return LiveObject._deserialize(root, parentToChildren, pool);
   }

--- a/packages/liveblocks-client/src/utils.ts
+++ b/packages/liveblocks-client/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Doc } from "./AbstractCrdt";
+import type { ManagedPool } from "./AbstractCrdt";
 import { assertNever, nn } from "./assert";
 import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
@@ -96,20 +96,20 @@ export function isSameNodeOrChildOf(node: LiveNode, parent: LiveNode): boolean {
 export function deserialize(
   [id, crdt]: IdTuple<SerializedCrdt>,
   parentToChildren: ParentToChildNodeMap,
-  doc: Doc
+  pool: ManagedPool
 ): LiveNode {
   switch (crdt.type) {
     case CrdtType.OBJECT: {
-      return LiveObject._deserialize([id, crdt], parentToChildren, doc);
+      return LiveObject._deserialize([id, crdt], parentToChildren, pool);
     }
     case CrdtType.LIST: {
-      return LiveList._deserialize([id, crdt], parentToChildren, doc);
+      return LiveList._deserialize([id, crdt], parentToChildren, pool);
     }
     case CrdtType.MAP: {
-      return LiveMap._deserialize([id, crdt], parentToChildren, doc);
+      return LiveMap._deserialize([id, crdt], parentToChildren, pool);
     }
     case CrdtType.REGISTER: {
-      return LiveRegister._deserialize([id, crdt], parentToChildren, doc);
+      return LiveRegister._deserialize([id, crdt], parentToChildren, pool);
     }
     default: {
       throw new Error("Unexpected CRDT type");
@@ -120,17 +120,17 @@ export function deserialize(
 export function deserializeToLson(
   [id, crdt]: IdTuple<SerializedCrdt>,
   parentToChildren: ParentToChildNodeMap,
-  doc: Doc
+  pool: ManagedPool
 ): Lson {
   switch (crdt.type) {
     case CrdtType.OBJECT: {
-      return LiveObject._deserialize([id, crdt], parentToChildren, doc);
+      return LiveObject._deserialize([id, crdt], parentToChildren, pool);
     }
     case CrdtType.LIST: {
-      return LiveList._deserialize([id, crdt], parentToChildren, doc);
+      return LiveList._deserialize([id, crdt], parentToChildren, pool);
     }
     case CrdtType.MAP: {
-      return LiveMap._deserialize([id, crdt], parentToChildren, doc);
+      return LiveMap._deserialize([id, crdt], parentToChildren, pool);
     }
     case CrdtType.REGISTER: {
       return crdt.data;


### PR DESCRIPTION
> **Note** There is **no functional change introduced** with this PR, just a pure refactoring. Mostly just internal variable **name changes**.

Fixes #224.

This PR starts the process of simplifying some of the "doc" internals. What a "doc" is exactly has not been very clear historically, and we have been meaning to rename these internals to a name that makes more sense.

(For this PR, I considered renaming it to "context", but found that a bit too vague. Then I considered "room context", which might cause confusion with the `createRoomContext()` factory from the React package, which has nothing to do with this. I also considered "namespace", but that didn't fully capture the responsibility.)

Hopefully concept of a pool and the way it's now being constructed when setting up the machine, makes this more explicit/prominent, so it's less "hidden away"[^1].

Other name cleanups done here internally:

- `doc` → `(managed) pool`
- `state.items` → `state.nodes` (to reflect they're live nodes)
- `{get,set,delete}Item` → `{get,set,delete}Node` (ditto)

To make _serialize the opposite of _deserialize again (this really tripped me up!):
- `_serialize` -> `_toOps` (wasn't opposite of deserialize)
- `_toSerializedCrdt` → `_serialize` (_is_ the proper opposite of deserialize)

[^1]: With "hidden away", I mean the way the Doc instance [got constructed previously](https://github.com/liveblocks/liveblocks/blob/d57216a149dd6f1d60cba7abd78502ecca575e2c/packages/liveblocks-client/src/room.ts#L463-L471). This previously looked like a simple/innocent object construction. It wasn't obvious that this was constructing an important stateful object [with methods](https://github.com/liveblocks/liveblocks/blob/d57216a149dd6f1d60cba7abd78502ecca575e2c/packages/liveblocks-client/src/room.ts#L474-L484) that the LiveNode tree relied on so much.
