### PR TITLE
Simplify instructions for local linking

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,19 +21,7 @@ READMEs for instructions on how to set up your Liveblocks keys.
 If you are contributing to one of the core Liveblocks packages and want to try
 your changes against any of the examples, take the following steps:
 
-1. Change the dependency version in `examples/whatever-example/package.json` to
-   `"*"` instead of an explicit version number:
-   ```json
-   {
-     "dependencies": {
-       "@liveblocks/client": "*",  👈
-       "@liveblocks/node": "*",    👈
-       "@liveblocks/react": "*",   👈
-       ...
-     }
-   }
-   ```
-2. Declare the example as an NPM workspace, in the `package.json` in the root of
+1. Declare the example as an NPM workspace, in the `package.json` in the root of
    the monorepo:
    ```json
    {
@@ -45,9 +33,9 @@ your changes against any of the examples, take the following steps:
      ]
    }
    ```
-3. Run `npm install` from the root of this monorepo.
-4. Run `turbo run build` in the root of this monorepo.
-5. Now the example is linked to the local Liveblocks source code.
-6. Remember to NOT (!) check in the changes to the `package.json` files. It’s
+1. Run `npm install` from the root of this monorepo.
+1. Run `turbo run build` in the root of this monorepo.
+1. Now the example is linked to the local Liveblocks source code.
+1. Remember to NOT (!) check in the changes to the `package.json` files. It’s
    fine to develop against a locally linked package, but we want to keep the
    examples linked against _published_ versions of Liveblocks at all times.


### PR DESCRIPTION
I've removed a step from the instructions to link the examples locally. This seems to be enough already. I think I got confused here originally ¯\\\_(ツ)\_/¯!
