### PR TITLE
Disallow calling `useStorage()` without selector

### DIFF
--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -505,13 +505,8 @@ export function createRoomContext<
     }
   }
 
-  function useStorage(): ToImmutable<TStorage> | null;
   function useStorage<T>(
     selector: (root: ToImmutable<TStorage>) => T,
-    isEqual?: (prev: T | null, curr: T | null) => boolean
-  ): T | null;
-  function useStorage<T>(
-    maybeSelector?: (root: ToImmutable<TStorage>) => T,
     isEqual?: (prev: T | null, curr: T | null) => boolean
   ): T | null {
     type Snapshot = ToImmutable<TStorage> | null;
@@ -519,9 +514,6 @@ export function createRoomContext<
 
     const room = useRoom();
     const rootOrNull = useMutableStorageRoot();
-
-    const selector =
-      maybeSelector ?? (identity as (root: ToImmutable<TStorage>) => T);
 
     const wrappedSelector = React.useCallback(
       (rootOrNull: Snapshot): Selection =>
@@ -618,23 +610,15 @@ export function createRoomContext<
     );
   }
 
-  function useStorageSuspense(): ToImmutable<TStorage>;
   function useStorageSuspense<T>(
     selector: (root: ToImmutable<TStorage>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T;
-  function useStorageSuspense<T>(
-    selector?: (root: ToImmutable<TStorage>) => T,
-    isEqual?: (prev: T, curr: T) => boolean
-  ): T | ToImmutable<TStorage> {
+  ): T {
     useSuspendUntilStorageLoaded();
-
-    // NOTE: Lots of type forcing here, but only to avoid calling the hooks
-    // conditionally
     return useStorage(
-      selector as (root: ToImmutable<TStorage>) => T,
+      selector,
       isEqual as (prev: T | null, curr: T | null) => boolean
-    ) as T | ToImmutable<TStorage>;
+    ) as T;
   }
 
   function useSelfSuspense(): User<TPresence, TUserMeta>;

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -631,9 +631,6 @@ export function createRoomContext<
     isEqual?: (prev: T, curr: T) => boolean
   ): T | User<TPresence, TUserMeta> {
     useSuspendUntilPresenceLoaded();
-
-    // NOTE: Lots of type forcing here, but only to avoid calling the hooks
-    // conditionally
     return useSelf(
       selector as (me: User<TPresence, TUserMeta>) => T,
       isEqual as (prev: T | null, curr: T | null) => boolean
@@ -645,9 +642,6 @@ export function createRoomContext<
     isEqual?: (prev: T, curr: T) => boolean
   ): T | Others<TPresence, TUserMeta> {
     useSuspendUntilPresenceLoaded();
-
-    // NOTE: Lots of type forcing here, but only to avoid calling the hooks
-    // conditionally
     return useOthers(
       selector as (others: Others<TPresence, TUserMeta>) => T,
       isEqual as (prev: T, curr: T) => boolean
@@ -679,9 +673,6 @@ export function createRoomContext<
     isEqual?: (prev: T, curr: T) => boolean
   ): T | User<TPresence, TUserMeta> {
     useSuspendUntilPresenceLoaded();
-
-    // NOTE: Lots of type forcing here, but only to avoid calling the hooks
-    // conditionally
     return useOther(
       connectionId,
       selector as (other: User<TPresence, TUserMeta>) => T,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -206,14 +206,6 @@ export type RoomContextBundle<
   useStorageRoot(): [root: LiveObject<TStorage> | null];
 
   /**
-   * Returns your entire Liveblocks Storage as an immutable data structure.
-   *
-   * @example
-   * const root = useStorage();
-   */
-  useStorage(): ToImmutable<TStorage> | null;
-
-  /**
    * Extract arbitrary data from the Liveblocks Storage state, using an
    * arbitrary selector function.
    *
@@ -234,7 +226,7 @@ export type RoomContextBundle<
    */
   useStorage<T>(
     selector: (root: ToImmutable<TStorage>) => T,
-    isEqual?: (prev: T, curr: T) => boolean
+    isEqual?: (prev: T | null, curr: T | null) => boolean
   ): T | null;
 
   /**
@@ -584,14 +576,6 @@ export type RoomContextBundle<
      * const [root] = useStorageRoot();
      */
     useStorageRoot(): [root: LiveObject<TStorage> | null];
-
-    /**
-     * Returns your entire Liveblocks Storage as an immutable data structure.
-     *
-     * @example
-     * const root = useStorage();
-     */
-    useStorage(): ToImmutable<TStorage>;
 
     /**
      * Extract arbitrary data from the Liveblocks Storage state, using an


### PR DESCRIPTION
While working on the docs, it dawned on me that the `useStorage()` (without arguments) overload isn't that useful, and perhaps even leads people to adopt anti-patterns.

I don't think there is a single good use case for this construct:

```tsx
const root = useStorage();
```

If you absolutely want to do this, you can always still write:

```tsx
const root = useStorage((root) => root);
```

There are several benefits to removing this overload:

1. The function becomes simpler. There are no more overloads, just one signature. This helps with IntelliSense in editors.
2. Adopting the "get the entire root and subscribe to _any_ update" anti-pattern is harder to express. If you actually want it, it's still possible, but at least you must make it explicit.
3. We don't have to document/explain that it’s a bad idea to use this pattern in production if the pattern is no longer possible.

I don't see any downsides to remove this overload.
