### PR TITLE
Publish `@liveblocks/client` as ES2015 target

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -67,16 +67,6 @@ module.exports = {
           "Using `JSON.parse()` is type-unsafe. Prefer using the `tryParseJson()` utility method (from `src/utils`).",
       },
       {
-        selector: "FunctionDeclaration[async=true]",
-        message:
-          "Using `async` functions will emit extra support code in our CommonJS bundle, increasing its size. Using the Promise API instead will lead to a smaller bundle.",
-      },
-      {
-        selector: "ArrowFunctionExpression[async=true]",
-        message:
-          "Using `async` functions will emit extra support code in our CommonJS bundle, increasing its size. Using the Promise API instead will lead to a smaller bundle.",
-      },
-      {
         selector: "TSNonNullExpression",
         message:
           "Non-null assertions mask real problems. Please use `nn(...)` (from src/assert.ts) instead.",

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1393,7 +1393,7 @@ function makeStateMachine<
     }
   }
 
-  function getStorage(): Promise<{
+  async function getStorage(): Promise<{
     root: LiveObject<TStorage>;
   }> {
     if (state.root) {
@@ -1403,11 +1403,10 @@ function makeStateMachine<
       });
     }
 
-    return startLoadingStorage().then(() => {
-      return {
-        root: nn(state.root) as LiveObject<TStorage>,
-      };
-    });
+    await startLoadingStorage();
+    return {
+      root: nn(state.root) as LiveObject<TStorage>,
+    };
   }
 
   function undo() {
@@ -1808,24 +1807,21 @@ function prepareAuthEndpoint(
   }
 
   if (authentication.type === "custom") {
-    const authWithResponseValidation = (room: string) => {
-      return authentication.callback(room).then((response) => {
-        if (!response || !response.token) {
-          throw new Error(
-            'Authentication error. We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
-          );
-        }
-        return response;
-      });
+    return async (room: string) => {
+      const response = await authentication.callback(room);
+      if (!response || !response.token) {
+        throw new Error(
+          'Authentication error. We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
+        );
+      }
+      return response;
     };
-
-    return authWithResponseValidation;
   }
 
   throw new Error("Internal error. Unexpected authentication type");
 }
 
-function fetchAuthEndpoint(
+async function fetchAuthEndpoint(
   fetch: typeof window.fetch,
   endpoint: string,
   body: {
@@ -1833,38 +1829,35 @@ function fetchAuthEndpoint(
     publicApiKey?: string;
   }
 ): Promise<{ token: string }> {
-  return fetch(endpoint, {
+  const res = await fetch(endpoint, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
-  })
-    .then((res) => {
-      if (!res.ok) {
-        throw new AuthenticationError(
-          `Expected a status 200 but got ${res.status} when doing a POST request on "${endpoint}"`
-        );
-      }
-
-      return (res.json() as Promise<Json>).catch((er) => {
-        throw new AuthenticationError(
-          `Expected a JSON response when doing a POST request on "${endpoint}". ${er}`
-        );
-      });
-    })
-    .then((data) => {
-      if (!isPlainObject(data) || typeof data.token !== "string") {
-        throw new AuthenticationError(
-          `Expected a JSON response of the form \`{ token: "..." }\` when doing a POST request on "${endpoint}", but got ${JSON.stringify(
-            data
-          )}`
-        );
-      }
-
-      const { token } = data;
-      return { token };
-    });
+  });
+  if (!res.ok) {
+    throw new AuthenticationError(
+      `Expected a status 200 but got ${res.status} when doing a POST request on "${endpoint}"`
+    );
+  }
+  let data: Json;
+  try {
+    data = await (res.json() as Promise<Json>);
+  } catch (er) {
+    throw new AuthenticationError(
+      `Expected a JSON response when doing a POST request on "${endpoint}". ${er}`
+    );
+  }
+  if (!isPlainObject(data) || typeof data.token !== "string") {
+    throw new AuthenticationError(
+      `Expected a JSON response of the form \`{ token: "..." }\` when doing a POST request on "${endpoint}", but got ${JSON.stringify(
+        data
+      )}`
+    );
+  }
+  const { token } = data;
+  return { token };
 }
 
 class AuthenticationError extends Error {

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es5",
+  target: "es2015",
   format: [
     "cjs",
 


### PR DESCRIPTION
This brings the `@liveblocks/client` package up to par with our other packages, which were already targeting ES2015.

Please note that this **does not** mean that app developers that use Liveblocks cannot compile their app to ES5 if they want to support older browsers. That's still possible! It just means that the _input_ to their bundler will now be ES2015 code.

The reason we didn't do this before is that previously we were using Babel and it would expect a runtime dependency to `regenerator-runtime`, and explaining that was considered a pain point. Now that we've switched our builds to `tsup`, this is no longer necessary and there is no more implicit runtime dependency.

That's the reason why we can now also just use `async`/`await` in there.

### Bundle size drop

This also means a nice bundle size drop: almost 50%!

**Before (target = es5):**
```
144K	dist/chunk-ZNCSOBAX.js
 84K	dist/index.js
 24K	dist/internal.js
252K	total  ← 😐 
```

**After (target = es2015):**
```
 72K	dist/chunk-RS4TQ2LT.js
 48K	dist/index.js
 12K	dist/internal.js
132K	total  ← 🤩
```