### PR TITLE
Fix ESM build output issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.17.10
+
+- Fix a packaging bug
+
 # v0.17.9
 
 - Fix bug that could cause duplicate copies of @liveblocks/client to end up in

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,13 +13,31 @@ err () {
     echo "$@" >&2
 }
 
+gen_esm_wrapper () {
+    infile="$1"
+    outfile="$2"
+
+    ( cd "$DIST" && (
+      (
+        echo "export {"
+        grep -oEe 'exports[.]([^=]+)\=' "$infile" | cut -d. -f2 | cut -d' ' -f1 | sed -Ee 's/$/&,/'
+        echo "} from \"./$infile\""
+      ) > "$outfile"
+
+      prettier --write "$outfile"
+
+      # Test if output "runs" in Node
+      node "$outfile"
+    ) )
+}
+
 generate_esm_wrappers () {
     if [ -f "$DIST/internal.js" ]; then
-        npx gen-esm-wrapper "$DIST/internal.js" "$DIST/internal.mjs"
+        gen_esm_wrapper "internal.js" "internal.mjs"
     fi
 
     if [ -f "$DIST/index.js" ]; then
-        npx gen-esm-wrapper "$DIST/index.js" "$DIST/index.mjs"
+        gen_esm_wrapper "index.js" "index.mjs"
     fi
 }
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -244,7 +244,7 @@ build_pkg () {
 
 npm_pkg_exists () {
     PKGNAME="$1"
-    test "$(npm view "$PKGNAME@$VERSION" version)" = "$VERSION"
+    test "$(npm view "$PKGNAME@$VERSION" version 2>/dev/null)" = "$VERSION"
 }
 
 # This global variable will store the pasted OTP token


### PR DESCRIPTION
This morning, while investigating an unrelated issue on a random Codesandbox repo, I discovered that the 0.17.9 package would cause a weird issue when importing symbols.

Here is a comparison:
- Importing from 0.17.8 [works fine](https://codesandbox.io/s/crazy-lamarr-2qmo8b?file=/src/App.js)
- Importing from 0.17.9 [breaks](https://codesandbox.io/s/friendly-chebyshev-0x73tm?file=/src/App.js)
- Importing from 0.17.10 (the version produced with this PR) [works again](https://codesandbox.io/s/trusting-browser-3bfupf?file=/src/App.js)

The bug was caused by the `gen-esm-wrapper` NPM package we were using (introduced by #441). This module would generate the wrappers (`*.mjs`) in this form:

```ts
// Previously-generated wrapper
import mod from "./index.js";  // 👈 Importing "default" module causing the issue 👎 

export default mod;
export const Foo = mod.Foo;
export const bar = mod.bar;
...
```

The problem was that it assumes that a "default" import is always possible with the generated CJS module. So as per this PR, the build script will scan the `*.js` file for `exports.Foo = ...` constructs and directly import-and-reexport those.

```ts
// Now-generated wrapper
export { Foo, bar, ... } from "./index.js";
```

This means our packages don't/shouldn't use default exports.
