### PR TITLE
Add `useMutation()` API

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -56,7 +56,7 @@ function getEmptyOthers() {
   return EMPTY_OTHERS;
 }
 
-type MutationContext<
+export type MutationContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject
 > = {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -812,9 +812,9 @@ export function createRoomContext<
             return rv;
           }) as OmitFirstArg<F>;
         } else {
-          return (() => {
-            console.warn(
-              "Liveblocks mutation was called before Storage has been initialized. This mutation was ignored."
+          return ((): void => {
+            throw new Error(
+              "Mutation cannot be called while Liveblocks Storage has not loaded yet"
             );
           }) as OmitFirstArg<F>;
         }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -62,6 +62,17 @@ type MutationContext<
   ) => void;
 };
 
+/**
+ * For any function type, returns a similar function type without the first
+ * argument.
+ */
+type RemoveFirstArg<F> = F extends (
+  first: any,
+  ...rest: infer Args
+) => infer ReturnType
+  ? (...args: Args) => ReturnType
+  : never;
+
 export type RoomProviderProps<
   TPresence extends JsonObject,
   TStorage extends LsonObject
@@ -378,12 +389,7 @@ type RoomContextBundle<
   >(
     callback: F,
     deps?: unknown[]
-  ): F extends (
-    context: MutationContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
-    ...args: infer Args
-  ) => infer R
-    ? (...args: Args) => R
-    : never;
+  ): RemoveFirstArg<F>;
 };
 
 export function createRoomContext<
@@ -800,15 +806,7 @@ export function createRoomContext<
       context: MutationContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
       ...args: any[]
     ) => any
