### PR TITLE
Fancy console badges

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -1,3 +1,6 @@
+const rulesDirPlugin = require("eslint-plugin-rulesdir");
+rulesDirPlugin.RULES_DIR = "./rules";
+
 module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
@@ -6,6 +9,7 @@ module.exports = {
     "@typescript-eslint",
     "eslint-plugin-import",
     "eslint-plugin-simple-import-sort",
+    "eslint-plugin-rulesdir",
   ],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
@@ -54,6 +58,7 @@ module.exports = {
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------
+    "rulesdir/console-must-be-fancy": "error",
     "no-restricted-syntax": [
       "error",
       {

--- a/packages/liveblocks-client/package-lock.json
+++ b/packages/liveblocks-client/package-lock.json
@@ -21,6 +21,7 @@
         "dotenv": "^16.0.0",
         "eslint": "^8.12.0",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-rulesdir": "^0.2.1",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "fast-check": "^3.0.1",
         "jest": "^28.0.3",
@@ -5852,6 +5853,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/eslint-plugin-rulesdir": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.1.tgz",
+      "integrity": "sha512-t7rQvEyfE4JZJu6dPl4/uVr6Fr0fxopBhzVbtq3isfOHMKdlIe9xW/5CtIaWZI0E1U+wzAk0lEnZC8laCD5YLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/eslint-plugin-simple-import-sort": {
       "version": "7.0.0",
@@ -17561,6 +17571,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-rulesdir": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.1.tgz",
+      "integrity": "sha512-t7rQvEyfE4JZJu6dPl4/uVr6Fr0fxopBhzVbtq3isfOHMKdlIe9xW/5CtIaWZI0E1U+wzAk0lEnZC8laCD5YLA==",
+      "dev": true
     },
     "eslint-plugin-simple-import-sort": {
       "version": "7.0.0",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -51,6 +51,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.12.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-rulesdir": "^0.2.1",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "fast-check": "^3.0.1",
     "jest": "^28.0.3",

--- a/packages/liveblocks-client/rules/console-must-be-fancy.js
+++ b/packages/liveblocks-client/rules/console-must-be-fancy.js
@@ -1,0 +1,26 @@
+module.exports = {
+  meta: {
+    messages: {
+      addMissingImport:
+        "Don't use `console` directly. To fix: `import * as console from './fancy-console'` in this module.",
+    },
+  },
+
+  create(context) {
+    let seenFancyImport = false;
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value.includes("fancy-console")) {
+          seenFancyImport = true;
+        }
+      },
+
+      CallExpression(node) {
+        if (node.callee.object?.name === "console" && !seenFancyImport) {
+          context.report({ node: node.callee, messageId: "addMissingImport" });
+        }
+      },
+    };
+  },
+};

--- a/packages/liveblocks-client/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-client/src/__tests__/immutable.test.ts
@@ -1,4 +1,5 @@
 import { LiveList, LiveMap } from "..";
+import * as console from "../fancy-console";
 import {
   legacy_patchImmutableObject,
   lsonToJson,

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -1242,7 +1242,7 @@ describe("room", () => {
       );
 
       expect(consoleErrorSpy.mock.calls[0][0]).toEqual(
-        "Connection to Liveblocks websocket server closed. Reason:  (code: 4002). Retrying in 2000ms."
+        "Connection to websocket server closed. Reason:  (code: 4002). Retrying in 2000ms."
       );
 
       expect(state.numberOfRetry).toEqual(1);

--- a/packages/liveblocks-client/src/__tests__/room.test.ts
+++ b/packages/liveblocks-client/src/__tests__/room.test.ts
@@ -2,6 +2,7 @@ import { rest } from "msw";
 import { setupServer } from "msw/node";
 
 import type { RoomAuthToken } from "../AuthToken";
+import * as console from "../fancy-console";
 import { lsonToJson } from "../immutable";
 import { LiveList } from "../LiveList";
 import {

--- a/packages/liveblocks-client/src/deprecation.ts
+++ b/packages/liveblocks-client/src/deprecation.ts
@@ -19,7 +19,7 @@ export function deprecate(message: string, key = message): void {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
       _emittedDeprecationWarnings.add(key);
-      console.errorBold("Deprecation warning", message);
+      console.errorWithTitle("Deprecation warning", message);
     }
   }
 }
@@ -50,7 +50,7 @@ export function throwUsageError(message: string): void {
   if (process.env.NODE_ENV !== "production") {
     const usageError = new Error(message);
     usageError.name = "Usage error";
-    console.errorBold("Usage error", message);
+    console.errorWithTitle("Usage error", message);
     throw usageError;
   }
 }

--- a/packages/liveblocks-client/src/deprecation.ts
+++ b/packages/liveblocks-client/src/deprecation.ts
@@ -1,3 +1,5 @@
+import * as console from "./fancy-console";
+
 /**
  * Tools to help with the controlled deprecation of public APIs.
  *
@@ -17,7 +19,7 @@ export function deprecate(message: string, key = message): void {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
       _emittedDeprecationWarnings.add(key);
-      console.error(`DEPRECATION WARNING: ${message}`);
+      console.errorBold("Deprecation warning", message);
     }
   }
 }
@@ -48,6 +50,7 @@ export function throwUsageError(message: string): void {
   if (process.env.NODE_ENV !== "production") {
     const usageError = new Error(message);
     usageError.name = "Usage error";
+    console.errorBold("Usage error", message);
     throw usageError;
   }
 }

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -1,3 +1,5 @@
+/* eslint-disable rulesdir/console-must-be-fancy */
+
 const badge =
   "background:radial-gradient(106.94% 108.33% at -10% -5%,#ff1aa3 0,#ff881a 100%);border-radius:6px;color:#fff;padding:2px 6px";
 const bold = "font-weight:600";

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -15,7 +15,7 @@ function wrap(
 export const warn = wrap("warn");
 export const error = wrap("error");
 
-function wrapBold(
+function wrapWithTitle(
   method: "log" | "warn" | "error"
 ): (title: string, message: string, ...args: readonly unknown[]) => void {
   return typeof window === "undefined" || process.env.NODE_ENV === "test"
@@ -30,6 +30,6 @@ function wrapBold(
         );
 }
 
-// export const logBold = wrapBold("log");
-// export const warnBold = wrapBold("warn");
-export const errorBold = wrapBold("error");
+// export const logWithTitle = wrapWithTitle("log");
+// export const warnWithTitle = wrapWithTitle("warn");
+export const errorWithTitle = wrapWithTitle("error");

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -1,7 +1,7 @@
 /* eslint-disable rulesdir/console-must-be-fancy */
 
 const badge =
-  "background:radial-gradient(106.94% 108.33% at -10% -5%,#ff1aa3 0,#ff881a 100%);border-radius:6px;color:#fff;padding:2px 6px";
+  "background:radial-gradient(106.94% 108.33% at -10% -5%,#ff1aa3 0,#ff881a 100%);border-radius:3px;color:#fff;padding:2px 5px;font-family:sans-serif;font-weight:600";
 const bold = "font-weight:600";
 
 function wrap(

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -11,7 +11,7 @@ function wrap(
         console[method]("%cliveblocks", badge, message, ...args);
 }
 
-export const log = wrap("log");
+// export const log = wrap("log");
 export const warn = wrap("warn");
 export const error = wrap("error");
 
@@ -30,6 +30,6 @@ function wrapBold(
         );
 }
 
-export const logBold = wrapBold("log");
-export const warnBold = wrapBold("warn");
+// export const logBold = wrapBold("log");
+// export const warnBold = wrapBold("warn");
 export const errorBold = wrapBold("error");

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -10,7 +10,7 @@ function wrap(
   return typeof window === "undefined" || process.env.NODE_ENV === "test"
     ? console[method]
     : (message, ...args) =>
-        console[method]("%cliveblocks", badge, message, ...args);
+        console[method]("%cLiveblocks", badge, message, ...args);
 }
 
 // export const log = wrap("log");
@@ -24,7 +24,7 @@ function wrapWithTitle(
     ? console[method]
     : (title, message, ...args) =>
         console[method](
-          `%cliveblocks%c ${title}`,
+          `%cLiveblocks%c ${title}`,
           badge,
           bold,
           message,

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -1,0 +1,28 @@
+const badge =
+  "background:radial-gradient(106.94% 108.33% at -10% -5%,#ff1aa3 0,#ff881a 100%);border-radius:6px;color:#fff;padding:2px 6px";
+const bold = "font-weight:600";
+
+export const log = (message: string, ...args: readonly unknown[]) =>
+  console.log("%cliveblocks", badge, message, ...args);
+export const warn = (message: string, ...args: readonly unknown[]) =>
+  console.warn("%cliveblocks", badge, message, ...args);
+export const error = (message: string, ...args: readonly unknown[]) =>
+  console.error("%cliveblocks", badge, message, ...args);
+
+export const logBold = (
+  title: string,
+  message: string,
+  ...args: readonly unknown[]
+) => console.log(`%cliveblocks%c ${title}`, badge, bold, message, ...args);
+
+export const warnBold = (
+  title: string,
+  message: string,
+  ...args: readonly unknown[]
+) => console.warn(`%cliveblocks%c ${title}`, badge, bold, message, ...args);
+
+export const errorBold = (
+  title: string,
+  message: string,
+  ...args: readonly unknown[]
+) => console.error(`%cliveblocks%c ${title}`, badge, bold, message, ...args);

--- a/packages/liveblocks-client/src/fancy-console.ts
+++ b/packages/liveblocks-client/src/fancy-console.ts
@@ -2,27 +2,34 @@ const badge =
   "background:radial-gradient(106.94% 108.33% at -10% -5%,#ff1aa3 0,#ff881a 100%);border-radius:6px;color:#fff;padding:2px 6px";
 const bold = "font-weight:600";
 
-export const log = (message: string, ...args: readonly unknown[]) =>
-  console.log("%cliveblocks", badge, message, ...args);
-export const warn = (message: string, ...args: readonly unknown[]) =>
-  console.warn("%cliveblocks", badge, message, ...args);
-export const error = (message: string, ...args: readonly unknown[]) =>
-  console.error("%cliveblocks", badge, message, ...args);
+function wrap(
+  method: "log" | "warn" | "error"
+): (message: string, ...args: readonly unknown[]) => void {
+  return typeof window === "undefined" || process.env.NODE_ENV === "test"
+    ? console[method]
+    : (message, ...args) =>
+        console[method]("%cliveblocks", badge, message, ...args);
+}
 
-export const logBold = (
-  title: string,
-  message: string,
-  ...args: readonly unknown[]
-) => console.log(`%cliveblocks%c ${title}`, badge, bold, message, ...args);
+export const log = wrap("log");
+export const warn = wrap("warn");
+export const error = wrap("error");
 
-export const warnBold = (
-  title: string,
-  message: string,
-  ...args: readonly unknown[]
-) => console.warn(`%cliveblocks%c ${title}`, badge, bold, message, ...args);
+function wrapBold(
+  method: "log" | "warn" | "error"
+): (title: string, message: string, ...args: readonly unknown[]) => void {
+  return typeof window === "undefined" || process.env.NODE_ENV === "test"
+    ? console[method]
+    : (title, message, ...args) =>
+        console[method](
+          `%cliveblocks%c ${title}`,
+          badge,
+          bold,
+          message,
+          ...args
+        );
+}
 
-export const errorBold = (
-  title: string,
-  message: string,
-  ...args: readonly unknown[]
-) => console.error(`%cliveblocks%c ${title}`, badge, bold, message, ...args);
+export const logBold = wrapBold("log");
+export const warnBold = wrapBold("warn");
+export const errorBold = wrapBold("error");

--- a/packages/liveblocks-client/src/immutable.ts
+++ b/packages/liveblocks-client/src/immutable.ts
@@ -1,3 +1,4 @@
+import * as console from "./fancy-console";
 import { LiveList } from "./LiveList";
 import { LiveMap } from "./LiveMap";
 import { LiveObject } from "./LiveObject";

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -5,6 +5,7 @@ import type { RoomAuthToken } from "./AuthToken";
 import { isTokenExpired, parseRoomAuthToken } from "./AuthToken";
 import type { Callback, Observable } from "./EventSource";
 import { makeEventSource } from "./EventSource";
+import * as console from "./fancy-console";
 import { LiveObject } from "./LiveObject";
 import { MeRef } from "./MeRef";
 import { OthersRef } from "./OthersRef";

--- a/packages/liveblocks-client/src/room.ts
+++ b/packages/liveblocks-client/src/room.ts
@@ -1154,7 +1154,7 @@ function makeStateMachine<
 
         if (process.env.NODE_ENV !== "production") {
           console.error(
-            `Connection to Liveblocks websocket server closed. Reason: ${error.message} (code: ${error.code}). Retrying in ${delay}ms.`
+            `Connection to websocket server closed. Reason: ${error.message} (code: ${error.code}). Retrying in ${delay}ms.`
           );
         }
 


### PR DESCRIPTION
Adds fancy/branded badges to our console logs:

![Screen Shot 2022-09-28 at 22 11 02@2x](https://user-images.githubusercontent.com/83844/192879293-93d3e711-0d98-4535-819b-0a988d221146.png)

These can be used like normal console methods, simply by importing this module as a global:

```tsx
import * as console from "./fancy-console";

console.log('foo');
console.warn('foo');
console.error('foo');
```

---

In addition, there also exists a version that allows you to log out a title (printed in bold):

```tsx
console.errorBold('Some title', 'Lorem ipsum dolor sit amet');
```

<img width="695" alt="Screen Shot 2022-09-28 at 22 16 46@2x" src="https://user-images.githubusercontent.com/83844/192880133-608bff90-236a-4c7b-a47f-25fae181248c.png">
