### PR TITLE
Fix bug in whiteboard example

### DIFF
--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -291,9 +291,14 @@ function Canvas() {
     [canvasState, selection]
   );
 
-  const unselectLayers = useMutation(({ setMyPresence }) => {
-    setMyPresence({ selection: [] }, { addToHistory: true });
-  }, []);
+  const unselectLayers = useMutation(
+    ({ setMyPresence }) => {
+      if (selection.length > 0) {
+        setMyPresence({ selection: [] }, { addToHistory: true });
+      }
+    },
+    [selection]
+  );
 
   /**
    * Insert the first path point and start drawing with the pencil


### PR DESCRIPTION
While testing some of the 0.18 hooks, I found a tiny bug in the whiteboard example.

To see the bug:
1. Open https://liveblocks.io/examples/collaborative-whiteboard-advanced/nextjs
2. Notice the "Undo" button being disabled
3. Click on the empty canvas once
4. Notice the "Undo" button getting enabled

The cause of the bug is that clicking triggers an unselection, which gets put on the undo stack. This PR fixes that by only unselecting if there is an actual selection.
