### PR TITLE
Support nested batches

### DIFF
--- a/packages/liveblocks-client/src/__tests__/doc.test.ts
+++ b/packages/liveblocks-client/src/__tests__/doc.test.ts
@@ -317,6 +317,30 @@ describe("Storage", () => {
       });
     });
 
+    it("batch callbacks can return a value", async () => {
+      const { storage, batch } = await prepareStorageTest<{
+        items: LiveList<string>;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedList("0:1", "0:0", "items"),
+        ],
+        1
+      );
+
+      const items = storage.root.get("items");
+
+      const numInserted = batch(() => {
+        const before = items.length;
+        items.push("A");
+        items.push("B");
+        items.push("C");
+        return items.length - before;
+      });
+
+      expect(numInserted).toEqual(3);
+    });
+
     it("calling undo during a batch should throw", async () => {
       const { undo, batch } = await prepareStorageTest<{ a: number }>(
         [createSerializedObject("0:0", { a: 0 })],

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -117,7 +117,7 @@ type Machine<
   ): void;
   broadcastEvent(event: TRoomEvent, options?: BroadcastOptions): void;
 
-  batch(callback: () => void): void;
+  batch<T>(callback: () => T): T;
   undo(): void;
   redo(): void;
   canUndo(): boolean;
@@ -1476,7 +1476,7 @@ function makeStateMachine<
     return state.redoStack.length > 0;
   }
 
-  function batch(callback: () => void) {
+  function batch<T>(callback: () => T): T {
     if (state.activeBatch) {
       throw new Error("batch should not be called during a batch");
     }
@@ -1492,7 +1492,7 @@ function makeStateMachine<
     };
 
     try {
-      callback();
+      return callback();
     } finally {
       // "Pop" the current batch of the state, closing the active batch, but
       // handling it separately here

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1478,7 +1478,10 @@ function makeStateMachine<
 
   function batch<T>(callback: () => T): T {
     if (state.activeBatch) {
-      throw new Error("batch should not be called during a batch");
+      // If there already is an active batch, we don't have to handle this in
+      // any special way. That outer active batch will handle the batch. This
+      // nested call can be a no-op.
+      return callback();
     }
 
     state.activeBatch = {

--- a/packages/liveblocks-client/src/types/index.ts
+++ b/packages/liveblocks-client/src/types/index.ts
@@ -700,7 +700,7 @@ export type Room<
    *   room.updatePresence({ cursor: { x: 100, y: 100 }});
    * });
    */
-  batch: (fn: () => void) => void;
+  batch<T>(fn: () => T): T;
 
   /**
    * @internal Utilities only used for unit testing.

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -92,7 +92,7 @@ type RoomContextBundle<
    * All the modifications are merged in a single history item (undo/redo).
    * All the subscribers are called only after the batch is over.
    */
-  useBatch(): (callback: () => void) => void;
+  useBatch<T>(): (callback: () => T) => T;
 
   /**
    * Returns a callback that lets you broadcast custom events to other users in the room
@@ -859,7 +859,7 @@ export function createRoomContext<
     return canRedo;
   }
 
-  function useBatch(): (callback: () => void) => void {
+  function useBatch<T>(): (callback: () => T) => T {
     return useRoom().batch;
   }
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -1032,13 +1032,10 @@ export function createRoomContext<
             root,
             setMyPresence,
           };
-          return ((...args) => {
-            let rv;
-            room.batch(() => {
-              rv = callback(mutationCtx, ...args);
-            });
-            return rv;
-          }) as OmitFirstArg<F>;
+          return ((...args) =>
+            room.batch(() =>
+              callback(mutationCtx, ...args)
+            )) as OmitFirstArg<F>;
         } else {
           return ((): void => {
             throw new Error(


### PR DESCRIPTION
Fixes #416, to be included with 0.18.

In this PR, I've simplified the internal state variables that manage the active batch a bit. Also, I've allowed `room.batch(<callback>)` to optionally return a value. For example, such return values can be useful if you're batching an insertion of a new shape, and you want to return the inserted shape ID from the batch call.

Lastly, nesting batch() calls makes all inner batches simple no-ops. The active batch gets handled by the outermost batch call only.