### PR TITLE
Fix type of `BaseUserMeta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.18.5 (not yet released)
+# v0.18.5
 
 Bug fix:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v0.18.5 (not yet released)
 
+Bug fix:
+
+- Fixes a small bug in a type definition. The newly added `scopes` field is
+  optional, but this wasn’t correctly reflected by the `BaseUserMeta` type.
+
 Internal updates:
 
 - Switch the monorepo over to Turborepo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 Bug fix:
 
-- Fixes a small bug in a type definition. The newly added `scopes` field is
-  optional, but this wasn’t correctly reflected by the `BaseUserMeta` type.
+- Fixes a small bug in a type definition, `scopes` was removed from `BaseUserMeta`.
 
 Internal updates:
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -907,7 +907,7 @@ function makeStateMachine<
     }
   }
 
-  function isStorageReadOnly(scopes: string[] = [RoomScope.Write]) {
+  function isStorageReadOnly(scopes: string[]) {
     return (
       scopes.includes(RoomScope.Read) &&
       scopes.includes(RoomScope.PresenceWrite) &&

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -907,7 +907,7 @@ function makeStateMachine<
     }
   }
 
-  function isReadOnly(scopes: string[] = [RoomScope.Write]) {
+  function isStorageReadOnly(scopes: string[] = [RoomScope.Write]) {
     return (
       scopes.includes(RoomScope.Read) &&
       scopes.includes(RoomScope.PresenceWrite) &&
@@ -927,7 +927,7 @@ function makeStateMachine<
         id: token.actor,
         userInfo: token.info,
         userId: token.id,
-        isReadOnly: isReadOnly(token.scopes),
+        isReadOnly: isStorageReadOnly(token.scopes),
       },
       batchUpdates
     );
@@ -1010,7 +1010,7 @@ function makeStateMachine<
         connectionId,
         user.id,
         user.info,
-        isReadOnly(user.scopes)
+        isStorageReadOnly(user.scopes)
       );
     }
     return { type: "reset" };
@@ -1036,7 +1036,7 @@ function makeStateMachine<
       message.actor,
       message.id,
       message.info,
-      isReadOnly(message.scopes)
+      isStorageReadOnly(message.scopes)
     );
     // Send current presence to new user
     // TODO: Consider storing it on the backend

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -907,7 +907,7 @@ function makeStateMachine<
     }
   }
 
-  function isReadOnly(scopes: string[]) {
+  function isReadOnly(scopes: string[] = [RoomScope.Write]) {
     return (
       scopes.includes(RoomScope.Read) &&
       scopes.includes(RoomScope.PresenceWrite) &&

--- a/packages/liveblocks-core/src/types/BaseUserMeta.ts
+++ b/packages/liveblocks-core/src/types/BaseUserMeta.ts
@@ -1,5 +1,8 @@
 import type { Json } from "./Json";
 
+/**
+ * This type is used by clients to define... TODO
+ */
 export type BaseUserMeta = {
   /**
    * The id of the user that has been set in the authentication endpoint.
@@ -11,9 +14,4 @@ export type BaseUserMeta = {
    * Additional user information that has been set in the authentication endpoint.
    */
   info?: Json;
-
-  /**
-   * Permissions that the user has in the room.
-   */
-  scopes?: string[];
 };

--- a/packages/liveblocks-core/src/types/BaseUserMeta.ts
+++ b/packages/liveblocks-core/src/types/BaseUserMeta.ts
@@ -15,5 +15,5 @@ export type BaseUserMeta = {
   /**
    * Permissions that the user has in the room.
    */
-  scopes: string[];
+  scopes?: string[];
 };

--- a/packages/liveblocks-core/src/types/BaseUserMeta.ts
+++ b/packages/liveblocks-core/src/types/BaseUserMeta.ts
@@ -1,7 +1,7 @@
 import type { Json } from "./Json";
 
 /**
- * This type is used by clients to define... TODO
+ * This type is used by clients to define the metadata for a user.
  */
 export type BaseUserMeta = {
   /**

--- a/packages/liveblocks-core/src/types/ServerMsg.ts
+++ b/packages/liveblocks-core/src/types/ServerMsg.ts
@@ -155,7 +155,7 @@ export type BroadcastedEventServerMsg<TRoomEvent extends Json> = {
 export type RoomStateServerMsg<TUserMeta extends BaseUserMeta> = {
   type: ServerMsgCode.ROOM_STATE;
   users: {
-    [actor: number]: TUserMeta;
+    [actor: number]: TUserMeta & { scopes: string[] };
   };
 };
 


### PR DESCRIPTION
Removes `scopes` from `BaseUserMeta` and adds the property to the definition of `RoomStateServerMsg`.

Scopes should not be defined by clients as they are internal to Liveblocks.