### PR TITLE
Dependency cruiser

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run type tests
         run: npm run test:types -- --filter ${{ matrix.pkg }}
 
+      - name: Run dependency tests
+        run: npm run test:deps -- --filter ${{ matrix.pkg }}
+
       - name: Run lint checks
         run: npm run lint -- --filter ${{ matrix.pkg }}
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -123,5 +123,5 @@ jobs:
         run: npm install
 
       - name: Run e2e client specs tests
-        run: npm run test-e2e
+        run: npm run test:e2e
         working-directory: packages/liveblocks-core

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "e2e/next-sandbox"
       ],
       "devDependencies": {
+        "dependency-cruiser": "^11.16.1",
         "gen-esm-wrapper": "^1.1.3",
         "prettier": "^2.7.1",
         "tsd": "^0.24.1",
@@ -2049,9 +2050,9 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2074,6 +2075,24 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.3.0.tgz",
+      "integrity": "sha512-75lAs9H19ldmW+fAbyqHdjgdCrz0pWGXKmnqFoh8PyVd1L2RIb4RzYrSjmopeqv3E1G3/Pimu6GgLlrGbrkF7w==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -2959,6 +2978,119 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dependency-cruiser": {
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-11.18.0.tgz",
+      "integrity": "sha512-RzIwcb+7KhGLozDf0zWolT+pljNcSBfnadNz5utG08mDkQdYAbR11iXgmNtQ6bMKsLnvOkSTTCZBrIWF/4Ux9w==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "8.8.1",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.3.0",
+        "acorn-walk": "8.2.0",
+        "ajv": "8.11.0",
+        "chalk": "^4.1.2",
+        "commander": "9.4.1",
+        "enhanced-resolve": "5.10.0",
+        "figures": "^3.2.0",
+        "get-stream": "^6.0.1",
+        "glob": "7.2.0",
+        "handlebars": "4.7.7",
+        "indent-string": "^4.0.0",
+        "interpret": "^2.2.0",
+        "is-installed-globally": "0.4.0",
+        "json5": "2.2.1",
+        "lodash": "4.17.21",
+        "prompts": "2.4.2",
+        "rechoir": "^0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "^7.3.7",
+        "semver-try-require": "5.0.4",
+        "teamcity-service-messages": "0.1.14",
+        "tsconfig-paths-webpack-plugin": "4.0.0",
+        "watskeburt": "0.8.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.js",
+        "depcruise-baseline": "bin/depcruise-baseline.js",
+        "depcruise-fmt": "bin/depcruise-fmt.js",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.js",
+        "dependency-cruise": "bin/dependency-cruise.js",
+        "dependency-cruiser": "bin/dependency-cruise.js"
+      },
+      "engines": {
+        "node": "^12.20||^14||>=16"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3061,6 +3193,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -4370,6 +4515,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/global-dirs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "dev": true,
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globals": {
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
@@ -4420,6 +4580,27 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/hard-rejection": {
@@ -4687,6 +4868,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/inquirer": {
       "version": "8.2.4",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
@@ -4740,6 +4930,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/irregular-plurals": {
@@ -4896,6 +5095,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -4942,6 +5157,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -6478,6 +6702,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "node_modules/next": {
       "version": "12.3.1",
       "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
@@ -7383,6 +7613,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7417,6 +7659,15 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true,
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -7448,6 +7699,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7609,6 +7869,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -7658,6 +7927,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-try-require": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/semver-try-require/-/semver-try-require-5.0.4.tgz",
+      "integrity": "sha512-Abn38ZyrV6BV+tjyf2T9b6Qx7GiVIIrkiTLHEDDeboNzAPPBAqLnbW+eRtiln7iqNGBOmQrXtQSjCLOTGK+NyA==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "^12||^14||>=16"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -8044,6 +8325,21 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/teamcity-service-messages": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/teamcity-service-messages/-/teamcity-service-messages-0.1.14.tgz",
+      "integrity": "sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w==",
+      "dev": true
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -8240,6 +8536,59 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
+      "integrity": "sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
@@ -8535,6 +8884,19 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8668,6 +9030,30 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-0.8.1.tgz",
+      "integrity": "sha512-QpTiPIyYJMzr+HxwZSM1pZk9sfOFhycuINSC2N+SmFwA4PVA++GNxaCC8Lr9PGWGwxB+uGlpTlF9IrfiqUBPeg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "9.4.1"
+      },
+      "bin": {
+        "watskeburt": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^12.20||^14||>=16"
+      }
+    },
+    "node_modules/watskeburt/node_modules/commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/wcwidth": {
@@ -8816,6 +9202,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -12119,9 +12511,9 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -12137,6 +12529,21 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
+    },
+    "acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true
+    },
+    "acorn-loose": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.3.0.tgz",
+      "integrity": "sha512-75lAs9H19ldmW+fAbyqHdjgdCrz0pWGXKmnqFoh8PyVd1L2RIb4RzYrSjmopeqv3E1G3/Pimu6GgLlrGbrkF7w==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.5.0"
+      }
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -12761,6 +13168,91 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
+    "dependency-cruiser": {
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-11.18.0.tgz",
+      "integrity": "sha512-RzIwcb+7KhGLozDf0zWolT+pljNcSBfnadNz5utG08mDkQdYAbR11iXgmNtQ6bMKsLnvOkSTTCZBrIWF/4Ux9w==",
+      "dev": true,
+      "requires": {
+        "acorn": "8.8.1",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.3.0",
+        "acorn-walk": "8.2.0",
+        "ajv": "8.11.0",
+        "chalk": "^4.1.2",
+        "commander": "9.4.1",
+        "enhanced-resolve": "5.10.0",
+        "figures": "^3.2.0",
+        "get-stream": "^6.0.1",
+        "glob": "7.2.0",
+        "handlebars": "4.7.7",
+        "indent-string": "^4.0.0",
+        "interpret": "^2.2.0",
+        "is-installed-globally": "0.4.0",
+        "json5": "2.2.1",
+        "lodash": "4.17.21",
+        "prompts": "2.4.2",
+        "rechoir": "^0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "^7.3.7",
+        "semver-try-require": "5.0.4",
+        "teamcity-service-messages": "0.1.14",
+        "tsconfig-paths-webpack-plugin": "4.0.0",
+        "watskeburt": "0.8.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -12838,6 +13330,16 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
+      }
+    },
+    "enhanced-resolve": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
       }
     },
     "entities": {
@@ -13712,6 +14214,15 @@
         "is-glob": "^4.0.3"
       }
     },
