### PR TITLE
Expose read-only Presence in Mutation contexts

### DIFF
--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -444,7 +444,7 @@ describe("useCanUndo / useCanRedo", () => {
     const canRedo = renderHook(() => useCanRedo());
     const undo = renderHook(() => useUndo());
     const mutation = renderHook(() =>
-      useMutation(({ root }) => root.get("obj").set("a", Math.random()))
+      useMutation(({ root }) => root.get("obj").set("a", Math.random()), [])
     );
 
     expect(canUndo.result.current).toEqual(false);

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -618,7 +618,7 @@ export function createRoomContext<
       context: MutationContext<TPresence, TStorage, TUserMeta>,
       ...args: any[]
     ) => any
-  >(callback: F, deps?: unknown[]): OmitFirstArg<F> {
+  >(callback: F, deps: readonly unknown[]): OmitFirstArg<F> {
     const room = useRoom();
     return React.useMemo(
       () => {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -628,7 +628,7 @@ export function createRoomContext<
           )) as OmitFirstArg<F>;
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      deps !== undefined ? [room, ...deps] : [room, callback]
+      [room, ...deps]
     );
   }
 

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -808,7 +808,49 @@ export type RoomContextBundle<
     ) => void;
 
     /**
-     * TODO: Document me.
+     * Create a callback function that can be called to mutate Liveblocks
+     * state.
+     *
+     * The first argument that gets passed into your callback will be
+     * a "mutation context", which exposes the following:
+     *
+     *   - `root` - The mutable Storage root.
+     *              You can normal mutation on Live structures with this, for
+     *              example: root.get('layers').get('layer1').set('fill',
+     *              'red')
+     *
+     *   - `setMyPresence` - Call this with a new (partial) Presence value.
+     *
+     *   - `self` - A read-only version of the latest self, if you need it to
+     *              compute the next state.
+     *
+     *   - `others` - A read-only version of the latest others list, if you
+     *                need it to compute the next state.
+     *
+     * useMutation is like React's useCallback, except that the first argument
+     * that gets passed into your callback will be a "mutation context".
+     *
+     * If you want get access to the immutable root somewhere in your mutation,
+     * you can use `root.ToImmutable()`.
+     *
+     * @example
+     * const fillLayers = useMutation(
+     *   ({ root }, color: Color) => {
+     *     ...
+     *   },
+     *   [],
+     * );
+     *
+     * fillLayers('red');
+     *
+     * const deleteLayers = useMutation(
+     *   ({ root }) => {
+     *     ...
+     *   },
+     *   [],
+     * );
+     *
+     * deleteLayers();
      */
     useMutation<
       F extends (

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -476,7 +476,7 @@ export type RoomContextBundle<
     ) => any
   >(
     callback: F,
-    deps?: unknown[]
+    deps: readonly unknown[]
   ): OmitFirstArg<F>;
 
   suspense: {
@@ -817,7 +817,7 @@ export type RoomContextBundle<
       ) => any
     >(
       callback: F,
-      deps?: unknown[]
+      deps: readonly unknown[]
     ): OmitFirstArg<F>;
 
     //

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -42,9 +42,12 @@ export type OmitFirstArg<F> = F extends (
 
 export type MutationContext<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
+  TUserMeta extends BaseUserMeta
 > = {
   root: LiveObject<TStorage>;
+  self: User<TPresence, TUserMeta>;
+  others: Others<TPresence, TUserMeta>;
   setMyPresence: (
     patch: Partial<TPresence>,
     options?: { addToHistory: boolean }
@@ -424,11 +427,51 @@ export type RoomContextBundle<
   ) => void;
 
   /**
-   * TODO: Document me.
+   * Create a callback function that can be called to mutate Liveblocks state.
+   *
+   * The first argument that gets passed into your callback will be a "mutation
+   * context", which exposes the following:
+   *
+   *   - `root` - The mutable Storage root.
+   *              You can normal mutation on Live structures with this, for
+   *              example: root.get('layers').get('layer1').set('fill', 'red')
+   *
+   *   - `setMyPresence` - Call this with a new (partial) Presence value.
+   *
+   *   - `self` - A read-only version of the latest self, if you need it to
+   *              compute the next state.
+   *
+   *   - `others` - A read-only version of the latest others list, if you need
+   *                it to compute the next state.
+   *
+   * useMutation is like React's useCallback, except that the first argument
+   * that gets passed into your callback will be a "mutation context".
+   *
+   * If you want get access to the immutable root somewhere in your mutation,
+   * you can use `root.ToImmutable()`.
+   *
+   * @example
+   * const fillLayers = useMutation(
+   *   ({ root }, color: Color) => {
+   *     ...
+   *   },
+   *   [],
+   * );
+   *
+   * fillLayers('red');
+   *
+   * const deleteLayers = useMutation(
+   *   ({ root }) => {
+   *     ...
+   *   },
+   *   [],
+   * );
+   *
+   * deleteLayers();
    */
   useMutation<
     F extends (
-      context: MutationContext<TPresence, TStorage>,
+      context: MutationContext<TPresence, TStorage, TUserMeta>,
       ...args: any[]
     ) => any
   >(
@@ -769,7 +812,7 @@ export type RoomContextBundle<
      */
     useMutation<
       F extends (
-        context: MutationContext<TPresence, TStorage>,
+        context: MutationContext<TPresence, TStorage, TUserMeta>,
         ...args: any[]
       ) => any
     >(


### PR DESCRIPTION
The mutation context is the first argument you get passed when using the `useMutation()` hook.

It currently gets passed `{ root, setMyPresence }`, but this PR changes that to `{ root, self, others, setMyPresence }`. This has quite a big practical benefit, namely that if your mutations rely on the current user's (or other user's) presence, you won't have to externally get a reference to those and keep invalidating your callback function.

```ts
const selection = useSelf(user => user.presence.selection);
const myCallback = useMutation(
  ({ root }) => {
    doSomething(root, selection);
  },
  [selection]
);
```

Now:

```ts
const myCallback = useMutation(
  ({ root, self }) => {
    doSomething(root, self.presence.selection);
  },
  []
);
```

This enables you to write much cleaner mutations. See f2623295591a1614437771c9fb2bad1d7ee75986 for an example of that. See also this [feedback](https://github.com/liveblocks/liveblocks/pull/384#discussion_r967249977).
