### PR TITLE
Added missing initialPresence prop to our guides

### DIFF
--- a/docs/pages/errors/liveblocks-react/RoomProvider-id-property-is-required.mdx
+++ b/docs/pages/errors/liveblocks-react/RoomProvider-id-property-is-required.mdx
@@ -17,7 +17,7 @@ import { RoomProvider } from "@liveblocks/react";
 
 function Component() {
   return (
-    <RoomProvider id="your-room-id">
+    <RoomProvider id="your-room-id" initialPresence={{}}>
       <YourComponent />
     </RoomProvider>
   );

--- a/docs/pages/get-started/react.mdx
+++ b/docs/pages/get-started/react.mdx
@@ -92,7 +92,7 @@ import { RoomProvider } from "./liveblocks.config.js";
 
 function Index() {
   return (
-    <RoomProvider id="my-room-id">
+    <RoomProvider id="my-room-id" initialPresence={{}}>
       <ClientSideSuspense fallback={<div>Loading...</div>}>
         {() => <App />}
       </ClientSideSuspense>

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react.mdx
@@ -114,7 +114,7 @@ import { RoomProvider } from "./liveblocks.config";
 
 ReactDOM.render(
   <React.StrictMode>
-    <RoomProvider id="react-whiteboard-app">
+    <RoomProvider id="react-whiteboard-app" initialPresence={{}}>
       <App />
     </RoomProvider>
   </React.StrictMode>,
@@ -136,7 +136,7 @@ for all users in the room.
 
 Initialize the storage with the `initialStorage` prop on the `RoomProvider`.
 
-```jsx highlight="6,16-19" file="src/index.js"
+```jsx highlight="6,16-20" file="src/index.js"
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
@@ -153,6 +153,7 @@ ReactDOM.render(
   <React.StrictMode>
     <RoomProvider
       id="react-whiteboard-app"
+      initialPresence={{}}
       initialStorage={{
         shapes: new LiveMap(),
       }}


### PR DESCRIPTION
Some of our React guides were missing the `initialPresence` prop on the `<RoomProvider />`, meaning that people got errors when pasting our code into their code editors.

This PR fixes this issue.