### PR TITLE
Fix packaging/bundling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-# v0.17.10
+# v0.17.11
+
+General:
 
 - Fix a packaging bug
+
+In **@liveblocks/react**:
+
 - Deprecate an undocumented API
 
 # v0.17.9

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -7,14 +7,14 @@
   "types": "./index.d.ts",
   "exports": {
     "./internal": {
-      "types": "./internal.d.ts",
       "require": "./internal.js",
-      "import": "./internal.mjs"
+      "import": "./internal.mjs",
+      "types": "./internal.d.ts"
     },
     ".": {
-      "types": "./index.d.ts",
       "require": "./index.js",
-      "import": "./index.mjs"
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
     }
   },
   "files": [

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -5,6 +5,13 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
+    }
+  },
   "files": [
     "**"
   ],

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -5,6 +5,13 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
+    }
+  },
   "files": [
     "**"
   ],

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -5,6 +5,13 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
+    }
+  },
   "files": [
     "**"
   ],

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -5,6 +5,13 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs",
+      "types": "./index.d.ts"
+    }
+  },
   "files": [
     "**"
   ],

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,31 +13,13 @@ err () {
     echo "$@" >&2
 }
 
-gen_esm_wrapper () {
-    infile="$1"
-    outfile="$2"
-
-    ( cd "$DIST" && (
-      (
-        echo "export {"
-        grep -oEe 'exports[.]([^=]+)\=' "$infile" | cut -d. -f2 | cut -d' ' -f1 | sed -Ee 's/$/&,/'
-        echo "} from \"./$infile\""
-      ) > "$outfile"
-
-      prettier --write "$outfile"
-
-      # Test if output "runs" in Node
-      node "$outfile"
-    ) )
-}
-
 generate_esm_wrappers () {
     if [ -f "$DIST/internal.js" ]; then
-        gen_esm_wrapper "internal.js" "internal.mjs"
+        npx gen-esm-wrapper "$DIST/internal.js" "$DIST/internal.mjs"
     fi
 
     if [ -f "$DIST/index.js" ]; then
-        gen_esm_wrapper "index.js" "index.mjs"
+        npx gen-esm-wrapper "$DIST/index.js" "$DIST/index.mjs"
     fi
 }
 


### PR DESCRIPTION
Turns out the take on #455 was wrong. This PR reverts that change, in favor of the _correct_ fix.

The real underlying issue here was that only the client package had an `exports` definition in its package.json, and our other ones didn't.

I can confirm this fixes the issues both on CodeSandbox, and in our Nuxtjs example builds, so I'll release this fix as 0.17.11 now ASAP.