### PR TITLE
Fix publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -319,7 +319,7 @@ npm install
 commit_to_git "Bump to $VERSION" "package-lock.json" "packages/"
 
 echo "==> Rebuilding packages"
-turbo run build --force
+node_modules/.bin/turbo run build --force
 
 # Publish to NPM
 for pkgdir in ${PACKAGE_DIRS[@]}; do


### PR DESCRIPTION
This fixes the bug in the publish script where it errors with "turbo not found". It was a thing I missed, because I'm using [direnv](https://direnv.net/) to automatically manage my env vars on a per-directory basis, and "turbo" was always on my path.

Also, I think we're not enforcing specific `npm` and `node` versions yet here, which might be another issue. @FlowFlorent Lmk if this fix doesn't resolve the issues you're facing locally with this.