### PR TITLE
Structural fix for the zombie child problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v0.18.3
+
+- In **@liveblocks/react**:
+
+  Fixes the "zombie-child" problem in React 17 or lower. If you’re on React 17
+  or lower, we’ll now start to enforce that you pass the
+  `unstable_batchedUpdates` prop to RoomProvider. This helps Liveblocks
+  circumvent the zombie child problem, which might save you hours of debugging
+  time in the future!
+
+  ```tsx
+  // ⚠️  Only if you’re on React 17 or lower
+  import { unstable_batchedUpdates } from "react-dom";  // 👈
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={...}
+    initialStorage={...}
+    unstable_batchedUpdates={unstable_batchedUpdates}  // 👈
+  >
+    <App />
+  </RoomProvider>
+  ```
+
+  To read more, see
+  https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child-details
+
 # v0.18.2
 
 - In **@liveblocks/react**:

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -21,6 +21,13 @@ type EnterOptions<
   // Enter options are just room initializers, plus an internal option
   RoomInitializers<TPresence, TStorage> & {
     /**
+     * HACK: This option should be passed in from React v17 or earlier if you
+     * want to avoid the zombie child problem. Not necessary in React v18 or
+     * later.
+     */
+    unstable_batchedUpdates?: (cb: () => void) => void;
+
+    /**
      * INTERNAL OPTION: Only used in a SSR context when you want an empty room
      * to make sure your react tree is rendered properly without connecting to
      * websocket
@@ -118,6 +125,8 @@ export function createClient(options: ClientOptions): Client {
         polyfills: clientOptions.polyfills,
         WebSocketPolyfill: clientOptions.WebSocketPolyfill, // Backward-compatible API for setting polyfills
         fetchPolyfill: clientOptions.fetchPolyfill, // Backward-compatible API for setting polyfills
+
+        unstable_batchedUpdates: options?.unstable_batchedUpdates,
 
         liveblocksServer:
           // TODO Patch this using public but marked internal fields?

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -21,9 +21,13 @@ type EnterOptions<
   // Enter options are just room initializers, plus an internal option
   RoomInitializers<TPresence, TStorage> & {
     /**
-     * HACK: This option should be passed in from React v17 or earlier if you
-     * want to avoid the zombie child problem. Not necessary in React v18 or
-     * later.
+     * A custom callback that will get wrapped around all emitted
+     * notifications. Typically used in the context of a React 17 (or lower)
+     * application to pass in a reference to
+     * a `ReactDOM.unstable_batchedUpdates` or
+     * `ReactNative.unstable_batchedUpdates` here, to announce to the React
+     * renderer that a series of updates can follow that should lead to
+     * a single rerender.
      */
     unstable_batchedUpdates?: (cb: () => void) => void;
 

--- a/packages/liveblocks-client/src/client.ts
+++ b/packages/liveblocks-client/src/client.ts
@@ -21,13 +21,12 @@ type EnterOptions<
   // Enter options are just room initializers, plus an internal option
   RoomInitializers<TPresence, TStorage> & {
     /**
-     * A custom callback that will get wrapped around all emitted
-     * notifications. Typically used in the context of a React 17 (or lower)
-     * application to pass in a reference to
-     * a `ReactDOM.unstable_batchedUpdates` or
-     * `ReactNative.unstable_batchedUpdates` here, to announce to the React
-     * renderer that a series of updates can follow that should lead to
-     * a single rerender.
+     * Only necessary when you’re using Liveblocks with React v17 or lower.
+     *
+     * If so, pass in a reference to `ReactDOM.unstable_batchedUpdates` here.
+     * This will allow Liveblocks to circumvent the so-called "zombie child
+     * problem". To learn more, see
+     * https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child
      */
     unstable_batchedUpdates?: (cb: () => void) => void;
 

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -274,12 +274,12 @@ type Config = {
   polyfills?: Polyfills;
 
   /**
-   * A custom callback that will get wrapped around all emitted notifications.
-   * Typically used in the context of a React 17 (or lower) application to pass
-   * in a reference to a `ReactDOM.unstable_batchedUpdates` or
-   * `ReactNative.unstable_batchedUpdates` here, to announce to the React
-   * renderer that a series of updates can follow that should lead to a single
-   * rerender.
+   * Only necessary when you’re using Liveblocks with React v17 or lower.
+   *
+   * If so, pass in a reference to `ReactDOM.unstable_batchedUpdates` here.
+   * This will allow Liveblocks to circumvent the so-called "zombie child
+   * problem". To learn more, see
+   * https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child
    */
   unstable_batchedUpdates?: (cb: () => void) => void;
 
@@ -305,8 +305,7 @@ function makeStateMachine<
   mockedEffects?: Effects<TPresence, TRoomEvent>
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const doNotBatchUpdates = (cb: () => void): void => cb();
-  const batchUpdates =
-    config.unstable_batchedUpdates ?? doNotBatchUpdates;
+  const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;
 
   const pool: ManagedPool = {
     roomId: config.roomId,

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -39,7 +39,6 @@ const missing_unstable_batchedUpdates = (
   reactVersion: number,
   roomId: string
 ) =>
-  // XXX  Add link to docs
   `We noticed you’re using React ${reactVersion}. Please pass unstable_batchedUpdates at the RoomProvider level until you’re ready to upgrade to React 18:
 
     import { unstable_batchedUpdates } from "react-dom";  // or "react-native"
@@ -50,11 +49,7 @@ const missing_unstable_batchedUpdates = (
       ...
     </RoomProvider>
 
-🤔 Why?
-There’s a problem with React 17 or lower that is known as the “stale props” and/or “zombie child” problem.
-By passing unstable_batchedUpdates to RoomProvider, we can circumvent this problem for your app.
-
-See XXX for more information`;
+Why? Please see https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child for more information`;
 
 const superfluous_unstable_batchedUpdates =
   "You don’t need to pass unstable_batchedUpdates to RoomProvider anymore, since you’re on React 18+ already.";

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -106,7 +106,12 @@ export function createRoomContext<
   > | null>(null);
 
   function RoomProvider(props: RoomProviderProps<TPresence, TStorage>) {
-    const { id: roomId, initialPresence, initialStorage } = props;
+    const {
+      id: roomId,
+      initialPresence,
+      initialStorage,
+      unstable_batchedUpdates,
+    } = props;
 
     if (process.env.NODE_ENV !== "production") {
       if (!roomId) {
@@ -124,14 +129,16 @@ export function createRoomContext<
     const frozen = useInitial({
       initialPresence,
       initialStorage,
+      unstable_batchedUpdates,
     });
 
     const [room, setRoom] = React.useState<
       Room<TPresence, TStorage, TUserMeta, TRoomEvent>
     >(() =>
       client.enter(roomId, {
-        initialPresence,
-        initialStorage,
+        initialPresence: frozen.initialPresence,
+        initialStorage: frozen.initialStorage,
+        unstable_batchedUpdates: frozen.unstable_batchedUpdates,
         DO_NOT_USE_withoutConnecting: typeof window === "undefined",
       } as RoomInitializers<TPresence, TStorage>)
     );
@@ -141,6 +148,7 @@ export function createRoomContext<
         client.enter(roomId, {
           initialPresence: frozen.initialPresence,
           initialStorage: frozen.initialStorage,
+          unstable_batchedUpdates: frozen.unstable_batchedUpdates,
           DO_NOT_USE_withoutConnecting: typeof window === "undefined",
         } as RoomInitializers<TPresence, TStorage>)
       );

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -26,6 +26,14 @@ export type RoomProviderProps<
      */
     id: string;
     children: React.ReactNode;
+    /**
+     * Optionally, pass in a reference to `ReactDOM.unstable_batchedUpdates`,
+     * which will be used by the client to avoid the zombie child problem by
+     * batching all external Liveblocks notifications. This is a good idea if
+     * you're on React v17 or lower. Not necessary when you're on React v18 or
+     * later.
+     */
+    unstable_batchedUpdates?: (cb: () => void) => void;
   } & RoomInitializers<TPresence, TStorage>
 >;
 

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -26,12 +26,20 @@ export type RoomProviderProps<
      */
     id: string;
     children: React.ReactNode;
+
     /**
-     * Optionally, pass in a reference to `ReactDOM.unstable_batchedUpdates`,
-     * which will be used by the client to avoid the zombie child problem by
-     * batching all external Liveblocks notifications. This is a good idea if
-     * you're on React v17 or lower. Not necessary when you're on React v18 or
-     * later.
+     * If you're on React 17 or lower, pass in a reference to
+     * `ReactDOM.unstable_batchedUpdates` or
+     * `ReactNative.unstable_batchedUpdates` here.
+     *
+     * @example
+     * import { unstable_batchedUpdates } from "react-dom";
+     *
+     * <RoomProvider ... unstable_batchedUpdates={unstable_batchedUpdates} />
+     *
+     * This will prevent you from running into the so-called "stale props"
+     * and/or "zombie child" problem that React 17 and lower can suffer from.
+     * Not necessary when you're on React v18 or later.
      */
     unstable_batchedUpdates?: (cb: () => void) => void;
   } & RoomInitializers<TPresence, TStorage>


### PR DESCRIPTION
This PR reverts the fix I made last week (#506), and instead fixes the zombie child problem structurally—not just for the `useOther` hook. In the `useOther` hook, the problem was most apparent because that function explicitly throws, but the problem was more broad than this.

Fixes #511.

As mentioned in https://github.com/liveblocks/liveblocks/issues/511#issuecomment-1258500696, this zombie child problem is only a problem in React<18, and not in React>=18. See that comment for an explanation of why this is a problem in React 17 and lower.

In this more structural solution, the RoomProvider can pass a reference to `unstable_batchedUpdates` (from ReactDOM or ReactNative), down to the client, which will then wrap all notification callbacks in a single "render batch". It looks like this:

```tsx
import { unstable_batchedUpdates } from "react-dom";  // or…
// import { unstable_batchedUpdates } from "react-native";

<RoomProvider
  id="my-room"
  unstable_batchedUpdates={unstable_batchedUpdates}  // 👈
/>
```

Including this line fixes the zombie child problem and is generally a good idea to use. In React>=18, this is not needed, but if you include it, it still works, as it's a no-op there.

## Downsides
While this solution may be the Proper/Robust/Structural Fix™, it has a few downsides that I don't like much 🤔

First of all, ideally we'd hide this implementation detail entirely. But we cannot "automatically" fix this under the hood, because `unstable_batchedUpdates` is a renderer-specific implementation detail. It either must come from ReactDOM or ReactNative (or whatever render you’re using). The `@liveblocks/react` package only directly depends on `react`, not on renderers like `react-dom` or `react-native`.

Secondly, this is an optional field, but ideally it should be set in all cases where users are on React 17 or lower. Ideally it would be mandatory to set in those cases. If we don't make it mandatory to configure, then users may use the non-batching version for a long time in production before stumbling on the stable props / zombie child issue, and will have a hard time debugging it. After that pain, they may learn about the existence of this fix, but it's a frustrating journey that can be prevented if this would be mandatory.
