### PR TITLE
Convert advanced whiteboard example to 0.18

### DIFF
--- a/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
+++ b/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
@@ -41,12 +41,12 @@ type Storage = {
 export const {
   useMyPresence,
   useOthers,
-  useList,
   RoomProvider,
-  useMap,
   useHistory,
   useBatch,
   useCanUndo,
   useCanRedo,
   useRoom,
+
+  suspense: { useList, useMap, useStorage },
 } = createRoomContext<Presence, Storage /* UserMeta, RoomEvent */>(client);

--- a/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
+++ b/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
@@ -40,6 +40,7 @@ type Storage = {
 
 export const {
   useMyPresence,
+  useUpdateMyPresence,
   RoomProvider,
   useHistory,
   useBatch,
@@ -47,5 +48,13 @@ export const {
   useCanRedo,
   useRoom,
 
-  suspense: { useList, useMap, useOther, useOtherIds, useOthers, useStorage },
+  suspense: {
+    useList,
+    useMap,
+    useOther,
+    useOtherIds,
+    useOthers,
+    useSelf,
+    useStorage,
+  },
 } = createRoomContext<Presence, Storage /* UserMeta, RoomEvent */>(client);

--- a/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
+++ b/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
@@ -39,23 +39,13 @@ type Storage = {
 // type RoomEvent = {};
 
 export const {
-  useMyPresence,
   useUpdateMyPresence,
   RoomProvider,
   useHistory,
-  useBatch,
   useCanUndo,
   useCanRedo,
   useMutation,
   useRoom,
 
-  suspense: {
-    useList,
-    useMap,
-    useOther,
-    useOtherIds,
-    useOthers,
-    useSelf,
-    useStorage,
-  },
+  suspense: { useOther, useOtherIds, useOthers, useSelf, useStorage },
 } = createRoomContext<Presence, Storage /* UserMeta, RoomEvent */>(client);

--- a/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
+++ b/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
@@ -46,6 +46,7 @@ export const {
   useBatch,
   useCanUndo,
   useCanRedo,
+  useMutation,
   useRoom,
 
   suspense: {

--- a/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
+++ b/examples/nextjs-whiteboard-advanced/liveblocks.config.ts
@@ -40,7 +40,6 @@ type Storage = {
 
 export const {
   useMyPresence,
-  useOthers,
   RoomProvider,
   useHistory,
   useBatch,
@@ -48,5 +47,5 @@ export const {
   useCanRedo,
   useRoom,
 
-  suspense: { useList, useMap, useStorage },
+  suspense: { useList, useMap, useOther, useOtherIds, useOthers, useStorage },
 } = createRoomContext<Presence, Storage /* UserMeta, RoomEvent */>(client);

--- a/examples/nextjs-whiteboard-advanced/package-lock.json
+++ b/examples/nextjs-whiteboard-advanced/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/node": "^0.17.11",
-        "@liveblocks/react": "^0.17.11",
+        "@liveblocks/client": "^0.18.0-beta2",
+        "@liveblocks/node": "^0.18.0-beta2",
+        "@liveblocks/react": "^0.18.0-beta2",
         "nanoid": "^3.1.25",
         "next": "^12.1.6",
         "perfect-freehand": "^0.5.3",
@@ -27,24 +27,27 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.0-beta2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.0-beta2.tgz",
+      "integrity": "sha512-omvEnzspghr6pTqNOhnfzxhJhdvYsepmv1Pd1oOCau6Hs1G5XJFFEH3mmV0/aLbagOojTRAqeQfC+4NKwu0c/g=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.0-beta2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.0-beta2.tgz",
+      "integrity": "sha512-fn5000++Xjur82xXUV9Jk5LJCa5EgdzJ9Xpl+OkuxB6Z8mBAGvnWFD5geTRLWfTDI/+BfimtyZa6uXilzd/h0g==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.17.11.tgz",
-      "integrity": "sha512-WYFLJTN+3h24ODyOKcPHZU80mwi/l9BWDsrig/bIFgr9w8wIk/cci30ngyeIglwP0LLcgte073dRNf4pkpFf5Q==",
+      "version": "0.18.0-beta2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.18.0-beta2.tgz",
+      "integrity": "sha512-Q57XnJ7cDeZF1gP/yaPWtCMsqQsm5L8x/S9q9P1Vmw936CiOhG2Ap2uY1c8PvQp6JBs1fu6OReyYH5O+GdHl3w==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.0-beta2",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -1459,6 +1462,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1502,23 +1513,25 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.0-beta2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.0-beta2.tgz",
+      "integrity": "sha512-omvEnzspghr6pTqNOhnfzxhJhdvYsepmv1Pd1oOCau6Hs1G5XJFFEH3mmV0/aLbagOojTRAqeQfC+4NKwu0c/g=="
     },
     "@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.0-beta2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.0-beta2.tgz",
+      "integrity": "sha512-fn5000++Xjur82xXUV9Jk5LJCa5EgdzJ9Xpl+OkuxB6Z8mBAGvnWFD5geTRLWfTDI/+BfimtyZa6uXilzd/h0g==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.17.11.tgz",
-      "integrity": "sha512-WYFLJTN+3h24ODyOKcPHZU80mwi/l9BWDsrig/bIFgr9w8wIk/cci30ngyeIglwP0LLcgte073dRNf4pkpFf5Q==",
-      "requires": {}
+      "version": "0.18.0-beta2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.18.0-beta2.tgz",
+      "integrity": "sha512-Q57XnJ7cDeZF1gP/yaPWtCMsqQsm5L8x/S9q9P1Vmw936CiOhG2Ap2uY1c8PvQp6JBs1fu6OReyYH5O+GdHl3w==",
+      "requires": {
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "@next/env": {
       "version": "12.1.6",
@@ -2399,6 +2412,12 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/node": "^0.17.11",
-    "@liveblocks/react": "^0.17.11",
+    "@liveblocks/client": "^0.18.0-beta2",
+    "@liveblocks/node": "^0.18.0-beta2",
+    "@liveblocks/react": "^0.18.0-beta2",
     "nanoid": "^3.1.25",
     "next": "^12.1.6",
     "perfect-freehand": "^0.5.3",

--- a/examples/nextjs-whiteboard-advanced/src/components/Cursor.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/Cursor.tsx
@@ -1,10 +1,17 @@
+import { useOther } from "../../liveblocks.config";
+import { connectionIdToColor } from "../utils";
+
 type Props = {
-  color: string;
-  x: number;
-  y: number;
+  connectionId: number;
 };
 
-export default function Cursor({ color, x, y }: Props) {
+export default function Cursor({ connectionId }: Props) {
+  const cursor = useOther(connectionId, (user) => user.presence.cursor);
+  if (!cursor) {
+    return null;
+  }
+
+  const { x, y } = cursor;
   return (
     <path
       style={{
@@ -12,7 +19,7 @@ export default function Cursor({ color, x, y }: Props) {
         transform: `translateX(${x}px) translateY(${y}px)`,
       }}
       d="M5.65376 12.3673H5.46026L5.31717 12.4976L0.500002 16.8829L0.500002 1.19841L11.7841 12.3673H5.65376Z"
-      fill={color}
+      fill={connectionIdToColor(connectionId)}
     />
   );
 }

--- a/examples/nextjs-whiteboard-advanced/src/components/Cursor.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/Cursor.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useOther } from "../../liveblocks.config";
 import { connectionIdToColor } from "../utils";
 
@@ -5,7 +6,7 @@ type Props = {
   connectionId: number;
 };
 
-export default function Cursor({ connectionId }: Props) {
+function Cursor({ connectionId }: Props) {
   const cursor = useOther(connectionId, (user) => user.presence.cursor);
   if (!cursor) {
     return null;
@@ -23,3 +24,5 @@ export default function Cursor({ connectionId }: Props) {
     />
   );
 }
+
+export default memo(Cursor);

--- a/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
@@ -3,7 +3,7 @@ import React, { memo } from "react";
 import Ellipse from "./Ellipse";
 import Path from "./Path";
 import Rectangle from "./Rectangle";
-import { CanvasMode, Layer, LayerType } from "../types";
+import { CanvasMode, LayerType } from "../types";
 import { colorToCss } from "../utils";
 
 type Props = {
@@ -15,7 +15,10 @@ type Props = {
 
 const LayerComponent = memo(
   ({ mode, onLayerPointerDown, id, selectionColor }: Props) => {
-    const layer = useStorage((root) => root.layers.get(id))!;
+    const layer = useStorage((root) => root.layers.get(id));
+    if (!layer) {
+      return null;
+    }
 
     const isAnimated =
       mode !== CanvasMode.Translating && mode !== CanvasMode.Resizing;

--- a/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
@@ -1,6 +1,5 @@
-import { LiveObject } from "@liveblocks/client";
-import { useRoom } from "../../liveblocks.config";
-import React, { memo, useEffect, useState } from "react";
+import { useStorage } from "../../liveblocks.config";
+import React, { memo } from "react";
 import Ellipse from "./Ellipse";
 import Path from "./Path";
 import Rectangle from "./Rectangle";
@@ -9,14 +8,15 @@ import { colorToCss } from "../utils";
 
 type Props = {
   id: string;
-  layer: Layer;
   mode: CanvasMode;
   onLayerPointerDown: (e: React.PointerEvent, layerId: string) => void;
   selectionColor?: string;
 };
 
 const LayerComponent = memo(
-  ({ layer, mode, onLayerPointerDown, id, selectionColor }: Props) => {
+  ({ mode, onLayerPointerDown, id, selectionColor }: Props) => {
+    const layer = useStorage((root) => root.layers.get(id))!;
+
     const isAnimated =
       mode !== CanvasMode.Translating && mode !== CanvasMode.Resizing;
 

--- a/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
@@ -9,7 +9,7 @@ import { colorToCss } from "../utils";
 
 type Props = {
   id: string;
-  layer: LiveObject<Layer>;
+  layer: Layer;
   mode: CanvasMode;
   onLayerPointerDown: (e: React.PointerEvent, layerId: string) => void;
   selectionColor?: string;
@@ -18,28 +18,15 @@ type Props = {
 // We can use react memo because "layer" is a LiveObject and it's mutable. This component will only be re-rendered if the layer is updated.
 const LayerComponent = memo(
   ({ layer, mode, onLayerPointerDown, id, selectionColor }: Props) => {
-    const [layerData, setLayerData] = useState(layer.toObject());
-
-    const room = useRoom();
-
-    // Layer is a nested LiveObject inside a LiveMap, so we need to subscribe to changes made to a specific layer
-    useEffect(() => {
-      function onChange() {
-        setLayerData(layer.toObject());
-      }
-
-      return room.subscribe(layer, onChange);
-    }, [room, layer]);
-
     const isAnimated =
       mode !== CanvasMode.Translating && mode !== CanvasMode.Resizing;
 
-    switch (layerData.type) {
+    switch (layer.type) {
       case LayerType.Ellipse:
         return (
           <Ellipse
             id={id}
-            layer={layerData}
+            layer={layer}
             onPointerDown={onLayerPointerDown}
             isAnimated={isAnimated}
             selectionColor={selectionColor}
@@ -49,12 +36,12 @@ const LayerComponent = memo(
         return (
           <Path
             key={id}
-            points={layerData.points}
+            points={layer.points}
             isAnimated={isAnimated}
             onPointerDown={(e) => onLayerPointerDown(e, id)}
-            x={layerData.x}
-            y={layerData.y}
-            fill={layerData.fill ? colorToCss(layerData.fill) : "#CCC"}
+            x={layer.x}
+            y={layer.y}
+            fill={layer.fill ? colorToCss(layer.fill) : "#CCC"}
             stroke={selectionColor}
           />
         );
@@ -62,7 +49,7 @@ const LayerComponent = memo(
         return (
           <Rectangle
             id={id}
-            layer={layerData}
+            layer={layer}
             onPointerDown={onLayerPointerDown}
             isAnimated={isAnimated}
             selectionColor={selectionColor}

--- a/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/LayerComponent.tsx
@@ -15,7 +15,6 @@ type Props = {
   selectionColor?: string;
 };
 
-// We can use react memo because "layer" is a LiveObject and it's mutable. This component will only be re-rendered if the layer is updated.
 const LayerComponent = memo(
   ({ layer, mode, onLayerPointerDown, id, selectionColor }: Props) => {
     const isAnimated =

--- a/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
@@ -1,45 +1,55 @@
-import { useOthers } from "../../liveblocks.config";
+import { useOthers, useOtherIds } from "../../liveblocks.config";
+import { shallow } from "@liveblocks/client";
 import React from "react";
-import { colorToCss, connectionIdToColor } from "../utils";
+import { colorToCss } from "../utils";
 import Cursor from "./Cursor";
 import Path from "./Path";
 
-const MultiplayerGuides = React.memo(() => {
-  const others = useOthers();
+const Cursors = React.memo(() => {
+  const ids = useOtherIds();
   return (
     <>
-      {others.map((user) => {
-        if (user.presence.cursor) {
-          return (
-            <Cursor
-              key={`cursor-${user.connectionId}`}
-              x={user.presence.cursor.x}
-              y={user.presence.cursor.y}
-              color={connectionIdToColor(user.connectionId)}
-            />
-          );
-        }
-        return null;
-      })}
+      {ids.map((connectionId) => (
+        <Cursor key={connectionId} connectionId={connectionId} />
+      ))}
+    </>
+  );
+});
+
+const Drafts = React.memo(() => {
+  const others = useOtherIds(
+    (other) => ({
+      pencilDraft: other.presence.pencilDraft,
+      penColor: other.presence.penColor,
+    }),
+    shallow
+  );
+  return (
+    <>
       {/* All the drawing of other users in the room that are currently in progress */}
-      {others.map((user) => {
-        if (user.presence.pencilDraft) {
+      {others.map(({ connectionId, data }) => {
+        if (data.pencilDraft) {
           return (
             <Path
+              key={connectionId}
               x={0}
               y={0}
-              key={`pencil-${user.connectionId}`}
-              points={user.presence.pencilDraft}
-              fill={
-                user.presence.penColor
-                  ? colorToCss(user.presence.penColor)
-                  : "#CCC"
-              }
+              points={data.pencilDraft}
+              fill={data.penColor ? colorToCss(data.penColor) : "#CCC"}
             />
           );
         }
         return null;
       })}
+    </>
+  );
+});
+
+const MultiplayerGuides = React.memo(() => {
+  return (
+    <>
+      <Cursors />
+      <Drafts />
     </>
   );
 });

--- a/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
@@ -1,4 +1,4 @@
-import { useOthers, useOtherIds } from "../../liveblocks.config";
+import { useOtherIds } from "../../liveblocks.config";
 import { shallow } from "@liveblocks/client";
 import React from "react";
 import { colorToCss } from "../utils";

--- a/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
@@ -5,7 +5,7 @@ import { colorToCss } from "../utils";
 import Cursor from "./Cursor";
 import Path from "./Path";
 
-const Cursors = React.memo(() => {
+function Cursors() {
   const ids = useOtherIds();
   return (
     <>
@@ -14,9 +14,9 @@ const Cursors = React.memo(() => {
       ))}
     </>
   );
-});
+}
 
-const Drafts = React.memo(() => {
+function Drafts() {
   const others = useOtherIds(
     (other) => ({
       pencilDraft: other.presence.pencilDraft,
@@ -43,9 +43,9 @@ const Drafts = React.memo(() => {
       })}
     </>
   );
-});
+}
 
-const MultiplayerGuides = React.memo(() => {
+export default React.memo(function MultiplayerGuides() {
   return (
     <>
       <Cursors />
@@ -53,5 +53,3 @@ const MultiplayerGuides = React.memo(() => {
     </>
   );
 });
-
-export default MultiplayerGuides;

--- a/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/MultiplayerGuides.tsx
@@ -9,7 +9,7 @@ const MultiplayerGuides = React.memo(() => {
   return (
     <>
       {others.map((user) => {
-        if (user.presence?.cursor) {
+        if (user.presence.cursor) {
           return (
             <Cursor
               key={`cursor-${user.connectionId}`}
@@ -23,7 +23,7 @@ const MultiplayerGuides = React.memo(() => {
       })}
       {/* All the drawing of other users in the room that are currently in progress */}
       {others.map((user) => {
-        if (user.presence?.pencilDraft) {
+        if (user.presence.pencilDraft) {
           return (
             <Path
               x={0}

--- a/examples/nextjs-whiteboard-advanced/src/components/SelectionBox.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/SelectionBox.tsx
@@ -1,11 +1,10 @@
-import { LiveMap, LiveObject } from "@liveblocks/client";
 import { memo } from "react";
 import styles from "./SelectionBox.module.css";
 import { Layer, LayerType, Side, XYWH } from "../types";
 
 type SelectionBoxProps = {
   selection: string[];
-  layers: LiveMap<string, LiveObject<Layer>>;
+  layers: ReadonlyMap<string, Layer>;
   bounds: XYWH;
   onResizeHandlePointerDown: (corner: Side, initialBounds: XYWH) => void;
   isAnimated: boolean;
@@ -24,7 +23,7 @@ const SelectionBox = memo(
     const isShowingHandles =
       selection.length === 1 &&
       // Resize path is not supported
-      layers.get(selection[0])?.get("type") !== LayerType.Path;
+      layers.get(selection[0])?.type !== LayerType.Path;
 
     return (
       <>

--- a/examples/nextjs-whiteboard-advanced/src/components/SelectionBox.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/SelectionBox.tsx
@@ -1,11 +1,10 @@
 import { memo } from "react";
 import styles from "./SelectionBox.module.css";
-import { Layer, LayerType, Side, XYWH } from "../types";
+import useSelectionBounds from "../hooks/useSelectionBounds";
+import { useSelf, useStorage } from "../../liveblocks.config";
+import { LayerType, Side, XYWH } from "../types";
 
 type SelectionBoxProps = {
-  selection: string[];
-  layers: ReadonlyMap<string, Layer>;
-  bounds: XYWH;
   onResizeHandlePointerDown: (corner: Side, initialBounds: XYWH) => void;
   isAnimated: boolean;
 };
@@ -13,17 +12,22 @@ type SelectionBoxProps = {
 const HANDLE_WIDTH = 8;
 
 const SelectionBox = memo(
-  ({
-    layers,
-    bounds,
-    onResizeHandlePointerDown,
-    selection,
-    isAnimated,
-  }: SelectionBoxProps) => {
-    const isShowingHandles =
-      selection.length === 1 &&
-      // Resize path is not supported
-      layers.get(selection[0])?.type !== LayerType.Path;
+  ({ onResizeHandlePointerDown, isAnimated }: SelectionBoxProps) => {
+    // We should show resize handles if exactly one shape is selected and it's
+    // not a path layer
+    const soleLayerId = useSelf((me) =>
+      me.presence.selection.length === 1 ? me.presence.selection[0] : null
+    );
+
+    const isShowingHandles = useStorage(
+      (root) =>
+        soleLayerId && root.layers.get(soleLayerId)?.type !== LayerType.Path
+    );
+
+    const bounds = useSelectionBounds();
+    if (!bounds) {
+      return null;
+    }
 
     return (
       <>

--- a/examples/nextjs-whiteboard-advanced/src/components/SelectionTools.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/SelectionTools.tsx
@@ -1,24 +1,23 @@
-import React from "react";
+import { memo } from "react";
 import ColorPicker from "./ColorPicker";
 import IconButton from "./IconButton";
-import { Color } from "../types";
+import { Camera, Color } from "../types";
 import styles from "./SelectionTools.module.css";
+import useSelectionBounds from "../hooks/useSelectionBounds";
 import { useSelf, useMutation } from "../../liveblocks.config";
 
 type SelectionToolsProps = {
   isAnimated: boolean;
-  x: number;
-  y: number;
+  camera: Camera;
   setLastUsedColor: (color: Color) => void;
   moveToFront: () => void;
   moveToBack: () => void;
   deleteItems: () => void;
 };
 
-export default function SelectionTools({
+function SelectionTools({
   isAnimated,
-  x,
-  y,
+  camera,
   setLastUsedColor,
   moveToFront,
   moveToBack,
@@ -37,6 +36,13 @@ export default function SelectionTools({
     [selection, setLastUsedColor]
   );
 
+  const selectionBounds = useSelectionBounds();
+  if (!selectionBounds) {
+    return null;
+  }
+
+  const x = selectionBounds.width / 2 + selectionBounds.x + camera.x;
+  const y = selectionBounds.y + camera.y;
   return (
     <div
       className={styles.selection_inspector}
@@ -86,3 +92,5 @@ export default function SelectionTools({
     </div>
   );
 }
+
+export default memo(SelectionTools);

--- a/examples/nextjs-whiteboard-advanced/src/components/SelectionTools.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/components/SelectionTools.tsx
@@ -3,12 +3,13 @@ import ColorPicker from "./ColorPicker";
 import IconButton from "./IconButton";
 import { Color } from "../types";
 import styles from "./SelectionTools.module.css";
+import { useSelf, useMutation } from "../../liveblocks.config";
 
 type SelectionToolsProps = {
   isAnimated: boolean;
   x: number;
   y: number;
-  setFill: (color: Color) => void;
+  setLastUsedColor: (color: Color) => void;
   moveToFront: () => void;
   moveToBack: () => void;
   deleteItems: () => void;
@@ -18,11 +19,24 @@ export default function SelectionTools({
   isAnimated,
   x,
   y,
-  setFill,
+  setLastUsedColor,
   moveToFront,
   moveToBack,
   deleteItems,
 }: SelectionToolsProps) {
+  const selection = useSelf((me) => me.presence.selection);
+
+  const setFill = useMutation(
+    ({ root }, fill: Color) => {
+      const liveLayers = root.get("layers");
+      setLastUsedColor(fill);
+      selection.forEach((id) => {
+        liveLayers.get(id)?.set("fill", fill);
+      });
+    },
+    [selection, setLastUsedColor]
+  );
+
   return (
     <div
       className={styles.selection_inspector}

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useDeleteLayers.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useDeleteLayers.ts
@@ -6,7 +6,7 @@ import { useSelf, useMutation } from "../../liveblocks.config";
 export default function useDeleteLayers() {
   const selection = useSelf((me) => me.presence.selection);
   return useMutation(
-    ({ root }) => {
+    ({ root, setMyPresence }) => {
       const liveLayers = root.get("layers");
       const liveLayerIds = root.get("layerIds");
       for (const id of selection) {
@@ -18,6 +18,7 @@ export default function useDeleteLayers() {
           liveLayerIds.delete(index);
         }
       }
+      setMyPresence({ selection: [] }, { addToHistory: true });
     },
     [selection]
   );

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useDeleteLayers.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useDeleteLayers.ts
@@ -1,0 +1,24 @@
+import { useSelf, useMutation } from "../../liveblocks.config";
+
+/**
+ * Delete all the selected layers.
+ */
+export default function useDeleteLayers() {
+  const selection = useSelf((me) => me.presence.selection);
+  return useMutation(
+    ({ root }) => {
+      const liveLayers = root.get("layers");
+      const liveLayerIds = root.get("layerIds");
+      for (const id of selection) {
+        // Delete the layer from the layers LiveMap
+        liveLayers.delete(id);
+        // Find the layer index in the z-index list and remove it
+        const index = liveLayerIds.indexOf(id);
+        if (index !== -1) {
+          liveLayerIds.delete(index);
+        }
+      }
+    },
+    [selection]
+  );
+}

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
@@ -1,10 +1,51 @@
 import { useStorage, useSelf } from "../../liveblocks.config";
-import { useMemo } from "react";
-import { XYWH } from "../types";
-import { boundingBox } from "../utils";
+import { Layer, XYWH } from "../types";
+import { shallow } from "@liveblocks/react";
 
-export default function useSelectionBounds(): XYWH | null {
-  const layers = useStorage((root) => root.layers);
+function boundingBox(layers: Layer[]): XYWH | null {
+  if (layers.length === 0) {
+    return null;
+  }
+
+  if (layers.length === 0) {
+    return null;
+  }
+
+  let left = layers[0].x;
+  let right = layers[0].x + layers[0].width;
+  let top = layers[0].y;
+  let bottom = layers[0].y + layers[0].height;
+
+  for (let i = 1; i < layers.length; i++) {
+    const { x, y, width, height } = layers[i];
+    if (left > x) {
+      left = x;
+    }
+    if (right < x + width) {
+      right = x + width;
+    }
+    if (top > y) {
+      top = y;
+    }
+    if (bottom < y + height) {
+      bottom = y + height;
+    }
+  }
+
+  return {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+export default function useSelectionBounds() {
   const selection = useSelf((me) => me.presence.selection);
-  return useMemo(() => boundingBox(layers, selection), [layers, selection]);
+  return useStorage((root) => {
+    const selectedLayers = selection.map(
+      (layerId) => root.layers.get(layerId)!
+    );
+    return boundingBox(selectedLayers);
+  }, shallow);
 }

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
@@ -1,26 +1,10 @@
-import { useRoom, useMap, useMyPresence } from "../../liveblocks.config";
-import { useState, useEffect } from "react";
+import { useStorage, useMyPresence } from "../../liveblocks.config";
+import { useMemo } from "react";
 import { XYWH } from "../types";
 import { boundingBox } from "../utils";
 
 export default function useSelectionBounds(): XYWH | null {
-  const layers = useMap("layers");
+  const layers = useStorage((root) => root.layers);
   const [{ selection }] = useMyPresence();
-
-  const [bounds, setBounds] = useState(boundingBox(layers, selection));
-  const room = useRoom();
-
-  useEffect(() => {
-    function onChange() {
-      setBounds(boundingBox(layers, selection));
-    }
-
-    onChange();
-
-    // We need to subscribe to the layers map updates and to the updates on the layers themselves.
-    // If User A deletes or modified a layer that is currently selected by UserB, the selection bounds needs to be refreshed.
-    return room.subscribe(layers, onChange, { isDeep: true });
-  }, [room, layers, selection]);
-
-  return bounds;
+  return useMemo(() => boundingBox(layers, selection), [layers, selection]);
 }

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
@@ -1,10 +1,10 @@
-import { useStorage, useMyPresence } from "../../liveblocks.config";
+import { useStorage, useSelf } from "../../liveblocks.config";
 import { useMemo } from "react";
 import { XYWH } from "../types";
 import { boundingBox } from "../utils";
 
 export default function useSelectionBounds(): XYWH | null {
   const layers = useStorage((root) => root.layers);
-  const [{ selection }] = useMyPresence();
+  const selection = useSelf((me) => me.presence.selection);
   return useMemo(() => boundingBox(layers, selection), [layers, selection]);
 }

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
@@ -3,18 +3,15 @@ import { Layer, XYWH } from "../types";
 import { shallow } from "@liveblocks/react";
 
 function boundingBox(layers: Layer[]): XYWH | null {
-  if (layers.length === 0) {
+  const first = layers[0];
+  if (!first) {
     return null;
   }
 
-  if (layers.length === 0) {
-    return null;
-  }
-
-  let left = layers[0].x;
-  let right = layers[0].x + layers[0].width;
-  let top = layers[0].y;
-  let bottom = layers[0].y + layers[0].height;
+  let left = first.x;
+  let right = first.x + first.width;
+  let top = first.y;
+  let bottom = first.y + first.height;
 
   for (let i = 1; i < layers.length; i++) {
     const { x, y, width, height } = layers[i];
@@ -43,9 +40,9 @@ function boundingBox(layers: Layer[]): XYWH | null {
 export default function useSelectionBounds() {
   const selection = useSelf((me) => me.presence.selection);
   return useStorage((root) => {
-    const selectedLayers = selection.map(
-      (layerId) => root.layers.get(layerId)!
-    );
+    const selectedLayers = selection
+      .map((layerId) => root.layers.get(layerId)!)
+      .filter(Boolean);
     return boundingBox(selectedLayers);
   }, shallow);
 }

--- a/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
+++ b/examples/nextjs-whiteboard-advanced/src/hooks/useSelectionBounds.ts
@@ -1,13 +1,12 @@
-import { LiveMap, LiveObject } from "@liveblocks/client";
-import { useRoom } from "../../liveblocks.config";
+import { useRoom, useMap, useMyPresence } from "../../liveblocks.config";
 import { useState, useEffect } from "react";
-import { Layer, XYWH } from "../types";
+import { XYWH } from "../types";
 import { boundingBox } from "../utils";
 
-export default function useSelectionBounds(
-  layers: LiveMap<string, LiveObject<Layer>>,
-  selection: string[]
-): XYWH | null {
+export default function useSelectionBounds(): XYWH | null {
+  const layers = useMap("layers");
+  const [{ selection }] = useMyPresence();
+
   const [bounds, setBounds] = useState(boundingBox(layers, selection));
   const room = useRoom();
 

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -103,7 +103,7 @@ function Canvas() {
   const canUndo = useCanUndo();
   const canRedo = useCanRedo();
 
-  const selectionBounds = useSelectionBounds(liveLayers, selection);
+  const selectionBounds = useSelectionBounds();
 
   useDisableScrollBounce();
 

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -122,8 +122,10 @@ function Canvas() {
   /**
    * Delete all the selected layers.
    */
-  const deleteLayers = useCallback(() => {
-    batch(() => {
+  const deleteLayers = useMutation(
+    ({ root }) => {
+      const liveLayers = root.get("layers");
+      const liveLayerIds = root.get("layerIds");
       for (const id of selection) {
         // Delete the layer from the layers LiveMap
         liveLayers.delete(id);
@@ -133,8 +135,9 @@ function Canvas() {
           liveLayerIds.delete(index);
         }
       }
-    });
-  }, [liveLayerIds, liveLayers, selection]);
+    },
+    [selection]
+  );
 
   /**
    * Hook used to listen to Undo / Redo and delete selected layers

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -210,8 +210,9 @@ function Canvas() {
   /**
    * Move all the selected layers to the front
    */
-  const moveToFront = useCallback(() => {
-    batch(() => {
+  const moveToFront = useMutation(
+    ({ root }) => {
+      const liveLayerIds = root.get("layerIds");
       const indices: number[] = [];
 
       const arr = liveLayerIds.toArray();
@@ -228,8 +229,9 @@ function Canvas() {
           arr.length - 1 - (indices.length - 1 - i)
         );
       }
-    });
-  }, [liveLayerIds, selection]);
+    },
+    [selection]
+  );
 
   /**
    * Move all the selected layers to the back

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -484,6 +484,34 @@ function Canvas() {
     return layerIdsToColorSelection;
   }, [selections]);
 
+  const pointerMove = useMutation(
+    ({ setMyPresence }, e: React.PointerEvent) => {
+      e.preventDefault();
+      const current = pointerEventToCanvasPoint(e, camera);
+      if (canvasState.mode === CanvasMode.Pressing) {
+        startMultiSelection(current, canvasState.origin);
+      } else if (canvasState.mode === CanvasMode.SelectionNet) {
+        updateSelectionNet(current, canvasState.origin);
+      } else if (canvasState.mode === CanvasMode.Translating) {
+        translateSelectedLayers(current);
+      } else if (canvasState.mode === CanvasMode.Resizing) {
+        resizeSelectedLayer(current);
+      } else if (canvasState.mode === CanvasMode.Pencil) {
+        continueDrawing(current, e);
+      }
+      setMyPresence({ cursor: current });
+    },
+    [
+      camera,
+      canvasState,
+      continueDrawing,
+      resizeSelectedLayer,
+      startMultiSelection,
+      translateSelectedLayers,
+      updateSelectionNet,
+    ]
+  );
+
   return (
     <>
       <div className={styles.canvas}>
@@ -527,22 +555,7 @@ function Canvas() {
           onPointerLeave={() => {
             setPresence({ cursor: null });
           }}
-          onPointerMove={(e) => {
-            e.preventDefault();
-            const current = pointerEventToCanvasPoint(e, camera);
-            if (canvasState.mode === CanvasMode.Pressing) {
-              startMultiSelection(current, canvasState.origin);
-            } else if (canvasState.mode === CanvasMode.SelectionNet) {
-              updateSelectionNet(current, canvasState.origin);
-            } else if (canvasState.mode === CanvasMode.Translating) {
-              translateSelectedLayers(current);
-            } else if (canvasState.mode === CanvasMode.Resizing) {
-              resizeSelectedLayer(current);
-            } else if (canvasState.mode === CanvasMode.Pencil) {
-              continueDrawing(current, e);
-            }
-            setPresence({ cursor: current });
-          }}
+          onPointerMove={pointerMove}
           onPointerUp={(e) => {
             const point = pointerEventToCanvasPoint(e, camera);
 

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -583,23 +583,15 @@ function Canvas() {
               transform: `translate(${camera.x}px, ${camera.y}px)`,
             }}
           >
-            {layerIds.map((layerId) => {
-              const layer = layers.get(layerId);
-              if (layer == null) {
-                return null;
-              }
-
-              return (
-                <LayerComponent
-                  key={layerId}
-                  id={layerId}
-                  mode={canvasState.mode}
-                  onLayerPointerDown={onLayerPointerDown}
-                  layer={layer}
-                  selectionColor={layerIdsToColorSelection[layerId]}
-                />
-              );
-            })}
+            {layerIds.map((layerId) => (
+              <LayerComponent
+                key={layerId}
+                id={layerId}
+                mode={canvasState.mode}
+                onLayerPointerDown={onLayerPointerDown}
+                selectionColor={layerIdsToColorSelection[layerId]}
+              />
+            ))}
             {/* Blue square that show the selection of the current users. Also contains the resize handles. */}
             {selectionBounds && (
               <SelectionBox

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -459,9 +459,8 @@ function Canvas() {
   const layerIdsToColorSelection = useMemo(() => {
     const layerIdsToColorSelection: Record<string, string> = {};
 
-    const users = others.toArray();
-    for (const user of users) {
-      const selection = user.presence?.selection;
+    for (const user of others) {
+      const selection = user.presence.selection;
       if (selection == null || selection.length === 0) {
         continue;
       }

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -584,8 +584,8 @@ function Canvas() {
               transform: `translate(${camera.x}px, ${camera.y}px)`,
             }}
           >
-            {liveLayerIds.map((layerId) => {
-              const layer = liveLayers.get(layerId);
+            {layerIds.map((layerId) => {
+              const layer = layers.get(layerId);
               if (layer == null) {
                 return null;
               }

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -28,7 +28,6 @@ import {
   colorToCss,
   connectionIdToColor,
   findIntersectingLayersWithRectangle,
-  getMutableSelectedLayers,
   penPointsToPathLayer,
   pointerEventToCanvasPoint,
   resizeBounds,
@@ -170,10 +169,9 @@ function Canvas() {
     ({ root }, fill: Color) => {
       const liveLayers = root.get("layers");
       setLastUsedColor(fill);
-      const selectedLayers = getMutableSelectedLayers(liveLayers, selection);
-      for (const layer of selectedLayers) {
-        layer.set("fill", fill);
-      }
+      selection.forEach((id) => {
+        liveLayers.get(id)?.set("fill", fill);
+      });
     },
     [selection, setLastUsedColor]
   );

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -36,7 +36,6 @@ import { nanoid } from "nanoid";
 import { useRouter } from "next/router";
 import LayerComponent from "./components/LayerComponent";
 import SelectionTools from "./components/SelectionTools";
-import useSelectionBounds from "./hooks/useSelectionBounds";
 import useDisableScrollBounce from "./hooks/useDisableScrollBounce";
 import MultiplayerGuides from "./components/MultiplayerGuides";
 import Path from "./components/Path";
@@ -105,8 +104,6 @@ function Canvas() {
   const history = useHistory();
   const canUndo = useCanUndo();
   const canRedo = useCanRedo();
-
-  const selectionBounds = useSelectionBounds();
 
   useDisableScrollBounce();
 
@@ -556,20 +553,17 @@ function Canvas() {
   return (
     <>
       <div className={styles.canvas}>
-        {selectionBounds && (
-          <SelectionTools
-            isAnimated={
-              canvasState.mode !== CanvasMode.Translating &&
-              canvasState.mode !== CanvasMode.Resizing
-            }
-            x={selectionBounds.width / 2 + selectionBounds.x + camera.x}
-            y={selectionBounds.y + camera.y}
-            setLastUsedColor={setLastUsedColor}
-            moveToFront={moveToFront}
-            moveToBack={moveToBack}
-            deleteItems={deleteLayers}
-          />
-        )}
+        <SelectionTools
+          isAnimated={
+            canvasState.mode !== CanvasMode.Translating &&
+            canvasState.mode !== CanvasMode.Resizing
+          }
+          camera={camera}
+          setLastUsedColor={setLastUsedColor}
+          moveToFront={moveToFront}
+          moveToBack={moveToBack}
+          deleteItems={deleteLayers}
+        />
         <svg
           className={styles.renderer_svg}
           onWheel={onWheel}

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -336,32 +336,31 @@ function Canvas() {
   /**
    * Move selected layers on the canvas
    */
-  const translateSelectedLayers = useCallback(
-    (point: Point) => {
+  const translateSelectedLayers = useMutation(
+    ({ root }, point: Point) => {
       if (canvasState.mode !== CanvasMode.Translating) {
         return;
       }
 
-      batch(() => {
-        const offset = {
-          x: point.x - canvasState.current.x,
-          y: point.y - canvasState.current.y,
-        };
+      const offset = {
+        x: point.x - canvasState.current.x,
+        y: point.y - canvasState.current.y,
+      };
 
-        for (const id of selection) {
-          const layer = liveLayers.get(id);
-          if (layer) {
-            layer.update({
-              x: layer.get("x") + offset.x,
-              y: layer.get("y") + offset.y,
-            });
-          }
+      const liveLayers = root.get("layers");
+      for (const id of selection) {
+        const layer = liveLayers.get(id);
+        if (layer) {
+          layer.update({
+            x: layer.get("x") + offset.x,
+            y: layer.get("y") + offset.y,
+          });
         }
+      }
 
-        setState({ mode: CanvasMode.Translating, current: point });
-      });
+      setState({ mode: CanvasMode.Translating, current: point });
     },
-    [liveLayers, canvasState, selection, batch]
+    [canvasState, selection]
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -37,6 +37,7 @@ import { useRouter } from "next/router";
 import LayerComponent from "./components/LayerComponent";
 import SelectionTools from "./components/SelectionTools";
 import useDisableScrollBounce from "./hooks/useDisableScrollBounce";
+import useDeleteLayers from "./hooks/useDeleteLayers";
 import MultiplayerGuides from "./components/MultiplayerGuides";
 import Path from "./components/Path";
 import ToolsBar from "./components/ToolsBar";
@@ -107,25 +108,7 @@ function Canvas() {
 
   useDisableScrollBounce();
 
-  /**
-   * Delete all the selected layers.
-   */
-  const deleteLayers = useMutation(
-    ({ root }) => {
-      const liveLayers = root.get("layers");
-      const liveLayerIds = root.get("layerIds");
-      for (const id of selection) {
-        // Delete the layer from the layers LiveMap
-        liveLayers.delete(id);
-        // Find the layer index in the z-index list and remove it
-        const index = liveLayerIds.indexOf(id);
-        if (index !== -1) {
-          liveLayerIds.delete(index);
-        }
-      }
-    },
-    [selection]
-  );
+  const deleteLayers = useDeleteLayers();
 
   /**
    * Hook used to listen to Undo / Redo and delete selected layers
@@ -178,55 +161,6 @@ function Canvas() {
       setState({ mode: CanvasMode.Translating, current: point });
     },
     [setState, selection, camera, history, canvasState.mode]
-  );
-
-  /**
-   * Move all the selected layers to the front
-   */
-  const moveToFront = useMutation(
-    ({ root }) => {
-      const liveLayerIds = root.get("layerIds");
-      const indices: number[] = [];
-
-      const arr = liveLayerIds.toArray();
-
-      for (let i = 0; i < arr.length; i++) {
-        if (selection.includes(arr[i])) {
-          indices.push(i);
-        }
-      }
-
-      for (let i = indices.length - 1; i >= 0; i--) {
-        liveLayerIds.move(
-          indices[i],
-          arr.length - 1 - (indices.length - 1 - i)
-        );
-      }
-    },
-    [selection]
-  );
-
-  /**
-   * Move all the selected layers to the back
-   */
-  const moveToBack = useMutation(
-    ({ root }) => {
-      const liveLayerIds = root.get("layerIds");
-      const indices: number[] = [];
-
-      const arr = liveLayerIds.toArray();
-
-      for (let i = 0; i < arr.length; i++) {
-        if (selection.includes(arr[i])) {
-          indices.push(i);
-        }
-      }
-
-      for (let i = 0; i < indices.length; i++) {
-        liveLayerIds.move(indices[i], i);
-      }
-    },
-    [selection]
   );
 
   /**
@@ -560,9 +494,6 @@ function Canvas() {
           }
           camera={camera}
           setLastUsedColor={setLastUsedColor}
-          moveToFront={moveToFront}
-          moveToBack={moveToBack}
-          deleteItems={deleteLayers}
         />
         <svg
           className={styles.renderer_svg}

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -5,6 +5,7 @@ import {
   RoomProvider,
   useMap,
   useHistory,
+  useStorage,
   useBatch,
   useCanUndo,
   useCanRedo,
@@ -28,7 +29,7 @@ import {
   colorToCss,
   connectionIdToColor,
   findIntersectingLayersWithRectangle,
-  getSelectedLayers,
+  getMutableSelectedLayers,
   penPointsToPathLayer,
   pointerEventToCanvasPoint,
   resizeBounds,
@@ -84,8 +85,10 @@ function Loading() {
 
 function Canvas() {
   // layers is a map that contains all the shapes drawn on the canvas
+  const layers = useStorage((root) => root.layers);
   const liveLayers = useMap("layers");
   // layerIds is list of all the layer ids ordered by their z-index
+  const layerIds = useStorage((root) => root.layerIds);
   const liveLayerIds = useList("layerIds");
 
   const [{ selection, pencilDraft }, setPresence] = useMyPresence();
@@ -160,7 +163,7 @@ function Canvas() {
   const setFill = useCallback(
     (fill: Color) => {
       setLastUsedColor(fill);
-      const selectedLayers = getSelectedLayers(liveLayers, selection);
+      const selectedLayers = getMutableSelectedLayers(liveLayers, selection);
       batch(() => {
         for (const layer of selectedLayers) {
           layer.set("fill", fill);
@@ -436,8 +439,8 @@ function Canvas() {
         current,
       });
       const ids = findIntersectingLayersWithRectangle(
-        liveLayerIds,
-        liveLayers,
+        layerIds,
+        layers,
         origin,
         current
       );

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -394,14 +394,14 @@ function Canvas() {
   /**
    * Insert the first path point and start drawing with the pencil
    */
-  const startDrawing = useCallback(
-    (point: Point, pressure: number) => {
-      setPresence({
+  const startDrawing = useMutation(
+    ({ setMyPresence }, point: Point, pressure: number) => {
+      setMyPresence({
         pencilDraft: [[point.x, point.y, pressure]],
         penColor: lastUsedColor,
       });
     },
-    [setPresence]
+    []
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -387,9 +387,9 @@ function Canvas() {
     [canvasState]
   );
 
-  const unselectLayers = useCallback(() => {
-    setPresence({ selection: [] }, { addToHistory: true });
-  }, [setPresence]);
+  const unselectLayers = useMutation(({ setMyPresence }) => {
+    setMyPresence({ selection: [] }, { addToHistory: true });
+  }, []);
 
   /**
    * Insert the first path point and start drawing with the pencil

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -448,8 +448,8 @@ function Canvas() {
   /**
    * Update the position of the selection net and select the layers accordingly
    */
-  const updateSelectionNet = useCallback(
-    (current: Point, origin: Point) => {
+  const updateSelectionNet = useMutation(
+    ({ setMyPresence }, current: Point, origin: Point) => {
       setState({
         mode: CanvasMode.SelectionNet,
         origin: origin,
@@ -461,9 +461,9 @@ function Canvas() {
         origin,
         current
       );
-      setPresence({ selection: ids });
+      setMyPresence({ selection: ids });
     },
-    [liveLayers, liveLayerIds, setPresence]
+    [layerIds, layers]
   );
 
   const selections = useOtherIds((other) => other.presence.selection);

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -606,7 +606,7 @@ function Canvas() {
               <SelectionBox
                 selection={selection}
                 bounds={selectionBounds}
-                layers={liveLayers}
+                layers={layers}
                 onResizeHandlePointerDown={onResizeHandlePointerDown}
                 isAnimated={
                   canvasState.mode !== CanvasMode.Translating &&

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -172,17 +172,16 @@ function Canvas() {
   /**
    * Change the color of all the selected layers
    */
-  const setFill = useCallback(
-    (fill: Color) => {
+  const setFill = useMutation(
+    ({ root }, fill: Color) => {
+      const liveLayers = root.get("layers");
       setLastUsedColor(fill);
       const selectedLayers = getMutableSelectedLayers(liveLayers, selection);
-      batch(() => {
-        for (const layer of selectedLayers) {
-          layer.set("fill", fill);
-        }
-      });
+      for (const layer of selectedLayers) {
+        layer.set("fill", fill);
+      }
     },
-    [liveLayers, selection, setLastUsedColor]
+    [selection, setLastUsedColor]
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -366,8 +366,8 @@ function Canvas() {
   /**
    * Resize selected layer. Only resizing a single layer is allowed.
    */
-  const resizeSelectedLayer = useCallback(
-    (point: Point) => {
+  const resizeSelectedLayer = useMutation(
+    ({ root }, point: Point) => {
       if (canvasState.mode !== CanvasMode.Resizing) {
         return;
       }
@@ -378,12 +378,13 @@ function Canvas() {
         point
       );
 
+      const liveLayers = root.get("layers");
       const layer = liveLayers.get(selection[0]);
       if (layer) {
         layer.update(bounds);
       }
     },
-    [canvasState, liveLayers]
+    [canvasState]
   );
 
   const unselectLayers = useCallback(() => {

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -593,18 +593,13 @@ function Canvas() {
               />
             ))}
             {/* Blue square that show the selection of the current users. Also contains the resize handles. */}
-            {selectionBounds && (
-              <SelectionBox
-                selection={selection}
-                bounds={selectionBounds}
-                layers={layers}
-                onResizeHandlePointerDown={onResizeHandlePointerDown}
-                isAnimated={
-                  canvasState.mode !== CanvasMode.Translating &&
-                  canvasState.mode !== CanvasMode.Resizing
-                }
-              />
-            )}
+            <SelectionBox
+              onResizeHandlePointerDown={onResizeHandlePointerDown}
+              isAnimated={
+                canvasState.mode !== CanvasMode.Translating &&
+                canvasState.mode !== CanvasMode.Resizing
+              }
+            />
             {/* Selection net that appears when the user is selecting multiple layers at once */}
             {canvasState.mode === CanvasMode.SelectionNet &&
               canvasState.current != null && (

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -161,20 +161,6 @@ function Canvas() {
   }, [selection, deleteLayers, history]);
 
   /**
-   * Change the color of all the selected layers
-   */
-  const setFill = useMutation(
-    ({ root }, fill: Color) => {
-      const liveLayers = root.get("layers");
-      setLastUsedColor(fill);
-      selection.forEach((id) => {
-        liveLayers.get(id)?.set("fill", fill);
-      });
-    },
-    [selection, setLastUsedColor]
-  );
-
-  /**
    * Select the layer if not already selected and start translating the selection
    */
   const onLayerPointerDown = useMutation(
@@ -578,7 +564,7 @@ function Canvas() {
             }
             x={selectionBounds.width / 2 + selectionBounds.x + camera.x}
             y={selectionBounds.y + camera.y}
-            setFill={setFill}
+            setLastUsedColor={setLastUsedColor}
             moveToFront={moveToFront}
             moveToBack={moveToBack}
             deleteItems={deleteLayers}

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -187,8 +187,8 @@ function Canvas() {
   /**
    * Select the layer if not already selected and start translating the selection
    */
-  const onLayerPointerDown = useCallback(
-    (e: React.PointerEvent, layerId: string) => {
+  const onLayerPointerDown = useMutation(
+    ({ setMyPresence }, e: React.PointerEvent, layerId: string) => {
       if (
         canvasState.mode === CanvasMode.Pencil ||
         canvasState.mode === CanvasMode.Inserting
@@ -200,11 +200,11 @@ function Canvas() {
       e.stopPropagation();
       const point = pointerEventToCanvasPoint(e, camera);
       if (!selection.includes(layerId)) {
-        setPresence({ selection: [layerId] }, { addToHistory: true });
+        setMyPresence({ selection: [layerId] }, { addToHistory: true });
       }
       setState({ mode: CanvasMode.Translating, current: point });
     },
-    [setPresence, setState, selection, camera, history, canvasState.mode]
+    [setState, selection, camera, history, canvasState.mode]
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -307,34 +307,31 @@ function Canvas() {
   /**
    * Transform the drawing of the current user in a layer and reset the presence to delete the draft.
    */
-  const insertPath = useCallback(() => {
-    if (
-      pencilDraft == null ||
-      pencilDraft.length < 2 ||
-      liveLayers.size >= MAX_LAYERS
-    ) {
-      setPresence({ pencilDraft: null });
-      return;
-    }
+  const insertPath = useMutation(
+    ({ root, setMyPresence }) => {
+      const liveLayers = root.get("layers");
+      if (
+        pencilDraft == null ||
+        pencilDraft.length < 2 ||
+        liveLayers.size >= MAX_LAYERS
+      ) {
+        setMyPresence({ pencilDraft: null });
+        return;
+      }
 
-    batch(() => {
       const id = nanoid();
       liveLayers.set(
         id,
         new LiveObject(penPointsToPathLayer(pencilDraft, lastUsedColor))
       );
+
+      const liveLayerIds = root.get("layerIds");
       liveLayerIds.push(id);
-      setPresence({ pencilDraft: null });
+      setMyPresence({ pencilDraft: null });
       setState({ mode: CanvasMode.Pencil });
-    });
-  }, [
-    liveLayers,
-    setPresence,
-    batch,
-    liveLayerIds,
-    lastUsedColor,
-    pencilDraft,
-  ]);
+    },
+    [lastUsedColor, pencilDraft]
+  );
 
   /**
    * Move selected layers on the canvas

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -2,13 +2,10 @@ import {
   useOtherIds,
   useMutation,
   useUpdateMyPresence,
-  useList,
   RoomProvider,
-  useMap,
   useHistory,
   useStorage,
   useSelf,
-  useBatch,
   useCanUndo,
   useCanRedo,
 } from "../liveblocks.config";
@@ -88,10 +85,8 @@ function Loading() {
 function Canvas() {
   // layers is a map that contains all the shapes drawn on the canvas
   const layers = useStorage((root) => root.layers);
-  const liveLayers = useMap("layers");
   // layerIds is list of all the layer ids ordered by their z-index
   const layerIds = useStorage((root) => root.layerIds);
-  const liveLayerIds = useList("layerIds");
 
   const { selection, pencilDraft } = useSelf(
     (me) => ({
@@ -110,7 +105,6 @@ function Canvas() {
     g: 142,
     b: 42,
   });
-  const batch = useBatch();
   const history = useHistory();
   const canUndo = useCanUndo();
   const canRedo = useCanRedo();

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -236,8 +236,9 @@ function Canvas() {
   /**
    * Move all the selected layers to the back
    */
-  const moveToBack = useCallback(() => {
-    batch(() => {
+  const moveToBack = useMutation(
+    ({ root }) => {
+      const liveLayerIds = root.get("layerIds");
       const indices: number[] = [];
 
       const arr = liveLayerIds.toArray();
@@ -251,8 +252,9 @@ function Canvas() {
       for (let i = 0; i < indices.length; i++) {
         liveLayerIds.move(indices[i], i);
       }
-    });
-  }, [liveLayerIds, selection]);
+    },
+    [selection]
+  );
 
   /**
    * Start resizing the layer

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -81,9 +81,6 @@ function Loading() {
 }
 
 function Canvas() {
-  // layers is a map that contains all the shapes drawn on the canvas
-  const layers = useStorage((root) => root.layers);
-  // layerIds is list of all the layer ids ordered by their z-index
   const layerIds = useStorage((root) => root.layerIds);
 
   const { selection, pencilDraft } = useSelf(
@@ -356,7 +353,8 @@ function Canvas() {
    * Update the position of the selection net and select the layers accordingly
    */
   const updateSelectionNet = useMutation(
-    ({ setMyPresence }, current: Point, origin: Point) => {
+    ({ root, setMyPresence }, current: Point, origin: Point) => {
+      const layers = root.get("layers").toImmutable();
       setState({
         mode: CanvasMode.SelectionNet,
         origin: origin,
@@ -370,7 +368,7 @@ function Canvas() {
       );
       setMyPresence({ selection: ids });
     },
-    [layerIds, layers]
+    [layerIds]
   );
 
   const selections = useOtherIds((other) => other.presence.selection);

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -407,8 +407,8 @@ function Canvas() {
   /**
    * Continue the drawing and send the current draft to other users in the room
    */
-  const continueDrawing = useCallback(
-    (point: Point, e: React.PointerEvent) => {
+  const continueDrawing = useMutation(
+    ({ setMyPresence }, point: Point, e: React.PointerEvent) => {
       if (
         canvasState.mode !== CanvasMode.Pencil ||
         e.buttons !== 1 ||
@@ -417,7 +417,7 @@ function Canvas() {
         return;
       }
 
-      setPresence({
+      setMyPresence({
         cursor: point,
         pencilDraft:
           pencilDraft.length === 1 &&
@@ -427,7 +427,7 @@ function Canvas() {
             : [...pencilDraft, [point.x, point.y, e.pressure]],
       });
     },
-    [canvasState.mode, setPresence, pencilDraft]
+    [canvasState.mode, pencilDraft]
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -9,6 +9,7 @@ import {
   useCanUndo,
   useCanRedo,
 } from "../liveblocks.config";
+import { ClientSideSuspense } from "@liveblocks/react";
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -63,38 +64,30 @@ export default function Room() {
       }}
     >
       <div className={styles.container}>
-        <WhiteboardTool />
+        <ClientSideSuspense fallback={<Loading />}>
+          {() => <Canvas />}
+        </ClientSideSuspense>
       </div>
     </RoomProvider>
   );
 }
 
-function WhiteboardTool() {
+function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.loading}>
+        <img src="https://liveblocks.io/loading.svg" alt="Loading" />
+      </div>
+    </div>
+  );
+}
+
+function Canvas() {
   // layers is a LiveMap that contains all the shapes drawn on the canvas
   const layers = useMap("layers");
   // layerIds is LiveList of all the layer ids ordered by their z-index
   const layerIds = useList("layerIds");
 
-  if (layerIds == null || layers == null) {
-    return (
-      <div className={styles.container}>
-        <div className={styles.loading}>
-          <img src="https://liveblocks.io/loading.svg" alt="Loading" />
-        </div>
-      </div>
-    );
-  }
-
-  return <Canvas layers={layers} layerIds={layerIds} />;
-}
-
-function Canvas({
-  layerIds,
-  layers,
-}: {
-  layerIds: LiveList<string>;
-  layers: LiveMap<string, LiveObject<Layer>>;
-}) {
   const [{ selection, pencilDraft }, setPresence] = useMyPresence();
   const [canvasState, setState] = useState<CanvasState>({
     mode: CanvasMode.None,

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -274,29 +274,34 @@ function Canvas() {
   /**
    * Insert an ellipse or a rectangle at the given position and select it
    */
-  const insertLayer = useCallback(
-    (layerType: LayerType.Ellipse | LayerType.Rectangle, position: Point) => {
+  const insertLayer = useMutation(
+    (
+      { root, setMyPresence },
+      layerType: LayerType.Ellipse | LayerType.Rectangle,
+      position: Point
+    ) => {
+      const liveLayers = root.get("layers");
       if (liveLayers.size >= MAX_LAYERS) {
         return;
       }
 
-      batch(() => {
-        const layerId = nanoid();
-        const layer = new LiveObject({
-          type: layerType,
-          x: position.x,
-          y: position.y,
-          height: 100,
-          width: 100,
-          fill: lastUsedColor,
-        });
-        liveLayerIds.push(layerId);
-        liveLayers.set(layerId, layer);
-        setPresence({ selection: [layerId] }, { addToHistory: true });
-        setState({ mode: CanvasMode.None });
+      const liveLayerIds = root.get("layerIds");
+      const layerId = nanoid();
+      const layer = new LiveObject({
+        type: layerType,
+        x: position.x,
+        y: position.y,
+        height: 100,
+        width: 100,
+        fill: lastUsedColor,
       });
+      liveLayerIds.push(layerId);
+      liveLayers.set(layerId, layer);
+
+      setMyPresence({ selection: [layerId] }, { addToHistory: true });
+      setState({ mode: CanvasMode.None });
     },
-    [batch, liveLayerIds, liveLayers, setPresence, lastUsedColor]
+    [lastUsedColor]
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -1,5 +1,6 @@
 import {
   useOtherIds,
+  useMutation,
   useUpdateMyPresence,
   useList,
   RoomProvider,

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -378,7 +378,7 @@ function Canvas() {
         layer.update(bounds);
       }
     },
-    [canvasState]
+    [canvasState, selection]
   );
 
   const unselectLayers = useMutation(({ setMyPresence }) => {
@@ -395,7 +395,7 @@ function Canvas() {
         penColor: lastUsedColor,
       });
     },
-    []
+    [lastUsedColor]
   );
 
   /**

--- a/examples/nextjs-whiteboard-advanced/src/utils.ts
+++ b/examples/nextjs-whiteboard-advanced/src/utils.ts
@@ -143,20 +143,6 @@ export function findIntersectingLayersWithRectangle(
   return ids;
 }
 
-export function getMutableSelectedLayers(
-  layers: LiveMap<string, LiveObject<Layer>>,
-  selection: string[]
-): LiveObject<Layer>[] {
-  const result = [];
-  for (const id of selection) {
-    const layer = layers.get(id);
-    if (layer) {
-      result.push(layer);
-    }
-  }
-  return result;
-}
-
 function getSelectedLayers(
   layers: ReadonlyMap<string, Layer>,
   selection: string[]

--- a/examples/nextjs-whiteboard-advanced/src/utils.ts
+++ b/examples/nextjs-whiteboard-advanced/src/utils.ts
@@ -9,7 +9,6 @@ import {
   PathLayer,
   Camera,
 } from "./types";
-import type { LiveObject, LiveMap } from "@liveblocks/client";
 
 export function colorToCss(color: Color) {
   return `#${color.r.toString(16).padStart(2, "0")}${color.g
@@ -141,63 +140,6 @@ export function findIntersectingLayersWithRectangle(
   }
 
   return ids;
-}
-
-function getSelectedLayers(
-  layers: ReadonlyMap<string, Layer>,
-  selection: string[]
-): Layer[] {
-  const result = [];
-  for (const id of selection) {
-    const layer = layers.get(id);
-    if (layer) {
-      result.push(layer);
-    }
-  }
-  return result;
-}
-
-export function boundingBox(
-  allLayers: ReadonlyMap<string, Layer>,
-  selection: string[]
-): XYWH | null {
-  if (selection.length === 0) {
-    return null;
-  }
-
-  const layers = getSelectedLayers(allLayers, selection);
-
-  if (layers.length === 0) {
-    return null;
-  }
-
-  let left = layers[0].x;
-  let right = layers[0].x + layers[0].width;
-  let top = layers[0].y;
-  let bottom = layers[0].y + layers[0].height;
-
-  for (let i = 1; i < layers.length; i++) {
-    const { x, y, width, height } = layers[i];
-    if (left > x) {
-      left = x;
-    }
-    if (right < x + width) {
-      right = x + width;
-    }
-    if (top > y) {
-      top = y;
-    }
-    if (bottom < y + height) {
-      bottom = y + height;
-    }
-  }
-
-  return {
-    x: left,
-    y: top,
-    width: right - left,
-    height: bottom - top,
-  };
 }
 
 export function getSvgPathFromStroke(stroke: number[][]) {

--- a/examples/nextjs-whiteboard-advanced/src/utils.ts
+++ b/examples/nextjs-whiteboard-advanced/src/utils.ts
@@ -9,7 +9,7 @@ import {
   PathLayer,
   Camera,
 } from "./types";
-import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
+import type { LiveObject, LiveMap } from "@liveblocks/client";
 
 export function colorToCss(color: Color) {
   return `#${color.r.toString(16).padStart(2, "0")}${color.g
@@ -56,13 +56,13 @@ export function resizeBounds(bounds: XYWH, corner: Side, point: Point): XYWH {
 
 export function findIntersectingLayerWithPoint(
   layerIds: string[],
-  layers: LiveMap<string, LiveObject<Layer>>,
+  layers: Map<string, Layer>,
   point: Point
 ) {
   for (let i = layerIds.length - 1; i >= 0; i--) {
     const layerId = layerIds[i];
     const layer = layers.get(layerId);
-    if (layer && isHittingLayer(layer.toObject(), point)) {
+    if (layer && isHittingLayer(layer, point)) {
       return layerId;
     }
   }
@@ -109,8 +109,8 @@ export function isHittingEllipse(layer: EllipseLayer, point: Point) {
  * TODO: Implement ellipse and path / selection net collision
  */
 export function findIntersectingLayersWithRectangle(
-  layerIds: LiveList<string>,
-  layers: LiveMap<string, LiveObject<Layer>>,
+  layerIds: readonly string[],
+  layers: ReadonlyMap<string, Layer>,
   a: Point,
   b: Point
 ) {
@@ -129,7 +129,7 @@ export function findIntersectingLayersWithRectangle(
       continue;
     }
 
-    const { x, y, height, width } = layer.toObject();
+    const { x, y, height, width } = layer;
     if (
       rect.x + rect.width > x &&
       rect.x < x + width &&
@@ -143,7 +143,7 @@ export function findIntersectingLayersWithRectangle(
   return ids;
 }
 
-export function getSelectedLayers(
+export function getMutableSelectedLayers(
   layers: LiveMap<string, LiveObject<Layer>>,
   selection: string[]
 ): LiveObject<Layer>[] {
@@ -157,17 +157,29 @@ export function getSelectedLayers(
   return result;
 }
 
+function getSelectedLayers(
+  layers: ReadonlyMap<string, Layer>,
+  selection: string[]
+): Layer[] {
+  const result = [];
+  for (const id of selection) {
+    const layer = layers.get(id);
+    if (layer) {
+      result.push(layer);
+    }
+  }
+  return result;
+}
+
 export function boundingBox(
-  allLayers: LiveMap<string, LiveObject<Layer>>,
+  allLayers: ReadonlyMap<string, Layer>,
   selection: string[]
 ): XYWH | null {
   if (selection.length === 0) {
     return null;
   }
 
-  const layers = getSelectedLayers(allLayers, selection).map((l) =>
-    l.toObject()
-  );
+  const layers = getSelectedLayers(allLayers, selection);
 
   if (layers.length === 0) {
     return null;


### PR DESCRIPTION
This PR converts `nextjs-whiteboard-advanced` to the new 0.18 APIs, and uses new best practices. I kept the commit history super clean and atomic, so I encourage you to read this PR commit-by-commit, using GitHub's next/prev buttons to navigate. Each change shows one conversion, so you can easily compare "old" vs "new" patterns.

The end result is a massive improvement, not only making the code simpler, but also the app is a lot faster because the amount of rerenders has drastically dropped.

Just look at the rerender counter for the main canvas area to see the difference 😄 

### Before

https://user-images.githubusercontent.com/83844/188910815-9097010d-6094-4e70-8daa-9ed96edecd6e.mp4

### After

https://user-images.githubusercontent.com/83844/188910842-91b1abd8-fd3c-469e-955c-76747e6d5aab.mp4
