### PR TITLE
fix small error when checking for liveblocks key

### DIFF
--- a/docs/pages/guides/nextjs-starter-kit.mdx
+++ b/docs/pages/guides/nextjs-starter-kit.mdx
@@ -252,6 +252,12 @@ Navigate there and add your details, for example, if you’re signing in with
 },
 ```
 
+You will also need to add a `NEXTAUTH_SECRET` to your `.env.local` file for demo authentication to work.  
+This value can be easily generated using the command line and running the following: 
+```
+openssl rand -base64 32
+```
+
 ### Ready to go
 
 The Next.js Starter Kit is now ready to use! After setting up authentication,

--- a/docs/pages/guides/nextjs-starter-kit.mdx
+++ b/docs/pages/guides/nextjs-starter-kit.mdx
@@ -252,12 +252,6 @@ Navigate there and add your details, for example, if you’re signing in with
 },
 ```
 
-You will also need to add a `NEXTAUTH_SECRET` to your `.env.local` file for demo authentication to work.  
-This value can be easily generated using the command line and running the following: 
-```
-openssl rand -base64 32
-```
-
 ### Ready to go
 
 The Next.js Starter Kit is now ready to use! After setting up authentication,

--- a/starter-kits/nextjs-starter-kit/liveblocks.server.config.ts
+++ b/starter-kits/nextjs-starter-kit/liveblocks.server.config.ts
@@ -11,7 +11,7 @@ if (!SECRET_API_KEY) {
 Example .env.local file:
 LIVEBLOCKS_SECRET_KEY=sk_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-You can find your secret keys on https://liveblocks.io/dashboard 
+You can find your secret keys on https://liveblocks.io/dashboard/apikeys 
 Follow the full starter kit guide on https://liveblocks.io/docs/guides/nextjs-starter-kit
  
 `);

--- a/starter-kits/nextjs-starter-kit/liveblocks.server.config.ts
+++ b/starter-kits/nextjs-starter-kit/liveblocks.server.config.ts
@@ -5,7 +5,7 @@ export const API_BASE_URL = "https://api.liveblocks.io";
 export const SECRET_API_KEY = process.env.LIVEBLOCKS_SECRET_KEY;
 
 // ============================================================================
-if (SECRET_API_KEY) {
+if (!SECRET_API_KEY) {
   throw new Error(`You must add your Liveblocks secret key to .env.local to use the starter kit 
 
 Example .env.local file:


### PR DESCRIPTION
Just adds a ternary to the secret key check as the error thrown should only happen if the key does not exist :) 

Also adds instruction for adding the NEXAUTH_SECRET Key to env.local.  Its mentioned in the config file, but not obvious.