### PR TITLE
Add handling for RejectedStorageOpServerMsg

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1752,6 +1752,8 @@ function makeStateMachine<
                 `Storage ops rejected by server: ${message.reason}`
               );
             }
+
+            break;
           }
         }
       }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1743,13 +1743,13 @@ function makeStateMachine<
           // as a developer-owned bug. In production, these errors are not expected to happen.
           case ServerMsgCode.REJECT_STORAGE_OP: {
             console.errorWithTitle(
-              "Storage op rejection error",
+              "Storage mutation rejection error",
               message.reason
             );
 
             if (process.env.NODE_ENV !== "production") {
               throw new Error(
-                `Storage ops rejected by server: ${message.reason}`
+                `Storage mutations rejected by server: ${message.reason}`
               );
             }
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1735,6 +1735,24 @@ function makeStateMachine<
 
             break;
           }
+
+          // Receiving a RejectedOps message in the client means that the server is no
+          // longer in sync with the client. Trying to synchronize the client again by
+          // rolling back particular Ops may be hard/impossible. It's fine to not try and
+          // accept the out-of-sync reality and throw an error. We look at this kind of bug
+          // as a developer-owned bug. In production, these errors are not expected to happen.
+          case ServerMsgCode.REJECT_STORAGE_OP: {
+            console.errorWithTitle(
+              "Storage op rejection error",
+              message.reason
+            );
+
+            if (process.env.NODE_ENV !== "production") {
+              throw new Error(
+                `Storage ops rejected by server: ${message.reason}`
+              );
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Adds rudimentary client-side handling for RejectedStorageOp server messages by

- In development builds: log the error to the console and also throw it, so it's in the developer's face
- In production builds: only log the error to the console

