### PR TITLE
Upgrade examples to 0.19.7

### DIFF
--- a/examples/javascript-live-cursors/package-lock.json
+++ b/examples/javascript-live-cursors/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@liveblocks/javascript-live-cursors",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6"
+        "@liveblocks/client": "^0.19.7"
       },
       "devDependencies": {
         "esbuild": "^0.12.2",
@@ -16,17 +16,17 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/esbuild": {
       "version": "0.12.2",
@@ -55,17 +55,17 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "esbuild": {
       "version": "0.12.2",

--- a/examples/javascript-live-cursors/package.json
+++ b/examples/javascript-live-cursors/package.json
@@ -7,7 +7,7 @@
     "build": "esbuild app.js --bundle --outfile=static/app.js"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6"
+    "@liveblocks/client": "^0.19.7"
   },
   "devDependencies": {
     "esbuild": "^0.12.2",

--- a/examples/javascript-todo-list/package-lock.json
+++ b/examples/javascript-todo-list/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@liveblocks/javascript-todo-list",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6"
+        "@liveblocks/client": "^0.19.7"
       },
       "devDependencies": {
         "esbuild": "^0.14.25",
@@ -16,17 +16,17 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/esbuild": {
       "version": "0.14.25",
@@ -401,17 +401,17 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "esbuild": {
       "version": "0.14.25",

--- a/examples/javascript-todo-list/package.json
+++ b/examples/javascript-todo-list/package.json
@@ -12,6 +12,6 @@
     "prettier": "^2.6.2"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6"
+    "@liveblocks/client": "^0.19.7"
   }
 }

--- a/examples/nextjs-3d-builder/package-lock.json
+++ b/examples/nextjs-3d-builder/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/nextjs-3d-builder",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "@react-three/drei": "^9.16.0",
         "@react-three/fiber": "^8.0.27",
         "next": "^12.1.6",
@@ -64,25 +64,25 @@
       "integrity": "sha512-bbZIpW6fdyf7FMaeDmw3cBbkTqsecxEkwlVKgVfqqXWBPLH6azxhPA2V9F7OhoZSVrsnMYw7QuyK6qutXPjEew=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -1084,25 +1084,25 @@
       "integrity": "sha512-bbZIpW6fdyf7FMaeDmw3cBbkTqsecxEkwlVKgVfqqXWBPLH6azxhPA2V9F7OhoZSVrsnMYw7QuyK6qutXPjEew=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-3d-builder/package.json
+++ b/examples/nextjs-3d-builder/package.json
@@ -9,8 +9,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "@react-three/drei": "^9.16.0",
     "@react-three/fiber": "^8.0.27",
     "next": "^12.1.6",

--- a/examples/nextjs-form/package-lock.json
+++ b/examples/nextjs-form/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@liveblocks/nextjs-form",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -23,33 +23,33 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -494,33 +494,33 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-form/package.json
+++ b/examples/nextjs-form/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-avatars-advanced/package-lock.json
+++ b/examples/nextjs-live-avatars-advanced/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@liveblocks/nextjs-live-avatars-advanced",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "classnames": "^2.3.1",
         "framer-motion": "^6.3.6",
         "next": "^12.2.5",
@@ -43,33 +43,33 @@
       "optional": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -779,33 +779,33 @@
       "optional": true
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-avatars-advanced/package.json
+++ b/examples/nextjs-live-avatars-advanced/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "classnames": "^2.3.1",
     "framer-motion": "^6.3.6",
     "next": "^12.2.5",

--- a/examples/nextjs-live-avatars/package-lock.json
+++ b/examples/nextjs-live-avatars/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@liveblocks/nextjs-live-avatars",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -26,33 +26,33 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -1346,33 +1346,33 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-avatars/package.json
+++ b/examples/nextjs-live-avatars/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors-advanced/package-lock.json
+++ b/examples/nextjs-live-cursors-advanced/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@liveblocks/nextjs-live-cursors-advanced",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "framer-motion": "^6.3.6",
         "next": "^12.2.5",
         "react": "^18.2.0",
@@ -42,33 +42,33 @@
       "optional": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -773,33 +773,33 @@
       "optional": true
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-cursors-advanced/package.json
+++ b/examples/nextjs-live-cursors-advanced/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "framer-motion": "^6.3.6",
     "next": "^12.2.5",
     "react": "^18.2.0",

--- a/examples/nextjs-live-cursors-chat/package-lock.json
+++ b/examples/nextjs-live-cursors-chat/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@liveblocks/nextjs-live-cursors-chat",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -26,33 +26,33 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -1370,33 +1370,33 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-cursors-chat/package.json
+++ b/examples/nextjs-live-cursors-chat/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors-scroll/package-lock.json
+++ b/examples/nextjs-live-cursors-scroll/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/nextjs-live-cursors-scroll",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -25,25 +25,25 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -1323,25 +1323,25 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-cursors-scroll/package.json
+++ b/examples/nextjs-live-cursors-scroll/package.json
@@ -9,8 +9,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-cursors/package-lock.json
+++ b/examples/nextjs-live-cursors/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/nextjs-live-cursors",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -25,25 +25,25 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -1329,25 +1329,25 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-cursors/package.json
+++ b/examples/nextjs-live-cursors/package.json
@@ -9,8 +9,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-live-form-selection/package-lock.json
+++ b/examples/nextjs-live-form-selection/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/nextjs-live-form-selection",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "next": "^12.1.6",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -22,25 +22,25 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -470,25 +470,25 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-live-form-selection/package.json
+++ b/examples/nextjs-live-form-selection/package.json
@@ -9,8 +9,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/examples/nextjs-whiteboard-advanced/package-lock.json
+++ b/examples/nextjs-whiteboard-advanced/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@liveblocks/nextjs-whiteboard-advanced",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "nanoid": "^3.1.25",
         "next": "^12.1.6",
         "perfect-freehand": "^0.5.3",
@@ -28,33 +28,33 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -1523,33 +1523,33 @@
   },
   "dependencies": {
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -9,9 +9,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "nanoid": "^3.1.25",
     "next": "^12.1.6",
     "perfect-freehand": "^0.5.3",

--- a/examples/react-dashboard/package-lock.json
+++ b/examples/react-dashboard/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/react-dashboard",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1",
@@ -2792,25 +2792,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -18041,25 +18041,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/react-dashboard/package.json
+++ b/examples/react-dashboard/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",

--- a/examples/react-native-todo-list/package-lock.json
+++ b/examples/react-native-todo-list/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/react-native-todo-list",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "base-64": "^1.0.0",
         "react": "^17.0.2",
         "react-native": "^0.68.2",
@@ -2345,25 +2345,25 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -13445,25 +13445,25 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/react-native-todo-list/package.json
+++ b/examples/react-native-todo-list/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "base-64": "^1.0.0",
     "react": "^17.0.2",
     "react-native": "^0.68.2",

--- a/examples/react-todo-list/package-lock.json
+++ b/examples/react-todo-list/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/react-todo-list",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
@@ -2729,25 +2729,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -17892,25 +17892,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/react-todo-list/package.json
+++ b/examples/react-todo-list/package.json
@@ -10,8 +10,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",

--- a/examples/react-whiteboard/package-lock.json
+++ b/examples/react-whiteboard/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/react-whiteboard",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/react": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/react": "^0.19.7",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "^5.0.1"
@@ -2726,25 +2726,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -17518,25 +17518,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/react": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.6.tgz",
-      "integrity": "sha512-c4+n7S2NMLzvz78r2x8eIUjQu5hWYVXeSzYKibBnQM00UztS3FIlN90+6EI737N+/ArwkFstn5VH0hUGuU0XbA==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-0.19.7.tgz",
+      "integrity": "sha512-nbtiZdSTQSVkzyd1buK0bqdkajrm8nQVZjffPCHm2lQceWVN2GnurXakg0A41ttK7nhfDjmbl7c7GlFCRYatDQ==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6",
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/examples/react-whiteboard/package.json
+++ b/examples/react-whiteboard/package.json
@@ -10,8 +10,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/react": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/react": "^0.19.7",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1"

--- a/examples/redux-todo-list/package-lock.json
+++ b/examples/redux-todo-list/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/redux-todo-list",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/redux": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/redux": "^0.19.7",
         "@reduxjs/toolkit": "^1.8.4",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2729,25 +2729,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.6.tgz",
-      "integrity": "sha512-aZ54b+ztIbkT4GSp7t8lu/AYXdaUpw/iR/3C9MPzQjVBOu9lrwsXE3pp4wmAOOz+omHHls/Y9qCHRhG9qNOOgw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.7.tgz",
+      "integrity": "sha512-GJmgigMzCAmiqI6EZe5iF547ZmlgVMvXWLLCUc1I1S6FV8sgo7FhD6WZayl9c5zJpfdg6bo6m894NayvpQlgow==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       },
       "peerDependencies": {
         "redux": "^4"
@@ -17659,25 +17659,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/redux": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.6.tgz",
-      "integrity": "sha512-aZ54b+ztIbkT4GSp7t8lu/AYXdaUpw/iR/3C9MPzQjVBOu9lrwsXE3pp4wmAOOz+omHHls/Y9qCHRhG9qNOOgw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.7.tgz",
+      "integrity": "sha512-GJmgigMzCAmiqI6EZe5iF547ZmlgVMvXWLLCUc1I1S6FV8sgo7FhD6WZayl9c5zJpfdg6bo6m894NayvpQlgow==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@nodelib/fs.scandir": {

--- a/examples/redux-todo-list/package.json
+++ b/examples/redux-todo-list/package.json
@@ -10,8 +10,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/redux": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/redux": "^0.19.7",
     "@reduxjs/toolkit": "^1.8.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/redux-whiteboard/package-lock.json
+++ b/examples/redux-whiteboard/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/redux-whiteboard",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/redux": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/redux": "^0.19.7",
         "@reduxjs/toolkit": "^1.8.4",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -2729,25 +2729,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/redux": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.6.tgz",
-      "integrity": "sha512-aZ54b+ztIbkT4GSp7t8lu/AYXdaUpw/iR/3C9MPzQjVBOu9lrwsXE3pp4wmAOOz+omHHls/Y9qCHRhG9qNOOgw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.7.tgz",
+      "integrity": "sha512-GJmgigMzCAmiqI6EZe5iF547ZmlgVMvXWLLCUc1I1S6FV8sgo7FhD6WZayl9c5zJpfdg6bo6m894NayvpQlgow==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       },
       "peerDependencies": {
         "redux": "^4"
@@ -17659,25 +17659,25 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/redux": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.6.tgz",
-      "integrity": "sha512-aZ54b+ztIbkT4GSp7t8lu/AYXdaUpw/iR/3C9MPzQjVBOu9lrwsXE3pp4wmAOOz+omHHls/Y9qCHRhG9qNOOgw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/redux/-/redux-0.19.7.tgz",
+      "integrity": "sha512-GJmgigMzCAmiqI6EZe5iF547ZmlgVMvXWLLCUc1I1S6FV8sgo7FhD6WZayl9c5zJpfdg6bo6m894NayvpQlgow==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@nodelib/fs.scandir": {

--- a/examples/redux-whiteboard/package.json
+++ b/examples/redux-whiteboard/package.json
@@ -10,8 +10,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/redux": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/redux": "^0.19.7",
     "@reduxjs/toolkit": "^1.8.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/solidjs-live-avatars/package-lock.json
+++ b/examples/solidjs-live-avatars/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@liveblocks/solidjs-live-avatars",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
         "solid-js": "^1.3.13"
       },
       "devDependencies": {
@@ -504,17 +504,17 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -1764,17 +1764,17 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "ansi-styles": {
       "version": "3.2.1",

--- a/examples/solidjs-live-avatars/package.json
+++ b/examples/solidjs-live-avatars/package.json
@@ -13,7 +13,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
     "solid-js": "^1.3.13"
   }
 }

--- a/examples/solidjs-live-cursors/package-lock.json
+++ b/examples/solidjs-live-cursors/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@liveblocks/solidjs-live-cursors",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
         "@motionone/solid": "^10.8.1",
         "@solid-primitives/keyed": "^1.0.0",
         "motion": "^10.8.1",
@@ -507,17 +507,17 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@motionone/animation": {
       "version": "10.8.0",
@@ -1907,17 +1907,17 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@motionone/animation": {
       "version": "10.8.0",

--- a/examples/solidjs-live-cursors/package.json
+++ b/examples/solidjs-live-cursors/package.json
@@ -13,7 +13,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
     "@motionone/solid": "^10.8.1",
     "@solid-primitives/keyed": "^1.0.0",
     "motion": "^10.8.1",

--- a/examples/sveltekit-live-avatars/package-lock.json
+++ b/examples/sveltekit-live-avatars/package-lock.json
@@ -7,8 +7,8 @@
       "name": "@liveblocks/sveltekit-live-avatars",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6"
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^1.0.0",
@@ -381,22 +381,22 @@
       "dev": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -1360,22 +1360,22 @@
       "dev": true
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/sveltekit-live-avatars/package.json
+++ b/examples/sveltekit-live-avatars/package.json
@@ -21,7 +21,7 @@
     "vite": "^4.0.4"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6"
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7"
   }
 }

--- a/examples/sveltekit-live-cursors/package-lock.json
+++ b/examples/sveltekit-live-cursors/package-lock.json
@@ -7,8 +7,8 @@
       "name": "@liveblocks/sveltekit-live-cursors",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/node": "^0.19.6"
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/node": "^0.19.7"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^1.0.0",
@@ -381,22 +381,22 @@
       "dev": true
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -1360,22 +1360,22 @@
       "dev": true
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/node": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.6.tgz",
-      "integrity": "sha512-7CKJ7Qr92Zd54J813Yv8QR/cZg6EiJ9SsBID9PHOpSY/Y2/xRXxmDCFN1NSSLQ9aPIkQ+MBas4ouhmuBoUwLww==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-0.19.7.tgz",
+      "integrity": "sha512-F8IWESn1x4V7o4dLdYvsfGN9FXkEVCnKHxEzCU8HCcTI2YBSGBsWX+SHIKtdVocy41CgZf8w/R1QUxsgxG6Hwg==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/examples/sveltekit-live-cursors/package.json
+++ b/examples/sveltekit-live-cursors/package.json
@@ -21,7 +21,7 @@
     "vite": "^4.0.4"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/node": "^0.19.6"
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/node": "^0.19.7"
   }
 }

