### PR TITLE
Fix bug: don't throw in `useOther`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - In **@liveblocks/react**:
 
+  - Make sure that `useOther` will not rerender if tracked users already left
+    the room, so that child components won't get rerendered before the parent
+    got the chance to unmount them.
   - Disallow `useOther` without selector
 
 # v0.18.1

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -246,27 +246,57 @@ export function createRoomContext<
     return useOthers(wrappedSelector, wrappedIsEqual);
   }
 
-  const sentinel = Symbol();
+  const NOT_FOUND = Symbol();
+
+  type NotFound = typeof NOT_FOUND;
 
   function useOther<T>(
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T {
+  ): T | undefined {
+    const lastKnownValue = React.useRef<T | NotFound>(NOT_FOUND);
+
     const wrappedSelector = React.useCallback(
       (others: Others<TPresence, TUserMeta>) => {
         // TODO: Make this O(1) instead of O(n)?
         const other = others.find(
           (other) => other.connectionId === connectionId
         );
-        return other !== undefined ? selector(other) : sentinel;
+        if (other !== undefined) {
+          //
+          // NOTE:
+          // Whenever we run the selector, we'll retain the last known value.
+          // This value will be used if ever there comes a point where the
+          // tracked user leaves the room, but this selector will still be
+          // called for it, because the component using it hasn't been
+          // unmounted yet.
+          //
+          // Not doing so would, under normal use circumstances, throw an error
+          // (see below), only for the component to be unmounted moments later.
+          //
+          // This is something we'll have to address more properly, by not
+          // notifying child components before notifying parents. This change
+          // is a temporary stopgap while we prepare the more structural fix.
+          //
+          const value = selector(other);
+          lastKnownValue.current = value;
+          return value;
+        } else {
+          //
+          // NOTE:
+          // By returning the same value here, we will ensure that the isEqual
+          // check will make sure to not trigger a rerender for this component.
+          //
+          return lastKnownValue.current;
+        }
       },
       [connectionId, selector]
     );
 
     const wrappedIsEqual = React.useCallback(
-      (prev: T | typeof sentinel, curr: T | typeof sentinel): boolean => {
-        if (prev === sentinel || curr === sentinel) {
+      (prev: T | NotFound, curr: T | NotFound): boolean => {
+        if (prev === NOT_FOUND || curr === NOT_FOUND) {
           return prev === curr;
         }
 
@@ -277,11 +307,12 @@ export function createRoomContext<
     );
 
     const other = useOthers(wrappedSelector, wrappedIsEqual);
-    if (other === sentinel) {
+    if (other === NOT_FOUND) {
       throw new Error(
         `No such other user with connection id ${connectionId} exists`
       );
     }
+
     return other;
   }
 
@@ -640,7 +671,7 @@ export function createRoomContext<
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T {
+  ): T | undefined {
     useSuspendUntilPresenceLoaded();
     return useOther(connectionId, selector, isEqual);
   }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -254,7 +254,7 @@ export function createRoomContext<
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T | undefined {
+  ): T {
     const lastKnownValue = React.useRef<T | NotFound>(NOT_FOUND);
 
     const wrappedSelector = React.useCallback(
@@ -671,7 +671,7 @@ export function createRoomContext<
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T | undefined {
+  ): T {
     useSuspendUntilPresenceLoaded();
     return useOther(connectionId, selector, isEqual);
   }

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -388,7 +388,7 @@ export type RoomContextBundle<
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T;
+  ): T | undefined;
 
   /**
    * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.
@@ -750,7 +750,7 @@ export type RoomContextBundle<
       connectionId: number,
       selector: (other: User<TPresence, TUserMeta>) => T,
       isEqual?: (prev: T, curr: T) => boolean
-    ): T;
+    ): T | undefined;
 
     /**
      * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -388,7 +388,7 @@ export type RoomContextBundle<
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T | undefined;
+  ): T;
 
   /**
    * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.
@@ -750,7 +750,7 @@ export type RoomContextBundle<
       connectionId: number,
       selector: (other: User<TPresence, TUserMeta>) => T,
       isEqual?: (prev: T, curr: T) => boolean
-    ): T | undefined;
+    ): T;
 
     /**
      * useUpdateMyPresence is similar to useMyPresence but it only returns the function to update the current user presence.


### PR DESCRIPTION
This PR makes `useOther` return the last known value instead of [throwing an error](https://github.com/liveblocks/liveblocks/blob/main/packages/liveblocks-react/src/factory.tsx#L305-L307) when tracking a user that just left the room, but before its controlling parent has had the chance to unmount them.

![Screen Shot 2022-09-21 at 14 08 48@2x](https://user-images.githubusercontent.com/83844/191500157-c0ebb41e-adf3-44f2-b529-2d81420b1c1a.png)

This is a pragmatic workaround, and considered a temporary stopgap, for a potentially larger issue where children should get rerendered as part of the same rendering batch as their controlling parent, so that React will not try to rerender the child first. But this will require a bit more research. Until then, this should at least avoid the annoying crash from happening under normal usage circumstances.
