### PR TITLE
Fix LiveObject object key set undo with pending changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.19.8
+
+Fix LiveObject key set undo if key has pending local changes.
 
 # v0.19.7
 

--- a/packages/liveblocks-core/src/__tests__/_updatesUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_updatesUtils.ts
@@ -119,6 +119,17 @@ export function serializeUpdateToJson(
   return assertNever(update, "Unsupported LiveStructure type");
 }
 
+export function objectUpdate<TContents extends LsonObject>(
+  contents: ToJson<TContents>,
+  updates: LiveObjectUpdateDelta<TContents>
+): JsonLiveObjectUpdate<TContents> {
+  return {
+    type: "LiveObject",
+    node: contents,
+    updates,
+  };
+}
+
 export function listUpdate<TItem extends Lson>(
   items: ToJson<TItem>[],
   updates: JsonLiveListUpdateDelta<TItem>[]

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -286,7 +286,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     if (op.type === OpCode.UPDATE_OBJECT) {
       return this._applyUpdate(op, isLocal);
     } else if (op.type === OpCode.DELETE_OBJECT_KEY) {
-      return this._applyDeleteObjectKey(op);
+      return this._applyDeleteObjectKey(op, isLocal);
     }
 
     return super._apply(op, isLocal);
@@ -395,7 +395,10 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applyDeleteObjectKey(op: DeleteObjectKeyOp): ApplyResult {
+  private _applyDeleteObjectKey(
+    op: DeleteObjectKeyOp,
+    isLocal: boolean
+  ): ApplyResult {
     const key = op.key;
 
     // If property does not exist, exit without notifying
@@ -403,9 +406,9 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       return { modified: false };
     }
 
-    // If a local operation exists on the same key
-    // prevent flickering by not applying delete op.
-    if (this._propToLastUpdate.get(key) !== undefined) {
+    // If a local operation exists on the same key and we receive a remote
+    // one prevent flickering by not applying delete op.
+    if (!isLocal && this._propToLastUpdate.get(key) !== undefined) {
       return { modified: false };
     }
 

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
@@ -418,12 +418,10 @@ describe("LiveObject", () => {
         ],
         async ({ assert, batch, root, machine }) => {
           const items = root.get("items");
-          machine.pauseHistory();
           batch(() => {
             items.set("a", "A");
             items.set("b", "A");
           });
-          machine.resumeHistory();
 
           expect(items.toObject()).toEqual({ a: "A", b: "A" });
           assert([


### PR DESCRIPTION
While looking into https://github.com/liveblocks/liveblocks/issues/628 I discovered a bug in the LiveObject `_applyDeleteObjectKey` function that causes local history changes not to be applied. Probably not the cause of that issue, but something worth fixing regardless.