### PR TITLE
Fix bug where updating my presence could sometimes fail

### DIFF
--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1166,7 +1166,11 @@ function makeStateMachine<
       if (state.lastConnectionId !== undefined) {
         state.buffer.me = {
           type: "full",
-          data: state.me.current,
+          data:
+            // Because state.me.current is a readonly object, we'll have to
+            // make a copy here. Otherwise, type errors happen later when
+            // "patching" my presence.
+            { ...state.me.current },
         };
         tryFlushing();
       }


### PR DESCRIPTION
Today, I ran into an issue when converting another one of our examples, and noticed that under certain circumstances, it's possible to run into the following error when developing locally:

<img width="969" alt="Screen Shot 2022-09-21 at 11 57 11@2x" src="https://user-images.githubusercontent.com/83844/191475539-dd13c957-7eb5-4bc8-95bf-afebdf182dfb.png">

This isn't an issue in production, but certainly annoying. This PR fixes that bug.