+    "global-dirs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "dev": true,
+      "requires": {
+        "ini": "2.0.0"
+      }
+    },
     "globals": {
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
@@ -13748,6 +14259,19 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -13929,6 +14453,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true
+    },
     "inquirer": {
       "version": "8.2.4",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
@@ -13973,6 +14503,12 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true
     },
     "irregular-plurals": {
       "version": "3.3.0",
@@ -14074,6 +14610,16 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      }
+    },
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -14103,6 +14649,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -15237,6 +15789,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "next": {
       "version": "12.3.1",
       "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
@@ -15835,6 +16393,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.20.0"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -15864,6 +16431,12 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
+    "regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -15883,6 +16456,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -15989,6 +16568,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -16026,6 +16614,15 @@
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
+      }
+    },
+    "semver-try-require": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/semver-try-require/-/semver-try-require-5.0.4.tgz",
+      "integrity": "sha512-Abn38ZyrV6BV+tjyf2T9b6Qx7GiVIIrkiTLHEDDeboNzAPPBAqLnbW+eRtiln7iqNGBOmQrXtQSjCLOTGK+NyA==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.8"
       }
     },
     "set-cookie-parser": {
@@ -16309,6 +16906,18 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true
+    },
+    "teamcity-service-messages": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/teamcity-service-messages/-/teamcity-service-messages-0.1.14.tgz",
+      "integrity": "sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w==",
+      "dev": true
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -16459,6 +17068,46 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "dev": true
+        },
+        "tsconfig-paths": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
+          "integrity": "sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==",
+          "dev": true,
+          "requires": {
+            "json5": "^2.2.1",
+            "minimist": "^1.2.6",
+            "strip-bom": "^3.0.0"
+          }
         }
       }
     },
@@ -16640,6 +17289,13 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -16745,6 +17401,23 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "watskeburt": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-0.8.1.tgz",
+      "integrity": "sha512-QpTiPIyYJMzr+HxwZSM1pZk9sfOFhycuINSC2N+SmFwA4PVA++GNxaCC8Lr9PGWGwxB+uGlpTlF9IrfiqUBPeg==",
+      "dev": true,
+      "requires": {
+        "commander": "9.4.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "dev": true
+        }
       }
     },
     "wcwidth": {
@@ -16862,6 +17535,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "turbo run dev"
   },
   "devDependencies": {
+    "dependency-cruiser": "^11.16.1",
     "gen-esm-wrapper": "^1.1.3",
     "prettier": "^2.7.1",
     "tsd": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "test:types": "turbo run test:types",
+    "test:deps": "turbo run test:deps",
     "lint": "turbo run lint",
     "dev": "turbo run dev"
   },

