### PR TITLE
Deprecate (old meaning of) `useStorage` hook in 0.17.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.17.10
 
 - Fix a packaging bug
+- Deprecate an undocumented API
 
 # v0.17.9
 

--- a/packages/liveblocks-react/scripts/generate-compat.ts
+++ b/packages/liveblocks-react/scripts/generate-compat.ts
@@ -33,6 +33,7 @@ const GENERATE_FOR_HOOKS = [
   "useRoom",
   "useSelf",
   "useStorage",
+  "useStorageRoot",
   "useUndo",
   "useUpdateMyPresence",
 ];

--- a/packages/liveblocks-react/src/compat.tsx
+++ b/packages/liveblocks-react/src/compat.tsx
@@ -194,6 +194,22 @@ export function useSelf<
 
 /**
  * @deprecated Please use `createRoomContext()` instead of importing
+ * `useStorageRoot` from `@liveblocks/react` directly. See
+ * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
+ */
+export function useStorageRoot<TStorage extends LsonObject>(): [
+  root: LiveObject<TStorage> | null
+] {
+  deprecate(
+    "Please use `createRoomContext()` instead of importing `useStorageRoot` from `@liveblocks/react` directly. See https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details."
+  );
+  return _hooks.useStorageRoot() as unknown as [
+    root: LiveObject<TStorage> | null
+  ];
+}
+
+/**
+ * @deprecated Please use `createRoomContext()` instead of importing
  * `useStorage` from `@liveblocks/react` directly. See
  * https://liveblocks.io/docs/guides/upgrading#upgrading-from-0-16-to-0-17 for details.
  */

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -13,7 +13,7 @@ import type {
 } from "@liveblocks/client";
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import type { Resolve, RoomInitializers } from "@liveblocks/client/internal";
-import { errorIf } from "@liveblocks/client/internal";
+import { deprecate, errorIf } from "@liveblocks/client/internal";
 import * as React from "react";
 
 import { useClient as _useClient } from "./client";
@@ -227,7 +227,13 @@ type RoomContextBundle<
    * Storage.
    *
    * @example
-   * const [root] = useStorage();
+   * const [root] = useStorageRoot();
+   */
+  useStorageRoot(): [root: LiveObject<TStorage> | null];
+
+  /**
+   * @deprecated In the next major version, we're changing the meaning of `useStorage()`.
+   * Please use `useStorageRoot()` instead for the current behavior.
    */
   useStorage(): [root: LiveObject<TStorage> | null];
 
@@ -554,7 +560,7 @@ export function createRoomContext<
     return room.getSelf();
   }
 
-  function useStorage(): [root: LiveObject<TStorage> | null] {
+  function useStorageRoot(): [root: LiveObject<TStorage> | null] {
     const room = useRoom();
     const [root, setState] = React.useState<LiveObject<TStorage> | null>(null);
 
@@ -576,6 +582,13 @@ export function createRoomContext<
     }, [room]);
 
     return [root];
+  }
+
+  function useStorage(): [root: LiveObject<TStorage> | null] {
+    deprecate(
+      "In the upcoming 0.18 version, the name `useStorage()` is going to be repurposed for a new hook. Please use `useStorageRoot()` instead to keep the current behavior."
+    );
+    return useStorageRoot();
   }
 
   function useMap_deprecated<TKey extends string, TValue extends Lson>(
@@ -832,7 +845,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     initialValue: T
   ): LookupResult<T> {
     const room = useRoom();
-    const [root] = useStorage();
+    const [root] = useStorageRoot();
     const rerender = useRerender();
 
     // Note: We'll hold on to the initial value given here, and ignore any
@@ -911,6 +924,7 @@ Please see https://bit.ly/3Niy5aP for details.`
     useRedo,
     useRoom,
     useSelf,
+    useStorageRoot,
     useStorage,
     useUndo,
     useUpdateMyPresence,

--- a/packages/liveblocks-react/src/index.tsx
+++ b/packages/liveblocks-react/src/index.tsx
@@ -13,6 +13,7 @@ export {
   useEventListener,
   useSelf,
   useStorage,
+  useStorageRoot,
   useMap,
   useList,
   useObject,


### PR DESCRIPTION
This PR deprecates the `useStorage` hook. This API is currently undocumented, but we know about some customers that are relying on it. We want to free up the name for a new API that's currently planned for 0.18.

By deprecating it now, people that upgrade to the latest version of 0.17.x will be guided to change it to `useStorageRoot()` to retain API compatibility.
