### PR TITLE
Final name decisions

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -210,7 +210,7 @@ export function createRoomContext<
     );
   }
 
-  function useConnectionIds(): readonly number[] {
+  function useOthersConnectionIds(): readonly number[] {
     return useOthers(connectionIdSelector, shallow);
   }
 
@@ -674,9 +674,9 @@ export function createRoomContext<
     ) as T | Others<TPresence, TUserMeta>;
   }
 
-  function useConnectionIdsSuspense(): readonly number[] {
+  function useOthersConnectionIdsSuspense(): readonly number[] {
     useSuspendUntilPresenceLoaded();
-    return useConnectionIds();
+    return useOthersConnectionIds();
   }
 
   function useOthersWithDataSuspense<T>(
@@ -746,7 +746,7 @@ export function createRoomContext<
     useUpdateMyPresence,
     useOthers,
     useOthersWithData,
-    useConnectionIds,
+    useOthersConnectionIds,
     useOther,
 
     useMutation,
@@ -781,7 +781,7 @@ export function createRoomContext<
       useUpdateMyPresence,
       useOthers: useOthersSuspense,
       useOthersWithData: useOthersWithDataSuspense,
-      useConnectionIds: useConnectionIdsSuspense,
+      useOthersConnectionIds: useOthersConnectionIdsSuspense,
       useOther: useOtherSuspense,
 
       useMutation,

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -214,7 +214,7 @@ export function createRoomContext<
     return useOthers(connectionIdSelector, shallow);
   }
 
-  function useOthersWithData<T>(
+  function useOthersMapped<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
   ): readonly { readonly connectionId: number; readonly data: T }[] {
@@ -679,12 +679,12 @@ export function createRoomContext<
     return useOthersConnectionIds();
   }
 
-  function useOthersWithDataSuspense<T>(
+  function useOthersMappedSuspense<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
   ): readonly { readonly connectionId: number; readonly data: T }[] {
     useSuspendUntilPresenceLoaded();
-    return useOthersWithData(itemSelector, itemIsEqual);
+    return useOthersMapped(itemSelector, itemIsEqual);
   }
 
   function useOtherSuspense(connectionId: number): User<TPresence, TUserMeta>;
@@ -745,7 +745,7 @@ export function createRoomContext<
     useMyPresence,
     useUpdateMyPresence,
     useOthers,
-    useOthersWithData,
+    useOthersMapped,
     useOthersConnectionIds,
     useOther,
 
@@ -780,7 +780,7 @@ export function createRoomContext<
       useMyPresence,
       useUpdateMyPresence,
       useOthers: useOthersSuspense,
-      useOthersWithData: useOthersWithDataSuspense,
+      useOthersMapped: useOthersMappedSuspense,
       useOthersConnectionIds: useOthersConnectionIdsSuspense,
       useOther: useOtherSuspense,
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -217,30 +217,26 @@ export function createRoomContext<
   function useOthersMapped<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
-  ): readonly { readonly connectionId: number; readonly data: T }[] {
+  ): ReadonlyArray<readonly [connectionId: number, data: T]> {
     const wrappedSelector = React.useCallback(
       (others: Others<TPresence, TUserMeta>) =>
-        others.map((other) => ({
-          connectionId: other.connectionId,
-          data: itemSelector(other),
-        })),
+        others.map(
+          (other) => [other.connectionId, itemSelector(other)] as const
+        ),
       [itemSelector]
     );
 
     const wrappedIsEqual = React.useCallback(
       (
-        a: { readonly connectionId: number; readonly data: T }[],
-        b: { readonly connectionId: number; readonly data: T }[]
+        a: ReadonlyArray<readonly [connectionId: number, data: T]>,
+        b: ReadonlyArray<readonly [connectionId: number, data: T]>
       ): boolean => {
         const eq = itemIsEqual ?? Object.is;
         return (
           a.length === b.length &&
           a.every((atuple, index) => {
             const btuple = b[index];
-            return (
-              atuple.connectionId === btuple.connectionId &&
-              eq(atuple.data, btuple.data)
-            );
+            return atuple[0] === btuple[0] && eq(atuple[1], btuple[1]);
           })
         );
       },
@@ -682,7 +678,7 @@ export function createRoomContext<
   function useOthersMappedSuspense<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
-  ): readonly { readonly connectionId: number; readonly data: T }[] {
+  ): ReadonlyArray<readonly [connectionId: number, data: T]> {
     useSuspendUntilPresenceLoaded();
     return useOthersMapped(itemSelector, itemIsEqual);
   }

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -381,7 +381,7 @@ export type RoomContextBundle<
   useOthersMapped<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
-  ): readonly { readonly connectionId: number; readonly data: T }[];
+  ): ReadonlyArray<readonly [connectionId: number, data: T]>;
 
   /**
    * Given a connection ID (as obtained by using `useOthersConnectionIds`), you can
@@ -761,7 +761,7 @@ export type RoomContextBundle<
     useOthersMapped<T>(
       itemSelector: (other: User<TPresence, TUserMeta>) => T,
       itemIsEqual?: (prev: T, curr: T) => boolean
-    ): readonly { readonly connectionId: number; readonly data: T }[];
+    ): ReadonlyArray<readonly [connectionId: number, data: T]>;
 
     /**
      * Given a connection ID (as obtained by using `useOthersConnectionIds`),

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -361,11 +361,11 @@ export type RoomContextBundle<
    * re-renders that will be triggered.
    *
    * @example
-   * const avatars = useOthersWithData(user => user.info.avatar);
+   * const avatars = useOthersMapped(user => user.info.avatar);
    * //    ^^^^^^^
    * //    { connectionId: number; data: string }[]
    *
-   * The selector function you pass to useOthersWithData() is called an "item
+   * The selector function you pass to useOthersMapped() is called an "item
    * selector", and operates on a single user at a time. If you provide an
    * (optional) "item comparison" function, it will be used to compare each
    * item pairwise.
@@ -373,12 +373,12 @@ export type RoomContextBundle<
    * For example, to select multiple properties:
    *
    * @example
-   * const avatarsAndCursors = useOthersWithData(
+   * const avatarsAndCursors = useOthersMapped(
    *   user => [u.info.avatar, u.presence.cursor],
    *   shallow,  // 👈
    * );
    */
