### PR TITLE
Added withoutConnecting flag to RoomProvider

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -39,6 +39,7 @@ export type RoomProviderProps<
      */
     id: string;
     children: React.ReactNode;
+    withoutConnecting?: boolean;
   } & RoomInitializers<TPresence, TStorage>
 >;
 
@@ -355,6 +356,7 @@ export function createRoomContext<
       id: roomId,
       initialPresence,
       initialStorage,
+      withoutConnecting = false,
       defaultPresence, // Will get removed in 0.18
       defaultStorageRoot, // Will get removed in 0.18
     } = props;
@@ -398,7 +400,8 @@ export function createRoomContext<
         initialStorage,
         defaultPresence, // Will get removed in 0.18
         defaultStorageRoot, // Will get removed in 0.18
-        DO_NOT_USE_withoutConnecting: typeof window === "undefined",
+        DO_NOT_USE_withoutConnecting:
+          typeof window === "undefined" || withoutConnecting,
       } as RoomInitializers<TPresence, TStorage>)
     );
 
@@ -409,14 +412,15 @@ export function createRoomContext<
           initialStorage: frozen.initialStorage,
           defaultPresence: frozen.defaultPresence, // Will get removed in 0.18
           defaultStorageRoot: frozen.defaultStorageRoot, // Will get removed in 0.18
-          DO_NOT_USE_withoutConnecting: typeof window === "undefined",
+          DO_NOT_USE_withoutConnecting:
+            typeof window === "undefined" || withoutConnecting,
         } as RoomInitializers<TPresence, TStorage>)
       );
 
       return () => {
         _client.leave(roomId);
       };
-    }, [_client, roomId, frozen]);
+    }, [_client, roomId, frozen, withoutConnecting]);
 
     return (
       <RoomContext.Provider value={room}>{props.children}</RoomContext.Provider>


### PR DESCRIPTION
Added option `withoutConnecting` to skip the initial connection on mount of `<RoomProvider />` component.

```tsx
<RoomProvider id={roomId} withoutConnecting>
  <App />
</RoomProvider>
```

We're using the internal option to skip the connection in SSR mode:

https://github.com/liveblocks/liveblocks/blob/528ff8d3d0d589d0078dddf340c9b22fc655f4f2/packages/liveblocks-react/src/factory.tsx#L396-L402

https://github.com/liveblocks/liveblocks/blob/c70fed4818f243dc476fbb6a9d7286568f6e6486/packages/liveblocks-client/src/client.ts#L23-L28

Related to https://github.com/liveblocks/liveblocks/discussions/477