### PR TITLE
Update all non-React examples to 0.18

### DIFF
--- a/examples/javascript-live-cursors/app.js
+++ b/examples/javascript-live-cursors/app.js
@@ -16,7 +16,7 @@ const client = createClient({
   publicApiKey: PUBLIC_KEY,
 });
 
-const room = client.enter(roomId, { cursor: null });
+const room = client.enter(roomId, { initialPresence: { cursor: null } });
 
 const cursorsContainer = document.getElementById("cursors-container");
 const text = document.getElementById("text");

--- a/examples/javascript-live-cursors/package-lock.json
+++ b/examples/javascript-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11"
+        "@liveblocks/client": "^0.18.2"
       },
       "devDependencies": {
         "esbuild": "^0.12.2",
@@ -15,9 +15,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/esbuild": {
       "version": "0.12.2",
@@ -46,9 +46,9 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "esbuild": {
       "version": "0.12.2",

--- a/examples/javascript-live-cursors/package.json
+++ b/examples/javascript-live-cursors/package.json
@@ -6,7 +6,7 @@
     "build": "esbuild app.js --bundle --outfile=static/app.js"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11"
+    "@liveblocks/client": "^0.18.2"
   },
   "devDependencies": {
     "esbuild": "^0.12.2",

--- a/examples/nuxtjs-live-avatars/package-lock.json
+++ b/examples/nuxtjs-live-avatars/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/node": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/node": "^0.18.2",
         "core-js": "^3.9.1",
         "express": "^4.17.1",
         "nuxt": "^2.15.3"
@@ -1599,14 +1599,14 @@
       "dev": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -18878,14 +18878,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/nuxtjs-live-avatars/package.json
+++ b/examples/nuxtjs-live-avatars/package.json
@@ -9,8 +9,8 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/node": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/node": "^0.18.2",
     "core-js": "^3.9.1",
     "express": "^4.17.1",
     "nuxt": "^2.15.3"

--- a/examples/nuxtjs-live-avatars/pages/index.vue
+++ b/examples/nuxtjs-live-avatars/pages/index.vue
@@ -47,6 +47,9 @@ const client = createClient({
   authEndpoint: "/api/auth",
 });
 
+// Presence not used in this example
+const initialPresence = {};
+
 let roomId = "nuxtjs-live-avatars";
 
 export default Vue.extend({
@@ -59,7 +62,7 @@ export default Vue.extend({
   mounted: function () {
     overrideRoomId();
 
-    const room = client.enter(roomId);
+    const room = client.enter(roomId, { initialPresence });
     this._unsubscribeOthers = room.subscribe("others", this.onOthersChange);
     this._unsubscribeConnection = room.subscribe(
       "connection",

--- a/examples/redux-todo-list/package-lock.json
+++ b/examples/redux-todo-list/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/redux": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/redux": "^0.18.2",
         "@reduxjs/toolkit": "^1.8.4",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2728,16 +2728,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.17.11.tgz",
-      "integrity": "sha512-F85fpQpug8f6N/yFRa4gZhno1F2HULMu+BwOz9iHbo4Sv/6o2IZ/Eevm8Lhlkigr2CTcLfKjeZNmPpBj+4DNww==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.18.2.tgz",
+      "integrity": "sha512-TSeYphOH0YFC+XWE9AJv8Xqpj09wQzSfScz/SXxwa7gDo/PWkhHkCIDsetaE59iWG45F8m8I6E81wXTrc47FnA==",
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "redux": "^4"
       }
     },
@@ -17647,14 +17647,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/redux": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.17.11.tgz",
-      "integrity": "sha512-F85fpQpug8f6N/yFRa4gZhno1F2HULMu+BwOz9iHbo4Sv/6o2IZ/Eevm8Lhlkigr2CTcLfKjeZNmPpBj+4DNww==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.18.2.tgz",
+      "integrity": "sha512-TSeYphOH0YFC+XWE9AJv8Xqpj09wQzSfScz/SXxwa7gDo/PWkhHkCIDsetaE59iWG45F8m8I6E81wXTrc47FnA==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/redux-todo-list/package.json
+++ b/examples/redux-todo-list/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/redux": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/redux": "^0.18.2",
     "@reduxjs/toolkit": "^1.8.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/redux-whiteboard/package-lock.json
+++ b/examples/redux-whiteboard/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/redux": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/redux": "^0.18.2",
         "@reduxjs/toolkit": "^1.8.4",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2728,16 +2728,16 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.17.11.tgz",
-      "integrity": "sha512-F85fpQpug8f6N/yFRa4gZhno1F2HULMu+BwOz9iHbo4Sv/6o2IZ/Eevm8Lhlkigr2CTcLfKjeZNmPpBj+4DNww==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.18.2.tgz",
+      "integrity": "sha512-TSeYphOH0YFC+XWE9AJv8Xqpj09wQzSfScz/SXxwa7gDo/PWkhHkCIDsetaE59iWG45F8m8I6E81wXTrc47FnA==",
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "redux": "^4"
       }
     },
@@ -17647,14 +17647,14 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/redux": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.17.11.tgz",
-      "integrity": "sha512-F85fpQpug8f6N/yFRa4gZhno1F2HULMu+BwOz9iHbo4Sv/6o2IZ/Eevm8Lhlkigr2CTcLfKjeZNmPpBj+4DNww==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.18.2.tgz",
+      "integrity": "sha512-TSeYphOH0YFC+XWE9AJv8Xqpj09wQzSfScz/SXxwa7gDo/PWkhHkCIDsetaE59iWG45F8m8I6E81wXTrc47FnA==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/redux-whiteboard/package.json
+++ b/examples/redux-whiteboard/package.json
@@ -9,8 +9,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/redux": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/redux": "^0.18.2",
     "@reduxjs/toolkit": "^1.8.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/solidjs-live-avatars/package-lock.json
+++ b/examples/solidjs-live-avatars/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
         "solid-js": "^1.3.13"
       },
       "devDependencies": {
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -1755,9 +1755,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "ansi-styles": {
       "version": "3.2.1",

--- a/examples/solidjs-live-avatars/package.json
+++ b/examples/solidjs-live-avatars/package.json
@@ -12,7 +12,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
     "solid-js": "^1.3.13"
   }
 }

--- a/examples/solidjs-live-cursors/package-lock.json
+++ b/examples/solidjs-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
         "@motionone/solid": "^10.8.1",
         "@solid-primitives/keyed": "^1.0.0",
         "motion": "^10.8.1",
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@motionone/animation": {
       "version": "10.8.0",
@@ -1898,9 +1898,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@motionone/animation": {
       "version": "10.8.0",

--- a/examples/solidjs-live-cursors/package.json
+++ b/examples/solidjs-live-cursors/package.json
@@ -12,7 +12,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
     "@motionone/solid": "^10.8.1",
     "@solid-primitives/keyed": "^1.0.0",
     "motion": "^10.8.1",

--- a/examples/sveltekit-live-avatars/package-lock.json
+++ b/examples/sveltekit-live-avatars/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/node": "^0.17.11"
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/node": "^0.18.2"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "next",
@@ -54,14 +54,14 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -2746,14 +2746,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/sveltekit-live-avatars/package.json
+++ b/examples/sveltekit-live-avatars/package.json
@@ -24,7 +24,7 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/node": "^0.17.11"
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/node": "^0.18.2"
   }
 }

--- a/examples/sveltekit-live-cursors/package-lock.json
+++ b/examples/sveltekit-live-cursors/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/node": "^0.17.11"
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/node": "^0.18.2"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "next",
@@ -54,14 +54,14 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -2746,14 +2746,14 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/sveltekit-live-cursors/package.json
+++ b/examples/sveltekit-live-cursors/package.json
@@ -24,7 +24,7 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/node": "^0.17.11"
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/node": "^0.18.2"
   }
 }

