### PR TITLE
Deprecate websocket:read/write permissions

### DIFF
--- a/packages/liveblocks-client/src/AuthToken.ts
+++ b/packages/liveblocks-client/src/AuthToken.ts
@@ -1,14 +1,7 @@
 import type { Json, JsonObject } from "./types";
 import { b64decode, isPlainObject, tryParseJson } from "./utils";
 
-export const SCOPES = [
-  "websocket:presence",
-  "websocket:storage",
-  "room:read",
-  "room:write",
-  "rooms:read",
-  "rooms:write",
-] as const;
+export const SCOPES = ["room:read", "room:write"] as const;
 
 export type Scope = typeof SCOPES[number];
 

--- a/packages/liveblocks-client/src/AuthToken.ts
+++ b/packages/liveblocks-client/src/AuthToken.ts
@@ -1,10 +1,6 @@
 import type { Json, JsonObject } from "./types";
 import { b64decode, isPlainObject, tryParseJson } from "./utils";
 
-export const SCOPES = ["room:read", "room:write"] as const;
-
-export type Scope = typeof SCOPES[number];
-
 export type AppOnlyAuthToken = {
   appId: string;
   roomId?: never; // Discriminating field for AuthToken type
@@ -42,10 +38,6 @@ function hasJwtMeta(data: unknown): data is JwtMetadata {
 export function isTokenExpired(token: JwtMetadata): boolean {
   const now = Date.now() / 1000;
   return now > token.exp - 300 || now < token.iat + 300;
-}
-
-export function isScope(value: unknown): value is Scope {
-  return (SCOPES as readonly unknown[]).includes(value);
 }
 
 function isStringList(value: unknown): value is string[] {

--- a/packages/liveblocks-client/src/internal.ts
+++ b/packages/liveblocks-client/src/internal.ts
@@ -12,18 +12,8 @@
  */
 
 export { assertNever, nn } from "./assert";
-export type {
-  AppOnlyAuthToken,
-  AuthToken,
-  RoomAuthToken,
-  Scope,
-} from "./AuthToken";
-export {
-  isAppOnlyAuthToken,
-  isAuthToken,
-  isRoomAuthToken,
-  isScope,
-} from "./AuthToken";
+export type { AppOnlyAuthToken, AuthToken, RoomAuthToken } from "./AuthToken";
+export { isAppOnlyAuthToken, isAuthToken, isRoomAuthToken } from "./AuthToken";
 export {
   deprecate,
   deprecateIf,


### PR DESCRIPTION
### Description

Deprecates permissions:
- `websocket:presence`
- `websocket:storage`
- `rooms:write`
- `rooms:read`

### Related PR

**BLOCKED BY**: https://github.com/liveblocks/liveblocks-cloudflare/pull/207

### Ticket
Related to https://github.com/liveblocks/liveblocks.io/issues/435