### PR TITLE
Fix bug: useConnectionIds suspense version wasn't suspending

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -674,6 +674,11 @@ export function createRoomContext<
     ) as T | Others<TPresence, TUserMeta>;
   }
 
+  function useConnectionIdsSuspense(): readonly number[] {
+    useSuspendUntilPresenceLoaded();
+    return useConnectionIds();
+  }
+
   function useOthersWithDataSuspense<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
@@ -776,7 +781,7 @@ export function createRoomContext<
       useUpdateMyPresence,
       useOthers: useOthersSuspense,
       useOthersWithData: useOthersWithDataSuspense,
-      useConnectionIds,
+      useConnectionIds: useConnectionIdsSuspense,
       useOther: useOtherSuspense,
 
       useMutation,


### PR DESCRIPTION
Tiny bug: the `useConnectionIds()`, when imported as Suspense version, wasn't actually suspending, ever. Instead it returned an empty array, like the normal version of `useConnectionIds()` does during load. This behavior is subtle. During loading, `useConnectionIds()` will now correctly suspend, and then "jump" to, say, an array of three users, without ever seeing an empty array.
