### PR TITLE
room.hasPendingStorageModifications

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -155,8 +155,8 @@ The second argument is a configuration for the presence and storage.
   `new LiveList()`, `new LiveObject({ a: 1 })`, etc.) or be serializable to
   JSON.
 - `shouldInitiallyConnect` (optional) - Whether or not the room connects to
-  Liveblocks servers. Default is `true`. Usually set to `false` when the client is
-  used from the server to not call the authentication endpoint or connect via
+  Liveblocks servers. Default is `true`. Usually set to `false` when the client
+  is used from the server to not call the authentication endpoint or connect via
   WebSocket.
 
 ```ts
@@ -501,6 +501,11 @@ room.history.resume();
 room.history.undo();
 // room.getPresence() equals { cursor: { x: 0, y: 0 } }
 ```
+
+### Room.hasPendingStorageModifications
+
+Whether or not the room has storage modifications that have not been
+acknowledged by the server.
 
 ## Storage
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -481,6 +481,11 @@ export type Room<
   batch<T>(fn: () => T): T;
 
   /**
+   * Whether or not the room has storage modifications that have not been acknowledged by the server.
+   */
+  hasPendingStorageModifications(): boolean;
+
+  /**
    * @internal Utilities only used for unit testing.
    */
   __INTERNAL_DO_NOT_USE: {
@@ -558,6 +563,7 @@ type Machine<
   canRedo(): boolean;
   pauseHistory(): void;
   resumeHistory(): void;
+  hasPendingStorageModifications(): boolean;
 
   getStorage(): Promise<{
     root: LiveObject<TStorage>;
@@ -2130,6 +2136,10 @@ function makeStateMachine<
     }
   }
 
+  function hasPendingStorageModifications() {
+    return state.offlineOperations.size > 0;
+  }
+
   function simulateSocketClose() {
     if (state.socket) {
       state.socket = null;
@@ -2175,6 +2185,7 @@ function makeStateMachine<
     canRedo,
     pauseHistory,
     resumeHistory,
+    hasPendingStorageModifications,
 
     getStorage,
     getStorageSnapshot,
@@ -2335,6 +2346,7 @@ export function createRoom<
       pause: machine.pauseHistory,
       resume: machine.resumeHistory,
     },
+    hasPendingStorageModifications: machine.hasPendingStorageModifications,
 
     __INTERNAL_DO_NOT_USE: {
       simulateCloseWebsocket: machine.simulateSocketClose,


### PR DESCRIPTION
Until we persist offline operations to IndexedDB, we want to let the developer know if any storage modifications have not been acknowledged by the server.