--- a/examples/vuejs-live-cursors/package-lock.json
+++ b/examples/vuejs-live-cursors/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@liveblocks/vuejs-live-cursors",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
         "core-js": "^3.6.5",
         "vue": "^2.6.11"
       },
@@ -1765,17 +1765,17 @@
       }
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -15730,17 +15730,17 @@
       }
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/examples/vuejs-live-cursors/package.json
+++ b/examples/vuejs-live-cursors/package.json
@@ -8,7 +8,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
     "core-js": "^3.6.5",
     "vue": "^2.6.11"
   },

--- a/examples/zustand-todo-list/package-lock.json
+++ b/examples/zustand-todo-list/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/zustand-todo-list",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/zustand": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/zustand": "^0.19.7",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2927,25 +2927,25 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.6.tgz",
-      "integrity": "sha512-pm4cpKe9Mqarr2+CpeoF91FSP3E+Y22PG+WSHYYZ5Te83nWMwoQTbmEht6GKUdSFvf5xbSLyY5zdYiYW/Knytw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.7.tgz",
+      "integrity": "sha512-9KCZv616Bz6kcEjZa3VQI4Pm0LZchPPXTM9/sGQICLSH/vKNqM3LiO5WnjxdyZvyODfAAii2JWPX7VmpSrzQ5g==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       },
       "peerDependencies": {
         "zustand": "^4.1.3"
@@ -18612,25 +18612,25 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/zustand": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.6.tgz",
-      "integrity": "sha512-pm4cpKe9Mqarr2+CpeoF91FSP3E+Y22PG+WSHYYZ5Te83nWMwoQTbmEht6GKUdSFvf5xbSLyY5zdYiYW/Knytw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.7.tgz",
+      "integrity": "sha512-9KCZv616Bz6kcEjZa3VQI4Pm0LZchPPXTM9/sGQICLSH/vKNqM3LiO5WnjxdyZvyODfAAii2JWPX7VmpSrzQ5g==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@nodelib/fs.scandir": {

--- a/examples/zustand-todo-list/package.json
+++ b/examples/zustand-todo-list/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/zustand": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/zustand": "^0.19.7",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/examples/zustand-whiteboard/package-lock.json
+++ b/examples/zustand-whiteboard/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@liveblocks/zustand-whiteboard",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^0.19.6",
-        "@liveblocks/zustand": "^0.19.6",
+        "@liveblocks/client": "^0.19.7",
+        "@liveblocks/zustand": "^0.19.7",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2927,25 +2927,25 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "dependencies": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "node_modules/@liveblocks/zustand": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.6.tgz",
-      "integrity": "sha512-pm4cpKe9Mqarr2+CpeoF91FSP3E+Y22PG+WSHYYZ5Te83nWMwoQTbmEht6GKUdSFvf5xbSLyY5zdYiYW/Knytw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.7.tgz",
+      "integrity": "sha512-9KCZv616Bz6kcEjZa3VQI4Pm0LZchPPXTM9/sGQICLSH/vKNqM3LiO5WnjxdyZvyODfAAii2JWPX7VmpSrzQ5g==",
       "dependencies": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       },
       "peerDependencies": {
         "zustand": "^4.1.3"
@@ -18612,25 +18612,25 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@liveblocks/client": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.6.tgz",
-      "integrity": "sha512-TaJ9qBEvvNyXHIQCAjIoLodZ60/G5Kq0RrYHlow1FATWPY1/rFshrERWiJIiITeUQ4WsA5CN3V+cI1jqSnQHGg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-0.19.7.tgz",
+      "integrity": "sha512-aFciXrIzDIcpMR/HF9etjJsNa4ETw7Mvw1Q0UCRYa20UVaMK0DABmfIZlFFrr4G6nYXxJehOpEf3Fee6FHu1Pw==",
       "requires": {
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@liveblocks/core": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.6.tgz",
-      "integrity": "sha512-orUD/joPVL0hOm0S3bopZD8MeMKezBQ2l6tHr68nxyV+3SxfAL45uXxnPUX8d82UU5JO1zzVjqWB3FKJEsZTtw=="
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-0.19.7.tgz",
+      "integrity": "sha512-n1GlmFtSTjUDxrXk4pR5+EWPezmGI99TX9lbslgD+L8PaWMFndzn9mu5ZIzbp1UaFqyizwylthK16nV+vUG6Cg=="
     },
     "@liveblocks/zustand": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.6.tgz",
-      "integrity": "sha512-pm4cpKe9Mqarr2+CpeoF91FSP3E+Y22PG+WSHYYZ5Te83nWMwoQTbmEht6GKUdSFvf5xbSLyY5zdYiYW/Knytw==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@liveblocks/zustand/-/zustand-0.19.7.tgz",
+      "integrity": "sha512-9KCZv616Bz6kcEjZa3VQI4Pm0LZchPPXTM9/sGQICLSH/vKNqM3LiO5WnjxdyZvyODfAAii2JWPX7VmpSrzQ5g==",
       "requires": {
-        "@liveblocks/client": "0.19.6",
-        "@liveblocks/core": "0.19.6"
+        "@liveblocks/client": "0.19.7",
+        "@liveblocks/core": "0.19.7"
       }
     },
     "@nodelib/fs.scandir": {

--- a/examples/zustand-whiteboard/package.json
+++ b/examples/zustand-whiteboard/package.json
@@ -4,8 +4,8 @@
   "license": "Apache-2.0",
   "private": true,
   "dependencies": {
-    "@liveblocks/client": "^0.19.6",
-    "@liveblocks/zustand": "^0.19.6",
+    "@liveblocks/client": "^0.19.7",
+    "@liveblocks/zustand": "^0.19.7",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",


### PR DESCRIPTION
This upgrades all _trivial_ examples to the latest patch version. I'll open separate PRs for the non-trivial example upgrades.

The three ones that were non-trivial are done here:
- https://github.com/liveblocks/liveblocks/pull/633
- https://github.com/liveblocks/liveblocks/pull/634
- https://github.com/liveblocks/liveblocks/pull/635
