### PR TITLE
fix typo in openapi doc

### DIFF
--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -33,15 +33,25 @@
                           "lastConnectionAt": "2022-08-08T23:23:15.281Z",
                           "createdAt": "2022-08-08T23:23:15.281Z",
                           "metadata": {
-                            "name": ["My room"],
-                            "type": ["whiteboard"]
+                            "name": [
+                              "My room"
+                            ],
+                            "type": [
+                              "whiteboard"
+                            ]
                           },
-                          "defaultAccesses": ["room:write"],
+                          "defaultAccesses": [
+                            "room:write"
+                          ],
                           "groupsAccesses": {
-                            "product": ["room:write"]
+                            "product": [
+                              "room:write"
+                            ]
                           },
                           "usersAccesses": {
-                            "vinod": ["room:write"]
+                            "vinod": [
+                              "room:write"
+                            ]
                           }
                         }
                       ]
@@ -133,12 +143,18 @@
                       "metadata": {
                         "color": "blue"
                       },
-                      "defaultAccesses": ["room:write"],
+                      "defaultAccesses": [
+                        "room:write"
+                      ],
                       "groupsAccesses": {
-                        "product": ["room:write"]
+                        "product": [
+                          "room:write"
+                        ]
                       },
                       "usersAccesses": {
-                        "alice": ["room:write"]
+                        "alice": [
+                          "room:write"
+                        ]
                       }
                     }
                   }
@@ -170,15 +186,21 @@
                 "example": {
                   "value": {
                     "id": "my-room-3ebc26e2bf96",
-                    "defaultAccesses": ["room:write"],
+                    "defaultAccesses": [
+                      "room:write"
+                    ],
                     "metadata": {
                       "color": "blue"
                     },
                     "usersAccesses": {
-                      "alice": ["room:write"]
+                      "alice": [
+                        "room:write"
+                      ]
                     },
                     "groupsAccesses": {
-                      "product": ["room:write"]
+                      "product": [
+                        "room:write"
+                      ]
                     }
                   }
                 }
@@ -223,15 +245,26 @@
                       "metadata": {
                         "color": "blue",
                         "size": "10",
-                        "target": ["abc", "def"]
+                        "target": [
+                          "abc",
+                          "def"
+                        ]
                       },
-                      "defaultAccesses": ["room:write"],
+                      "defaultAccesses": [
+                        "room:write"
+                      ],
                       "groupsAccesses": {
-                        "marketing": ["room:write"]
+                        "marketing": [
+                          "room:write"
+                        ]
                       },
                       "usersAccesses": {
-                        "alice": ["room:write"],
-                        "vinod": ["room:write"]
+                        "alice": [
+                          "room:write"
+                        ],
+                        "vinod": [
+                          "room:write"
+                        ]
                       }
                     }
                   }
@@ -273,15 +306,26 @@
                       "metadata": {
                         "color": "blue",
                         "size": "10",
-                        "target": ["abc", "def"]
+                        "target": [
+                          "abc",
+                          "def"
+                        ]
                       },
-                      "defaultAccesses": ["room:write"],
+                      "defaultAccesses": [
+                        "room:write"
+                      ],
                       "groupsAccesses": {
-                        "marketing": ["room:write"]
+                        "marketing": [
+                          "room:write"
+                        ]
                       },
                       "usersAccesses": {
-                        "alice": ["room:write"],
-                        "vinod": ["room:write"]
+                        "alice": [
+                          "room:write"
+                        ],
+                        "vinod": [
+                          "room:write"
+                        ]
                       }
                     }
                   }
@@ -303,7 +347,7 @@
           }
         },
         "operationId": "post-rooms-roomId",
