### PR TITLE
Adds `create-liveblocks-app` installer command to each readme file

### DIFF
--- a/examples/javascript-live-cursors/README.md
+++ b/examples/javascript-live-cursors/README.md
@@ -20,9 +20,13 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors.png" width="536" alt="Live Cursors" />
 
+```
+npx create-liveblocks-app --example javascript-live-cursors
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`app.js`](./app.js) by your **public** key

--- a/examples/javascript-todo-list/README.md
+++ b/examples/javascript-todo-list/README.md
@@ -25,9 +25,13 @@ also be able to see who else is currently online and when a user is typing.
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/todo-list.png" width="536" alt="Collaborative To-do List" />
 
+```
+npx create-liveblocks-app --example javascript-todo-list
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the
   [dashboard](https://liveblocks.io/dashboard/apikeys)

--- a/examples/nextjs-3d-builder/README.md
+++ b/examples/nextjs-3d-builder/README.md
@@ -22,9 +22,13 @@ This example shows how to build a collaborative 3D builder with [Liveblocks](htt
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/3d-builder.png" width="536" alt="Multiplayer 3D Builder" />
 
+```
+npx create-liveblocks-app --example nextjs-
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable

--- a/examples/nextjs-block-text-editor-advanced/README.md
+++ b/examples/nextjs-block-text-editor-advanced/README.md
@@ -22,9 +22,13 @@ This example shows how to build a collaborative block text editor with
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/block-text-editor-advanced.png" width="536" alt="Collaborative Block Text Editor (Advanced)" />
 
+```
+npx create-liveblocks-app --example nextjs-block-text-editor-advanced
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the
   [dashboard](https://liveblocks.io/dashboard/apikeys)

--- a/examples/nextjs-form/README.md
+++ b/examples/nextjs-form/README.md
@@ -21,9 +21,13 @@ This example shows how to build a collaborative form with [Liveblocks](https://l
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/form.png" width="536" alt="Multiplayer Form" />
 
+```
+npx create-liveblocks-app --example nextjs-form
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -22,9 +22,13 @@ This example shows how to build an advanced live avatar stack with [Liveblocks](
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-avatars-advanced.png" width="536" alt="Live Avatar Stack (Advanced)" />
 
+```
+npx create-liveblocks-app --example nextjs-live-avatars-advanced
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/nextjs-live-avatars/README.md
+++ b/examples/nextjs-live-avatars/README.md
@@ -21,9 +21,13 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-avatars.png" width="536" alt="Live Avatar Stack" />
 
+```
+npx create-liveblocks-app --example nextjs-live-avatars
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/nextjs-live-cursors-advanced/README.md
+++ b/examples/nextjs-live-cursors-advanced/README.md
@@ -22,9 +22,13 @@ This example shows how to build advanced live cursors with [Liveblocks](https://
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors-advanced.png" width="536" alt="Live Cursors (Advanced)" />
 
+```
+npx create-liveblocks-app --example nextjs-live-cursors-advanced
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/nextjs-live-cursors-chat/README.md
+++ b/examples/nextjs-live-cursors-chat/README.md
@@ -21,9 +21,13 @@ This example shows how to build live cursors along chat and reactions with [Live
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors-chat.png" width="536" alt="Live Cursors Chat and Reactions" />
 
+```
+npx create-liveblocks-app --example nextjs-live-cursors-chat
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable

--- a/examples/nextjs-live-cursors-scroll/README.md
+++ b/examples/nextjs-live-cursors-scroll/README.md
@@ -21,9 +21,13 @@ This example shows how to build live cursors within a responsive scrollable page
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors-scroll.png" width="536" alt="Live Cursors Scrollable Page" />
 
+```
+npx create-liveblocks-app --example nextjs-live-cursors-scroll
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable

--- a/examples/nextjs-live-cursors/README.md
+++ b/examples/nextjs-live-cursors/README.md
@@ -21,9 +21,13 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors.png" width="536" alt="Live Cursors" />
 
+```
+npx create-liveblocks-app --example nextjs-live-cursors
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable

--- a/examples/nextjs-live-form-selection/README.md
+++ b/examples/nextjs-live-form-selection/README.md
@@ -21,9 +21,13 @@ This example shows how to build live selection on a form with [Liveblocks](https
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-form-selection.png" width="536" alt="Live Form Selection" />
 
+```
+npx create-liveblocks-app --example nextjs-live-form-selection
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable

--- a/examples/nextjs-spreadsheet-advanced/README.md
+++ b/examples/nextjs-spreadsheet-advanced/README.md
@@ -18,9 +18,13 @@ This example shows how to build an advanced collaborative spreadsheet with [Live
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/collaborative-spreadsheet-advanced.png" width="536" alt="Collaborative Spreadsheet (Advanced)" />
 
+```
+npx create-liveblocks-app --example nextjs-spreadsheet-advanced
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/nextjs-whiteboard-advanced/README.md
+++ b/examples/nextjs-whiteboard-advanced/README.md
@@ -21,9 +21,13 @@ This example shows how to build an advanced collaborative whiteboard with [Liveb
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/whiteboard-advanced.png" width="536" alt="Collaborative Whiteboard (Advanced)" />
 
+```
+npx create-liveblocks-app --example nextjs-whiteboard-advanced
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/nuxtjs-live-avatars/README.md
+++ b/examples/nuxtjs-live-avatars/README.md
@@ -21,9 +21,13 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-avatars.png" width="536" alt="Live Avatar Stack" />
 
+```
+npx create-liveblocks-app --example nuxtjs-live-avatars
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/react-dashboard/README.md
+++ b/examples/react-dashboard/README.md
@@ -20,9 +20,13 @@ This example shows how to build collaborative data visualization with [Liveblock
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/dashboard.png" width="536" alt="Multiplayer Dashboard" />
 
+```
+npx create-liveblocks-app --example react-dashboard
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) by your **public** key

--- a/examples/react-native-todo-list/README.md
+++ b/examples/react-native-todo-list/README.md
@@ -16,9 +16,13 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/todo-list-native.png" width="536" alt="Collaborative To-do List" />
 
+```
+npx create-liveblocks-app --example react-native-todo-list
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.ts`](./liveblocks.config.ts) by your **public** key

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -22,9 +22,13 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/todo-list.png" width="536" alt="Collaborative To-do List" />
 
+```
+npx create-liveblocks-app --example react-todo-list
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) by your **public** key

--- a/examples/react-whiteboard/README.md
+++ b/examples/react-whiteboard/README.md
@@ -21,9 +21,13 @@ This example shows how to build a collaborative whiteboard with
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/whiteboard.png" width="536" alt="Collaborative Whiteboard" />
 
+```
+npx create-liveblocks-app --example react-whiteboard
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the
   [dashboard](https://liveblocks.io/dashboard/apikeys)

--- a/examples/redux-todo-list/README.md
+++ b/examples/redux-todo-list/README.md
@@ -23,9 +23,13 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/todo-list.png" width="536" alt="Collaborative To-do List" />
 
+```
+npx create-liveblocks-app --example redux-todo-list
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`store.js`](./src/store.js) by your **public** key

--- a/examples/redux-whiteboard/README.md
+++ b/examples/redux-whiteboard/README.md
@@ -23,9 +23,13 @@ This example shows how to build a collaborative whiteboard with
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/whiteboard.png" width="536" alt="Collaborative Whiteboard" />
 
+```
+npx create-liveblocks-app --example redux-whiteboard
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the
   [dashboard](https://liveblocks.io/dashboard/apikeys)

--- a/examples/solidjs-live-avatars/README.md
+++ b/examples/solidjs-live-avatars/README.md
@@ -21,9 +21,13 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-avatars.png" width="536" alt="Live Avatar Stack" />
 
+```
+npx create-liveblocks-app --example solidjs-live-avatars
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`index.jsx`](./src/index.jsx) with your **public** key

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -21,9 +21,13 @@ This example shows how to build a live cursors with [Liveblocks](https://liveblo
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors.png" width="536" alt="Live Cursors" />
 
+```
+npx create-liveblocks-app --example solidjs-live-cursors
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`index.jsx`](./src/index.jsx) with your **public** key

--- a/examples/sveltekit-live-avatars/README.md
+++ b/examples/sveltekit-live-avatars/README.md
@@ -21,9 +21,13 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-avatars.png" width="536" alt="Live Avatar Stack" />
 
+```
+npx create-liveblocks-app --example sveltekit-live-avatars
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/sveltekit-live-cursors/README.md
+++ b/examples/sveltekit-live-cursors/README.md
@@ -21,9 +21,13 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors.png" width="536" alt="Live Cursors" />
 
+```
+npx create-liveblocks-app --example sveltekit-live-cursors
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -20,9 +20,13 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/live-cursors.png" width="536" alt="Live Cursors" />
 
+```
+npx create-liveblocks-app --example vuejs-live-cursors
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`App.vue`](./src/App.vue) by your **public** key

--- a/examples/zustand-todo-list/README.md
+++ b/examples/zustand-todo-list/README.md
@@ -23,9 +23,13 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/todo-list.png" width="536" alt="Collaborative To-do List" />
 
+```
+npx create-liveblocks-app --example zustand-todo-list
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`store.ts`](./src/store.ts) by your **public** key

--- a/examples/zustand-whiteboard/README.md
+++ b/examples/zustand-whiteboard/README.md
@@ -23,9 +23,13 @@ This example shows how to build a collaborative whiteboard with
 
 <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/examples/whiteboard.png" width="536" alt="Collaborative Whiteboard" />
 
+```
+npx create-liveblocks-app --example zustand-whiteboard
+```
+
 ## Getting started
 
-- Install all dependencies with `npm install`
+- Download and install the project with the above command
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the
   [dashboard](https://liveblocks.io/dashboard/apikeys)


### PR DESCRIPTION
Each Liveblocks example can now be downloaded and installed via CLI command. This PR adds the command to each README file. 

Example:
```
npx create-liveblocks-app --example nextjs-live-cursors
```

**TODO**
- [ ] Figure out formatting on examples pages
- [x] Wait for this to be merged:
  - https://github.com/liveblocks/liveblocks/pull/596
