### PR TITLE
Code organization cleanups in base packages

### DIFF
--- a/packages/liveblocks-client/.eslintrc.js
+++ b/packages/liveblocks-client/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     // ----------------------------------------------------------------------
     // Overrides from default rule config used in all other projects!
     // ----------------------------------------------------------------------
-    /* None yet 😇 ! */
+    "@typescript-eslint/no-explicit-any": "off",
 
     // ----------------------------------------------------------------------
     // Extra rules for this project specifically

--- a/packages/liveblocks-client/src/__tests__/_utils.ts
+++ b/packages/liveblocks-client/src/__tests__/_utils.ts
@@ -1,0 +1,89 @@
+import { remove } from "@liveblocks/core";
+
+export class MockWebSocket implements WebSocket {
+  CONNECTING = 0;
+  OPEN = 1;
+  CLOSING = 2;
+  CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  isMock = true;
+
+  callbacks = {
+    open: [] as Array<(event?: WebSocketEventMap["open"]) => void>,
+    close: [] as Array<(event?: WebSocketEventMap["close"]) => void>,
+    error: [] as Array<(event?: WebSocketEventMap["error"]) => void>,
+    message: [] as Array<(event?: WebSocketEventMap["message"]) => void>,
+  };
+
+  sentMessages: string[] = [];
+  readyState: number;
+
+  constructor(
+    public url: string,
+    private onSend: (message: string) => void = () => {}
+  ) {
+    this.readyState = this.CLOSED;
+    MockWebSocket.instances.push(this);
+  }
+
+  close(_code?: number, _reason?: string): void {
+    this.readyState = this.CLOSED;
+  }
+
+  addEventListener<T extends "open" | "close" | "error" | "message">(
+    event: T,
+    callback: (event: WebSocketEventMap[T]) => void
+  ) {
+    this.callbacks[event].push(callback as any);
+  }
+
+  removeEventListener<T extends "open" | "close" | "error" | "message">(
+    event: T,
+    callback: (event: WebSocketEventMap[T]) => void
+  ) {
+    remove(this.callbacks[event], callback as any);
+  }
+
+  send(message: string) {
+    this.sentMessages.push(message);
+    this.onSend(message);
+  }
+
+  open() {
+    this.readyState = this.OPEN;
+    for (const callback of this.callbacks.open) {
+      callback();
+    }
+  }
+
+  closeFromBackend(event?: CloseEvent) {
+    this.readyState = this.CLOSED;
+    for (const callback of this.callbacks.close) {
+      callback(event);
+    }
+  }
+
+  // Fields and methods below are not implemented
+
+  binaryType: BinaryType = "blob";
+  bufferedAmount: number = 0;
+  extensions: string = "";
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null = () => {
+    throw new Error("NOT IMPLEMENTED");
+  };
+  onerror: ((this: WebSocket, ev: Event) => any) | null = () => {
+    throw new Error("NOT IMPLEMENTED");
+  };
+  onmessage: ((this: WebSocket, ev: MessageEvent<any>) => any) | null = () => {
+    throw new Error("NOT IMPLEMENTED");
+  };
+  onopen: ((this: WebSocket, ev: Event) => any) | null = () => {
+    throw new Error("NOT IMPLEMENTED");
+  };
+  protocol: string = "";
+  dispatchEvent(_event: Event): boolean {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/liveblocks-client/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-client/src/__tests__/client.node.test.ts
@@ -6,7 +6,7 @@
 import { Response } from "node-fetch";
 
 import { createClient } from "..";
-import type { ClientOptions } from "../types";
+import type { ClientOptions } from "../client";
 import { MockWebSocket } from "./_utils";
 
 const token =

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -1,7 +1,7 @@
+export { createClient } from "./client";
 export type {
   BaseUserMeta,
   BroadcastOptions,
-  Client,
   History,
   Immutable,
   Json,
@@ -14,13 +14,7 @@ export type {
   StorageUpdate,
   User,
 } from "@liveblocks/core";
-export {
-  createClient,
-  LiveList,
-  LiveMap,
-  LiveObject,
-  shallow,
-} from "@liveblocks/core";
+export { LiveList, LiveMap, LiveObject, shallow } from "@liveblocks/core";
 
 /**
  * Helper type to help users adopt to Lson types from interface definitions.

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -28,7 +28,6 @@ import type {
   ToImmutable,
 } from "../types";
 import { ClientMsgCode, CrdtType, ServerMsgCode } from "../types";
-import { remove } from "../utils";
 import type { JsonStorageUpdate } from "./_updatesUtils";
 import { serializeUpdateToJson } from "./_updatesUtils";
 
@@ -49,94 +48,6 @@ function deepClone<T extends Json>(items: T): T {
   // won't lead to type unsafety, so this use case is okay.
   // eslint-disable-next-line no-restricted-syntax
   return JSON.parse(JSON.stringify(items));
-}
-
-export class MockWebSocket implements WebSocket {
-  CONNECTING = 0;
-  OPEN = 1;
-  CLOSING = 2;
-  CLOSED = 3;
-
-  static instances: MockWebSocket[] = [];
-
-  isMock = true;
-
-  callbacks = {
-    open: [] as Array<(event?: WebSocketEventMap["open"]) => void>,
-    close: [] as Array<(event?: WebSocketEventMap["close"]) => void>,
-    error: [] as Array<(event?: WebSocketEventMap["error"]) => void>,
-    message: [] as Array<(event?: WebSocketEventMap["message"]) => void>,
-  };
-
-  sentMessages: string[] = [];
-  readyState: number;
-
-  constructor(
-    public url: string,
-    private onSend: (message: string) => void = () => {}
-  ) {
-    this.readyState = this.CLOSED;
-    MockWebSocket.instances.push(this);
-  }
-
-  close(_code?: number, _reason?: string): void {
-    this.readyState = this.CLOSED;
-  }
-
-  addEventListener<T extends "open" | "close" | "error" | "message">(
-    event: T,
-    callback: (event: WebSocketEventMap[T]) => void
-  ) {
-    this.callbacks[event].push(callback as any);
-  }
-
-  removeEventListener<T extends "open" | "close" | "error" | "message">(
-    event: T,
-    callback: (event: WebSocketEventMap[T]) => void
-  ) {
-    remove(this.callbacks[event], callback as any);
-  }
-
-  send(message: string) {
-    this.sentMessages.push(message);
-    this.onSend(message);
-  }
-
-  open() {
-    this.readyState = this.OPEN;
-    for (const callback of this.callbacks.open) {
-      callback();
-    }
-  }
-
-  closeFromBackend(event?: CloseEvent) {
-    this.readyState = this.CLOSED;
-    for (const callback of this.callbacks.close) {
-      callback(event);
-    }
-  }
-
-  // Fields and methods below are not implemented
-
-  binaryType: BinaryType = "blob";
-  bufferedAmount: number = 0;
-  extensions: string = "";
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null = () => {
-    throw new Error("NOT IMPLEMENTED");
-  };
-  onerror: ((this: WebSocket, ev: Event) => any) | null = () => {
-    throw new Error("NOT IMPLEMENTED");
-  };
-  onmessage: ((this: WebSocket, ev: MessageEvent<any>) => any) | null = () => {
-    throw new Error("NOT IMPLEMENTED");
-  };
-  onopen: ((this: WebSocket, ev: Event) => any) | null = () => {
-    throw new Error("NOT IMPLEMENTED");
-  };
-  protocol: string = "";
-  dispatchEvent(_event: Event): boolean {
-    throw new Error("Method not implemented.");
-  }
 }
 
 export const FIRST_POSITION = makePosition();

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -14,7 +14,6 @@
 export { assertNever, nn } from "./assert";
 export type { AppOnlyAuthToken, AuthToken, RoomAuthToken } from "./AuthToken";
 export { isAppOnlyAuthToken, isAuthToken, isRoomAuthToken } from "./AuthToken";
-export { createClient } from "./client";
 export {
   deprecate,
   deprecateIf,
@@ -31,6 +30,8 @@ export { LiveList } from "./LiveList";
 export { LiveMap } from "./LiveMap";
 export { LiveObject } from "./LiveObject";
 export { comparePosition, makePosition } from "./position";
+export type { InternalRoom } from "./room";
+export { createRoom } from "./room";
 export { shallow } from "./shallow";
 export type {
   BroadcastedEventServerMsg,
@@ -76,7 +77,6 @@ export type {
 export type {
   BaseUserMeta,
   BroadcastOptions,
-  Client,
   History,
   Immutable,
   Json,
@@ -99,7 +99,13 @@ export {
 export type { ToImmutable } from "./types/Immutable";
 export { isJsonArray, isJsonObject, isJsonScalar } from "./types/Json";
 export { isChildCrdt, isRootCrdt } from "./types/SerializedCrdt";
-export { b64decode, freeze, isPlainObject, tryParseJson } from "./utils";
+export {
+  b64decode,
+  freeze,
+  isPlainObject,
+  remove,
+  tryParseJson,
+} from "./utils";
 
 /**
  * Helper type to help users adopt to Lson types from interface definitions.

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1782,7 +1782,6 @@ function defaultState<
   };
 }
 
-/** @internal */
 export type InternalRoom<
   TPresence extends JsonObject,
   TStorage extends LsonObject,

--- a/packages/liveblocks-core/src/types/index.ts
+++ b/packages/liveblocks-core/src/types/index.ts
@@ -198,43 +198,6 @@ export type RoomInitializers<
   shouldInitiallyConnect?: boolean;
 }>;
 
-export type Client = {
-  /**
-   * Gets a room. Returns null if {@link Client.enter} has not been called previously.
-   *
-   * @param roomId The id of the room
-   */
-  getRoom<
-    TPresence extends JsonObject,
-    TStorage extends LsonObject = LsonObject,
-    TUserMeta extends BaseUserMeta = BaseUserMeta,
-    TRoomEvent extends Json = never
-  >(
-    roomId: string
-  ): Room<TPresence, TStorage, TUserMeta, TRoomEvent> | null;
-
-  /**
-   * Enters a room and returns it.
-   * @param roomId The id of the room
-   * @param options Optional. You can provide initializers for the Presence or Storage when entering the Room.
-   */
-  enter<
-    TPresence extends JsonObject,
-    TStorage extends LsonObject = LsonObject,
-    TUserMeta extends BaseUserMeta = BaseUserMeta,
-    TRoomEvent extends Json = never
-  >(
-    roomId: string,
-    options: RoomInitializers<TPresence, TStorage>
-  ): Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
-
-  /**
-   * Leaves a room.
-   * @param roomId The id of the room
-   */
-  leave(roomId: string): void;
-};
-
 /**
  * Represents all the other users connected in the room. Treated as immutable.
  */
@@ -283,28 +246,6 @@ export type Polyfills = {
   fetch?: typeof fetch;
   WebSocket?: any;
 };
-
-/**
- * The authentication endpoint that is called to ensure that the current user has access to a room.
- * Can be an url or a callback if you need to add additional headers.
- */
-export type ClientOptions = {
-  throttle?: number;
-  polyfills?: Polyfills;
-
-  /**
-   * Backward-compatible way to set `polyfills.fetch`.
-   */
-  fetchPolyfill?: Polyfills["fetch"];
-
-  /**
-   * Backward-compatible way to set `polyfills.WebSocket`.
-   */
-  WebSocketPolyfill?: Polyfills["WebSocket"];
-} & (
-  | { publicApiKey: string; authEndpoint?: never }
-  | { publicApiKey?: never; authEndpoint: AuthEndpoint }
-);
 
 export type AuthorizeResponse = {
   token: string;


### PR DESCRIPTION
Most importantly, this moves client-related code back into @liveblocks/client.