### PR TITLE
Improve code coverage

### DIFF
--- a/packages/liveblocks-core/jest.config.js
+++ b/packages/liveblocks-core/jest.config.js
@@ -1,1 +1,12 @@
-module.exports = require("@liveblocks/jest-config");
+/** @type {import('jest').Config} */
+
+const commonJestConfig = require("@liveblocks/jest-config");
+
+module.exports = {
+  // Our standard Jest configuration, used by all projects in this monorepo
+  ...commonJestConfig,
+
+  // Collect code coverage for this project
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ["/__tests__/"],
+};

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -23,7 +23,7 @@
     "build": "tsup && ../../scripts/build.sh",
     "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
-    "test": "jest --silent --verbose",
+    "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --watch",
     "test:e2e": "jest --silent --verbose --config=./jest.config.e2e.js",
     "test:deps": "depcruise src --exclude __tests__ --config",

--- a/packages/liveblocks-core/src/lib/__tests__/EventSource.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/EventSource.test.ts
@@ -1,0 +1,157 @@
+import fc from "fast-check";
+
+import { makeEventSource } from "../EventSource";
+
+const anything = () =>
+  fc.anything({
+    withBigInt: true,
+    withBoxedValues: true,
+    withDate: true,
+    withMap: true,
+    withNullPrototype: true,
+    withObjectString: true,
+    withSet: true,
+    withTypedArray: true,
+    withSparseArray: true,
+  });
+
+describe("EventSource", () => {
+  it("normal usage", () => {
+    fc.assert(
+      fc.property(
+        anything(),
+
+        (payload) => {
+          const callback = jest.fn();
+          const hub = makeEventSource();
+
+          hub.observable.subscribe(callback);
+          hub.notify(payload);
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback.mock.calls.length).toBe(3);
+          for (const [arg] of callback.mock.calls) {
+            expect(arg).toBe(payload);
+          }
+        }
+      )
+    );
+  });
+
+  it("registering multiple callbacks", () => {
+    fc.assert(
+      fc.property(
+        anything(),
+
+        (payload) => {
+          const callback1 = jest.fn();
+          const callback2 = jest.fn();
+          const hub = makeEventSource();
+
+          hub.observable.subscribe(callback1);
+          hub.notify(payload);
+
+          hub.observable.subscribe(callback2);
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback1.mock.calls.length).toBe(3);
+          for (const [arg] of callback1.mock.calls) {
+            expect(arg).toBe(payload);
+          }
+
+          expect(callback2.mock.calls.length).toBe(2);
+          for (const [arg] of callback2.mock.calls) {
+            expect(arg).toBe(payload);
+          }
+        }
+      )
+    );
+  });
+
+  it("subscribing once", () => {
+    fc.assert(
+      fc.property(
+        anything(),
+
+        (payload) => {
+          const callback = jest.fn();
+          const hub = makeEventSource();
+
+          const dereg1 = hub.observable.subscribeOnce(callback);
+          hub.notify(payload);
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback.mock.calls.length).toBe(1); // Called only once, not three times
+          for (const [arg] of callback.mock.calls) {
+            expect(arg).toBe(payload);
+          }
+
+          // Deregistering has no effect
+          dereg1();
+          hub.notify(payload);
+          expect(callback.mock.calls.length).toBe(1); // Called only once, not three times
+        }
+      )
+    );
+  });
+
+  it("deregisering usage", () => {
+    fc.assert(
+      fc.property(
+        anything(),
+
+        (payload) => {
+          const callback1 = jest.fn();
+          const callback2 = jest.fn();
+          const hub = makeEventSource();
+
+          const dereg1 = hub.observable.subscribe(callback1);
+
+          // Registering the same function instance multiple times has no
+          // observable effect
+          const dereg2a = hub.observable.subscribe(callback2);
+          const dereg2b = hub.observable.subscribe(callback2);
+
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback1.mock.calls.length).toBe(2); // Both get updates
+          expect(callback2.mock.calls.length).toBe(2);
+
+          // Deregister callback1
+          dereg1();
+
+          hub.notify(payload);
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback1.mock.calls.length).toBe(2); // Callback1 stopped getting updates
+          expect(callback2.mock.calls.length).toBe(5); // Callback2 still receives updates
+
+          // Deregister callback2
+          dereg2a();
+
+          hub.notify(payload);
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback1.mock.calls.length).toBe(2); // Callback1 already stopped getting updates before
+          expect(callback2.mock.calls.length).toBe(5); // Callback2 now also stopped getting them
+
+          // Deregister callback2 again (has no effect)
+          dereg2b();
+
+          hub.notify(payload);
+          hub.notify(payload);
+          hub.notify(payload);
+
+          expect(callback1.mock.calls.length).toBe(2); // Callback1 already stopped getting updates before
+          expect(callback2.mock.calls.length).toBe(5); // Callback2 already stopped getting updates before
+        }
+      )
+    );
+  });
+});