--- a/packages/liveblocks-core/.dependency-cruiser.js
+++ b/packages/liveblocks-core/.dependency-cruiser.js
@@ -1,7 +1,6 @@
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {
   forbidden: [
-    /* rules from the 'recommended' preset: */
     {
       name: "no-circular",
       severity: "warn",
@@ -13,6 +12,7 @@ module.exports = {
         circular: true,
       },
     },
+
     {
       name: "no-orphans",
       comment:
@@ -33,6 +33,7 @@ module.exports = {
       },
       to: {},
     },
+
     {
       name: "no-deprecated-core",
       comment:
@@ -66,6 +67,7 @@ module.exports = {
         ],
       },
     },
+
     {
       name: "not-to-deprecated",
       comment:
@@ -77,6 +79,7 @@ module.exports = {
         dependencyTypes: ["deprecated"],
       },
     },
+
     {
       name: "no-non-package-json",
       severity: "error",
@@ -90,6 +93,7 @@ module.exports = {
         dependencyTypes: ["npm-no-pkg", "npm-unknown"],
       },
     },
+
     {
       name: "not-to-unresolvable",
       comment:
@@ -101,6 +105,7 @@ module.exports = {
         couldNotResolve: true,
       },
     },
+
     {
       name: "no-duplicate-dep-types",
       comment:
@@ -126,70 +131,51 @@ module.exports = {
         "implement functionality this is odd. Either you're writing a test outside the test folder " +
         "or there's something in the test folder that isn't a test.",
       severity: "error",
-      from: {
-        pathNot: "^(src/__tests__)",
-      },
-      to: {
-        path: "^(src/__tests__)",
-      },
+      from: { pathNot: "/__tests__/" },
+      to: { path: "/__tests__/" },
     },
+
+    // "Swimlane 0" - lib/
     {
-      name: "not-to-spec",
+      name: "illegal-import-from-libs",
       comment:
-        "This module depends on a spec (test) file. The sole responsibility of a spec file is to test code. " +
-        "If there's something in a spec that's of use to other modules, it doesn't have that single " +
-        "responsibility anymore. Factor it out into (e.g.) a separate utility/ helper or a mock.",
+        "All modules in lib/ must have no other dependencies. They aren't Liveblocks-specific. They could, theoretically, be NPM packages of their own.",
       severity: "error",
-      from: {},
-      to: {
-        path: "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$",
-      },
+      from: { path: "^src/lib/" },
+      to: { pathNot: "^src/(lib)/" },
     },
+
+    // "Swimlane 1" - protocol/
     {
-      name: "not-to-dev-dep",
+      name: "illegal-import-from-protocol",
+      comment:
+        "All modules in protocol/ must have no other dependencies apart from lib/.",
       severity: "error",
-      comment:
-        "This module depends on an npm package from the 'devDependencies' section of your " +
-        "package.json. It looks like something that ships to production, though. To prevent problems " +
-        "with npm packages that aren't there on production declare it (only!) in the 'dependencies'" +
-        "section of your package.json. If this module is development only - add it to the " +
-        "from.pathNot re of the not-to-dev-dep rule in the dependency-cruiser configuration",
-      from: {
-        path: "^(src)",
-        pathNot:
-          "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$",
-      },
-      to: {
-        dependencyTypes: ["npm-dev"],
-      },
+      from: { path: "^src/protocol/" },
+      to: { pathNot: "^src/(protocol|lib)/" },
     },
+
+    // "Swimlane 2" - types/
     {
-      name: "optional-deps-used",
-      severity: "info",
+      name: "illegal-import-from-types",
       comment:
-        "This module depends on an npm package that is declared as an optional dependency " +
-        "in your package.json. As this makes sense in limited situations only, it's flagged here. " +
-        "If you're using an optional dependency here by design - add an exception to your" +
-        "dependency-cruiser configuration.",
-      from: {},
-      to: {
-        dependencyTypes: ["npm-optional"],
-      },
+        "All modules in types/ must have no other dependencies apart from protocol/ or lib/.",
+      severity: "error",
+      from: { path: "^src/types/" },
+      to: { pathNot: "^src/(types|protocol|lib)/" },
     },
+
+    // "Swimlane 3" - refs/
     {
-      name: "peer-deps-used",
+      name: "illegal-import-from-refs",
       comment:
-        "This module depends on an npm package that is declared as a peer dependency " +
-        "in your package.json. This makes sense if your package is e.g. a plugin, but in " +
-        "other cases - maybe not so much. If the use of a peer dependency is intentional " +
-        "add an exception to your dependency-cruiser configuration.",
-      severity: "warn",
-      from: {},
-      to: {
-        dependencyTypes: ["npm-peer"],
-      },
+        "All modules in refs/ must have no other dependencies apart from types/, protocol/ or lib/.",
+      severity: "error",
+      from: { path: "^src/refs/" },
+      to: { pathNot: "^src/(refs|types|protocol|lib)/" },
     },
   ],
+
   options: {
     /* conditions specifying which files not to follow further when encountered:
        - path: a regular expression to match
@@ -426,4 +412,3 @@ module.exports = {
     },
   },
 };
-// generated: dependency-cruiser@11.16.1 on 2022-10-14T14:11:20.984Z

--- a/packages/liveblocks-core/.dependency-cruiser.js
+++ b/packages/liveblocks-core/.dependency-cruiser.js
@@ -174,6 +174,16 @@ module.exports = {
       from: { path: "^src/refs/" },
       to: { pathNot: "^src/(refs|types|protocol|lib)/" },
     },
+
+    // "Swimlane 4" - crdts/
+    {
+      name: "illegal-import-from-crdts",
+      comment:
+        "All modules in crdts/ must have no other dependencies apart from refs/, types/, protocol/ or lib/.",
+      severity: "error",
+      from: { path: "^src/crdts/" },
+      to: { pathNot: "^src/(crdts|refs|types|protocol|lib)/" },
+    },
   ],
 
   options: {

--- a/packages/liveblocks-core/.dependency-cruiser.js
+++ b/packages/liveblocks-core/.dependency-cruiser.js
@@ -1,0 +1,429 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    /* rules from the 'recommended' preset: */
+    {
+      name: "no-circular",
+      severity: "warn",
+      comment:
+        "This dependency is part of a circular relationship. You might want to revise " +
+        "your solution (i.e. use dependency inversion, make sure the modules have a single responsibility) ",
+      from: {},
+      to: {
+        circular: true,
+      },
+    },
+    {
+      name: "no-orphans",
+      comment:
+        "This is an orphan module - it's likely not used (anymore?). Either use it or " +
+        "remove it. If it's logical this module is an orphan (i.e. it's a config file), " +
+        "add an exception for it in your dependency-cruiser configuration. By default " +
+        "this rule does not scrutinize dot-files (e.g. .eslintrc.js), TypeScript declaration " +
+        "files (.d.ts), tsconfig.json and some of the babel and webpack configs.",
+      severity: "warn",
+      from: {
+        orphan: true,
+        pathNot: [
+          "(^|/)\\.[^/]+\\.(js|cjs|mjs|ts|json)$", // dot files
+          "\\.d\\.ts$", // TypeScript declaration files
+          "(^|/)tsconfig\\.json$", // TypeScript config
+          "(^|/)(babel|webpack)\\.config\\.(js|cjs|mjs|ts|json)$", // other configs
+        ],
+      },
+      to: {},
+    },
+    {
+      name: "no-deprecated-core",
+      comment:
+        "A module depends on a node core module that has been deprecated. Find an alternative - these are " +
+        "bound to exist - node doesn't deprecate lightly.",
+      severity: "warn",
+      from: {},
+      to: {
+        dependencyTypes: ["core"],
+        path: [
+          "^(v8/tools/codemap)$",
+          "^(v8/tools/consarray)$",
+          "^(v8/tools/csvparser)$",
+          "^(v8/tools/logreader)$",
+          "^(v8/tools/profile_view)$",
+          "^(v8/tools/profile)$",
+          "^(v8/tools/SourceMap)$",
+          "^(v8/tools/splaytree)$",
+          "^(v8/tools/tickprocessor-driver)$",
+          "^(v8/tools/tickprocessor)$",
+          "^(node-inspect/lib/_inspect)$",
+          "^(node-inspect/lib/internal/inspect_client)$",
+          "^(node-inspect/lib/internal/inspect_repl)$",
+          "^(async_hooks)$",
+          "^(punycode)$",
+          "^(domain)$",
+          "^(constants)$",
+          "^(sys)$",
+          "^(_linklist)$",
+          "^(_stream_wrap)$",
+        ],
+      },
+    },
+    {
+      name: "not-to-deprecated",
+      comment:
+        "This module uses a (version of an) npm module that has been deprecated. Either upgrade to a later " +
+        "version of that module, or find an alternative. Deprecated modules are a security risk.",
+      severity: "warn",
+      from: {},
+      to: {
+        dependencyTypes: ["deprecated"],
+      },
+    },
+    {
+      name: "no-non-package-json",
+      severity: "error",
+      comment:
+        "This module depends on an npm package that isn't in the 'dependencies' section of your package.json. " +
+        "That's problematic as the package either (1) won't be available on live (2 - worse) will be " +
+        "available on live with an non-guaranteed version. Fix it by adding the package to the dependencies " +
+        "in your package.json.",
+      from: {},
+      to: {
+        dependencyTypes: ["npm-no-pkg", "npm-unknown"],
+      },
+    },
+    {
+      name: "not-to-unresolvable",
+      comment:
+        "This module depends on a module that cannot be found ('resolved to disk'). If it's an npm " +
+        "module: add it to your package.json. In all other cases you likely already know what to do.",
+      severity: "error",
+      from: {},
+      to: {
+        couldNotResolve: true,
+      },
+    },
+    {
+      name: "no-duplicate-dep-types",
+      comment:
+        "Likely this module depends on an external ('npm') package that occurs more than once " +
+        "in your package.json i.e. bot as a devDependencies and in dependencies. This will cause " +
+        "maintenance problems later on.",
+      severity: "warn",
+      from: {},
+      to: {
+        moreThanOneDependencyType: true,
+        // as it's pretty common to have a type import be a type only import
+        // _and_ (e.g.) a devDependency - don't consider type-only dependency
+        // types for this rule
+        dependencyTypesNot: ["type-only"],
+      },
+    },
+
+    /* rules you might want to tweak for your specific situation: */
+    {
+      name: "not-to-test",
+      comment:
+        "This module depends on code within a folder that should only contain tests. As tests don't " +
+        "implement functionality this is odd. Either you're writing a test outside the test folder " +
+        "or there's something in the test folder that isn't a test.",
+      severity: "error",
+      from: {
+        pathNot: "^(src/__tests__)",
+      },
+      to: {
+        path: "^(src/__tests__)",
+      },
+    },
+    {
+      name: "not-to-spec",
+      comment:
+        "This module depends on a spec (test) file. The sole responsibility of a spec file is to test code. " +
+        "If there's something in a spec that's of use to other modules, it doesn't have that single " +
+        "responsibility anymore. Factor it out into (e.g.) a separate utility/ helper or a mock.",
+      severity: "error",
+      from: {},
+      to: {
+        path: "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$",
+      },
+    },
+    {
+      name: "not-to-dev-dep",
+      severity: "error",
+      comment:
+        "This module depends on an npm package from the 'devDependencies' section of your " +
+        "package.json. It looks like something that ships to production, though. To prevent problems " +
+        "with npm packages that aren't there on production declare it (only!) in the 'dependencies'" +
+        "section of your package.json. If this module is development only - add it to the " +
+        "from.pathNot re of the not-to-dev-dep rule in the dependency-cruiser configuration",
+      from: {
+        path: "^(src)",
+        pathNot:
+          "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$",
+      },
+      to: {
+        dependencyTypes: ["npm-dev"],
+      },
+    },
+    {
+      name: "optional-deps-used",
+      severity: "info",
+      comment:
+        "This module depends on an npm package that is declared as an optional dependency " +
+        "in your package.json. As this makes sense in limited situations only, it's flagged here. " +
+        "If you're using an optional dependency here by design - add an exception to your" +
+        "dependency-cruiser configuration.",
+      from: {},
+      to: {
+        dependencyTypes: ["npm-optional"],
+      },
+    },
+    {
+      name: "peer-deps-used",
+      comment:
+        "This module depends on an npm package that is declared as a peer dependency " +
+        "in your package.json. This makes sense if your package is e.g. a plugin, but in " +
+        "other cases - maybe not so much. If the use of a peer dependency is intentional " +
+        "add an exception to your dependency-cruiser configuration.",
+      severity: "warn",
+      from: {},
+      to: {
+        dependencyTypes: ["npm-peer"],
+      },
+    },
+  ],
+  options: {
+    /* conditions specifying which files not to follow further when encountered:
+       - path: a regular expression to match
+       - dependencyTypes: see https://github.com/sverweij/dependency-cruiser/blob/master/doc/rules-reference.md#dependencytypes-and-dependencytypesnot
+       for a complete list
+    */
+    doNotFollow: {
+      path: "node_modules",
+    },
+
+    /* conditions specifying which dependencies to exclude
+       - path: a regular expression to match
+       - dynamic: a boolean indicating whether to ignore dynamic (true) or static (false) dependencies.
+          leave out if you want to exclude neither (recommended!)
+    */
+    // exclude : {
+    //   path: '',
+    //   dynamic: true
+    // },
+
+    /* pattern specifying which files to include (regular expression)
+       dependency-cruiser will skip everything not matching this pattern
+    */
+    // includeOnly : '',
+
+    /* dependency-cruiser will include modules matching against the focus
+       regular expression in its output, as well as their neighbours (direct
+       dependencies and dependents)
+    */
+    // focus : '',
+
+    /* list of module systems to cruise */
+    // moduleSystems: ['amd', 'cjs', 'es6', 'tsd'],
+
+    /* prefix for links in html and svg output (e.g. 'https://github.com/you/yourrepo/blob/develop/'
+       to open it on your online repo or `vscode://file/${process.cwd()}/` to 
+       open it in visual studio code),
+     */
+    // prefix: '',
+
+    /* false (the default): ignore dependencies that only exist before typescript-to-javascript compilation
+       true: also detect dependencies that only exist before typescript-to-javascript compilation
+       "specify": for each dependency identify whether it only exists before compilation or also after
+     */
+    tsPreCompilationDeps: true,
+
+    /* list of extensions (typically non-parseable) to scan. Empty by default. */
+    // extraExtensionsToScan: [".json", ".jpg", ".png", ".svg", ".webp"],
+
+    /* if true combines the package.jsons found from the module up to the base
+       folder the cruise is initiated from. Useful for how (some) mono-repos
+       manage dependencies & dependency definitions.
+     */
+    // combinedDependencies: false,
+
+    /* if true leave symlinks untouched, otherwise use the realpath */
+    // preserveSymlinks: false,
+
+    /* TypeScript project file ('tsconfig.json') to use for
+       (1) compilation and
+       (2) resolution (e.g. with the paths property)
+
+       The (optional) fileName attribute specifies which file to take (relative to
+       dependency-cruiser's current working directory). When not provided
+       defaults to './tsconfig.json'.
+     */
+    tsConfig: {
+      fileName: "tsconfig.json",
+    },
+
+    /* Webpack configuration to use to get resolve options from.
+
+       The (optional) fileName attribute specifies which file to take (relative
+       to dependency-cruiser's current working directory. When not provided defaults
+       to './webpack.conf.js'.
+
+       The (optional) `env` and `args` attributes contain the parameters to be passed if
+       your webpack config is a function and takes them (see webpack documentation
+       for details)
+     */
+    // webpackConfig: {
+    //  fileName: './webpack.config.js',
+    //  env: {},
+    //  args: {},
+    // },
+
+    /* Babel config ('.babelrc', '.babelrc.json', '.babelrc.json5', ...) to use
+      for compilation (and whatever other naughty things babel plugins do to
+      source code). This feature is well tested and usable, but might change
+      behavior a bit over time (e.g. more precise results for used module 
+      systems) without dependency-cruiser getting a major version bump.
+     */
+    // babelConfig: {
+    //   fileName: './.babelrc'
+    // },
+
+    /* List of strings you have in use in addition to cjs/ es6 requires
+       & imports to declare module dependencies. Use this e.g. if you've
+       re-declared require, use a require-wrapper or use window.require as
+       a hack.
+    */
+    // exoticRequireStrings: [],
+    /* options to pass on to enhanced-resolve, the package dependency-cruiser
+       uses to resolve module references to disk. You can set most of these
+       options in a webpack.conf.js - this section is here for those
+       projects that don't have a separate webpack config file.
+
+       Note: settings in webpack.conf.js override the ones specified here.
+     */
+    enhancedResolveOptions: {
+      /* List of strings to consider as 'exports' fields in package.json. Use
+         ['exports'] when you use packages that use such a field and your environment
+         supports it (e.g. node ^12.19 || >=14.7 or recent versions of webpack).
+
+        If you have an `exportsFields` attribute in your webpack config, that one
+         will have precedence over the one specified here.
+      */
+      exportsFields: ["exports"],
+      /* List of conditions to check for in the exports field. e.g. use ['imports']
+         if you're only interested in exposed es6 modules, ['require'] for commonjs,
+         or all conditions at once `(['import', 'require', 'node', 'default']`)
+         if anything goes for you. Only works when the 'exportsFields' array is
+         non-empty.
+
+        If you have a 'conditionNames' attribute in your webpack config, that one will
+        have precedence over the one specified here.
+      */
+      conditionNames: ["import", "require", "node", "default"],
+    },
+    reporterOptions: {
+      dot: {
+        /* pattern of modules that can be consolidated in the detailed
+           graphical dependency graph. The default pattern in this configuration
+           collapses everything in node_modules to one folder deep so you see
+           the external modules, but not the innards your app depends upon.
+         */
+        collapsePattern: "node_modules/[^/]+",
+
+        /* Options to tweak the appearance of your graph.See
+           https://github.com/sverweij/dependency-cruiser/blob/master/doc/options-reference.md#reporteroptions
+           for details and some examples. If you don't specify a theme
+           don't worry - dependency-cruiser will fall back to the default one.
+        */
+        theme: {
+          graph: {
+            // rankdir: "TD", // Vertical
+            /* use splines: "ortho" for straight lines. Be aware though
+               graphviz might take a long time calculating ortho(gonal)
+               routings.
+            */
+            splines: "true",
+          },
+          //   modules: [
+          //     {
+          //       criteria: { matchesFocus: true },
+          //       attributes: {
+          //         fillcolor: "lime",
+          //         penwidth: 2,
+          //       },
+          //     },
+          //     {
+          //       criteria: { matchesFocus: false },
+          //       attributes: {
+          //         fillcolor: "lightgrey",
+          //       },
+          //     },
+          //     {
+          //       criteria: { matchesReaches: true },
+          //       attributes: {
+          //         fillcolor: "lime",
+          //         penwidth: 2,
+          //       },
+          //     },
+          //     {
+          //       criteria: { matchesReaches: false },
+          //       attributes: {
+          //         fillcolor: "lightgrey",
+          //       },
+          //     },
+          //     {
+          //       criteria: { source: "^src/model" },
+          //       attributes: { fillcolor: "#ccccff" }
+          //     },
+          //     {
+          //       criteria: { source: "^src/view" },
+          //       attributes: { fillcolor: "#ccffcc" }
+          //     },
+          //   ],
+          //   dependencies: [
+          //     {
+          //       criteria: { "rules[0].severity": "error" },
+          //       attributes: { fontcolor: "red", color: "red" }
+          //     },
+          //     {
+          //       criteria: { "rules[0].severity": "warn" },
+          //       attributes: { fontcolor: "orange", color: "orange" }
+          //     },
+          //     {
+          //       criteria: { "rules[0].severity": "info" },
+          //       attributes: { fontcolor: "blue", color: "blue" }
+          //     },
+          //     {
+          //       criteria: { resolved: "^src/model" },
+          //       attributes: { color: "#0000ff77" }
+          //     },
+          //     {
+          //       criteria: { resolved: "^src/view" },
+          //       attributes: { color: "#00770077" }
+          //     }
+          //   ]
+        },
+      },
+      archi: {
+        /* pattern of modules that can be consolidated in the high level
+          graphical dependency graph. If you use the high level graphical
+          dependency graph reporter (`archi`) you probably want to tweak
+          this collapsePattern to your situation.
+        */
+        collapsePattern:
+          "^(packages|src|lib|app|bin|test(s?)|spec(s?))/[^/]+|node_modules/[^/]+",
+
+        /* Options to tweak the appearance of your graph.See
+           https://github.com/sverweij/dependency-cruiser/blob/master/doc/options-reference.md#reporteroptions
+           for details and some examples. If you don't specify a theme
+           for 'archi' dependency-cruiser will use the one specified in the
+           dot section (see above), if any, and otherwise use the default one.
+         */
+        // theme: {
+        // },
+      },
+      text: {
+        highlightFocused: true,
+      },
+    },
+  },
+};
+// generated: dependency-cruiser@11.16.1 on 2022-10-14T14:11:20.984Z

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -26,7 +26,9 @@
     "test": "jest --silent --verbose",
     "test:watch": "jest --silent --verbose --watch",
     "test:e2e": "jest --silent --verbose --config=./jest.config.e2e.js",
