### PR TITLE
Make all message/op types readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.19.2
+
+Fixes some internal type definitions.
+
 # v0.19.1
 
 Fixes an issue where `import`s from Liveblocks packages could not be resolved

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -545,8 +545,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
       this._items[indexOfItemWithSameKey] = child;
 
-      const reverse = existingItem._toOps(nn(this._id), key, this._pool);
-      addIntentAndDeletedIdToOperation(reverse, op.id);
+      const reverse = HACK_addIntentAndDeletedIdToOperation(
+        existingItem._toOps(nn(this._id), key, this._pool),
+        op.id
+      );
 
       const delta = [setDelta(indexOfItemWithSameKey, child)];
       const deletedDelta = this._detachItemAssociatedToSetOperation(
@@ -1105,11 +1107,15 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       const storageUpdates = new Map<string, LiveListUpdates<TItem>>();
       storageUpdates.set(this._id, makeUpdate(this, [setDelta(index, value)]));
 
-      const ops = value._toOps(this._id, position, this._pool);
-      addIntentAndDeletedIdToOperation(ops, existingId);
+      const ops = HACK_addIntentAndDeletedIdToOperation(
+        value._toOps(this._id, position, this._pool),
+        existingId
+      );
       this._unacknowledgedSets.set(position, nn(ops[0].opId));
-      const reverseOps = existingItem._toOps(this._id, position, undefined);
-      addIntentAndDeletedIdToOperation(reverseOps, id);
+      const reverseOps = HACK_addIntentAndDeletedIdToOperation(
+        existingItem._toOps(this._id, position, undefined),
+        id
+      );
 
       this._pool.dispatch(ops, reverseOps, storageUpdates);
     }
