### PR TITLE
example: helper function to convert storage notation to LiveObject

### DIFF
--- a/packages/liveblocks-core/src/lib/__tests__/storageNotationToLiveStructure.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/storageNotationToLiveStructure.test.ts
@@ -1,0 +1,44 @@
+import {
+  PlainLsonObject,
+  storageNotationToLiveObject,
+} from "../storageNotationToLiveStructure";
+
+describe("storageNotationToLiveObject", () => {
+  it("convert to LiveObject", () => {
+    const example: PlainLsonObject = {
+      liveblocksType: "LiveObject",
+      data: {
+        aLiveObject: {
+          liveblocksType: "LiveObject",
+          data: {
+            a: 1,
+          },
+        },
+        aLiveList: {
+          liveblocksType: "LiveList",
+          data: ["a", "b"],
+        },
+        aLiveMap: {
+          liveblocksType: "LiveMap",
+          data: {
+            a: 1,
+            b: 2,
+          },
+        },
+      },
+    };
+
+    const liveObject = storageNotationToLiveObject(example);
+
+    expect(liveObject._toImmutable()).toEqual({
+      aLiveList: ["a", "b"],
+      aLiveMap: new Map([
+        ["a", 1],
+        ["b", 2],
+      ]),
+      aLiveObject: {
+        a: 1,
+      },
+    });
+  });
+});

--- a/packages/liveblocks-core/src/lib/storageNotationToLiveStructure.ts
+++ b/packages/liveblocks-core/src/lib/storageNotationToLiveStructure.ts
@@ -1,0 +1,94 @@
+import { LiveList } from "../crdts/LiveList";
+import { LiveMap } from "../crdts/LiveMap";
+import { LiveObject } from "../crdts/LiveObject";
+import { isJsonObject, Json } from "./Json";
+
+type PlainLsonFields = Record<string, PlainLson>;
+
+export type PlainLsonObject = {
+  liveblocksType: "LiveObject";
+  data: PlainLsonFields;
+};
+
+type PlainLsonMap = {
+  liveblocksType: "LiveMap";
+  data: PlainLsonFields;
+};
+
+type PlainLsonList = {
+  liveblocksType: "LiveList";
+  data: PlainLson[];
+};
+
+type PlainLson = PlainLsonObject | PlainLsonMap | PlainLsonList | Json;
+
+export function storageNotationToLiveObject(
+  root: PlainLsonObject
+): LiveObject<any> {
+  return dataToLiveObject(root.data);
+}
+
+function dataToLiveNode(
+  data: PlainLson
+): LiveObject<any> | LiveList<any> | LiveMap<string, any> | Json {
+  if (isSpecialPlainLsonValue(data)) {
+    switch (data.liveblocksType) {
+      case "LiveObject": {
+        return dataToLiveObject(data.data);
+      }
+
+      case "LiveList": {
+        return dataToLiveList(data.data);
+      }
+
+      case "LiveMap": {
+        return dataToLiveMap(data.data);
+      }
+
+      default:
+        throw new Error("Unknown `liveblocksType` field");
+    }
+  } else {
+    return data;
+  }
+}
+
+function dataToLiveMap(map: PlainLsonFields): LiveMap<string, any> {
+  const liveMap = new LiveMap();
+
+  for (const [subKey, subValue] of Object.entries(map)) {
+    liveMap.set(subKey, dataToLiveNode(subValue));
+  }
+
+  return liveMap;
+}
+
+function dataToLiveList(list: PlainLson[]): LiveList<any> {
+  const liveList = new LiveList();
+
+  list.forEach((subValue) => {
+    liveList.push(dataToLiveNode(subValue));
+  });
+
+  return liveList;
+}
+
+function dataToLiveObject(value: PlainLsonFields): LiveObject<any> {
+  const liveObject = new LiveObject();
+
+  for (const [subKey, subValue] of Object.entries(value)) {
+    if (isSpecialPlainLsonValue(subValue)) {
+      liveObject.set(subKey, dataToLiveNode(subValue));
+    } else {
+      liveObject.set(subKey, subValue);
+    }
+  }
+
+  return liveObject;
+}
+
+function isSpecialPlainLsonValue(
+  value: PlainLson
+): value is PlainLsonObject | PlainLsonMap | PlainLsonList {
+  return isJsonObject(value) && value.liveblocksType !== undefined;
+}


### PR DESCRIPTION
This is a draft of a helper function that converts a storage as JSON, as returned by the REST API, to a LiveObject.