--- a/packages/liveblocks-core/src/lib/__tests__/freeze.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/freeze.test.ts
@@ -1,0 +1,12 @@
+import { freeze } from "../freeze";
+
+describe("freeze", () => {
+  it("freezes objects", () => {
+    const x = freeze({ a: 1 }) as Record<string, unknown>;
+    expect(() => {
+      x.b = 2;
+    }).toThrow();
+    expect(x.a).toEqual(1);
+    expect(x.b).toBeUndefined();
+  });
+});

--- a/packages/liveblocks-core/src/lib/__tests__/shallow.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/shallow.test.ts
@@ -93,6 +93,14 @@ describe("shallow", () => {
     expect(shallow({}, new Date())).toBe(false);
   });
 
+  it("key order does not matter", () => {
+    expect(shallow({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  it("different key counts are never equal", () => {
+    expect(shallow({ a: undefined, b: 1 }, { b: 1 })).toBe(false);
+  });
+
   it("sparse arrays", () => {
     // Sparse arrays should not break
     /* eslint-disable no-sparse-arrays */

--- a/packages/liveblocks-core/src/lib/__tests__/utils.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/utils.test.ts
@@ -1,4 +1,49 @@
-import { b64decode, compact, tryParseJson } from "../utils";
+import {
+  b64decode,
+  compact,
+  compactObject,
+  entries,
+  fromEntries,
+  isPlainObject,
+  keys,
+  remove,
+  tryParseJson,
+  values,
+} from "../utils";
+
+describe("TypeScript wrapper utils", () => {
+  it("keys (alias of Object.keys)", () => {
+    expect(keys({})).toEqual([]);
+    expect(keys({ a: 1 })).toEqual(["a"]);
+    expect(keys({ [1]: 1, [2]: 2 })).toEqual(["1", "2"]);
+  });
+
+  it("values (alias of Object.values)", () => {
+    expect(values({})).toEqual([]);
+    expect(values({ a: 1 })).toEqual([1]);
+    expect(values({ [1]: 1, [2]: 2 })).toEqual([1, 2]);
+  });
+
+  it("entries (alias of Object.entries)", () => {
+    expect(entries({})).toEqual([]);
+    expect(entries({ a: 1 })).toEqual([["a", 1]]);
+    expect(entries({ [1]: 1, [2]: 2 })).toEqual([
+      ["1", 1],
+      ["2", 2],
+    ]);
+  });
+
+  it("fromEntries (alias of Object.fromEntries)", () => {
+    expect(fromEntries([])).toEqual({});
+    expect(fromEntries([["a", 1]])).toEqual({ a: 1 });
+    expect(
+      fromEntries([
+        ["1", 1],
+        ["2", 2],
+      ])
+    ).toEqual({ [1]: 1, [2]: 2 });
+  });
+});
 
 describe("compact", () => {
   it("compact w/ empty list", () => {
@@ -13,6 +58,73 @@ describe("compact", () => {
       NaN,
       Infinity,
     ]);
+  });
+});
+
+describe("compactObject", () => {
+  it("compactObject w/ empty object", () => {
+    expect(compactObject({})).toStrictEqual({});
+    expect(
+      compactObject({
+        a: 1,
+        b: undefined,
+        c: "hi",
+        d: null,
+        e: "",
+        f: 0,
+        g: false,
+      })
+    ).toStrictEqual({
+      a: 1,
+      // b: undefined  👈 Not present in the result!
+      c: "hi",
+      d: null,
+      e: "",
+      f: 0,
+      g: false,
+    });
+    expect(
+      compactObject({ a: undefined, b: undefined, c: undefined })
+    ).toStrictEqual({});
+  });
+});
+
+describe("isPlainObject", () => {
+  it("isPlainObject", () => {
+    expect(isPlainObject(undefined)).toBe(false);
+    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject(false)).toBe(false);
+    expect(isPlainObject(0)).toBe(false);
+    expect(isPlainObject(1)).toBe(false);
+    expect(isPlainObject("")).toBe(false);
+    expect(isPlainObject("hi")).toBe(false);
+    expect(isPlainObject([])).toBe(false);
+    expect(isPlainObject(["hi"])).toBe(false);
+    expect(isPlainObject(new Date())).toBe(false);
+    expect(isPlainObject(new Error("hi"))).toBe(false);
+    expect(isPlainObject(() => "a function")).toBe(false);
+
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ a: 1 })).toBe(true);
+
+    expect(isPlainObject(Object.create(null))).toBe(true);
+    expect(isPlainObject(new Object())).toBe(true);
+  });
+});
+
+describe("tryParseJson", () => {
+  it("works like JSON.parse() on legal JSON inputs", () => {
+    expect(tryParseJson("true")).toEqual(true);
+    expect(tryParseJson("false")).toEqual(false);
+    expect(tryParseJson("null")).toEqual(null);
+    expect(tryParseJson('"hi"')).toEqual("hi");
+    expect(tryParseJson('["hi", {"a": 1}]')).toEqual(["hi", { a: 1 }]);
+  });
+
+  it("returns undefined for invalid JSON inputs", () => {
+    expect(tryParseJson("i am not a JSON value")).toBeUndefined();
+    expect(tryParseJson("'single quotes'")).toBeUndefined();
+    expect(tryParseJson("[[]")).toBeUndefined();
   });
 });
 
@@ -39,5 +151,24 @@ describe("b64decode", () => {
         "websocket:storage",
       ],
     });
+  });
+
+  test("payload contains characters with accents", () => {
+    expect(() => b64decode("i contain `invalid` chars")).toThrow();
+    expect(() => b64decode("---")).toThrow();
+  });
+});
+
+describe("remove", () => {
+  test("empty", () => {
+    const arr: string[] = [];
+    remove(arr, "something");
+    expect(arr).toEqual([]);
+  });
+
+  test("removes only the first occurrence", () => {
+    const arr: number[] = [1, 2, 3, 1, 2, 3];
+    remove(arr, 2);
+    expect(arr).toEqual([1, 3, 1, 2, 3]);
   });
 });

