### PR TITLE
Fix/nested update storage update handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+# v0.19.7
+
+Fix nested storage event handling issue.
+
 # v0.19.6
 
 Support authentication with cookies.

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -444,6 +444,7 @@ export function prepareStorageUpdateTest<
 >(
   items: IdTuple<SerializedCrdt>[],
   callback: (args: {
+    batch: (fn: () => void) => void;
     root: LiveObject<TStorage>;
     machine: Machine<TPresence, TStorage, TUserMeta, TRoomEvent>;
     assert: (updates: JsonStorageUpdate[][]) => void;
@@ -497,6 +498,7 @@ export function prepareStorageUpdateTest<
     }
 
     await callback({
+      batch: machine.batch,
       root: storage.root,
       machine,
       assert,

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -16,9 +16,9 @@ import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
 import { ServerMsgCode } from "../protocol/ServerMsg";
 import {
-  createRoom,
   _private_defaultState as defaultState,
   _private_makeStateMachine as makeStateMachine,
+  createRoom,
 } from "../room";
 import type { Others } from "../types/Others";
 import { WebsocketCloseCodes } from "../types/WebsocketCloseCodes";

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -23,11 +23,7 @@ import {
 } from "../room";
 import type { Others } from "../types/Others";
 import { WebsocketCloseCodes } from "../types/WebsocketCloseCodes";
-import {
-  listUpdate,
-  listUpdateInsert,
-  serializeUpdateToJson,
-} from "./_updatesUtils";
+import { listUpdate, listUpdateInsert } from "./_updatesUtils";
 import {
   createSerializedList,
   createSerializedObject,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1203,17 +1203,11 @@ function makeStateMachine<
 
         const applyOpResult = applyOp(op, source);
         if (applyOpResult.modified) {
-          const parentId =
-            applyOpResult.modified.node.parent.type === "HasParent"
-              ? nn(
-                  applyOpResult.modified.node.parent.node._id,
-                  "Expected parent node to have an ID"
-                )
-              : undefined;
+          const nodeId = applyOpResult.modified.node._id;
 
-          // If the parent is the root (undefined) or was created in the same batch, we don't want to notify
+          // If the modified node is not the root (undefined) and was created in the same batch, we don't want to notify
           // storage updates for the children.
-          if (!parentId || !createdNodeIds.has(parentId)) {
+          if (!(nodeId && createdNodeIds.has(nodeId))) {
             output.storageUpdates.set(
               nn(applyOpResult.modified.node._id),
               mergeStorageUpdates(
@@ -1231,7 +1225,7 @@ function makeStateMachine<
             op.type === OpCode.CREATE_MAP ||
             op.type === OpCode.CREATE_OBJECT
           ) {
-            createdNodeIds.add(nn(applyOpResult.modified.node._id));
+            createdNodeIds.add(nn(op.id));
           }
         }
       }


### PR DESCRIPTION
Based upon https://github.com/liveblocks/liveblocks/pull/622 (needed that helper to work).

Seems like there are two small error in the way we handle nested changes inside `applyOps`:
1. Because we are adding `applyOpResult.modified.node._id` to the `createdNodeIds` we are storing the parent of the inserted node, not the inserted node itself. => we are ignoring any further changes to that parent.
2. We should not be checking if `applyOpResult.modified.node.parent.type` was inserted because that is the parent of the node we are trying to modify. We should check if the node we are trying to modify is a node that was inserted instead (so `applyOpResult.modified.node.id`).

 