-  useOthersWithData<T>(
+  useOthersMapped<T>(
     itemSelector: (other: User<TPresence, TUserMeta>) => T,
     itemIsEqual?: (prev: T, curr: T) => boolean
   ): readonly { readonly connectionId: number; readonly data: T }[];
@@ -741,11 +741,11 @@ export type RoomContextBundle<
      * re-renders that will be triggered.
      *
      * @example
-     * const avatars = useOthersWithData(user => user.info.avatar);
+     * const avatars = useOthersMapped(user => user.info.avatar);
      * //    ^^^^^^^
      * //    { connectionId: number; data: string }[]
      *
-     * The selector function you pass to useOthersWithData() is called an "item
+     * The selector function you pass to useOthersMapped() is called an "item
      * selector", and operates on a single user at a time. If you provide an
      * (optional) "item comparison" function, it will be used to compare each
      * item pairwise.
@@ -753,12 +753,12 @@ export type RoomContextBundle<
      * For example, to select multiple properties:
      *
      * @example
-     * const avatarsAndCursors = useOthersWithData(
+     * const avatarsAndCursors = useOthersMapped(
      *   user => [u.info.avatar, u.presence.cursor],
      *   shallow,  // 👈
      * );
      */
-    useOthersWithData<T>(
+    useOthersMapped<T>(
       itemSelector: (other: User<TPresence, TUserMeta>) => T,
       itemIsEqual?: (prev: T, curr: T) => boolean
     ): readonly { readonly connectionId: number; readonly data: T }[];

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -349,10 +349,10 @@ export type RoomContextBundle<
    * for each user in the room, e.g. cursors.
    *
    * @example
-   * const ids = useConnectionIds();
+   * const ids = useOthersConnectionIds();
    * // [2, 4, 7]
    */
-  useConnectionIds(): readonly number[];
+  useOthersConnectionIds(): readonly number[];
 
   /**
    * Related to useOthers(), but optimized for selecting only "subsets" of
@@ -384,7 +384,7 @@ export type RoomContextBundle<
   ): readonly { readonly connectionId: number; readonly data: T }[];
 
   /**
-   * Given a connection ID (as obtained by using `useConnectionIds()`), you can
+   * Given a connection ID (as obtained by using `useOthersConnectionIds`), you can
    * call this selector deep down in your component stack to only have the
    * component re-render if properties for this particular user change.
    *
@@ -395,8 +395,8 @@ export type RoomContextBundle<
   useOther(connectionId: number): User<TPresence, TUserMeta>;
 
   /**
-   * Given a connection ID (as obtained by using `useConnectionIds()`), you can
-   * call this selector deep down in your component stack to only have the
+   * Given a connection ID (as obtained by using `useOthersConnectionIds`), you
+   * can call this selector deep down in your component stack to only have the
    * component re-render if properties for this particular user change.
    *
    * @example
@@ -729,10 +729,10 @@ export type RoomContextBundle<
      * for each user in the room, e.g. cursors.
      *
      * @example
-     * const ids = useConnectionIds();
+     * const ids = useOthersConnectionIds();
      * // [2, 4, 7]
      */
-    useConnectionIds(): readonly number[];
+    useOthersConnectionIds(): readonly number[];
 
     /**
      * Related to useOthers(), but optimized for selecting only "subsets" of
@@ -764,9 +764,10 @@ export type RoomContextBundle<
     ): readonly { readonly connectionId: number; readonly data: T }[];
 
     /**
-     * Given a connection ID (as obtained by using `useConnectionIds()`), you
-     * can call this selector deep down in your component stack to only have
-     * the component re-render if properties for this particular user change.
+     * Given a connection ID (as obtained by using `useOthersConnectionIds`),
+     * you can call this selector deep down in your component stack to only
+     * have the component re-render if properties for this particular user
+     * change.
      *
      * @example
      * // Returns full user and re-renders whenever anything on the user changes
@@ -775,9 +776,10 @@ export type RoomContextBundle<
     useOther(connectionId: number): User<TPresence, TUserMeta>;
 
     /**
-     * Given a connection ID (as obtained by using `useConnectionIds()`), you
-     * can call this selector deep down in your component stack to only have
-     * the component re-render if properties for this particular user change.
+     * Given a connection ID (as obtained by using `useOthersConnectionIds`),
+     * you can call this selector deep down in your component stack to only
+     * have the component re-render if properties for this particular user
+     * change.
      *
      * @example
      * // Returns only the selected values re-renders whenever that selection changes)


### PR DESCRIPTION
As discussed this afternoon. This PR implements the final decisions on naming:

- `useConnectionIds` → `useOthersConnectionIds`
- `useOthersWithData` → `useOthersMapped`
- Return type of `useOthersMapped` now is a tuple, instead of an object with `{ connectionId, data }` keys

These changes are intended to land in 0.18.0-beta4, which will get published tomorrow.