--- a/packages/liveblocks-core/src/lib/assert.ts
+++ b/packages/liveblocks-core/src/lib/assert.ts
@@ -17,6 +17,7 @@
  * this *statically*, rather than at runtime, and force you to handle the
  * 🍒 case.
  */
+// istanbul ignore next
 export function assertNever(_value: never, errmsg: string): never {
   throw new Error(errmsg);
 }
@@ -28,10 +29,13 @@ export function assertNever(_value: never, errmsg: string): never {
  * In production, nothing is asserted and this acts as a no-op.
  */
 export function assert(condition: boolean, errmsg: string): asserts condition {
-  if (process.env.NODE_ENV !== "production" && !condition) {
-    const err = new Error(errmsg);
-    err.name = "Assertion failure";
-    throw err;
+  if (process.env.NODE_ENV !== "production") {
+    // istanbul ignore if
+    if (!condition) {
+      const err = new Error(errmsg);
+      err.name = "Assertion failure";
+      throw err;
+    }
   }
 }
 

--- a/packages/liveblocks-core/src/lib/deprecation.ts
+++ b/packages/liveblocks-core/src/lib/deprecation.ts
@@ -15,6 +15,7 @@ const _emittedDeprecationWarnings: Set<string> = new Set();
  * Displays a deprecation warning in the dev console. Only in dev mode, and
  * only once per message/key. In production, this is a no-op.
  */
+// istanbul ignore next
 export function deprecate(message: string, key = message): void {
   if (process.env.NODE_ENV !== "production") {
     if (!_emittedDeprecationWarnings.has(key)) {
@@ -29,12 +30,14 @@ export function deprecate(message: string, key = message): void {
  * console if the first argument is truthy. Only in dev mode, and
  * only once per message/key. In production, this is a no-op.
  */
+// istanbul ignore next
 export function deprecateIf(
   condition: unknown,
   message: string,
   key = message
 ): void {
   if (process.env.NODE_ENV !== "production") {
+    // istanbul ignore if
     if (condition) {
       deprecate(message, key);
     }
@@ -46,6 +49,7 @@ export function deprecateIf(
  *
  * Only triggers in dev mode. In production, this is a no-op.
  */
+// istanbul ignore next
 export function throwUsageError(message: string): void {
   if (process.env.NODE_ENV !== "production") {
     const usageError = new Error(message);
@@ -62,6 +66,7 @@ export function throwUsageError(message: string): void {
  *
  * Only has effect in dev mode. In production, this is a no-op.
  */
+// istanbul ignore next
 export function errorIf(condition: unknown, message: string): void {
   if (process.env.NODE_ENV !== "production") {
     if (condition) {

--- a/packages/liveblocks-core/src/lib/fancy-console.ts
+++ b/packages/liveblocks-core/src/lib/fancy-console.ts
@@ -9,7 +9,8 @@ function wrap(
 ): (message: string, ...args: readonly unknown[]) => void {
   return typeof window === "undefined" || process.env.NODE_ENV === "test"
     ? console[method]
-    : (message, ...args) =>
+    : /* istanbul ignore next */
+      (message, ...args) =>
         console[method]("%cLiveblocks", badge, message, ...args);
 }
 
@@ -22,7 +23,8 @@ function wrapWithTitle(
 ): (title: string, message: string, ...args: readonly unknown[]) => void {
   return typeof window === "undefined" || process.env.NODE_ENV === "test"
     ? console[method]
-    : (title, message, ...args) =>
+    : /* istanbul ignore next */
+      (title, message, ...args) =>
         console[method](
           `%cLiveblocks%c ${title}`,
           badge,

--- a/packages/liveblocks-core/src/lib/freeze.ts
+++ b/packages/liveblocks-core/src/lib/freeze.ts
@@ -4,5 +4,5 @@
  */
 export const freeze: typeof Object.freeze =
   process.env.NODE_ENV === "production"
-    ? (((x: unknown) => x) as typeof Object.freeze)
+    ? /* istanbul ignore next */ (((x: unknown) => x) as typeof Object.freeze)
     : Object.freeze;

--- a/packages/liveblocks-core/src/lib/position.ts
+++ b/packages/liveblocks-core/src/lib/position.ts
@@ -71,6 +71,7 @@ function makePositionFromCodes(before: number[], after: number[]): number[] {
     const beforeDigit: number = before[index] || min;
     const afterDigit: number = after[index] || max;
 
+    // istanbul ignore if
     if (beforeDigit > afterDigit) {
       throw new Error(
         `Impossible to generate position between ${before} and ${after}`

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -115,7 +115,7 @@ export function compact<T>(items: readonly T[]): NonNullable<T>[] {
  * Returns a new object instance where all explictly-undefined values are
  * removed.
  */
-export function compactObject<O>(obj: O): O {
+export function compactObject<O extends Record<string, unknown>>(obj: O): O {
   const newObj = { ...obj };
   Object.keys(obj).forEach((k) => {
     const key = k as keyof O;

--- a/packages/liveblocks-core/src/refs/ValueRef.ts
+++ b/packages/liveblocks-core/src/refs/ValueRef.ts
@@ -2,7 +2,9 @@ import { freeze } from "../lib/freeze";
 import { compactObject } from "../lib/utils";
 import { ImmutableRef } from "./ImmutableRef";
 
-export class ValueRef<T> extends ImmutableRef<T> {
+export class ValueRef<
+  T extends Record<string, unknown>
+> extends ImmutableRef<T> {
   /** @internal */
   private _value: Readonly<T>;
 

--- a/packages/liveblocks-core/src/types/Immutable.ts
+++ b/packages/liveblocks-core/src/types/Immutable.ts
@@ -8,12 +8,3 @@ type Scalar = string | number | boolean | null;
 type ImmutableList = readonly Immutable[];
 type ImmutableObject = { readonly [key: string]: Immutable | undefined };
 type ImmutableMap = ReadonlyMap<string, Immutable>;
-
-export function isScalar(data: Immutable): data is Scalar {
-  return (
-    data === null ||
-    typeof data === "string" ||
-    typeof data === "number" ||
-    typeof data === "boolean"
-  );
-}

--- a/turbo.json
+++ b/turbo.json
@@ -12,10 +12,16 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": [],
+      "outputs": ["coverage/**"],
       // A package's `test` script should only be rerun when either a `.tsx`,
       // or `.ts` file has changed in `src` or `test` folders.
-      "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+      "inputs": [
+        "jest.*",
+        "src/**/*.tsx",
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "test/**/*.tsx"
+      ]
     },
     "test:types": {
       "dependsOn": ["build"],


### PR DESCRIPTION
This PR adds missing unit tests. This is an ongoing effort to increase code coverage in the core library. I'm starting with the `src/lib` directory here now, because those are the smallest building blocks.

This PR:

- Changes the jest test suite for `@liveblocks/core` to output a coverage report
- Locally, you can see the results when running the test script
- Also, it outputs a directory with an HTML report, in `coverage/` (see screenshots below)
- Adds missing unit tests for all `src/lib` modules, brining it to 100%

Other parts are still uncovered, and that is TBD later, incrementally.

### Before

<img width="1105" alt="Screen Shot 2022-11-04 at 14 15 03@2x" src="https://user-images.githubusercontent.com/83844/199982013-f7a25cc1-aa52-409d-ae76-51ad25186a0f.png">

### After

<img width="1106" alt="Screen Shot 2022-11-04 at 14 15 22@2x" src="https://user-images.githubusercontent.com/83844/199982022-f72743cc-50c5-4771-8758-a1295a1a4c98.png">
