### PR TITLE
Minor change: rename internal var

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1811,8 +1811,7 @@ function makeStateMachine<
   }
 
   function applyAndSendOps(
-    offlineOps: Map<string | undefined, Op>,
-    //                       ^^^^^^^^^ NOTE: Bug? Unintended?
+    offlineOps: Map<string, Op>,
     batchedUpdatesWrapper: (cb: () => void) => void
   ) {
     if (offlineOps.size === 0) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1630,7 +1630,7 @@ function makeStateMachine<
             // Client shouldn't resend these ops as part of the offline ops sending after reconnect.
             const unacknowledgedOps = new Map(state.unacknowledgedOps);
             createOrUpdateRootFromMessage(message, doNotBatchUpdates);
-            applyAndSendOfflineOps(unacknowledgedOps, doNotBatchUpdates);
+            applyAndSendOps(unacknowledgedOps, doNotBatchUpdates);
             if (_getInitialStateResolver !== null) {
               _getInitialStateResolver();
             }
@@ -1810,7 +1810,7 @@ function makeStateMachine<
     connect();
   }
 
-  function applyAndSendOfflineOps(
+  function applyAndSendOps(
     offlineOps: Map<string | undefined, Op>,
     //                       ^^^^^^^^^ NOTE: Bug? Unintended?
     batchedUpdatesWrapper: (cb: () => void) => void


### PR DESCRIPTION
Before our holiday break, we concluded that this internal variable name was a bit confusing, so this PR renames it to better describe its purpose.