### PR TITLE
Fix potential security issue in loops

### DIFF
--- a/packages/liveblocks-core/src/lib/__tests__/utils.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/utils.test.ts
@@ -14,6 +14,17 @@ import {
   values,
 } from "../utils";
 
+/**
+ * This Arbitrary generator ensures that the generated object won't include
+ * a __proto__ key, which makes expressing the tests easier. Tests to cover the
+ * __proto__ cases are written separately.
+ */
+const objectWithoutProto = () =>
+  fc.object().map((o) => {
+    delete o["__proto__"];
+    return o;
+  });
+
 describe("TypeScript wrapper utils", () => {
   it("keys (alias of Object.keys)", () => {
     expect(keys({})).toEqual([]);
@@ -97,10 +108,18 @@ describe("mapValues", () => {
     expect(mapValues({}, (x) => x)).toStrictEqual({});
   });
 
+  it("maps values, not keys", () => {
+    expect(mapValues({ a: 13, b: 0, c: -7 }, (n) => n * 2)).toStrictEqual({
+      a: 26,
+      b: 0,
+      c: -14,
+    });
+  });
+
   it("keys don't change", () => {
     fc.assert(
       fc.property(
-        fc.object(),
+        objectWithoutProto(),
 
         (obj) => {
           const result = mapValues(obj, () => Math.random());
@@ -130,13 +149,7 @@ describe("mapValues", () => {
 
     fc.assert(
       fc.property(
-        fc.object().map(
-          (o) => (
-            // Ensure the generator won't include objects with a __proto__ key in
-            // there. Those are handled by the test case above.
-            delete o["__proto__"], o
-          )
-        ),
+        objectWithoutProto(),
 
         (input) => {
           const output1 = mapValues(input, (x) => x);
@@ -148,14 +161,6 @@ describe("mapValues", () => {
         }
       )
     );
-  });
-
-  it("keys don't change", () => {
-    expect(mapValues({ a: 13, b: 0, c: -7 }, (n) => n * 2)).toStrictEqual({
-      a: 26,
-      b: 0,
-      c: -14,
-    });
   });
 });
 

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -65,6 +65,10 @@ export function mapValues<V, O extends Record<string, unknown>>(
   const result = {} as { [K in keyof O]: V };
   for (const pair of Object.entries(obj)) {
     const key: keyof O = pair[0];
+    if (key === "__proto__") {
+      // Avoid setting dangerous __proto__ keys
+      continue;
+    }
     const value = pair[1] as O[keyof O];
     result[key] = mapFn(value, key);
   }


### PR DESCRIPTION
I noticed [this failing test](https://github.com/liveblocks/liveblocks/actions/runs/3411431611/jobs/5675620804#step:7:389) pop up in another, unrelated, PR. Long live property-based testing 🙌 ! It generated a random input for which this test case failed.

Turns out that:

```js
> result = {};

// Now copy each input key one by one, like this…
> result["__proto__"] = { evil: "😈" };
> result["foo"] = 42;
> result["bar"] = 1337;
> /* etc */

> result
// { foo: 42, bar: 1337 }
> result.__proto__
{ evil: '😈' }
```

The end result doens't seem to "contain" key `"__proto__"`, but it did get set on the output invisibly. The fix for this is to ignore any potential `__proto__` keys on the original input object, and skipping to set them, because that could be used to alter the output in unsafe and unexpected ways.

All the more reason to (1) use more property-based testing and (2) use the now safe-by-default `mapValues` everywhere we use that pattern.