### PR TITLE
Fix undo batch with modify before set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v0.19.8
 
-Fix LiveObject key set undo if key has pending local changes.
+Fixes two history bugs:
+- The history didn't reliably undo LiveObject key set changes if any pending local changes existed on that key.
+- Changes performed inside `room.batch` were incorrectly ordered inside the history resulting in unexpected undo behavior in some cases.
 
 # v0.19.7
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -878,7 +878,7 @@ function makeStateMachine<
             )
           );
         });
-        activeBatch.reverseOps.push(...reverse);
+        activeBatch.reverseOps.unshift(...reverse);
       } else {
         batchUpdates(() => {
           addToUndoStack(reverse, doNotBatchUpdates);
@@ -1453,7 +1453,7 @@ function makeStateMachine<
 
     if (state.activeBatch) {
       if (options?.addToHistory) {
-        state.activeBatch.reverseOps.push({
+        state.activeBatch.reverseOps.unshift({
           type: "presence",
           data: oldValues,
         });


### PR DESCRIPTION
Fixes another small issue I've discovered while digging into history: We use `activeBatch.reverseOps.push` instead of `activeBatch.reverseOps.unshift` as we do for non-batched ops (see [addToUndoStack](https://github.com/liveblocks/liveblocks/blob/fa7126aa07deb393b0d83bd89f07f014b87c5648/packages/liveblocks-core/src/room.ts#L1084)) resulting in incorrect ordering of the reverse ops for changes done in `batch`

I based this upon https://github.com/liveblocks/liveblocks/pull/636 because I used the new `prepareDisconnectedStorageUpdateTest` helper introduced in that pr