--- a/examples/vuejs-live-cursors/package-lock.json
+++ b/examples/vuejs-live-cursors/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
         "core-js": "^3.6.5",
         "vue": "^2.6.11"
       },
@@ -1764,9 +1764,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -15721,9 +15721,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/examples/vuejs-live-cursors/package.json
+++ b/examples/vuejs-live-cursors/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
     "core-js": "^3.6.5",
     "vue": "^2.6.11"
   },

--- a/examples/zustand-todo-list/package-lock.json
+++ b/examples/zustand-todo-list/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/zustand": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/zustand": "^0.18.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2926,16 +2926,16 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.17.11.tgz",
-      "integrity": "sha512-7MriR8wsxEOVDAJRbicqxeE2nJ5y2gzYBXosf0oflD3eWrni2v3ve06Y9zaKBGb0Xckph/49JFVJvgY5eI9AWA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.18.2.tgz",
+      "integrity": "sha512-SbQIaTaKFl49UgX4HNUQzo6FlfBB35Z+0NPYCnn+INpOuGjp0YdwrQV2g1SINcVzcpFdSXgWPI5Izvkt4ZCe9A==",
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "zustand": "^3"
       }
     },
@@ -18585,14 +18585,14 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/zustand": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.17.11.tgz",
-      "integrity": "sha512-7MriR8wsxEOVDAJRbicqxeE2nJ5y2gzYBXosf0oflD3eWrni2v3ve06Y9zaKBGb0Xckph/49JFVJvgY5eI9AWA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.18.2.tgz",
+      "integrity": "sha512-SbQIaTaKFl49UgX4HNUQzo6FlfBB35Z+0NPYCnn+INpOuGjp0YdwrQV2g1SINcVzcpFdSXgWPI5Izvkt4ZCe9A==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/zustand-todo-list/package.json
+++ b/examples/zustand-todo-list/package.json
@@ -3,8 +3,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/zustand": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/zustand": "^0.18.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/examples/zustand-whiteboard/package-lock.json
+++ b/examples/zustand-whiteboard/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/zustand": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/zustand": "^0.18.2",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2926,16 +2926,16 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.17.11.tgz",
-      "integrity": "sha512-7MriR8wsxEOVDAJRbicqxeE2nJ5y2gzYBXosf0oflD3eWrni2v3ve06Y9zaKBGb0Xckph/49JFVJvgY5eI9AWA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.18.2.tgz",
+      "integrity": "sha512-SbQIaTaKFl49UgX4HNUQzo6FlfBB35Z+0NPYCnn+INpOuGjp0YdwrQV2g1SINcVzcpFdSXgWPI5Izvkt4ZCe9A==",
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "zustand": "^3"
       }
     },
@@ -18585,14 +18585,14 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/zustand": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.17.11.tgz",
-      "integrity": "sha512-7MriR8wsxEOVDAJRbicqxeE2nJ5y2gzYBXosf0oflD3eWrni2v3ve06Y9zaKBGb0Xckph/49JFVJvgY5eI9AWA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.18.2.tgz",
+      "integrity": "sha512-SbQIaTaKFl49UgX4HNUQzo6FlfBB35Z+0NPYCnn+INpOuGjp0YdwrQV2g1SINcVzcpFdSXgWPI5Izvkt4ZCe9A==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {

--- a/examples/zustand-whiteboard/package.json
+++ b/examples/zustand-whiteboard/package.json
@@ -3,8 +3,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/zustand": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/zustand": "^0.18.2",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
Since the changes in 0.18 are mostly focused on the React package, I think we can safely update these. To non-React examples, this upgrade should almost be a no-op. The only observable difference for these is that initial presence is now mandatory when entering the room, so I updated those.