### PR TITLE
Make initial presence mandatory

### DIFF
--- a/packages/liveblocks-client/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-client/src/__tests__/client.node.test.ts
@@ -216,7 +216,7 @@ describe("when env atob does not exist (atob polyfill handling)", () => {
           fetch: fetchMock,
           atob: undefined,
         },
-      } as ClientOptions);
+      });
     }).toThrowError(
       "You need to polyfill atob to use the client in your environment. Please follow the instructions at https://liveblocks.io/docs/errors/liveblocks-client/atob-polyfill"
     );
@@ -231,7 +231,7 @@ describe("when env atob does not exist (atob polyfill handling)", () => {
           fetch: fetchMock,
           atob: atobPolyfillMock,
         },
-      } as ClientOptions);
+      });
     }).not.toThrow();
   });
 });

--- a/packages/liveblocks-client/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-client/src/__tests__/client.node.test.ts
@@ -27,7 +27,7 @@ function atobPolyfillMock(data: string): string {
 
 function createClientAndEnter(options: ClientOptions) {
   const client = createClient(options);
-  client.enter("room");
+  client.enter("room", { initialPresence: {} });
 }
 
 describe("createClient", () => {

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -56,7 +56,7 @@ function setupStateMachine<
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
->(initialPresence?: TPresence) {
+>(initialPresence: TPresence) {
   const effects = mockEffects<TPresence, TRoomEvent>();
   const state = defaultState<TPresence, TStorage, TUserMeta, TRoomEvent>(
     initialPresence
@@ -108,7 +108,7 @@ describe("room / auth", () => {
     "custom authentication with missing token in callback response should throw",
     async (response) => {
       const room = createRoom(
-        {},
+        { initialPresence: {} as never },
         {
           ...defaultContext,
           authentication: {
@@ -136,7 +136,7 @@ describe("room / auth", () => {
 
   test("private authentication with 403 status should throw", async () => {
     const room = createRoom(
-      {},
+      { initialPresence: {} as never },
       {
         ...defaultContext,
         authentication: {
@@ -159,7 +159,7 @@ describe("room / auth", () => {
 
   test("private authentication that does not returns json should throw", async () => {
     const room = createRoom(
-      {},
+      { initialPresence: {} as never },
       {
         ...defaultContext,
         authentication: {
@@ -182,7 +182,7 @@ describe("room / auth", () => {
 
   test("private authentication that does not returns json should throw", async () => {
     const room = createRoom(
-      {},
+      { initialPresence: {} as never },
       {
         ...defaultContext,
         authentication: {
@@ -255,7 +255,7 @@ describe("room", () => {
   });
 
   test("if no presence has been set before the connection is open, an empty presence should be sent", () => {
-    const { machine, effects } = setupStateMachine();
+    const { machine, effects } = setupStateMachine({} as never);
 
     const ws = new MockWebSocket("");
     machine.connect();

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -1,3 +1,4 @@
+import { deprecateIf } from "./deprecation";
 import type { InternalRoom } from "./room";
 import { createRoom } from "./room";
 import type {
@@ -100,9 +101,14 @@ export function createClient(options: ClientOptions): Client {
       >;
     }
 
+    deprecateIf(
+      options.initialPresence == null,
+      "Please provide an initial presence value for the current user when entering the room."
+    );
+
     internalRoom = createRoom<TPresence, TStorage, TUserMeta, TRoomEvent>(
       {
-        initialPresence: options.initialPresence,
+        initialPresence: options.initialPresence ?? {},
         initialStorage: options.initialStorage,
       },
       {

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -86,7 +86,7 @@ export function createClient(options: ClientOptions): Client {
     TRoomEvent extends Json = never
   >(
     roomId: string,
-    options: EnterOptions<TPresence, TStorage> = {}
+    options: EnterOptions<TPresence, TStorage>
   ): Room<TPresence, TStorage, TUserMeta, TRoomEvent> {
     let internalRoom = rooms.get(roomId) as
       | InternalRoom<TPresence, TStorage, TUserMeta, TRoomEvent>

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1595,7 +1595,7 @@ function defaultState<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 >(
-  initialPresence?: TPresence,
+  initialPresence: TPresence,
   initialStorage?: TStorage
 ): State<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const others = new OthersRef<TPresence, TUserMeta>();
@@ -1618,7 +1618,7 @@ function defaultState<
         // Queue up the initial presence message as a Full Presence™ update
         {
           type: "full",
-          data: initialPresence == null ? ({} as TPresence) : initialPresence,
+          data: initialPresence,
         },
       messages: [],
       storageOperations: [],
@@ -1628,9 +1628,7 @@ function defaultState<
     },
 
     connection,
-    me: new MeRef(
-      initialPresence == null ? ({} as TPresence) : initialPresence
-    ),
+    me: new MeRef(initialPresence),
     others,
 
     defaultStorageRoot: initialStorage,

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -183,7 +183,7 @@ export type RoomInitializers<
    * The initial Presence to use and announce when you enter the Room. The
    * Presence is available on all users in the Room (me & others).
    */
-  initialPresence?: TPresence | ((roomId: string) => TPresence);
+  initialPresence: TPresence | ((roomId: string) => TPresence);
   /**
    * The initial Storage to use when entering a new Room.
    */
@@ -217,7 +217,7 @@ export type Client = {
     TRoomEvent extends Json = never
   >(
     roomId: string,
-    options?: RoomInitializers<TPresence, TStorage>
+    options: RoomInitializers<TPresence, TStorage>
   ): Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
 
   /**

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -182,7 +182,7 @@ const internalEnhancer = <T>(options: {
           return;
         }
 
-        room = client.enter(roomId);
+        room = client.enter(roomId, { initialPresence: {} as any });
 
         broadcastInitialPresence(room, reduxState, presenceMapping as any);
 

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -194,7 +194,7 @@ export function middleware<
         return;
       }
 
-      room = client.enter(roomId);
+      room = client.enter(roomId, { initialPresence: {} as TPresence });
 
       updateZustandLiveblocksState(set, {
         isStorageLoading: true,


### PR DESCRIPTION
This PR forces the `initialPresence` to be provided whenever you enter a room. It's no longer optional. As such, we will always know for sure that there is a `.presence` field on every user, both for `me` and for all the `others`.