### PR TITLE
[docs] Minor code fixes in Whiteboard React + Zustand tutorial

### DIFF
--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
@@ -954,6 +954,11 @@ const useStore = create<WithLiveblocks<State>>()(
       },
       deleteShape: () => {
         const { shapes, selectedShape, liveblocks } = get();
+        if (!selectedShape) {
+          /* Nothing todo */
+          return;
+        }
+        
         const { [selectedShape]: shapeToDelete, ...newShapes } = shapes;
         liveblocks.room?.updatePresence(
           { selectedShape: null },

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
@@ -645,7 +645,7 @@ export default function App() {
       <div className="canvas">{/* ... */}</div>
       <div className="toolbar">
         <button onClick={insertRectangle}>Rectangle</button>
-        <button onClick={deleteShape} disabled={selectedShape == null}>
+        <button onClick={deleteShape} disabled={selectedShape === null}>
           Delete
         </button>
       </div>
@@ -827,7 +827,7 @@ export default function App() {
       </div>
       <div className="toolbar">
         <button onClick={insertRectangle}>Rectangle</button>
-        <button onClick={deleteShape} disabled={selectedShape == null}>
+        <button onClick={deleteShape} disabled={selectedShape === null}>
           Delete
         </button>
         <button onClick={undo}>Undo</button>

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
@@ -915,7 +915,7 @@ To accomplish that, use
 with the option `addToHistory` to update `selectedShape`. Liveblocks middleware
 will update store `selectedShape` for you.
 
-```ts file="src/store.ts" highlight="11,20-26,29-35,38,40-44"
+```ts file="src/store.ts" highlight="11,20-26,29-35,38,44-48"
 /* ... */
 
 const useStore = create<WithLiveblocks<State>>()(
@@ -958,7 +958,6 @@ const useStore = create<WithLiveblocks<State>>()(
           /* Nothing todo */
           return;
         }
-        
         const { [selectedShape]: shapeToDelete, ...newShapes } = shapes;
         liveblocks.room?.updatePresence(
           { selectedShape: null },

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
@@ -603,11 +603,11 @@ const useStore = create<WithLiveblocks<State>>()(
       },
       deleteShape: () => {
         const { shapes, selectedShape } = get();
-        const { [selectedShape]: shapeToDelete, ...newShapes } = shapes;
         if (!selectedShape) {
           /* Nothing todo */
           return;
         }
+        const { [selectedShape]: shapeToDelete, ...newShapes } = shapes;
         set({
           shapes: newShapes,
           selectedShape: null,


### PR DESCRIPTION
Hi, loved getting to know liveblocks tonight!

A couple of minor fixes in the Whiteboard React + Zustand tutorial code blocks:
* In the first version of `deleteShape()`, moved the null check for `selectedShape` one line up as it's necessary for the destructuring assignment to work
* In the second version of `deleteShape()`, added this same null check as it seems to have been mistakenly left out
* In both times the Delete Shape toolbar button is mentioned, changed the disabled check from a double-equals to triple-equals sign

Looking forward to experimenting a bit more!