### PR TITLE
shouldInitiallyConnect documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ In **@liveblocks/react**:
 
 - Add a new property `shouldInitiallyConnect` to `RoomProvider` that let you
   control whether or not the room connects to Liveblocks servers. Default is
-  true.
+  `true`.
 
   By default equals to `typeof window !== "undefined"`, meaning the RoomProvider
   tries to connect to Liveblocks servers only on the client side.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,8 @@ for (const other of others) {
 In **@liveblocks/client**:
 
 - Add a new option `shouldInitiallyConnect` to `client.enter` that let you
-  control whether or not the room connects to Liveblock servers. Default is
-  true.
+  control whether or not the room connects to Liveblocks servers. Default is
+  `true`.
 
   Usually set to false when the client is used from the server to not call the
   authentication endpoint or connect via WebSocket.
@@ -102,7 +102,7 @@ In **@liveblocks/client**:
 In **@liveblocks/react**:
 
 - Add a new property `shouldInitiallyConnect` to `RoomProvider` that let you
-  control whether or not the room connects to Liveblock servers. Default is
+  control whether or not the room connects to Liveblocks servers. Default is
   true.
 
   By default equals to `typeof window !== "undefined"`, meaning the RoomProvider

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -155,7 +155,7 @@ The second argument is a configuration for the presence and storage.
   `new LiveList()`, `new LiveObject({ a: 1 })`, etc.) or be serializable to
   JSON.
 - `shouldInitiallyConnect` (optional) - Whether or not the room connects to
-  Liveblocks servers. Default is `true`. Usually set to false when the client is
+  Liveblocks servers. Default is `true`. Usually set to `false` when the client is
   used from the server to not call the authentication endpoint or connect via
   WebSocket.
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -154,6 +154,10 @@ The second argument is a configuration for the presence and storage.
   mutable by every client. Must either contain Live structures (e.g.
   `new LiveList()`, `new LiveObject({ a: 1 })`, etc.) or be serializable to
   JSON.
+- `shouldInitiallyConnect` (optional) - Whether or not the room connects to
+  Liveblock servers. Default is `true`. Usually set to false when the client is
+  used from the server to not call the authentication endpoint or connect via
+  WebSocket.
 
 ```ts
 const room = client.enter("my-room", {

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -155,7 +155,7 @@ The second argument is a configuration for the presence and storage.
   `new LiveList()`, `new LiveObject({ a: 1 })`, etc.) or be serializable to
   JSON.
 - `shouldInitiallyConnect` (optional) - Whether or not the room connects to
-  Liveblock servers. Default is `true`. Usually set to false when the client is
+  Liveblocks servers. Default is `true`. Usually set to false when the client is
   used from the server to not call the authentication endpoint or connect via
   WebSocket.
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -64,9 +64,24 @@ Makes a [`Room`] available in the component hierarchy below. When this component
 is unmounted, the current user leaves the room. That means that you can’t use
 two RoomProviders with the same room `id` in your React tree.
 
-The `initialPresence` and `initialStorage` props are ignored after the first
-render, so changes to the initial value argument won’t have an observable
-effect.
+- `initialPresence` - The initial Presence to use for the User currently
+  entering the Room. Presence data belongs to the current User and is readable
+  to all other Users in the room while the current User is connected to the
+  Room. Must be serializable to JSON.
+- `initialStorage` (optional) - The initial Storage structure to create when a
+  new Room is entered for the first time. Storage data is shared and belongs to
+  the Room itself. It persists even after all Users leave the room, and is
+  mutable by every client. Must either contain Live structures (e.g.
+  `new LiveList()`, `new LiveObject({ a: 1 })`, etc.) or be serializable to
+  JSON.
+- `shouldInitiallyConnect` (optional) - Whether or not the room connects to
+  Liveblock servers. Default is `true`. Usually set to false when the client is
+  used from the server to not call the authentication endpoint or connect via
+  WebSocket.
+
+The `initialPresence`, `initialStorage` and `shouldInitiallyConnect` props are
+ignored after the first render, so changes to the initial value argument won’t
+have an observable effect.
 
 ```tsx
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -74,10 +74,10 @@ two RoomProviders with the same room `id` in your React tree.
   mutable by every client. Must either contain Live structures (e.g.
   `new LiveList()`, `new LiveObject({ a: 1 })`, etc.) or be serializable to
   JSON.
-- `shouldInitiallyConnect` (optional) - Whether or not the room connects to
-  Liveblock servers. Default is `true`. Usually set to false when the client is
-  used from the server to not call the authentication endpoint or connect via
-  WebSocket.
+- `shouldInitiallyConnect` (optional) - Whether or not the room should connect
+  to Liveblocks servers when the RoomProvider is rendered. By default equals to
+  `typeof window !== "undefined"`, meaning the RoomProvider tries to connect to
+  Liveblocks servers only on the client side.
 
 The `initialPresence`, `initialStorage` and `shouldInitiallyConnect` props are
 ignored after the first render, so changes to the initial value argument won’t


### PR DESCRIPTION
Write the long overdue documentation for `shouldInitiallyConnect` documentation and fixes some typos.