-    "test:deps": "depcruise src --exclude __tests__ --config"
+    "test:deps": "depcruise src --exclude __tests__ --config",
+    "showdeps": "depcruise src --include-only '^src' --exclude='__tests__' --config --output-type dot | dot -T svg > /tmp/dependency-graph.svg && open /tmp/dependency-graph.svg",
+    "showdeps:high-level": "depcruise src --include-only '^src' --exclude='(^src/index.ts|shallow.ts|__tests__)' --collapse='^src/(refs|lib|compat|types|crdts|protocol)' --config --output-type dot | dot -T svg > /tmp/dependency-graph.svg && open /tmp/dependency-graph.svg"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint src/",
     "test": "jest --silent --verbose",
     "test:watch": "jest --silent --verbose --watch",
-    "test:e2e": "jest --silent --verbose --config=./jest.config.e2e.js"
+    "test:e2e": "jest --silent --verbose --config=./jest.config.e2e.js",
+    "test:deps": "depcruise src --exclude __tests__ --config"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint src/",
     "test": "jest --silent --verbose",
     "test:watch": "jest --silent --verbose --watch",
-    "test-e2e": "jest --silent --verbose --config=./jest.config.e2e.js"
+    "test:e2e": "jest --silent --verbose --config=./jest.config.e2e.js"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -5,6 +5,7 @@ import type { ToImmutable } from "../crdts/ToImmutable";
 import type { Json, JsonObject } from "../lib/Json";
 import { makePosition } from "../lib/position";
 import { remove } from "../lib/utils";
