### PR TITLE
Add references to DT in the documentation

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -553,9 +553,10 @@ room.reconnect();
 
 ## Storage
 
-<Banner title="The storage block is in beta">
+<Banner title="Need help troubleshooting your storage?">
 
-The following APIs are subject to change during the beta.
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -128,6 +128,13 @@ const room = useRoom();
 
 ## Presence
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 ### useMyPresence
 
 Return the presence of the current user, and a function to update it.
@@ -425,9 +432,10 @@ useErrorListener((error) => {
 
 ## Storage
 
-<Banner title="The storage block is in beta">
+<Banner title="Need help troubleshooting your storage?">
 
-The following APIs are subject to change during the beta.
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
 
 </Banner>
 
@@ -495,11 +503,14 @@ This hook returns `null` while storage is still loading. To avoid that, use the
 It’s recommended to select only the subset of Storage data that your component
 needs. This will avoid unnecessary rerenders that happen with overselection.
 
-In order to select one item from a LiveMap within the storage tree with the `useStorage` method, you can use the example below: 
+In order to select one item from a LiveMap within the storage tree with the
+`useStorage` method, you can use the example below:
+
 ```ts
-const key = 'errands'
-const myTodos = useStorage(root => root.todoMap.get(key))
+const key = "errands";
+const myTodos = useStorage((root) => root.todoMap.get(key));
 ```
+
 In order to query a LiveMap, and filter for specific values:
 
 ```ts

--- a/docs/pages/get-started/react-redux.mdx
+++ b/docs/pages/get-started/react-redux.mdx
@@ -145,6 +145,13 @@ export default function App() {
 
 ## Get other users in the room [#get-others]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 If you want to list all the people connected to the room, you can use
 `state.liveblocks.others` to get an array of the other users in the room.
 
@@ -241,6 +248,13 @@ function OthersCursors() {
 ```
 
 ## Sync and persist the state across client [#storage-intro]
+
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
 
 As opposed to the `presence`, some collaborative features require that every
 user interacts with the same piece of state. For example, in Google Docs, it is

--- a/docs/pages/get-started/react-zustand.mdx
+++ b/docs/pages/get-started/react-zustand.mdx
@@ -125,6 +125,13 @@ export default App;
 
 ## Get other users in the room [#get-others]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 If you want to list all the people connected to the room, you can use
 `liveblocks.others` to get an array of the other users in the room.
 
@@ -231,6 +238,13 @@ function App() {
 ```
 
 ## Sync and persist the state across client [#storage-intro]
+
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
 
 As opposed to the “presence”, some collaborative features require that every
 user interacts with the same piece of state. For example, in Google Docs, it is

--- a/docs/pages/get-started/react.mdx
+++ b/docs/pages/get-started/react.mdx
@@ -126,6 +126,13 @@ interested.
 
 ## Get other users in the room [#get-others]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 Now that the provider is set up, we can start using the Liveblocks hooks. The
 first we’ll add is [`useOthers`][], a hook that provides us information about
 which _other_ users are connected to the room.
@@ -296,6 +303,13 @@ be helpful for a number of other use cases such as
 [real-time form presence](/examples/browse/forms).
 
 ## Sync and persist the state across client [#storage-intro]
+
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
 
 Some collaborative features require a single shared state between all users—an
 example of this would be a
@@ -648,8 +662,8 @@ Liveblocks applications. What’s next?
   `@liveblocks/react` documentation
 - [Authentication](/docs/guides/authentication) - Learn how to authenticate your
   real-time application
-- [Managing Rooms](/docs/guides/managing-rooms-users-permissions) - Learn how to manage room
-  metadata and permissions
+- [Managing Rooms](/docs/guides/managing-rooms-users-permissions) - Learn how to
+  manage room metadata and permissions
 - [Multiplayer To-do List](/docs/tutorials/multiplayer-to-do-list) - Build a
   real-time to-do list in another tutorial
 - [Examples](/examples) - Get started with some live examples

--- a/docs/pages/guides/troubleshooting.mdx
+++ b/docs/pages/guides/troubleshooting.mdx
@@ -7,6 +7,13 @@ meta:
 
 ## Common issues [#common]
 
+<Banner title="Need help troubleshooting?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 ### ReferenceError: process is not defined [#process-not-defined]
 
 When calling `client.enter()`, you stumble upon the following error:

--- a/docs/pages/tutorials/multiplayer-to-do-list/javascript.mdx
+++ b/docs/pages/tutorials/multiplayer-to-do-list/javascript.mdx
@@ -110,6 +110,16 @@ We’ve also passed an `initialPresence` value here—we’ll be using this late
 
 ## Show who’s currently in the room [#who-is-here]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
+Now that Liveblocks is set up, we’re going to use [`room.subscribe("others")`][]
+to show who’s currently inside the room.
+
 <Figure>
   <video autoPlay loop muted playsInline>
     <source
@@ -118,9 +128,6 @@ We’ve also passed an `initialPresence` value here—we’ll be using this late
     />
   </video>
 </Figure>
-
-Now that Liveblocks is set up, we’re going to use [`room.subscribe("others")`][]
-to show who’s currently inside the room.
 
 Create a file `static/index.html` with the following content:
 
@@ -397,6 +404,18 @@ run();
 
 ## Sync and persist to-dos [#add-liveblocks-storage]
 
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
+As opposed to the `presence`, some collaborative features require that every
+user interacts with the same piece of state. For example, in Google Doc, it is
+the paragraphs, headings, images in the document. In Figma, it’s all the shapes
+that make your design. That’s what we call the room’s `storage`.
+
 <Figure>
   <video autoPlay loop muted playsInline>
     <source
@@ -405,11 +424,6 @@ run();
     />
   </video>
 </Figure>
-
-As opposed to the `presence`, some collaborative features require that every
-user interacts with the same piece of state. For example, in Google Doc, it is
-the paragraphs, headings, images in the document. In Figma, it’s all the shapes
-that make your design. That’s what we call the room’s `storage`.
 
 The room’s storage is a conflicts-free state that multiple users can edit at the
 same time. It is persisted to our backend even after everyone leaves the room.

--- a/docs/pages/tutorials/multiplayer-to-do-list/react-redux.mdx
+++ b/docs/pages/tutorials/multiplayer-to-do-list/react-redux.mdx
@@ -170,6 +170,13 @@ export default function App() {
 
 ## Show who’s currently in the room [#who-is-here]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 Now that Liveblocks is set up, we can start updating our code to display how
 many users are currently online.
 
@@ -436,6 +443,13 @@ export default function App() {
 ```
 
 ## Sync and persist to-dos [#add-liveblocks-storage]
+
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
 
 To-do list items will be stored even after all users disconnect, so we won't be
 using presence to store these values. For this, we need something new.

--- a/docs/pages/tutorials/multiplayer-to-do-list/react-zustand.mdx
+++ b/docs/pages/tutorials/multiplayer-to-do-list/react-zustand.mdx
@@ -142,6 +142,17 @@ export default function App() {
 
 ## Show who’s currently in the room [#who-is-here]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
+Now that Liveblocks is set up, we’re going to use the injected object
+[`liveblocks.others`](/docs/api-reference/liveblocks-zustand#liveblocks-state-others)
+to show who’s currently inside the room.
+
 <Figure>
   <video autoPlay loop muted playsInline>
     <source
@@ -150,10 +161,6 @@ export default function App() {
     />
   </video>
 </Figure>
-
-Now that Liveblocks is set up, we’re going to use the injected object
-[`liveblocks.others`](/docs/api-reference/liveblocks-zustand#liveblocks-state-others)
-to show who’s currently inside the room.
 
 ```tsx highlight="6-14,30" file="src/App.tsx"
 import React, { useEffect } from "react";
@@ -383,6 +390,13 @@ export default function App() {
 ```
 
 ## Sync and persist to-dos [#add-liveblocks-storage]
+
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
 
 To-do list items will be stored even after all users disconnect, so we won't be
 using presence to store these values. For this, we need something new.

--- a/docs/pages/tutorials/multiplayer-to-do-list/react.mdx
+++ b/docs/pages/tutorials/multiplayer-to-do-list/react.mdx
@@ -136,6 +136,13 @@ component from React. More information can be found
 
 ## Show who’s currently in the room [#who-is-here]
 
+<Banner title="Need help troubleshooting the presence?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
+
 Now that Liveblocks is set up, we can start using the hooks to display how many
 users are currently online.
 
@@ -146,7 +153,7 @@ users are currently online.
       type="video/mp4"
     />
   </video>
-  <div className="pointer-events-none absolute inset-0 rounded-lg shadow-thin-border-300" />
+  <div className="shadow-thin-border-300 pointer-events-none absolute inset-0 rounded-lg" />
 </figure>
 
 We’ll be doing this by adding [`useOthers`][], a selector hook that provides us
@@ -402,6 +409,13 @@ export default function App() {
 ```
 
 ## Sync and persist to-dos [#add-liveblocks-storage]
+
+<Banner title="Need help troubleshooting your storage?">
+
+Try our [Liveblocks DevTools extension](/devtools) to visualize your
+collaborative experiences as you build them, in real-time.
+
+</Banner>
 
 To-do list items will be stored even after all users disconnect, so we won’t be
 using presence to store these values. For this, we need something new.

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -72,7 +72,7 @@
           }
         },
         "operationId": "get-rooms",
-        "description": "Returns a list of your rooms. The rooms are returned sorted by creation date, from newest to oldest. You can filter rooms by metadata, users accesses and groups accesses.\n\nThere is a pagination system where the next page URL is returned in the response as `nextPage`.\nYou can also limit the number of rooms by query.\n\nFiltering by metadata works by giving key values like `metadata.color=red`. Of course you can combine multiple metadata clauses to refine the response like `metadata.color=red&metadata.type=text`. Notice here the operator AND is applied between each clauses.\n\nFiltering by groups or userId works by giving a list of groups like `groupIds=marketing,GZo7tQ,product` or/and a userId like `userId=user1`.\nNotice here the operator OR is applied between each `groupIds` and the `userId`.\n",
+        "description": "Note: if you need real-time visibility on your room activities, you can use our Liveblocks DevTools extension.\n\nReturns a list of your rooms. The rooms are returned sorted by creation date, from newest to oldest. You can filter rooms by metadata, users accesses and groups accesses.\n\nThere is a pagination system where the next page URL is returned in the response as `nextPage`.\nYou can also limit the number of rooms by query.\n\nFiltering by metadata works by giving key values like `metadata.color=red`. Of course you can combine multiple metadata clauses to refine the response like `metadata.color=red&metadata.type=text`. Notice here the operator AND is applied between each clauses.\n\nFiltering by groups or userId works by giving a list of groups like `groupIds=marketing,GZo7tQ,product` or/and a userId like `userId=user1`.\nNotice here the operator OR is applied between each `groupIds` and the `userId`.\n",
         "parameters": [
           {
             "schema": {
@@ -557,7 +557,7 @@
           }
         },
         "operationId": "get-rooms-roomId-storage",
-        "description": "Returns a room storage as JSON.\n\nSome implementation details:\nEach Liveblocks data structure is represented by a JSON element having two properties:\n`\"liveblocksType\": \"LiveObject\" | \"LiveList\" | \"LiveMap\"`\n`\"data\"` => contains the nested data structures (children) and data.\nThe root is always a `LiveObject`."
+        "description": "_Note: if you need real-time visibility_ on your storage activities, you can use our Liveblocks DevTools extension.\n\nReturns a room storage as JSON.\n\nSome implementation details:\nEach Liveblocks data structure is represented by a JSON element having two properties:\n`\"liveblocksType\": \"LiveObject\" | \"LiveList\" | \"LiveMap\"`\n`\"data\"` => contains the nested data structures (children) and data.\nThe root is always a `LiveObject`."
       },
       "post": {
         "summary": "Initialize storage",


### PR DESCRIPTION
Adding references to the DT in the documentation.

To note:
- I used the <Banner> component everywhere I could
- I replaced the "storage in beta" banner where I needed to put the new banner, duplicates felt weird and we're not in beta anymore
- I moved some paragraphs to make them more coherent between elements of a series
- I added a blurb in the openapi file but couldn't style it