### PR TITLE
Noop batch causes storage events to fire twice

### DIFF
--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -140,6 +140,32 @@ describe("LiveList", () => {
           }
         )
       );
+
+      test(
+        "batch insert and delete same item",
+        prepareStorageUpdateTest<{ items: LiveList<string> }>(
+          [
+            createSerializedObject("0:1", {}),
+            createSerializedList("0:2", "0:1", "items"),
+          ],
+          async ({ batch, assert, root }) => {
+            batch(() => {
+              const items = root.get("items");
+              items.insert("a", 0);
+              items.delete(0);
+            });
+
+            assert([
+              [
+                listUpdate(
+                  ["b"],
+                  [listUpdateInsert(0, "a"), listUpdateDelete(0)]
+                ),
+              ],
+            ]);
+          }
+        )
+      );
     });
 
     it("push LiveObject on empty list", async () => {


### PR DESCRIPTION
While going further down the history rabbit hole, I discovered another issue, this time not related to history, and I'm still trying to figure out the best approach to fix it.

When performing changes inside `batch` that are essentially noops (i.e., inserting and immediately removing the same list item), we fire storage events for those noop changes twice.

This stems from how we filter out remote updates when [handling remote changes](https://github.com/liveblocks/liveblocks/blob/c1722b159a76987fb152dff3c7f9dc3190037692/packages/liveblocks-core/src/room.ts#L1718): We ignore all operations that don't cause a change. This works fine for most cases, but not when we insert and remove the same item in the same batch because that batch will always cause an update (inserting and removing the item).