+import type { Authentication } from "../protocol/Authentication";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import type { ClientMsg } from "../protocol/ClientMsg";
 import { ClientMsgCode } from "../protocol/ClientMsg";
@@ -24,7 +25,6 @@ import { ServerMsgCode } from "../protocol/ServerMsg";
 import type {
   _private_Effects as Effects,
   _private_Machine as Machine,
-  Authentication,
 } from "../room";
 import {
   _private_defaultState as defaultState,

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -1,11 +1,11 @@
 import type { LiveObject } from "..";
-import type { RoomAuthToken } from "../AuthToken";
 import type { LsonObject } from "../crdts/Lson";
 import type { ToImmutable } from "../crdts/ToImmutable";
 import type { Json, JsonObject } from "../lib/Json";
 import { makePosition } from "../lib/position";
 import { remove } from "../lib/utils";
 import type { Authentication } from "../protocol/Authentication";
+import type { RoomAuthToken } from "../protocol/AuthToken";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import type { ClientMsg } from "../protocol/ClientMsg";
 import { ClientMsgCode } from "../protocol/ClientMsg";

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1,14 +1,14 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 
-import type { RoomAuthToken } from "../AuthToken";
-import { RoomScope } from "../AuthToken";
 import { LiveList } from "../crdts/LiveList";
 import type { LsonObject } from "../crdts/Lson";
 import { lsonToJson } from "../immutable";
 import * as console from "../lib/fancy-console";
 import type { Json, JsonObject } from "../lib/Json";
 import type { Authentication } from "../protocol/Authentication";
+import type { RoomAuthToken } from "../protocol/AuthToken";
+import { RoomScope } from "../protocol/AuthToken";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import { ClientMsgCode } from "../protocol/ClientMsg";
 import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -8,12 +8,12 @@ import type { LsonObject } from "../crdts/Lson";
 import { lsonToJson } from "../immutable";
 import * as console from "../lib/fancy-console";
 import type { Json, JsonObject } from "../lib/Json";
+import type { Authentication } from "../protocol/Authentication";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import { ClientMsgCode } from "../protocol/ClientMsg";
 import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
 import { ServerMsgCode } from "../protocol/ServerMsg";
-import type { Authentication } from "../room";
 import {
   _private_defaultState as defaultState,
   _private_makeStateMachine as makeStateMachine,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -2,14 +2,9 @@ import type { LsonObject } from "./crdts/Lson";
 import { deprecateIf } from "./lib/deprecation";
 import type { Json, JsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
+import type { Authentication } from "./protocol/Authentication";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
-import type {
-  Authentication,
-  InternalRoom,
-  Polyfills,
-  Room,
-  RoomInitializers,
-} from "./room";
+import type { InternalRoom, Polyfills, Room, RoomInitializers } from "./room";
 import { createRoom } from "./room";
 
 type EnterOptions<

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -1,11 +1,5 @@
 import { nn } from "../lib/assert";
 import { comparePosition, makePosition } from "../lib/position";
-import {
-  creationOpToLiveNode,
-  deserialize,
-  liveNodeToLson,
-  lsonToLiveNode,
-} from "./liveblocks-helpers";
 import type { CreateChildOp, CreateListOp, CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedList } from "../protocol/SerializedCrdt";
@@ -13,6 +7,12 @@ import { CrdtType } from "../protocol/SerializedCrdt";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
 import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import {
+  creationOpToLiveNode,
+  deserialize,
+  liveNodeToLson,
+  lsonToLiveNode,
+} from "./liveblocks-helpers";
 import { LiveRegister } from "./LiveRegister";
 import type { LiveNode, Lson } from "./Lson";
 import type { ToImmutable } from "./ToImmutable";

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -5,7 +5,7 @@ import {
   deserialize,
   liveNodeToLson,
   lsonToLiveNode,
-} from "../liveblocks-helpers";
+} from "./liveblocks-helpers";
 import type { CreateChildOp, CreateListOp, CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedList } from "../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -6,7 +6,7 @@ import {
   isLiveNode,
   liveNodeToLson,
   lsonToLiveNode,
-} from "../liveblocks-helpers";
+} from "./liveblocks-helpers";
 import type { CreateChildOp, CreateMapOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedMap } from "../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -1,12 +1,5 @@
 import { nn } from "../lib/assert";
 import { freeze } from "../lib/freeze";
