### PR TITLE
Fix prepareStorageUpdateTest helper room setup

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -451,14 +451,14 @@ export function prepareStorageUpdateTest<
 ): () => Promise<void> {
   return async () => {
     const { storage: refStorage, machine: refMachine } =
-      await prepareRoomWithStorage(items, 1);
+      await prepareRoomWithStorage(items, -1);
 
     const { storage, machine } = await prepareRoomWithStorage<
       TPresence,
       TStorage,
       TUserMeta,
       TRoomEvent
-    >(items, 0, (messages) => {
+    >(items, 1, (messages) => {
       for (const message of messages) {
         if (message.type === ClientMsgCode.UPDATE_STORAGE) {
           refMachine.onMessage(
@@ -496,7 +496,11 @@ export function prepareStorageUpdateTest<
       expect(refJsonUpdates).toEqual(updates);
     }
 
-    await callback({ root: storage.root, machine, assert });
+    await callback({
+      root: storage.root,
+      machine,
+      assert,
+    });
   };
 }
 

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -458,7 +458,7 @@ export function prepareStorageUpdateTest<
       TStorage,
       TUserMeta,
       TRoomEvent
-    >(items, 1, (messages) => {
+    >(items, -2, (messages) => {
       for (const message of messages) {
         if (message.type === ClientMsgCode.UPDATE_STORAGE) {
           refMachine.onMessage(


### PR DESCRIPTION
Fixes the underlying issue which caused my confusion in https://github.com/liveblocks/liveblocks/pull/620.

We initialize both clients with an actor id of `0` + the room storage with events with an actor id of `0`, so inserting new LiveNodes inside tests using the helper will cause unexpected issues. Seems like it was just luck this didn't happen until now.