### PR TITLE
Mention there are no upgrade instructions for 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.0.0
 
+This major release marks the maturity of Liveblocks. There are no upgrade instructions for 1.0.0.
+
 ## `@liveblocks/node`
 
 `authorize` option `userId` is now mandatory.


### PR DESCRIPTION
Seems useful to add this in the CHANGELOG explicitly.