### PR TITLE
Also disallow `useOther` to be called without a selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.18.2
+
+- In **@liveblocks/react**:
+
+  - Disallow `useOther` without selector
+
 # v0.18.1
 
 - In **@liveblocks/react**:

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -248,66 +248,41 @@ export function createRoomContext<
 
   const sentinel = Symbol();
 
-  function useOther(connectionId: number): User<TPresence, TUserMeta>;
   function useOther<T>(
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T;
-  function useOther<T>(
-    connectionId: number,
-    selector?: (other: User<TPresence, TUserMeta>) => T,
-    isEqual?: (prev: T, curr: T) => boolean
-  ): T | User<TPresence, TUserMeta> {
-    // Deliberately bypass React warnings about conditionally calling hooks
-    const _useCallback = React.useCallback;
-    const _useOthers = useOthers;
-    if (selector === undefined) {
-      const selector = _useCallback(
-        (others: Others<TPresence, TUserMeta>) =>
-          // TODO: Make this O(1) instead of O(n)?
-          others.find((other) => other.connectionId === connectionId),
-        [connectionId]
-      );
-      const other = _useOthers(selector, shallow);
-      if (other === undefined) {
-        throw new Error(
-          `No such other user with connection id ${connectionId} exists`
+  ): T {
+    const wrappedSelector = React.useCallback(
+      (others: Others<TPresence, TUserMeta>) => {
+        // TODO: Make this O(1) instead of O(n)?
+        const other = others.find(
+          (other) => other.connectionId === connectionId
         );
-      }
-      return other;
-    } else {
-      const wrappedSelector = _useCallback(
-        (others: Others<TPresence, TUserMeta>) => {
-          // TODO: Make this O(1) instead of O(n)?
-          const other = others.find(
-            (other) => other.connectionId === connectionId
-          );
-          return other !== undefined ? selector(other) : sentinel;
-        },
-        [connectionId, selector]
+        return other !== undefined ? selector(other) : sentinel;
+      },
+      [connectionId, selector]
+    );
+
+    const wrappedIsEqual = React.useCallback(
+      (prev: T | typeof sentinel, curr: T | typeof sentinel): boolean => {
+        if (prev === sentinel || curr === sentinel) {
+          return prev === curr;
+        }
+
+        const eq = isEqual ?? Object.is;
+        return eq(prev, curr);
+      },
+      [isEqual]
+    );
+
+    const other = useOthers(wrappedSelector, wrappedIsEqual);
+    if (other === sentinel) {
+      throw new Error(
+        `No such other user with connection id ${connectionId} exists`
       );
-
-      const wrappedIsEqual = _useCallback(
-        (prev: T | typeof sentinel, curr: T | typeof sentinel): boolean => {
-          if (prev === sentinel || curr === sentinel) {
-            return prev === curr;
-          }
-
-          const eq = isEqual ?? Object.is;
-          return eq(prev, curr);
-        },
-        [isEqual]
-      );
-
-      const other = _useOthers(wrappedSelector, wrappedIsEqual);
-      if (other === sentinel) {
-        throw new Error(
-          `No such other user with connection id ${connectionId} exists`
-        );
-      }
-      return other;
     }
+    return other;
   }
 
   function useBroadcastEvent(): (
@@ -661,23 +636,13 @@ export function createRoomContext<
     return useOthersMapped(itemSelector, itemIsEqual);
   }
 
-  function useOtherSuspense(connectionId: number): User<TPresence, TUserMeta>;
   function useOtherSuspense<T>(
     connectionId: number,
     selector: (other: User<TPresence, TUserMeta>) => T,
     isEqual?: (prev: T, curr: T) => boolean
-  ): T;
-  function useOtherSuspense<T>(
-    connectionId: number,
-    selector?: (other: User<TPresence, TUserMeta>) => T,
-    isEqual?: (prev: T, curr: T) => boolean
-  ): T | User<TPresence, TUserMeta> {
+  ): T {
     useSuspendUntilPresenceLoaded();
-    return useOther(
-      connectionId,
-      selector as (other: User<TPresence, TUserMeta>) => T,
-      isEqual as (prev: T, curr: T) => boolean
-    ) as T | User<TPresence, TUserMeta>;
+    return useOther(connectionId, selector, isEqual);
   }
 
   function useLegacyKeySuspense<TKey extends Extract<keyof TStorage, string>>(

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -376,17 +376,6 @@ export type RoomContextBundle<
   ): ReadonlyArray<readonly [connectionId: number, data: T]>;
 
   /**
-   * Given a connection ID (as obtained by using `useOthersConnectionIds`), you can
-   * call this selector deep down in your component stack to only have the
-   * component re-render if properties for this particular user change.
-   *
-   * @example
-   * // Returns full user and re-renders whenever anything on the user changes
-   * const secondUser = useOther(2);
-   */
-  useOther(connectionId: number): User<TPresence, TUserMeta>;
-
-  /**
    * Given a connection ID (as obtained by using `useOthersConnectionIds`), you
    * can call this selector deep down in your component stack to only have the
    * component re-render if properties for this particular user change.
@@ -746,18 +735,6 @@ export type RoomContextBundle<
       itemSelector: (other: User<TPresence, TUserMeta>) => T,
       itemIsEqual?: (prev: T, curr: T) => boolean
     ): ReadonlyArray<readonly [connectionId: number, data: T]>;
-
-    /**
-     * Given a connection ID (as obtained by using `useOthersConnectionIds`),
-     * you can call this selector deep down in your component stack to only
-     * have the component re-render if properties for this particular user
-     * change.
-     *
-     * @example
-     * // Returns full user and re-renders whenever anything on the user changes
-     * const secondUser = useOther(2);
-     */
-    useOther(connectionId: number): User<TPresence, TUserMeta>;
 
     /**
      * Given a connection ID (as obtained by using `useOthersConnectionIds`),


### PR DESCRIPTION
This disallows `useOther` to be called without a selector, which I wanted to change last week along with the [similar change](https://github.com/liveblocks/liveblocks/pull/492) I made for `useStorage`, but forgot, apparently.
