### PR TITLE
Add new APIs: `useOtherIds()` and `useOther(n)` for better others iteration

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -686,7 +686,7 @@ export function createRoomContext<
           const eq = isEqual ?? Object.is;
           return eq(a, b);
         },
-        [sentinel, isEqual]
+        [isEqual]
       );
 
       const other = _useOthers(wrappedSelector, wrappedIsEqual);

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -949,6 +949,8 @@ export function createRoomContext<
     useHistory,
     useMyPresence,
     useOthers,
+    // useOtherIds, // TODO: Implement
+    // useOther, // TODO: Implement
     useRedo,
     useRoom,
 
@@ -974,6 +976,8 @@ export function createRoomContext<
       useStorage: useStorageSuspense,
       useSelf: useSelfSuspense,
       useOthers: useOthersSuspense,
+      // useOtherIds: useOtherIdsSuspense, // TODO: Implement
+      // useOther: useOtherSuspense, // TODO: Implement
 
       // Legacy hooks
       useList: useLegacyKeySuspense,

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -600,11 +600,13 @@ export function createRoomContext<
   ):
     | readonly number[]
     | readonly { readonly connectionId: number; readonly data: T }[] {
-    const _useOthers = useOthers; // Deliberately bypass React warnings about conditionally calling hooks
+    // Deliberately bypass React warnings about conditionally calling hooks
+    const _useCallback = React.useCallback;
+    const _useOthers = useOthers;
     if (itemSelector === undefined) {
       return _useOthers(/* not inlined! */ connectionIdSelector, shallow);
     } else {
-      const wrappedSelector = React.useCallback(
+      const wrappedSelector = _useCallback(
         (others: Others<TPresence, TUserMeta>) =>
           others.map((other) => ({
             connectionId: other.connectionId,
@@ -613,7 +615,7 @@ export function createRoomContext<
         [itemSelector]
       );
 
-      const wrappedIsEqual = React.useCallback(
+      const wrappedIsEqual = _useCallback(
         (
           a: { readonly connectionId: number; readonly data: T }[],
           b: { readonly connectionId: number; readonly data: T }[]
@@ -650,9 +652,11 @@ export function createRoomContext<
     selector?: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (a: T, b: T) => boolean
   ): T | User<TPresence, TUserMeta> {
-    const _useOthers = useOthers; // Deliberately bypass React warnings about conditionally calling hooks
+    // Deliberately bypass React warnings about conditionally calling hooks
+    const _useCallback = React.useCallback;
+    const _useOthers = useOthers;
     if (selector === undefined) {
-      const selector = React.useCallback(
+      const selector = _useCallback(
         (others: Others<TPresence, TUserMeta>) =>
           // TODO: Make this O(1) instead of O(n)?
           others.find((other) => other.connectionId === connectionId),
@@ -666,7 +670,7 @@ export function createRoomContext<
       }
       return other;
     } else {
-      const wrappedSelector = React.useCallback(
+      const wrappedSelector = _useCallback(
         (others: Others<TPresence, TUserMeta>) => {
           // TODO: Make this O(1) instead of O(n)?
           const other = others.find(
@@ -677,7 +681,7 @@ export function createRoomContext<
         [connectionId, selector]
       );
 
-      const wrappedIsEqual = React.useCallback(
+      const wrappedIsEqual = _useCallback(
         (a: T | typeof sentinel, b: T | typeof sentinel): boolean => {
           if (a === sentinel || b === sentinel) {
             return a === b;


### PR DESCRIPTION
This attempts to fix the annoyances with `useOthers()`, as described in #463.

New APIs introduced here:

```tsx
const ids = useOtherIds();
// [2, 5, 11]

const cursors = useOtherIds(user => user.presence.cursor);
// [
//   { connectionId: 2, data: { x: -18, y: 292 } },
//   { connectionId: 5, data: null },
//   { connectionId: 11, data: { x: 38, y: -1 } },
// ]

const someUser = useOther(2);
// {
//   connectionId: 2,
//   id: 'internal-id-4',
//   info: {
//     avatar: 'https://user-images.githubusercontent.com/83844/188878306-73cece2d-d9b2-46c6-9b11-8bdc02d58d4f.png',
//   },
//   presence: {
//     cursor: { x: -18, y: 292 },
//   },
// }

const { x, y } = useOther(2, user => user.presence.cursor);
// { x: -18, y: 292 }

useOther(99);  // throws! "No such connection ID"
```
