### PR TITLE
Use sync external store hook in more places

### DIFF
--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -18,9 +18,13 @@ const client = createClient({ authEndpoint: "/api/auth" });
 
 export const {
   RoomProvider,
+  useCanRedo,
+  useCanUndo,
+  useMutation,
   useMyPresence,
   useObject,
   useOthers,
   useRoom,
   useStorage,
+  useUndo,
 } = createRoomContext<Presence, Storage>(client);

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -559,12 +559,10 @@ export function createRoomContext<
     (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void
   ] {
     const room = useRoom();
-    const presence = room.getPresence();
-    const rerender = useRerender();
+    const subscribe = room.events.me.subscribe;
+    const getSnapshot = room.getPresence;
+    const presence = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
     const setPresence = room.updatePresence;
-
-    React.useEffect(() => room.events.me.subscribe(rerender), [room, rerender]);
-
     return [presence, setPresence];
   }
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -34,6 +34,14 @@ type OmitFirstArg<F> = F extends (first: any, ...rest: infer A) => infer R
 const noop = () => {};
 const identity: <T>(x: T) => T = (x) => x;
 
+function useSyncExternalStore<Snapshot>(
+  s: (onStoreChange: () => void) => () => void,
+  g: () => Snapshot,
+  gg: undefined | null | (() => Snapshot)
+): Snapshot {
+  return useSyncExternalStoreWithSelector(s, g, gg, identity);
+}
+
 const EMPTY_OTHERS =
   // NOTE: asArrayWithLegacyMethods() wrapping should no longer be necessary in 0.19
   asArrayWithLegacyMethods([]);
@@ -809,13 +817,7 @@ export function createRoomContext<
     const subscribe = room.events.storageDidLoad.subscribeOnce;
     const getSnapshot = room.getStorageSnapshot;
     const getServerSnapshot = React.useCallback((): Snapshot => null, []);
-    const selector = identity;
-    return useSyncExternalStoreWithSelector(
-      subscribe,
-      getSnapshot,
-      getServerSnapshot,
-      selector
-    );
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   }
 
   // NOTE: This API exists for backward compatible reasons

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -839,26 +839,16 @@ export function createRoomContext<
 
   function useCanUndo(): boolean {
     const room = useRoom();
-    const [canUndo, setCanUndo] = React.useState(room.history.canUndo);
-
-    React.useEffect(
-      () => room.events.history.subscribe(({ canUndo }) => setCanUndo(canUndo)),
-      [room]
-    );
-
-    return canUndo;
+    const subscribe = room.events.history.subscribe;
+    const canUndo = room.history.canUndo;
+    return useSyncExternalStore(subscribe, canUndo, canUndo);
   }
 
   function useCanRedo(): boolean {
     const room = useRoom();
-    const [canRedo, setCanRedo] = React.useState(room.history.canRedo);
-
-    React.useEffect(
-      () => room.events.history.subscribe(({ canRedo }) => setCanRedo(canRedo)),
-      [room]
-    );
-
-    return canRedo;
+    const subscribe = room.events.history.subscribe;
+    const canRedo = room.history.canRedo;
+    return useSyncExternalStore(subscribe, canRedo, canRedo);
   }
 
   function useBatch<T>(): (callback: () => T) => T {


### PR DESCRIPTION
For consistency in the hooks definitions, there were more places where we can utilize the `useSyncExternalStore` semantics instead of rolling our own. This just makes all of our hooks slightly more similar in terms of their implementation.
