### PR TITLE
React redux whiteboard fix

### DIFF
--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-redux.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-redux.mdx
@@ -27,8 +27,8 @@ This guide assumes that you’re already familiar with
 [React](https://reactjs.org/) and [Redux](https://redux.js.org/). If you’re not
 using Redux, we recommend reading one of our dedicated whiteboard tutorials:
 
-- [React tutorial](/docs/tutorials/multiplayer-whiteboard/react)
-- [React + Zustand tutorial](/docs/tutorials/multiplayer-whiteboard/react-zustand)
+- [React tutorial](/docs/tutorials/collaborative-online-whiteboard/react)
+- [React + Zustand tutorial](/docs/tutorials/collaborative-online-whiteboard/react-zustand)
 
 The source code for this guide is
 [available on github](https://github.com/liveblocks/liveblocks/tree/main/examples/redux-whiteboard).
@@ -268,7 +268,8 @@ const Rectangle = ({ shape }) => {
 };
 ```
 
-_For a tidier look, here’s some styling to place within `src/App.css`._
+_Place the following within `src/App.css`, and then you will be able to
+insert rectangular shapes into the whiteboard._
 
 ```css file="src/App.css" isCollapsed isCollapsable
 body {

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
@@ -232,7 +232,8 @@ const Rectangle = ({ shape }: { shape: Shape }) => {
 };
 ```
 
-_For a tidier look, here’s some styling to place within `src/App.css`._
+_Place the following within `src/App.css`, and then you will be able to
+insert rectangular shapes into the whiteboard._
 
 ```css file="src/App.css" isCollapsed isCollapsable
 body {

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react-zustand.mdx
@@ -28,8 +28,8 @@ This guide assumes that you’re already familiar with
 If you’re not using Zustand, we recommend reading one of our dedicated
 whiteboard tutorials:
 
-- [React tutorial](/docs/tutorials/multiplayer-whiteboard/react)
-- [React + Redux tutorial](/docs/tutorials/multiplayer-whiteboard/react-redux)
+- [React tutorial](/docs/tutorials/collaborative-online-whiteboard/react)
+- [React + Redux tutorial](/docs/tutorials/collaborative-online-whiteboard/react-redux)
 
 The source code for this guide is
 [available on github](https://github.com/liveblocks/liveblocks/tree/main/examples/zustand-whiteboard).

--- a/docs/pages/tutorials/collaborative-online-whiteboard/react.mdx
+++ b/docs/pages/tutorials/collaborative-online-whiteboard/react.mdx
@@ -227,7 +227,8 @@ const Rectangle = ({ shape }) => {
 };
 ```
 
-_For a tidier look, here’s some styling to place within `src/App.css`._
+_Place the following within `src/App.css`, and then you will be able to
+insert rectangular shapes into the whiteboard._
 
 ```css file="src/App.css" isCollapsed isCollapsable
 body {


### PR DESCRIPTION
This PR tweaks two small issues in our documentation. 

1) That our collaborative whiteboard tutorial mentions adding `App.css` file for a "tidier" look- but we actually need it in order to make the rectangle styling show up when inserted (if you don't add the App.css file and you click the Rectangle button, nothing shows up because the classnames are not defined)

2). Links to React Zustand/ React were incorrectly named, likely due to an updated naming convention for the directory. This was causing TS to try to process a null value, and then generated a client side error leading to broken links/ page 
(See below)
<img width="844" alt="Screen Shot 2022-11-23 at 4 28 27 PM" src="https://user-images.githubusercontent.com/36981344/203668395-d6270098-6360-4310-b24b-0adea6b0351d.png">
