### PR TITLE
Convert `nextjs-live-avatars-advanced` example to 0.18

### DIFF
--- a/examples/nextjs-live-avatars-advanced/components/LiveAvatars.tsx
+++ b/examples/nextjs-live-avatars-advanced/components/LiveAvatars.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Avatar } from "./Avatar";
-import { useOthers, useSelf } from "../liveblocks.config";
+import { useOthersMapped, useSelf } from "../liveblocks.config";
 import { AnimatePresence, motion } from "framer-motion";
 
 /**
@@ -35,9 +35,18 @@ const avatarProps = {
 };
 
 export default function LiveAvatars() {
-  const users = useOthers().toArray();
+  //
+  // RATIONALE:
+  // Using useOthersMapped here and only selecting/subscribing to the "info"
+  // part of each user, which is static data that won't change (unlike
+  // presence). In this example we don't use presence, but in a real app this
+  // makes a difference: if we did not use a selector function here, these
+  // avatars would get needlessly re-rendered any time any of the others moved
+  // their cursors :)
+  //
+  const others = useOthersMapped((other) => other.info);
   const currentUser = useSelf();
-  const hasMoreUsers = users.length > MAX_OTHERS;
+  const hasMoreUsers = others.length > MAX_OTHERS;
 
   return (
     <div
@@ -50,32 +59,32 @@ export default function LiveAvatars() {
     >
       <AnimatePresence>
         {hasMoreUsers ? (
-          <motion.div {...animationProps} key="count">
-            <Avatar {...avatarProps} variant="more" count={users.length - 3} />
+          <motion.div key="count" {...animationProps}>
+            <Avatar {...avatarProps} variant="more" count={others.length - 3} />
           </motion.div>
         ) : null}
 
-        {users
+        {others
           .slice(0, MAX_OTHERS)
           .reverse()
-          .map(({ connectionId, info }) => (
-            <motion.div {...animationProps} key={connectionId}>
+          .map(([key, info]) => (
+            <motion.div key={key} {...animationProps}>
               <Avatar
                 {...avatarProps}
-                picture={info?.picture}
-                name={info?.name}
-                color={info?.color}
+                picture={info.picture}
+                name={info.name}
+                color={info.color}
               />
             </motion.div>
           ))}
 
         {currentUser ? (
-          <motion.div {...animationProps} key="you">
+          <motion.div key="you" {...animationProps}>
             <Avatar
               {...avatarProps}
-              picture={currentUser.info?.picture}
-              name={currentUser.info?.name + " (you)"}
-              color={currentUser.info?.color}
+              picture={currentUser.info.picture}
+              name={currentUser.info.name + " (you)"}
+              color={currentUser.info.color}
             />
           </motion.div>
         ) : null}

--- a/examples/nextjs-live-avatars-advanced/liveblocks.config.ts
+++ b/examples/nextjs-live-avatars-advanced/liveblocks.config.ts
@@ -37,7 +37,7 @@ type UserMeta = {
 // room. Must be JSON-serializable.
 // type RoomEvent = {};
 
-export const { RoomProvider, useOthers, useSelf } = createRoomContext<
+export const { RoomProvider, useOthersMapped, useSelf } = createRoomContext<
   Presence,
   Storage,
   UserMeta /* RoomEvent */

--- a/examples/nextjs-live-avatars-advanced/package-lock.json
+++ b/examples/nextjs-live-avatars-advanced/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/node": "^0.17.11",
-        "@liveblocks/react": "^0.17.11",
+        "@liveblocks/client": "^0.18.0-beta4",
+        "@liveblocks/node": "^0.18.0-beta4",
+        "@liveblocks/react": "^0.18.0-beta4",
         "classnames": "^2.3.1",
         "framer-motion": "^6.3.6",
         "next": "^12.2.5",
@@ -42,24 +42,27 @@
       "optional": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.0-beta4",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.0-beta4.tgz",
+      "integrity": "sha512-DE5JHbC7Ny1eKQi/fZSR1Bs2RASDx0921F4LDmaB1zyWmb72zgHbe258QZ36ZYHIJl/bcdPA9BeXVu9XMqTrnQ=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.0-beta4",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.0-beta4.tgz",
+      "integrity": "sha512-KLhNRUnG6N8PvoskTcLdNW8uVjRMJojb0EFdmiU8SjmRVBFkV16RBgh/Ar9INRAnrsVYHPr+JzxeJ1lXGVZ6kg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.17.11.tgz",
-      "integrity": "sha512-WYFLJTN+3h24ODyOKcPHZU80mwi/l9BWDsrig/bIFgr9w8wIk/cci30ngyeIglwP0LLcgte073dRNf4pkpFf5Q==",
+      "version": "0.18.0-beta4",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.18.0-beta4.tgz",
+      "integrity": "sha512-oxeUV9mnQgApN84g1Yi4gqj59424ONvD7cmDFD4RxivJCSRQxGg9ogfk2lpw5cgd/jpknC1VTW2ON9yGnT8zDA==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.0-beta4",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
@@ -766,23 +769,25 @@
       "optional": true
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.0-beta4",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.0-beta4.tgz",
+      "integrity": "sha512-DE5JHbC7Ny1eKQi/fZSR1Bs2RASDx0921F4LDmaB1zyWmb72zgHbe258QZ36ZYHIJl/bcdPA9BeXVu9XMqTrnQ=="
     },
     "@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.0-beta4",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.0-beta4.tgz",
+      "integrity": "sha512-KLhNRUnG6N8PvoskTcLdNW8uVjRMJojb0EFdmiU8SjmRVBFkV16RBgh/Ar9INRAnrsVYHPr+JzxeJ1lXGVZ6kg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.17.11.tgz",
-      "integrity": "sha512-WYFLJTN+3h24ODyOKcPHZU80mwi/l9BWDsrig/bIFgr9w8wIk/cci30ngyeIglwP0LLcgte073dRNf4pkpFf5Q==",
-      "requires": {}
+      "version": "0.18.0-beta4",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.18.0-beta4.tgz",
+      "integrity": "sha512-oxeUV9mnQgApN84g1Yi4gqj59424ONvD7cmDFD4RxivJCSRQxGg9ogfk2lpw5cgd/jpknC1VTW2ON9yGnT8zDA==",
+      "requires": {
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "@next/env": {
       "version": "12.2.5",

--- a/examples/nextjs-live-avatars-advanced/package.json
+++ b/examples/nextjs-live-avatars-advanced/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/node": "^0.17.11",
-    "@liveblocks/react": "^0.17.11",
+    "@liveblocks/client": "^0.18.0-beta4",
+    "@liveblocks/node": "^0.18.0-beta4",
+    "@liveblocks/react": "^0.18.0-beta4",
     "classnames": "^2.3.1",
     "framer-motion": "^6.3.6",
     "next": "^12.2.5",

--- a/examples/nextjs-live-avatars-advanced/pages/index.tsx
+++ b/examples/nextjs-live-avatars-advanced/pages/index.tsx
@@ -8,7 +8,7 @@ export default function Example() {
   const roomId = useOverrideRoomId("nextjs-live-avatars-advanced");
 
   return (
-    <RoomProvider id={roomId}>
+    <RoomProvider id={roomId} initialPresence={{}}>
       <main className={styles.main}>
         <LiveAvatars />
       </main>


### PR DESCRIPTION
Because this is an "advanced" example, I've used `useOthersMapped` here (instead of a simpler `useOthers()` call that we use in the non-advanced example) and explained why in a comment.