### PR TITLE
Redux cleanups

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -36,6 +36,7 @@ export type {
   BroadcastedEventServerMsg,
   BroadcastEventClientMsg,
   ClientMsg,
+  ConnectionState,
   CreateChildOp,
   CreateListOp,
   CreateMapOp,

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -78,10 +78,10 @@ export type WithLiveblocks<
   TUserMeta extends BaseUserMeta
 > = TState & { readonly liveblocks: LiveblocksContext<TPresence, TUserMeta> };
 
-const internalEnhancer = <T>(options: {
+const internalEnhancer = <TState>(options: {
   client: Client;
-  storageMapping?: Mapping<T>;
-  presenceMapping?: Mapping<T>;
+  storageMapping?: Mapping<TState>;
+  presenceMapping?: Mapping<TState>;
 }) => {
   if (process.env.NODE_ENV !== "production" && options.client == null) {
     throw missingClient();
@@ -343,10 +343,10 @@ function leaveRoom(roomId: string): {
  * Redux store enhancer that will make the `liveblocks` key available on your
  * Redux store.
  */
-export const liveblocksEnhancer = internalEnhancer as <T>(options: {
+export const liveblocksEnhancer = internalEnhancer as <TState>(options: {
   client: Client;
-  storageMapping?: Mapping<T>;
-  presenceMapping?: Mapping<T>;
+  storageMapping?: Mapping<TState>;
+  presenceMapping?: Mapping<TState>;
 }) => StoreEnhancer;
 
 /**
@@ -397,9 +397,9 @@ function isObject(value: any): value is object {
   return Object.prototype.toString.call(value) === "[object Object]";
 }
 
-function validateNoDuplicateKeys<T>(
-  storageMapping: Mapping<T>,
-  presenceMapping: Mapping<T>
+function validateNoDuplicateKeys<TState>(
+  storageMapping: Mapping<TState>,
+  presenceMapping: Mapping<TState>
 ) {
   for (const key in storageMapping) {
     if (presenceMapping[key] !== undefined) {
@@ -420,12 +420,12 @@ Partial<TState> {
   return partialState;
 }
 
-function patchState<T extends JsonObject>(
-  state: T,
+function patchState<TState extends JsonObject>(
+  state: TState,
   updates: any[], // StorageUpdate
-  mapping: Mapping<T>
+  mapping: Mapping<TState>
 ) {
-  const partialState: Partial<T> = {};
+  const partialState: Partial<TState> = {};
 
   for (const key in mapping) {
     partialState[key] = state[key];
@@ -433,7 +433,7 @@ function patchState<T extends JsonObject>(
 
   const patched = legacy_patchImmutableObject(partialState, updates);
 
-  const result: Partial<T> = {};
+  const result: Partial<TState> = {};
 
   for (const key in mapping) {
     result[key] = patched[key];
@@ -445,17 +445,17 @@ function patchState<T extends JsonObject>(
 /**
  * Remove false keys from mapping and generate to a new object to avoid potential mutation from outside the middleware
  */
-function validateMapping<T>(
-  mapping: Mapping<T>,
+function validateMapping<TState>(
+  mapping: Mapping<TState>,
   mappingType: "storageMapping" | "presenceMapping"
-): Mapping<T> {
+): Mapping<TState> {
   if (process.env.NODE_ENV !== "production") {
     if (!isObject(mapping)) {
       throw mappingShouldBeAnObject(mappingType);
     }
   }
 
-  const result: Mapping<T> = {};
+  const result: Mapping<TState> = {};
   for (const key in mapping) {
     if (
       process.env.NODE_ENV !== "production" &&

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -1,6 +1,7 @@
 import type {
   BaseUserMeta,
   Client,
+  Json,
   JsonObject,
   LiveObject,
   LsonObject,
@@ -85,6 +86,8 @@ const internalEnhancer = <TState>(options: {
   storageMapping?: Mapping<TState>;
   presenceMapping?: Mapping<TState>;
 }) => {
+  type OpaqueRoom = Room<JsonObject, LsonObject, BaseUserMeta, Json>;
+
   if (process.env.NODE_ENV !== "production" && options.client == null) {
     throw missingClient();
   }
@@ -104,9 +107,9 @@ const internalEnhancer = <TState>(options: {
   return (createStore: TODO) =>
     // prettier-ignore
     (reducer: TODO, initialState: TODO) => {
-      let room: Room<TODO, TODO, TODO, TODO> | null = null;
+      let room: OpaqueRoom | null = null;
       let isPatching: boolean = false;
-      let storageRoot: LiveObject<TODO> | null = null;
+      let storageRoot: LiveObject<LsonObject> | null = null;
       let unsubscribeCallbacks: Array<() => void> = [];
 
       const newReducer = (state: TODO, action: TODO) => {

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -220,10 +220,7 @@ const internalEnhancer = <T>(options: {
             if (isPatching === false) {
               store.dispatch({
                 type: ACTION_TYPES.PATCH_REDUX_STATE,
-                state: selectFields(
-                  room!.getPresence(),
-                  presenceMapping as any
-                ),
+                state: selectFields(room!.getPresence(), presenceMapping),
               });
             }
           })

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -100,7 +100,7 @@ const internalEnhancer = <T>(options: {
   }
 
   return (createStore: any) =>
-    (reducer: any, initialState: any, enhancer: any) => {
+    (reducer: any, initialState: any) => {
       let room: Room<any, any, any, any> | null = null;
       let isPatching: boolean = false;
       let storageRoot: LiveObject<any> | null = null;
@@ -183,7 +183,7 @@ const internalEnhancer = <T>(options: {
         }
       };
 
-      const store = createStore(newReducer, initialState, enhancer);
+      const store = createStore(newReducer, initialState);
 
       function enterRoom(roomId: string) {
         if (storageRoot) {

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -286,13 +286,13 @@ const internalEnhancer = <T>(options: {
         client.leave(roomId);
       }
 
-      function newDispatch(action: any, state: any) {
+      function newDispatch(action: any) {
         if (action.type === ACTION_TYPES.ENTER) {
           enterRoom(action.roomId);
         } else if (action.type === ACTION_TYPES.LEAVE) {
           leaveRoom(action.roomId);
         } else {
-          store.dispatch(action, state);
+          store.dispatch(action);
         }
       }
 

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -22,6 +22,8 @@ import {
   missingClient,
 } from "./errors";
 
+type TODO = any;
+
 export type Mapping<T> = {
   [K in keyof T]?: boolean;
 };
@@ -99,14 +101,15 @@ const internalEnhancer = <TState>(options: {
     validateNoDuplicateKeys(mapping, presenceMapping);
   }
 
-  return (createStore: any) =>
-    (reducer: any, initialState: any) => {
-      let room: Room<any, any, any, any> | null = null;
+  return (createStore: TODO) =>
+    // prettier-ignore
+    (reducer: TODO, initialState: TODO) => {
+      let room: Room<TODO, TODO, TODO, TODO> | null = null;
       let isPatching: boolean = false;
-      let storageRoot: LiveObject<any> | null = null;
+      let storageRoot: LiveObject<TODO> | null = null;
       let unsubscribeCallbacks: Array<() => void> = [];
 
-      const newReducer = (state: any, action: any) => {
+      const newReducer = (state: TODO, action: TODO) => {
         switch (action.type) {
           case ACTION_TYPES.PATCH_REDUX_STATE:
             return {
@@ -153,7 +156,7 @@ const internalEnhancer = <TState>(options: {
 
             if (room) {
               isPatching = true;
-              updatePresence(room!, state, newState, presenceMapping as any);
+              updatePresence(room!, state, newState, presenceMapping as TODO);
 
               room.batch(() => {
                 if (storageRoot) {
@@ -161,7 +164,7 @@ const internalEnhancer = <TState>(options: {
                     storageRoot,
                     state,
                     newState,
-                    mapping as any
+                    mapping as TODO
                   );
                 }
               });
@@ -193,7 +196,7 @@ const internalEnhancer = <TState>(options: {
         const initialPresence = selectFields(
           store.getState(),
           presenceMapping
-        ) as any;
+        ) as TODO;
 
         room = client.enter(roomId, { initialPresence });
 
@@ -231,7 +234,7 @@ const internalEnhancer = <TState>(options: {
         });
 
         room.getStorage().then(({ root }) => {
-          const updates: any = {};
+          const updates: TODO = {};
 
           room!.batch(() => {
             for (const key in mapping) {
@@ -262,7 +265,7 @@ const internalEnhancer = <TState>(options: {
                     state: patchState(
                       store.getState(),
                       updates,
-                      mapping as any
+                      mapping as TODO
                     ),
                   });
                 }
@@ -286,7 +289,7 @@ const internalEnhancer = <TState>(options: {
         client.leave(roomId);
       }
 
-      function newDispatch(action: any) {
+      function newDispatch(action: TODO) {
         if (action.type === ACTION_TYPES.ENTER) {
           enterRoom(action.roomId);
         } else if (action.type === ACTION_TYPES.LEAVE) {
@@ -371,13 +374,13 @@ function patchLiveblocksStorage<O extends LsonObject, TState>(
     if (oldState[key] !== newState[key]) {
       const oldVal = oldState[key];
       const newVal = newState[key];
-      patchLiveObjectKey(root, key, oldVal as any, newVal);
+      patchLiveObjectKey(root, key, oldVal as TODO, newVal);
     }
   }
 }
 
 function updatePresence<TPresence extends JsonObject>(
-  room: Room<TPresence, any, any, any>,
+  room: Room<TPresence, TODO, TODO, TODO>,
   oldState: TPresence,
   newState: TPresence,
   presenceMapping: Mapping<TPresence>
@@ -393,7 +396,7 @@ function updatePresence<TPresence extends JsonObject>(
   }
 }
 
-function isObject(value: any): value is object {
+function isObject(value: TODO): value is object {
   return Object.prototype.toString.call(value) === "[object Object]";
 }
 
@@ -422,7 +425,7 @@ Partial<TState> {
 
 function patchState<TState extends JsonObject>(
   state: TState,
-  updates: any[], // StorageUpdate
+  updates: TODO[], // StorageUpdate
   mapping: Mapping<TState>
 ) {
   const partialState: Partial<TState> = {};

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -43,7 +43,7 @@ type LiveblocksContext<
   /**
    * Other users in the room. Empty no room is currently synced
    */
-  readonly others: Array<User<TPresence, TUserMeta>>;
+  readonly others: readonly User<TPresence, TUserMeta>[];
   /**
    * Whether or not the room storage is currently loading
    */
@@ -210,7 +210,7 @@ const internalEnhancer = <T>(options: {
           room.events.others.subscribe(({ others }) => {
             store.dispatch({
               type: ACTION_TYPES.UPDATE_OTHERS,
-              others: others.toArray(),
+              others,
             });
           })
         );


### PR DESCRIPTION
Stacked on top of #422.

This PR cleans up the Redux package internals, so they are roughly equivalent to the quality of TypeScript we now offer since the Zustand upgrades. Removes a lot of type uncertainties. Targeted to be included in the 0.19 release.