@@ -1362,17 +1368,21 @@ function moveDelta(
  * As soon as we refactor the operations structure,
  * serializing a LiveStructure should not know anything about intent
  */
-function addIntentAndDeletedIdToOperation(
+function HACK_addIntentAndDeletedIdToOperation(
   ops: CreateChildOp[],
   deletedId: string | undefined
-) {
-  if (ops.length === 0) {
-    throw new Error(
-      "Internal error. Serialized LiveStructure should have at least 1 operation"
-    );
-  }
-
-  const firstOp = ops[0];
-  firstOp.intent = "set";
-  firstOp.deletedId = deletedId;
+): CreateChildOp[] {
+  return ops.map((op, index) => {
+    if (index === 0) {
+      // NOTE: Only patch the first Op here
+      const firstOp = op;
+      return {
+        ...firstOp,
+        intent: "set",
+        deletedId: deletedId,
+      };
+    } else {
+      return op;
+    }
+  });
 }

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -1379,7 +1379,7 @@ function HACK_addIntentAndDeletedIdToOperation(
       return {
         ...firstOp,
         intent: "set",
-        deletedId: deletedId,
+        deletedId,
       };
     } else {
       return op;

--- a/packages/liveblocks-core/src/protocol/ClientMsg.ts
+++ b/packages/liveblocks-core/src/protocol/ClientMsg.ts
@@ -33,7 +33,7 @@ export type UpdatePresenceClientMsg<TPresence extends JsonObject> =
   // Full Presence™ message
   //
   | {
-      type: ClientMsgCode.UPDATE_PRESENCE;
+      readonly type: ClientMsgCode.UPDATE_PRESENCE;
       /**
        * Set this to any number to signify that this is a Full Presence™
        * update, not a patch.
@@ -47,28 +47,28 @@ export type UpdatePresenceClientMsg<TPresence extends JsonObject> =
        * is a backward-compatible way of expressing that the `data` contains
        * all presence fields, and isn't a partial "patch".
        */
-      targetActor: number;
-      data: TPresence;
+      readonly targetActor: number;
+      readonly data: TPresence;
     }
 
   //
   // Partial Presence™ message
   //
   | {
-      type: ClientMsgCode.UPDATE_PRESENCE;
+      readonly type: ClientMsgCode.UPDATE_PRESENCE;
       /**
        * Absence of the `targetActor` field signifies that this is a Partial
        * Presence™ "patch".
        */
-      targetActor?: undefined;
-      data: Partial<TPresence>;
+      readonly targetActor?: undefined;
+      readonly data: Partial<TPresence>;
     };
 
 export type UpdateStorageClientMsg = {
-  type: ClientMsgCode.UPDATE_STORAGE;
-  ops: Op[];
+  readonly type: ClientMsgCode.UPDATE_STORAGE;
+  readonly ops: Op[];
 };
 
 export type FetchStorageClientMsg = {
-  type: ClientMsgCode.FETCH_STORAGE;
+  readonly type: ClientMsgCode.FETCH_STORAGE;
 };

--- a/packages/liveblocks-core/src/protocol/Op.ts
+++ b/packages/liveblocks-core/src/protocol/Op.ts
@@ -32,79 +32,79 @@ export type CreateChildOp =
   | CreateListOp;
 
 export type UpdateObjectOp = {
-  opId?: string;
-  id: string;
-  type: OpCode.UPDATE_OBJECT;
-  data: Partial<JsonObject>;
+  readonly opId?: string;
+  readonly id: string;
+  readonly type: OpCode.UPDATE_OBJECT;
+  readonly data: Partial<JsonObject>;
 };
 
 export type CreateObjectOp = {
-  opId?: string;
-  id: string;
-  intent?: "set";
-  deletedId?: string;
-  type: OpCode.CREATE_OBJECT;
-  parentId: string;
-  parentKey: string;
-  data: JsonObject;
+  readonly opId?: string;
+  readonly id: string;
+  readonly intent?: "set";
+  readonly deletedId?: string;
+  readonly type: OpCode.CREATE_OBJECT;
+  readonly parentId: string;
+  readonly parentKey: string;
+  readonly data: JsonObject;
 };
 
 export type CreateRootObjectOp = {
-  opId?: string;
-  id: string;
-  type: OpCode.CREATE_OBJECT;
-  data: JsonObject;
-  parentId?: never;
-  parentKey?: never;
+  readonly opId?: string;
+  readonly id: string;
+  readonly type: OpCode.CREATE_OBJECT;
+  readonly data: JsonObject;
+  readonly parentId?: never;
+  readonly parentKey?: never;
 };
 
 export type CreateListOp = {
-  opId?: string;
-  id: string;
-  intent?: "set";
-  deletedId?: string;
-  type: OpCode.CREATE_LIST;
-  parentId: string;
-  parentKey: string;
+  readonly opId?: string;
+  readonly id: string;
+  readonly intent?: "set";
+  readonly deletedId?: string;
+  readonly type: OpCode.CREATE_LIST;
+  readonly parentId: string;
+  readonly parentKey: string;
 };
 
 export type CreateMapOp = {
-  opId?: string;
-  id: string;
-  intent?: "set";
-  deletedId?: string;
-  type: OpCode.CREATE_MAP;
-  parentId: string;
-  parentKey: string;
+  readonly opId?: string;
+  readonly id: string;
+  readonly intent?: "set";
+  readonly deletedId?: string;
+  readonly type: OpCode.CREATE_MAP;
+  readonly parentId: string;
+  readonly parentKey: string;
 };
 
 export type CreateRegisterOp = {
-  opId?: string;
-  id: string;
-  intent?: "set";
-  deletedId?: string;
-  type: OpCode.CREATE_REGISTER;
-  parentId: string;
-  parentKey: string;
-  data: Json;
+  readonly opId?: string;
+  readonly id: string;
+  readonly intent?: "set";
+  readonly deletedId?: string;
+  readonly type: OpCode.CREATE_REGISTER;
+  readonly parentId: string;
+  readonly parentKey: string;
+  readonly data: Json;
 };
 
 export type DeleteCrdtOp = {
-  opId?: string;
-  id: string;
-  type: OpCode.DELETE_CRDT;
+  readonly opId?: string;
+  readonly id: string;
+  readonly type: OpCode.DELETE_CRDT;
 };
 
 export type SetParentKeyOp = {
-  opId?: string;
-  id: string;
-  type: OpCode.SET_PARENT_KEY;
-  parentKey: string;
+  readonly opId?: string;
+  readonly id: string;
+  readonly type: OpCode.SET_PARENT_KEY;
+  readonly parentKey: string;
 };
 
 export type DeleteObjectKeyOp = {
-  opId?: string;
-  id: string;
-  type: OpCode.DELETE_OBJECT_KEY;
-  key: string;
+  readonly opId?: string;
+  readonly id: string;
+  readonly type: OpCode.DELETE_OBJECT_KEY;
+  readonly key: string;
 };

--- a/packages/liveblocks-core/src/protocol/Op.ts
+++ b/packages/liveblocks-core/src/protocol/Op.ts
@@ -32,14 +32,14 @@ export type CreateChildOp =
   | CreateListOp;
 
 export type UpdateObjectOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly type: OpCode.UPDATE_OBJECT;
   readonly data: Partial<JsonObject>;
 };
 
 export type CreateObjectOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -50,7 +50,7 @@ export type CreateObjectOp = {
 };
 
 export type CreateRootObjectOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly type: OpCode.CREATE_OBJECT;
   readonly data: JsonObject;
@@ -59,7 +59,7 @@ export type CreateRootObjectOp = {
 };
 
 export type CreateListOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -69,7 +69,7 @@ export type CreateListOp = {
 };
 
 export type CreateMapOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -79,7 +79,7 @@ export type CreateMapOp = {
 };
 
 export type CreateRegisterOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -90,20 +90,20 @@ export type CreateRegisterOp = {
 };
 
 export type DeleteCrdtOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly type: OpCode.DELETE_CRDT;
 };
 
 export type SetParentKeyOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly type: OpCode.SET_PARENT_KEY;
   readonly parentKey: string;
 };
 
 export type DeleteObjectKeyOp = {
-  readonly opId?: string;
+  opId?: string;
   readonly id: string;
   readonly type: OpCode.DELETE_OBJECT_KEY;
   readonly key: string;

--- a/packages/liveblocks-core/src/protocol/Op.ts
+++ b/packages/liveblocks-core/src/protocol/Op.ts
@@ -32,14 +32,14 @@ export type CreateChildOp =
   | CreateListOp;
 
 export type UpdateObjectOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly type: OpCode.UPDATE_OBJECT;
   readonly data: Partial<JsonObject>;
 };
 
 export type CreateObjectOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -50,7 +50,7 @@ export type CreateObjectOp = {
 };
 
 export type CreateRootObjectOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly type: OpCode.CREATE_OBJECT;
   readonly data: JsonObject;