-  >(
-    callback: F,
-    deps?: unknown[]
-  ): F extends (
-    context: MutationContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
-    ...args: infer Args
-  ) => infer R
-    ? (...args: Args) => R
-    : never {
+  >(callback: F, deps?: unknown[]): RemoveFirstArg<F> {
     type TODO = any;
 
     const room = useRoom();

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -795,7 +795,7 @@ export function createRoomContext<
     ) => any
   >(callback: F, deps?: unknown[]): OmitFirstArg<F> {
     const room = useRoom();
-    const root = useStorage();
+    const root = useMutableStorageRoot();
     const setMyPresence = room.updatePresence;
     return React.useMemo(
       () => {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -50,11 +50,8 @@ function getEmptyOthers() {
 
 type MutationContext<
   TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TStorage extends LsonObject
 > = {
-  room: Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
   root: LiveObject<TStorage>;
   setMyPresence: (
     patch: Partial<TPresence>,
@@ -383,7 +380,7 @@ type RoomContextBundle<
 
   useMutation<
     F extends (
-      context: MutationContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
+      context: MutationContext<TPresence, TStorage>,
       ...args: any[]
     ) => any
   >(
@@ -803,7 +800,7 @@ export function createRoomContext<
    */
   function useMutation<
     F extends (
-      context: MutationContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
+      context: MutationContext<TPresence, TStorage>,
       ...args: any[]
     ) => any
   >(callback: F, deps?: unknown[]): RemoveFirstArg<F> {
@@ -818,12 +815,10 @@ export function createRoomContext<
     return React.useMemo(
       () => {
         if (root !== null) {
-          const mutationCtx: MutationContext<
-            TPresence,
-            TStorage,
-            TUserMeta,
-            TRoomEvent
-          > = { root, room, setMyPresence };
+          const mutationCtx: MutationContext<TPresence, TStorage> = {
+            root,
+            setMyPresence,
+          };
           return ((...args) => {
             let rv;
             room.batch(() => {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -807,8 +807,6 @@ export function createRoomContext<
       ...args: any[]
     ) => any
   >(callback: F, deps?: unknown[]): RemoveFirstArg<F> {
-    type TODO = any;
-
     const room = useRoom();
     const root = useStorage();
     const setMyPresence = React.useCallback(
@@ -818,7 +816,7 @@ export function createRoomContext<
     );
 
     return React.useMemo(
-      (): TODO => {
+      () => {
         if (root !== null) {
           const mutationCtx: MutationContext<
             TPresence,
@@ -826,14 +824,16 @@ export function createRoomContext<
             TUserMeta,
             TRoomEvent
           > = { root, room, setMyPresence };
-          return (...args: TODO): TODO =>
-            room.batch(() => callback(mutationCtx, ...args));
+          return ((...args) =>
+            room.batch(() =>
+              callback(mutationCtx, ...args)
+            )) as RemoveFirstArg<F>;
         } else {
-          return () => {
+          return (() => {
             console.warn(
               "Liveblocks mutation was called before Storage has been initialized. This mutation was ignored."
             );
-          };
+          }) as RemoveFirstArg<F>;
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -482,14 +482,7 @@ export function createRoomContext<
     patch: Partial<TPresence>,
     options?: { addToHistory: boolean }
   ) => void {
-    const room = useRoom();
-
-    return React.useCallback(
-      (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => {
-        room.updatePresence(patch, options);
-      },
-      [room]
-    );
+    return useRoom().updatePresence;
   }
 
   function useOthers(): Others<TPresence, TUserMeta>;
@@ -803,12 +796,7 @@ export function createRoomContext<
   >(callback: F, deps?: unknown[]): OmitFirstArg<F> {
     const room = useRoom();
     const root = useStorage();
-    const setMyPresence = React.useCallback(
-      (patch: Partial<TPresence>, options?: { addToHistory: boolean }) =>
-        room.updatePresence(patch, options),
-      [room]
-    );
-
+    const setMyPresence = room.updatePresence;
     return React.useMemo(
       () => {
         if (root !== null) {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -824,10 +824,13 @@ export function createRoomContext<
             TUserMeta,
             TRoomEvent
           > = { root, room, setMyPresence };
-          return ((...args) =>
-            room.batch(() =>
-              callback(mutationCtx, ...args)
-            )) as RemoveFirstArg<F>;
+          return ((...args) => {
+            let rv;
+            room.batch(() => {
+              rv = callback(mutationCtx, ...args);
+            });
+            return rv;
+          }) as RemoveFirstArg<F>;
         } else {
           return (() => {
             console.warn(

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -802,7 +802,7 @@ export function createRoomContext<
     ) => any
   >(
     callback: F,
-    deps: unknown[] = []
+    deps?: unknown[]
   ): F extends (
     context: MutationContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
     ...args: infer Args
@@ -839,14 +839,9 @@ export function createRoomContext<
         }
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [
-        root,
-        room,
-        setMyPresence,
-        /* deliberately NOT callback in here  */
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        ...deps,
-      ]
+      deps !== undefined
+        ? [root, room, setMyPresence, ...deps]
+        : [root, room, setMyPresence, callback]
     );
   }
 

--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -1,4 +1,5 @@
 export { createRoomContext } from "./factory";
+export type { MutationContext } from "./factory";
 
 // Re-exports from @liveblocks/client, for convenience
 export type { Json, JsonObject } from "@liveblocks/client";


### PR DESCRIPTION
This PR adds a new hook for mutating Liveblocks storage. This is about the millionth iteration I did on this. The earlier attempts that never made it to a PR were [the useActions idea](https://www.notion.so/liveblocks/Release-0-18-997d8dbd04d040598486e4f1c0cf5b1c#4e126e0f7eea40fb9339ad3c53068621) (didn't work for [complex reasons](https://www.notion.so/liveblocks/There-s-a-catch22-with-typing-out-this-useActions-API-9d3981a00d704254aee7adeeaacefd0c)) and [the useMutable idea](https://www.notion.so/liveblocks/Release-0-18-997d8dbd04d040598486e4f1c0cf5b1c#23ab54e2fec8457382933f1d141b4496) (still viable to add later, but wouldn't be a complete solution).

Rather than defining all actions somewhere centrally, this hook offers you the choice between local or central organisation, depending on your coding preferences. You can easily inline it locally in a component (if it's the only component needing that mutation), or manually define a custom hook based on this call if you want to centrally define your hooks to reuse them (like how @stevenfabre organized this [in the block-text-editor repo](https://github.com/liveblocks/block-text-editor/tree/main/src/hooks)).

```ts
import { useMutation } from './liveblocks.config';

const deleteLayers = useMutation(({ root, setMyPresence }) => { ... });
//    ^? () => void;
const fillLayers = useMutation(({ root, setMyPresence }, color: Color) => { ... });
//    ^? (color: Color) => void;
```

Some key characteristics provided by this seemingly simple API:

- The value passed into the provided callback function will be a **mutation context**. This includes a reference to a (mutable) `root`, and to `setMyPresence`. Basically all the tools you'll ever need to mutate something![^1][^2]
- The type of that first argument **gets inferred**, while the custom extra arguments you provided can still be annotated manually. See the `color: Color` example. This argument type **transfers to the `fillLayers` function**.
- The mutation will always be **batched** automatically, so no need for manually using `room.batch()` or the `useBatch()` hook. `useBatch()` can likely be sunsetted and replaced by this new hook, even.
- If your callback depends on closed-over variables in the surrounding scope, you can give it a **dependency array**, like you're familiar with in other React hooks. No need to manually wrap with `useCallback` or `useMemo` here.
- Because it's batched, all storage and presence updates are always **atomic**.
- Mutation callbacks can **return a value**. So a mutation like `addNewShape` can return the newly inserted shape ID. And `deleteSelection` can return how many shapes were deleted.
- Calling the mutation before storage is initialized will be a no-op (+ display a warning in the console)

Real world examples, rewritten from our advanced whiteboard example:

```ts
const setFill = useMutation(
  ({ root }, fill: Color) => {
    const layers = root.get("layers");
    setLastUsedColor(fill);
    const selectedLayers = getSelectedLayers(layers, selection);
    for (const layer of selectedLayers) {
      layer.set("fill", fill);
    }
  },
  [selection, setLastUsedColor]
);
```

And another example, which also mutates presence:

```ts
const deleteLayers = useMutation(
  ({ root, setMyPresence }) => {
    const layers = root.get("layers");
    const layerIds = root.get("layerIds");
    for (const id of selection) {
      // Delete the layer from the layers LiveMap
      layers.delete(id);
      // Find the layer index in the z-index list and remove it
      const index = layerIds.indexOf(id);
      if (index !== -1) {
        layerIds.delete(index);
      }
    }
    setMyPresence({ selection: [] }, { addToHistory: true });
  },
  [selection]
);
```

Btw, the code above could also easily be structured to take the selection as an argument, like so:

```ts
const deleteLayers = useMutation(
  ({ root, setMyPresence }, selection: string[]) => {
    /* ... */
  },
  []
);
```

That flexibility should make it really easy to adapt to a lot of use cases and coding preferences. What do y'all think about this API?


[^1]: Should we also expose `history` on the mutation context? This might be needed if people want to control pause/resuming during the mutation?
[^2]: And what about `broadcastEvent`?