-import {
-  creationOpToLiveNode,
-  deserialize,
-  isLiveNode,
-  liveNodeToLson,
-  lsonToLiveNode,
-} from "./liveblocks-helpers";
 import type { CreateChildOp, CreateMapOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedMap } from "../protocol/SerializedCrdt";
@@ -14,6 +7,13 @@ import { CrdtType } from "../protocol/SerializedCrdt";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
 import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import {
+  creationOpToLiveNode,
+  deserialize,
+  isLiveNode,
+  liveNodeToLson,
+  lsonToLiveNode,
+} from "./liveblocks-helpers";
 import type { LiveNode, Lson } from "./Lson";
 import type { ToImmutable } from "./ToImmutable";
 import type { UpdateDelta } from "./UpdateDelta";

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -7,7 +7,7 @@ import {
   deserializeToLson,
   isLiveNode,
   isLiveStructure,
-} from "../liveblocks-helpers";
+} from "./liveblocks-helpers";
 import type {
   CreateChildOp,
   CreateObjectOp,

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -2,12 +2,6 @@ import type { LiveNode, Lson, LsonObject } from "../crdts/Lson";
 import { nn } from "../lib/assert";
 import type { JsonObject } from "../lib/Json";
 import { fromEntries } from "../lib/utils";
-import {
-  creationOpToLson,
-  deserializeToLson,
-  isLiveNode,
-  isLiveStructure,
-} from "./liveblocks-helpers";
 import type {
   CreateChildOp,
   CreateObjectOp,
@@ -27,6 +21,12 @@ import { CrdtType } from "../protocol/SerializedCrdt";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
 import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
 import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import {
+  creationOpToLson,
+  deserializeToLson,
+  isLiveNode,
+  isLiveStructure,
+} from "./liveblocks-helpers";
 import type { ToImmutable } from "./ToImmutable";
 import type { UpdateDelta } from "./UpdateDelta";
 

--- a/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
@@ -1,5 +1,9 @@
-import type { JwtMetadata } from "../../AuthToken";
-import { isTokenExpired, parseRoomAuthToken, RoomScope } from "../../AuthToken";
+import type { JwtMetadata } from "../../protocol/AuthToken";
+import {
+  isTokenExpired,
+  parseRoomAuthToken,
+  RoomScope,
+} from "../../protocol/AuthToken";
 
 describe("isTokenExpired", () => {
   const MINUTES = 60 * 1000;

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -18,7 +18,7 @@ import {
   SECOND_POSITION,
   THIRD_POSITION,
 } from "../../__tests__/_utils";
-import { RoomScope } from "../../AuthToken";
+import { RoomScope } from "../../protocol/AuthToken";
 import { OpCode } from "../../protocol/Op";
 import type { IdTuple, SerializedCrdt } from "../../protocol/SerializedCrdt";
 import { CrdtType } from "../../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveMap.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveMap.test.ts
@@ -7,7 +7,7 @@ import {
   prepareStorageTest,
   reconnect,
 } from "../../__tests__/_utils";
-import { RoomScope } from "../../AuthToken";
+import { RoomScope } from "../../protocol/AuthToken";
 import { OpCode } from "../../protocol/Op";
 import type { IdTuple, SerializedCrdt } from "../../protocol/SerializedCrdt";
 import { CrdtType } from "../../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
@@ -6,7 +6,7 @@ import {
   prepareStorageTest,
   reconnect,
 } from "../../__tests__/_utils";
-import { RoomScope } from "../../AuthToken";
+import { RoomScope } from "../../protocol/AuthToken";
 import { OpCode } from "../../protocol/Op";
 import type { IdTuple, SerializedCrdt } from "../../protocol/SerializedCrdt";
 import { CrdtType } from "../../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
@@ -2,10 +2,10 @@ import {
   findNonSerializableValue,
   getTreesDiffOperations,
 } from "../liveblocks-helpers";
-import { OpCode } from "../protocol/Op";
-import { CrdtType } from "../protocol/SerializedCrdt";
-import type { NodeMap } from "../types/NodeMap";
-import { FIRST_POSITION, SECOND_POSITION } from "./_utils";
+import { OpCode } from "../../protocol/Op";
+import { CrdtType } from "../../protocol/SerializedCrdt";
+import type { NodeMap } from "../../types/NodeMap";
+import { FIRST_POSITION, SECOND_POSITION } from "../../__tests__/_utils";
 
 describe("getTreesDiffOperations", () => {
   test("new liveList Register item", () => {

--- a/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
@@ -1,11 +1,11 @@
+import { FIRST_POSITION, SECOND_POSITION } from "../../__tests__/_utils";
+import { OpCode } from "../../protocol/Op";
+import { CrdtType } from "../../protocol/SerializedCrdt";
+import type { NodeMap } from "../../types/NodeMap";
 import {
   findNonSerializableValue,
   getTreesDiffOperations,
 } from "../liveblocks-helpers";
-import { OpCode } from "../../protocol/Op";
-import { CrdtType } from "../../protocol/SerializedCrdt";
-import type { NodeMap } from "../../types/NodeMap";
-import { FIRST_POSITION, SECOND_POSITION } from "../../__tests__/_utils";
 
 describe("getTreesDiffOperations", () => {
   test("new liveList Register item", () => {

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -1,10 +1,3 @@
-import type { ManagedPool } from "./AbstractCrdt";
-import { type LiveListUpdates, LiveList } from "./LiveList";
-import { type LiveMapUpdates, LiveMap } from "./LiveMap";
-import { type LiveObjectUpdates, LiveObject } from "./LiveObject";
-import { LiveRegister } from "./LiveRegister";
-import type { LiveNode, LiveStructure, Lson, LsonObject } from "./Lson";
-import type { StorageUpdate } from "./StorageUpdates";
 import { assertNever, nn } from "../lib/assert";
 import type { Json } from "../lib/Json";
 import { entries, isPlainObject } from "../lib/utils";
@@ -13,6 +6,13 @@ import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
 import type { NodeMap, ParentToChildNodeMap } from "../types/NodeMap";
+import type { ManagedPool } from "./AbstractCrdt";
+import { type LiveListUpdates, LiveList } from "./LiveList";
+import { type LiveMapUpdates, LiveMap } from "./LiveMap";
+import { type LiveObjectUpdates, LiveObject } from "./LiveObject";
+import { LiveRegister } from "./LiveRegister";
+import type { LiveNode, LiveStructure, Lson, LsonObject } from "./Lson";
+import type { StorageUpdate } from "./StorageUpdates";
 
 export function creationOpToLiveNode(op: CreateOp): LiveNode {
   return lsonToLiveNode(creationOpToLson(op));

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -1,18 +1,18 @@
-import type { ManagedPool } from "./crdts/AbstractCrdt";
-import { type LiveListUpdates, LiveList } from "./crdts/LiveList";
-import { type LiveMapUpdates, LiveMap } from "./crdts/LiveMap";
-import { type LiveObjectUpdates, LiveObject } from "./crdts/LiveObject";
-import { LiveRegister } from "./crdts/LiveRegister";
-import type { LiveNode, LiveStructure, Lson, LsonObject } from "./crdts/Lson";
-import type { StorageUpdate } from "./crdts/StorageUpdates";
-import { assertNever, nn } from "./lib/assert";
-import type { Json } from "./lib/Json";
-import { entries, isPlainObject } from "./lib/utils";
-import type { CreateOp, Op } from "./protocol/Op";
-import { OpCode } from "./protocol/Op";
-import type { IdTuple, SerializedCrdt } from "./protocol/SerializedCrdt";
-import { CrdtType } from "./protocol/SerializedCrdt";
-import type { NodeMap, ParentToChildNodeMap } from "./types/NodeMap";
+import type { ManagedPool } from "./AbstractCrdt";
+import { type LiveListUpdates, LiveList } from "./LiveList";
+import { type LiveMapUpdates, LiveMap } from "./LiveMap";
+import { type LiveObjectUpdates, LiveObject } from "./LiveObject";
+import { LiveRegister } from "./LiveRegister";
+import type { LiveNode, LiveStructure, Lson, LsonObject } from "./Lson";
+import type { StorageUpdate } from "./StorageUpdates";
+import { assertNever, nn } from "../lib/assert";
+import type { Json } from "../lib/Json";
+import { entries, isPlainObject } from "../lib/utils";
+import type { CreateOp, Op } from "../protocol/Op";
+import { OpCode } from "../protocol/Op";
+import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
+import { CrdtType } from "../protocol/SerializedCrdt";
+import type { NodeMap, ParentToChildNodeMap } from "../types/NodeMap";
 
 export function creationOpToLiveNode(op: CreateOp): LiveNode {
   return lsonToLiveNode(creationOpToLson(op));

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -11,7 +11,7 @@ import {
   findNonSerializableValue,
   isLiveList,
   isLiveObject,
-} from "./liveblocks-helpers";
+} from "./crdts/liveblocks-helpers";
 
 function lsonObjectToJson<O extends LsonObject>(
   obj: O

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -1,3 +1,8 @@
+import {
+  findNonSerializableValue,
+  isLiveList,
+  isLiveObject,
+} from "./crdts/liveblocks-helpers";
 import { LiveList } from "./crdts/LiveList";
 import { LiveMap } from "./crdts/LiveMap";
 import { LiveObject } from "./crdts/LiveObject";
@@ -7,11 +12,6 @@ import type { StorageUpdate } from "./crdts/StorageUpdates";
 import * as console from "./lib/fancy-console";
 import type { Json, JsonObject } from "./lib/Json";
 import { isPlainObject } from "./lib/utils";
-import {
-  findNonSerializableValue,
-  isLiveList,
-  isLiveObject,
-} from "./crdts/liveblocks-helpers";
 
 function lsonObjectToJson<O extends LsonObject>(
   obj: O

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -11,8 +11,6 @@
  * https://join.team/liveblocks ;)
  */
 
-export type { AppOnlyAuthToken, AuthToken, RoomAuthToken } from "./AuthToken";
-export { isAppOnlyAuthToken, isAuthToken, isRoomAuthToken } from "./AuthToken";
 export type { Client } from "./client";
 export { createClient } from "./client";
 export { LiveList } from "./crdts/LiveList";
@@ -47,6 +45,16 @@ export { comparePosition, makePosition } from "./lib/position";
 export type { Resolve } from "./lib/Resolve";
 export { shallow } from "./lib/shallow";
 export { b64decode, isPlainObject, tryParseJson } from "./lib/utils";
+export type {
+  AppOnlyAuthToken,
+  AuthToken,
+  RoomAuthToken,
+} from "./protocol/AuthToken";
+export {
+  isAppOnlyAuthToken,
+  isAuthToken,
+  isRoomAuthToken,
+} from "./protocol/AuthToken";
 export type { BaseUserMeta } from "./protocol/BaseUserMeta";
 export type {
   BroadcastEventClientMsg,

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -1,5 +1,5 @@
-import type { Json, JsonObject } from "./lib/Json";
-import { b64decode, isPlainObject, tryParseJson } from "./lib/utils";
+import type { Json, JsonObject } from "../lib/Json";
+import { b64decode, isPlainObject, tryParseJson } from "../lib/utils";
 
 export type AppOnlyAuthToken = {
   appId: string;

--- a/packages/liveblocks-core/src/protocol/Authentication.ts
+++ b/packages/liveblocks-core/src/protocol/Authentication.ts
@@ -1,0 +1,14 @@
+export type Authentication =
+  | {
+      type: "public";
+      publicApiKey: string;
+      url: string;
+    }
+  | {
+      type: "private";
+      url: string;
+    }
+  | {
+      type: "custom";
+      callback: (room: string) => Promise<{ token: string }>;
+    };

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -21,6 +21,7 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
 import { compact, isPlainObject, tryParseJson } from "./lib/utils";
+import type { Authentication } from "./protocol/Authentication";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { ClientMsg } from "./protocol/ClientMsg";
 import { ClientMsgCode } from "./protocol/ClientMsg";
@@ -50,29 +51,12 @@ import type { Others, OthersEvent } from "./types/Others";
 import type { User } from "./types/User";
 import { WebsocketCloseCodes } from "./types/WebsocketCloseCodes";
 
-export type AuthorizeResponse = {
-  token: string;
-};
-
-export type Authentication =
-  | {
-      type: "public";
-      publicApiKey: string;
-      url: string;
-    }
-  | {
-      type: "private";
-      url: string;
-    }
-  | {
-      type: "custom";
-      callback: (room: string) => Promise<AuthorizeResponse>;
-    };
-
 type CustomEvent<TRoomEvent extends Json> = {
   connectionId: number;
   event: TRoomEvent;
 };
+
+type AuthCallback = (room: string) => Promise<{ token: string }>;
 
 export type Connection =
   /* The initial state, before connecting */
@@ -701,7 +685,7 @@ type State<
 
 type Effects<TPresence extends JsonObject, TRoomEvent extends Json> = {
   authenticate(
-    auth: (room: string) => Promise<AuthorizeResponse>,
+    auth: AuthCallback,
     createWebSocket: (token: string) => WebSocket
   ): void;
   send(messages: ClientMsg<TPresence, TRoomEvent>[]): void;
@@ -848,7 +832,7 @@ function makeStateMachine<
 
   const effects: Effects<TPresence, TRoomEvent> = mockedEffects || {
     authenticate(
-      auth: (room: string) => Promise<AuthorizeResponse>,
+      auth: AuthCallback,
       createWebSocket: (token: string) => WebSocket
     ) {
       const rawToken = state.token;
@@ -2377,7 +2361,7 @@ function prepareCreateWebSocket(
 function prepareAuthEndpoint(
   authentication: Authentication,
   fetchPolyfill?: typeof window.fetch
-): (room: string) => Promise<AuthorizeResponse> {
+): AuthCallback {
   if (authentication.type === "public") {
     if (typeof window === "undefined" && fetchPolyfill === undefined) {
       throw new Error(

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -20,7 +20,7 @@ import {
   isLiveNode,
   isSameNodeOrChildOf,
   mergeStorageUpdates,
-} from "./liveblocks-helpers";
+} from "./crdts/liveblocks-helpers";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { ClientMsg } from "./protocol/ClientMsg";
 import { ClientMsgCode } from "./protocol/ClientMsg";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3,6 +3,13 @@ import { isTokenExpired, parseRoomAuthToken, RoomScope } from "./AuthToken";
 import type { DocumentVisibilityState } from "./compat/DocumentVisibilityState";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { OpSource } from "./crdts/AbstractCrdt";
+import {
+  getTreesDiffOperations,
+  isLiveList,
+  isLiveNode,
+  isSameNodeOrChildOf,
+  mergeStorageUpdates,
+} from "./crdts/liveblocks-helpers";
 import { LiveObject } from "./crdts/LiveObject";
 import type { LiveNode, LiveStructure, LsonObject } from "./crdts/Lson";
 import type { StorageCallback, StorageUpdate } from "./crdts/StorageUpdates";
@@ -14,13 +21,6 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
 import { compact, isPlainObject, tryParseJson } from "./lib/utils";
-import {
-  getTreesDiffOperations,
-  isLiveList,
-  isLiveNode,
-  isSameNodeOrChildOf,
-  mergeStorageUpdates,
-} from "./crdts/liveblocks-helpers";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { ClientMsg } from "./protocol/ClientMsg";
 import { ClientMsgCode } from "./protocol/ClientMsg";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1,5 +1,3 @@
-import type { RoomAuthToken } from "./AuthToken";
-import { isTokenExpired, parseRoomAuthToken, RoomScope } from "./AuthToken";
 import type { DocumentVisibilityState } from "./compat/DocumentVisibilityState";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { OpSource } from "./crdts/AbstractCrdt";
@@ -22,6 +20,12 @@ import { isJsonArray, isJsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
 import { compact, isPlainObject, tryParseJson } from "./lib/utils";
 import type { Authentication } from "./protocol/Authentication";
+import type { RoomAuthToken } from "./protocol/AuthToken";
+import {
+  isTokenExpired,
+  parseRoomAuthToken,
+  RoomScope,
+} from "./protocol/AuthToken";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { ClientMsg } from "./protocol/ClientMsg";
 import { ClientMsgCode } from "./protocol/ClientMsg";

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,11 @@
       "dependsOn": ["build"],
       "inputs": ["test-d/**"]
     },
+    "test:deps": {
+      // A package's `test:deps` script has no dependencies and can be run
+      // whenever. It also has no filesystem outputs.
+      "outputs": []
+    },
     "lint": {
       // A package's `lint` script has no dependencies and can be run whenever.
       // It also has no filesystem outputs.


### PR DESCRIPTION
This PR adds dependency cruiser, a tool to enforce implicit import rules and make them explicit. It can also be used to generate a dependency graph for the project.

This PR adds to the `@liveblocks/core` package:

- The `.dependency-cruiser.js` config file, which contains all the rules to enforce
- Two new commands to visualize the dependency graph: `npm run showdeps` (detailed) and `npm run showdeps:high-level`
- A new `npm run test:deps` command, and uses it to enforce the rules in CI

The config file is large, but is, for the most part, the standard/generated config file. It contains generic rules that are good to enforce, so I kept those in. In addition, I added [our own custom rules](https://github.com/liveblocks/liveblocks/blob/fa844409925efd8229e57457fdb69463b8dffd7c/packages/liveblocks-core/.dependency-cruiser.js#L138-L186), which is the relevant section to review here.

To enable the fourth swimlane for the `crdts/` directory, I had to move the `liveblocks-helpers.ts` file into that `crdts/` directory. This means that the only remaining "cyclical imports" are now isolated in that directory.

Output of `npm run showdeps:high-level`:

![dependency-graph](https://user-images.githubusercontent.com/83844/199471913-03970daf-85ab-42de-beaa-2f13bee1abd9.svg)

<details>
<summary>Output of <code>npm run showdeps</code> for comparison. (You can see the dependency cycle inside `crdts/` here.)</summary>

![dependency-graph](https://user-images.githubusercontent.com/83844/199471955-e7dfc2e8-5739-4d1c-a866-07f73c950d19.svg)

</details>

As you can see, the module hierachy is very clear from the "high level" output. If you look at the dependencies in full detail, it's a bit more chaotic, but what's important is that you cannot "just import" stuff from anywhere: the hierarchy is and will remain maintained. It means that if you're studying code inside `crdts/`, you can know for sure that those modules don't know about the concept of a "room" or a "client".

Similarly, if you're studying code inside the `protocol/` directory, you can trust that none of that code is intertwined with other concepts, and the messages in there are just data definitions.

Hopefully this helps to bring a little bit more structure to navigating the code base, and to enforce that this setup will remain to be maintained over time, as the code base and the number of contributors grows.
