### PR TITLE
Update e2e tests to 0.18

### DIFF
--- a/e2e/next-sandbox/package-lock.json
+++ b/e2e/next-sandbox/package-lock.json
@@ -8,11 +8,11 @@
       "name": "next-sandbox",
       "version": "0.1.0",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
-        "@liveblocks/node": "^0.17.11",
-        "@liveblocks/react": "^0.17.11",
-        "@liveblocks/redux": "^0.17.11",
-        "@liveblocks/zustand": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
+        "@liveblocks/node": "^0.18.2",
+        "@liveblocks/react": "^0.18.2",
+        "@liveblocks/redux": "^0.18.2",
+        "@liveblocks/zustand": "^0.18.2",
         "@reduxjs/toolkit": "^1.8.4",
         "encoding": "^0.1.13",
         "next": "^12.2.5",
@@ -1813,42 +1813,45 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.17.11.tgz",
-      "integrity": "sha512-WYFLJTN+3h24ODyOKcPHZU80mwi/l9BWDsrig/bIFgr9w8wIk/cci30ngyeIglwP0LLcgte073dRNf4pkpFf5Q==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.18.2.tgz",
+      "integrity": "sha512-Ibzhfn7/iKrbnO7T46/6Ghv35W4IGsEakX9mp4tMCL5qmdzzY9+P9L/WOTJLTyR4tWYrfoAbhx27I+WTyXhKNw==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.17.11.tgz",
-      "integrity": "sha512-F85fpQpug8f6N/yFRa4gZhno1F2HULMu+BwOz9iHbo4Sv/6o2IZ/Eevm8Lhlkigr2CTcLfKjeZNmPpBj+4DNww==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.18.2.tgz",
+      "integrity": "sha512-TSeYphOH0YFC+XWE9AJv8Xqpj09wQzSfScz/SXxwa7gDo/PWkhHkCIDsetaE59iWG45F8m8I6E81wXTrc47FnA==",
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "redux": "^4"
       }
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.17.11.tgz",
-      "integrity": "sha512-7MriR8wsxEOVDAJRbicqxeE2nJ5y2gzYBXosf0oflD3eWrni2v3ve06Y9zaKBGb0Xckph/49JFVJvgY5eI9AWA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.18.2.tgz",
+      "integrity": "sha512-SbQIaTaKFl49UgX4HNUQzo6FlfBB35Z+0NPYCnn+INpOuGjp0YdwrQV2g1SINcVzcpFdSXgWPI5Izvkt4ZCe9A==",
       "peerDependencies": {
-        "@liveblocks/client": "0.17.11",
+        "@liveblocks/client": "0.18.2",
         "zustand": "^3"
       }
     },
@@ -9055,34 +9058,36 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@liveblocks/node": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.17.11.tgz",
-      "integrity": "sha512-9ws15L5lZzrJaEQHCQJH9tYZuQR3DJHQ92JrX+GJPOMAxt9tGAqhnXuZGohywss5YALoF0Prw+glIwrtn9xVZw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.18.2.tgz",
+      "integrity": "sha512-1QPsvgXZVPHydDMrbAbzbIcTUaF4FRh/6NPEn1hbRDvXj230YsBjBWO01PefS+JowffGFAIZAznVblc+zQKUNg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.17.11.tgz",
-      "integrity": "sha512-WYFLJTN+3h24ODyOKcPHZU80mwi/l9BWDsrig/bIFgr9w8wIk/cci30ngyeIglwP0LLcgte073dRNf4pkpFf5Q==",
-      "requires": {}
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.18.2.tgz",
+      "integrity": "sha512-Ibzhfn7/iKrbnO7T46/6Ghv35W4IGsEakX9mp4tMCL5qmdzzY9+P9L/WOTJLTyR4tWYrfoAbhx27I+WTyXhKNw==",
+      "requires": {
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "@liveblocks/redux": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.17.11.tgz",
-      "integrity": "sha512-F85fpQpug8f6N/yFRa4gZhno1F2HULMu+BwOz9iHbo4Sv/6o2IZ/Eevm8Lhlkigr2CTcLfKjeZNmPpBj+4DNww==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.18.2.tgz",
+      "integrity": "sha512-TSeYphOH0YFC+XWE9AJv8Xqpj09wQzSfScz/SXxwa7gDo/PWkhHkCIDsetaE59iWG45F8m8I6E81wXTrc47FnA==",
       "requires": {}
     },
     "@liveblocks/zustand": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.17.11.tgz",
-      "integrity": "sha512-7MriR8wsxEOVDAJRbicqxeE2nJ5y2gzYBXosf0oflD3eWrni2v3ve06Y9zaKBGb0Xckph/49JFVJvgY5eI9AWA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.18.2.tgz",
+      "integrity": "sha512-SbQIaTaKFl49UgX4HNUQzo6FlfBB35Z+0NPYCnn+INpOuGjp0YdwrQV2g1SINcVzcpFdSXgWPI5Izvkt4ZCe9A==",
       "requires": {}
     },
     "@next/env": {

--- a/e2e/next-sandbox/package.json
+++ b/e2e/next-sandbox/package.json
@@ -9,11 +9,11 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
-    "@liveblocks/node": "^0.17.11",
-    "@liveblocks/react": "^0.17.11",
-    "@liveblocks/redux": "^0.17.11",
-    "@liveblocks/zustand": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
+    "@liveblocks/node": "^0.18.2",
+    "@liveblocks/react": "^0.18.2",
+    "@liveblocks/redux": "^0.18.2",
+    "@liveblocks/zustand": "^0.18.2",
     "@reduxjs/toolkit": "^1.8.4",
     "encoding": "^0.1.13",
     "next": "^12.2.5",

--- a/e2e/node-sandbox/package-lock.json
+++ b/e2e/node-sandbox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@liveblocks/client": "^0.17.11",
+        "@liveblocks/client": "^0.18.2",
         "node-fetch": "2.6.7",
         "ws": "^8.5.0"
       },
@@ -873,9 +873,9 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -4737,9 +4737,9 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.17.11.tgz",
-      "integrity": "sha512-ToVzVa6KZE+TnElkV58uTPSKymgQ/fC6mRPtNKGA/SHC8BdgNbULHBV5Van4XWKnoC4BMyC+TAcukwEaeNxREw=="
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.18.2.tgz",
+      "integrity": "sha512-LDpLbG4TToZItHE6eLwoU2B9OIzIHMsxVvO2/h9ahAkIm7lOaqKKbZpt7FYDN8xeJmhR6jVDRfQK0b2LwgVCug=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/e2e/node-sandbox/package.json
+++ b/e2e/node-sandbox/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@liveblocks/client": "^0.17.11",
+    "@liveblocks/client": "^0.18.2",
     "node-fetch": "2.6.7",
     "ws": "^8.5.0"
   },


### PR DESCRIPTION
Simple upgrade. We should probably add tests in here for the new hooks, too.