-        "description": "Updates specific properties of a room. It's not necessary to provide the entire room's information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"users_accesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.\n\n",
+        "description": "Updates specific properties of a room. It's not necessary to provide the entire room's information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"usersAccesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.\n\n",
         "requestBody": {
           "content": {
             "application/json": {
@@ -313,13 +357,21 @@
               "examples": {
                 "example-1": {
                   "value": {
-                    "defaultAccesses": ["room:write"],
-                    "users_accesses": {
-                      "vinod": ["room:write"],
-                      "alice": ["room:write"]
+                    "defaultAccesses": [
+                      "room:write"
+                    ],
+                    "usersAccesses": {
+                      "vinod": [
+                        "room:write"
+                      ],
+                      "alice": [
+                        "room:write"
+                      ]
                     },
-                    "groups_accesses": {
-                      "marketing": ["room:write"]
+                    "groupsAccesses": {
+                      "marketing": [
+                        "room:write"
+                      ]
                     },
                     "metadata": {
                       "color": "blue"
@@ -432,7 +484,10 @@
                       "type": "string"
                     },
                     "data": {
-                      "type": ["string", "object"]
+                      "type": [
+                        "string",
+                        "object"
+                      ]
                     }
                   }
                 },
@@ -449,7 +504,10 @@
                         },
                         "aLiveList": {
                           "liveblocksType": "LiveList",
-                          "data": ["a", "b"]
+                          "data": [
+                            "a",
+                            "b"
+                          ]
                         },
                         "aLiveMap": {
                           "liveblocksType": "LiveMap",
@@ -493,7 +551,10 @@
                       "type": "string"
                     },
                     "data": {
-                      "type": ["string", "object"]
+                      "type": [
+                        "string",
+                        "object"
+                      ]
                     }
                   }
                 },
@@ -510,7 +571,10 @@
                         },
                         "aLiveList": {
                           "liveblocksType": "LiveList",
-                          "data": ["a", "b"]
+                          "data": [
+                            "a",
+                            "b"
+                          ]
                         },
                         "aLiveMap": {
                           "liveblocksType": "LiveMap",
@@ -564,7 +628,10 @@
                       },
                       "aLiveList": {
                         "liveblocksType": "LiveList",
-                        "data": ["a", "b"]
+                        "data": [
+                          "a",
+                          "b"
+                        ]
                       },
                       "aLiveMap": {
                         "liveblocksType": "LiveMap",
@@ -647,10 +714,16 @@
                 "example-1": {
                   "value": {
                     "userId": "b2c1c290-f2c9-45de-a74e-6b7aa0690f59",
-                    "groupIds": ["g1", "g2"],
+                    "groupIds": [
+                      "g1",
+                      "g2"
+                    ],
                     "userInfo": {
                       "name": "bob",
-                      "colors": ["blue", "red"]
+                      "colors": [
+                        "blue",
+                        "red"
+                      ]
                     }
                   }
                 }
@@ -748,7 +821,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["room"]
+            "enum": [
+              "room"
+            ]
           },
           "lastConnectionAt": {
             "type": "string",
@@ -765,7 +840,10 @@
             }
           },
           "defaultAccesses": {
-            "type": ["string", "array"],
+            "type": [
+              "string",
+              "array"
+            ],
             "uniqueItems": true,
             "items": {}
           },
@@ -800,15 +878,24 @@
             }
           },
           "usersAccesses": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "A map of user identifiers to permissions list. Setting the value as `null` will clear all users' accesses. Setting one user identifier as `null` will clear this user's accesses."
           },
           "groupsAccesses": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "A map of group identifiers to permissions list. Setting the value as `null` will clear all groups' accesses. Setting one group identifier as `null` will clear this group's accesses."
           },
           "metadata": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "A map of metadata keys to their values (`string` or `string[]`). Setting the value as `null` will clear all metadata. Setting a key as `null` will clear the key."
           }
         }
@@ -836,7 +923,10 @@
             "type": "object"
           }
         },
-        "required": ["id", "defaultAccesses"]
+        "required": [
+          "id",
+          "defaultAccesses"
+        ]
       },
       "Error": {
         "title": "Error",
@@ -915,7 +1005,10 @@
                   "type": "object"
                 },
                 "defaultAccesses": {
-                  "type": ["string", "array"],
+                  "type": [
+                    "string",
+                    "array"
+                  ],
                   "items": {}
                 },
                 "usersAccesses": {


### PR DESCRIPTION
Rename `users_accesses` to `usersAccesses` and `groups_accesses` to `groupsAccesses`.