@@ -59,7 +59,7 @@ export type CreateRootObjectOp = {
 };
 
 export type CreateListOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -69,7 +69,7 @@ export type CreateListOp = {
 };
 
 export type CreateMapOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -79,7 +79,7 @@ export type CreateMapOp = {
 };
 
 export type CreateRegisterOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly intent?: "set";
   readonly deletedId?: string;
@@ -90,20 +90,20 @@ export type CreateRegisterOp = {
 };
 
 export type DeleteCrdtOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly type: OpCode.DELETE_CRDT;
 };
 
 export type SetParentKeyOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly type: OpCode.SET_PARENT_KEY;
   readonly parentKey: string;
 };
 
 export type DeleteObjectKeyOp = {
-  opId?: string;
+  readonly opId?: string;
   readonly id: string;
   readonly type: OpCode.DELETE_OBJECT_KEY;
   readonly key: string;

--- a/packages/liveblocks-core/src/protocol/SerializedCrdt.ts
+++ b/packages/liveblocks-core/src/protocol/SerializedCrdt.ts
@@ -18,38 +18,38 @@ export type SerializedChild =
   | SerializedRegister;
 
 export type SerializedRootObject = {
-  type: CrdtType.OBJECT;
-  data: JsonObject;
+  readonly type: CrdtType.OBJECT;
+  readonly data: JsonObject;
 
   // Root objects don't have a parent relationship
-  parentId?: never;
-  parentKey?: never;
+  readonly parentId?: never;
+  readonly parentKey?: never;
 };
 
 export type SerializedObject = {
-  type: CrdtType.OBJECT;
-  parentId: string;
-  parentKey: string;
-  data: JsonObject;
+  readonly type: CrdtType.OBJECT;
+  readonly parentId: string;
+  readonly parentKey: string;
+  readonly data: JsonObject;
 };
 
 export type SerializedList = {
-  type: CrdtType.LIST;
-  parentId: string;
-  parentKey: string;
+  readonly type: CrdtType.LIST;
+  readonly parentId: string;
+  readonly parentKey: string;
 };
 
 export type SerializedMap = {
-  type: CrdtType.MAP;
-  parentId: string;
-  parentKey: string;
+  readonly type: CrdtType.MAP;
+  readonly parentId: string;
+  readonly parentKey: string;
 };
 
 export type SerializedRegister = {
-  type: CrdtType.REGISTER;
-  parentId: string;
-  parentKey: string;
-  data: Json;
+  readonly type: CrdtType.REGISTER;
+  readonly parentId: string;
+  readonly parentKey: string;
+  readonly data: Json;
 };
 
 export function isRootCrdt(crdt: SerializedCrdt): crdt is SerializedRootObject {

--- a/packages/liveblocks-core/src/protocol/ServerMsg.ts
+++ b/packages/liveblocks-core/src/protocol/ServerMsg.ts
@@ -51,11 +51,11 @@ export type UpdatePresenceServerMsg<TPresence extends JsonObject> =
   // Full Presence™ message
   //
   | {
-      type: ServerMsgCode.UPDATE_PRESENCE;
+      readonly type: ServerMsgCode.UPDATE_PRESENCE;
       /**
        * The User whose Presence has changed.
        */
-      actor: number;
+      readonly actor: number;
       /**
        * When set, signifies that this is a Full Presence™ update, not a patch.
        *
@@ -68,33 +68,33 @@ export type UpdatePresenceServerMsg<TPresence extends JsonObject> =
        * is a backward-compatible way of expressing that the `data` contains
        * all presence fields, and isn't a partial "patch".
        */
-      targetActor: number;
+      readonly targetActor: number;
       /**
        * The partial or full Presence of a User. If the `targetActor` field is set,
        * this will be the full Presence, otherwise it only contain the fields that
        * have changed since the last broadcast.
        */
-      data: TPresence;
+      readonly data: TPresence;
     }
 
   //
   // Partial Presence™ message
   //
   | {
-      type: ServerMsgCode.UPDATE_PRESENCE;
+      readonly type: ServerMsgCode.UPDATE_PRESENCE;
       /**
        * The User whose Presence has changed.
        */
-      actor: number;
+      readonly actor: number;
       /**
        * Not set for partial presence updates.
        */
-      targetActor?: undefined;
+      readonly targetActor?: undefined;
       /**
        * A partial Presence patch to apply to the User. It will only contain the
        * fields that have changed since the last broadcast.
        */
-      data: Partial<TPresence>;
+      readonly data: Partial<TPresence>;
     };
 
 /**
@@ -102,23 +102,23 @@ export type UpdatePresenceServerMsg<TPresence extends JsonObject> =
  * a new User has joined the Room.
  */
 export type UserJoinServerMsg<TUserMeta extends BaseUserMeta> = {
-  type: ServerMsgCode.USER_JOINED;
-  actor: number;
+  readonly type: ServerMsgCode.USER_JOINED;
+  readonly actor: number;
   /**
    * The id of the User that has been set in the authentication endpoint.
    * Useful to get additional information about the connected user.
    */
-  id: TUserMeta["id"];
+  readonly id: TUserMeta["id"];
   /**
    * Additional user information that has been set in the authentication
    * endpoint.
    */
-  info: TUserMeta["info"];
+  readonly info: TUserMeta["info"];
 
   /**
    * Permissions that the user has in the Room.
    */
-  scopes: string[];
+  readonly scopes: string[];
 };
 
 /**
@@ -126,8 +126,8 @@ export type UserJoinServerMsg<TUserMeta extends BaseUserMeta> = {
  * a new User has left the Room.
  */
 export type UserLeftServerMsg = {
-  type: ServerMsgCode.USER_LEFT;
-  actor: number;
+  readonly type: ServerMsgCode.USER_LEFT;
+  readonly actor: number;
 };
 
 /**
@@ -135,16 +135,16 @@ export type UserLeftServerMsg = {
  * a User broadcasted an Event to everyone in the Room.
  */
 export type BroadcastedEventServerMsg<TRoomEvent extends Json> = {
-  type: ServerMsgCode.BROADCASTED_EVENT;
+  readonly type: ServerMsgCode.BROADCASTED_EVENT;
   /**
    * The User who broadcasted the Event.
    */
-  actor: number;
+  readonly actor: number;
   /**
    * The arbitrary payload of the Event. This can be any JSON value. Clients
    * will have to manually verify/decode this event.
    */
-  event: TRoomEvent;
+  readonly event: TRoomEvent;
 };
 
 /**
@@ -153,9 +153,9 @@ export type BroadcastedEventServerMsg<TRoomEvent extends Json> = {
  * includes a list of all other Users that already are in the Room.
  */
 export type RoomStateServerMsg<TUserMeta extends BaseUserMeta> = {
-  type: ServerMsgCode.ROOM_STATE;
-  users: {
-    [actor: number]: TUserMeta & { scopes: string[] };
+  readonly type: ServerMsgCode.ROOM_STATE;
+  readonly users: {
+    readonly [actor: number]: TUserMeta & { scopes: string[] };
   };
 };
 
@@ -165,8 +165,8 @@ export type RoomStateServerMsg<TUserMeta extends BaseUserMeta> = {
  * payload includes the entire Storage document.
  */
 export type InitialDocumentStateServerMsg = {
-  type: ServerMsgCode.INITIAL_STORAGE_STATE;
-  items: IdTuple<SerializedCrdt>[];
+  readonly type: ServerMsgCode.INITIAL_STORAGE_STATE;
+  readonly items: IdTuple<SerializedCrdt>[];
 };
 
 /**
@@ -177,6 +177,6 @@ export type InitialDocumentStateServerMsg = {
  * mutations to make to the initially loaded document).
  */
 export type UpdateStorageServerMsg = {
-  type: ServerMsgCode.UPDATE_STORAGE;
-  ops: Op[];
+  readonly type: ServerMsgCode.UPDATE_STORAGE;
+  readonly ops: Op[];
 };

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -614,8 +614,8 @@ function isConnectionSelfAware(
 type HistoryOp<TPresence extends JsonObject> =
   | Op
   | {
-      type: "presence";
-      data: TPresence;
+      readonly type: "presence";
+      readonly data: TPresence;
     };
 
 type IdFactory = () => string;
@@ -1049,7 +1049,7 @@ function makeStateMachine<
   }
 
   function apply(
-    ops: HistoryOp<TPresence>[],
+    ops: readonly HistoryOp<TPresence>[],
     isLocal: boolean
   ): {
     reverse: HistoryOp<TPresence>[];

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1068,7 +1068,7 @@ function makeStateMachine<
 
     const createdNodeIds = new Set<string>();
 
-    for (let op of ops) {
+    for (const op of ops) {
       if (op.type === "presence") {
         const reverse = {
           type: "presence" as const,
@@ -1098,7 +1098,8 @@ function makeStateMachine<
 
         // Ops applied after undo/redo don't have an opId.
         if (!op.opId) {
-          op = { ...op, opId: pool.generateOpId() };
+          // XXX Stop using in-place mutation here! It makes this hard to reason about.
+          op.opId = pool.generateOpId();
         }
 
         if (isLocal) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1068,7 +1068,7 @@ function makeStateMachine<
 
     const createdNodeIds = new Set<string>();
 
-    for (const op of ops) {
+    for (let op of ops) {
       if (op.type === "presence") {
         const reverse = {
           type: "presence" as const,
@@ -1098,7 +1098,7 @@ function makeStateMachine<
 
         // Ops applied after undo/redo don't have an opId.
         if (!op.opId) {
-          op.opId = pool.generateOpId();
+          op = { ...op, opId: pool.generateOpId() };
         }
 
         if (isLocal) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -969,7 +969,7 @@ function makeStateMachine<
     // Get operations that represent the diff between 2 states.
     const ops = getTreesDiffOperations(currentItems, new Map(items));
 
-    const result = apply(ops, false);
+    const result = applyOps(ops, false);
 
     notify(result.updates, batchedUpdatesWrapper);
   }
@@ -1048,7 +1048,7 @@ function makeStateMachine<
     );
   }
 
-  function apply<O extends HistoryOp<TPresence>>(
+  function applyOps<O extends HistoryOp<TPresence>>(
     rawOps: readonly O[],
     isLocal: boolean
   ): {
@@ -1625,7 +1625,7 @@ function makeStateMachine<
           }
           // Write event
           case ServerMsgCode.UPDATE_STORAGE: {
-            const applyResult = apply(message.ops, false);
+            const applyResult = applyOps(message.ops, false);
             applyResult.updates.storageUpdates.forEach((value, key) => {
               updates.storageUpdates.set(
                 key,
@@ -1809,7 +1809,7 @@ function makeStateMachine<
 
     const ops = Array.from(offlineOps.values());
 
-    const result = apply(ops, true);
+    const result = applyOps(ops, true);
 
     messages.push({
       type: ClientMsgCode.UPDATE_STORAGE,
@@ -2017,7 +2017,7 @@ function makeStateMachine<
     }
 
     state.pausedHistory = null;
-    const result = apply(historyOps, true);
+    const result = applyOps(historyOps, true);
 
     batchUpdates(() => {
       notify(result.updates, doNotBatchUpdates);
@@ -2048,7 +2048,7 @@ function makeStateMachine<
     }
 
     state.pausedHistory = null;
-    const result = apply(historyOps, true);
+    const result = applyOps(historyOps, true);
 
     batchUpdates(() => {
       notify(result.updates, doNotBatchUpdates);


### PR DESCRIPTION
In some places (in this repo, and in other private repos), we're mutating the fields of Ops and other messages in-place, which makes reasoning about the data and refactoring of those bits unnecessarily hard. This PR changes the data types to readonly, so we can ensure that in-place mutation won't happen.

Targeted for release **0.19.2**.