### PR TITLE
Schema validation docs polish

### DIFF
--- a/docs/pages/guides/schema-validation.mdx
+++ b/docs/pages/guides/schema-validation.mdx
@@ -64,11 +64,10 @@ of the data you want to store in your rooms.
   </video>
 </Figure>
 
-<Banner title="Schema language specification">
+<Banner title="Schema syntax">
 
-Take a look at our
-[language specification](/docs/guides/schema-validation/language) to learn more
-about what kind of validations are currently supported.
+Learn more about our [schema syntax](/docs/guides/schema-validation/syntax) and
+what kind of validations are currently supported.
 
 </Banner>
 

--- a/docs/pages/guides/schema-validation/syntax.mdx
+++ b/docs/pages/guides/schema-validation/syntax.mdx
@@ -1,8 +1,8 @@
 ---
 meta:
-  title: "Schema language"
+  title: "Schema syntax"
   parentTitle: "Guides"
-  description: "Liveblocks schema language specification"
+  description: "Liveblocks schema syntax"
 ---
 
 <Banner title="Private beta">
@@ -14,10 +14,9 @@ to get access in the near future.
 
 </Banner>
 
-## Syntax
-
-The list below is exhaustive of the supported feature that will be implemented
-before the public beta.
+This document describes the language rules for writing your own Liveblocks
+schemas. It is an exhaustive account of all feature that will be implemented and
+supported before the public beta.
 
 Currently in the private beta phase we support: scalars, optionals, objects, and
 `LiveObject`. We’re sharing our plans for other syntaxes so you can give us

--- a/docs/pages/guides/schema-validation/syntax.mdx
+++ b/docs/pages/guides/schema-validation/syntax.mdx
@@ -22,7 +22,7 @@ Currently in the private beta phase we support: scalars, optionals, objects, and
 `LiveObject`. We’re sharing our plans for other syntaxes so you can give us
 early feedback [here](https://github.com/liveblocks/liveblocks/discussions/674).
 
-### Storage root
+## Storage root
 
 Each schema must include the `Storage` type, a special type of “root” object.
 
@@ -32,7 +32,7 @@ type Storage {
 }
 ```
 
-### Scalars
+## Scalars
 
 Familiar scalar types are globally available when you create a schema. We
 support:
@@ -69,7 +69,7 @@ root.set("height", "1.52");
 root.set("hasSiblings", "???");
 ```
 
-### Optionals
+## Optionals
 
 Each field inside an object type can be marked optional using the `?` operator.
 An optional field means that it can be deleted.
@@ -100,7 +100,7 @@ root.delete("name"); // `name` is not optional
   opposed to GraphQL.
 </Banner>
 
-### Objects
+## Objects
 
 Our language supports two different ways to declare object types:
 
@@ -135,7 +135,7 @@ root.set("scientist", { name: "Marie Curie", age: 66 });
 root.set("scientist", { name: "Marie Curie" }); // `age` is missing
 ```
 
-### LiveObject
+## LiveObject
 
 To use an object type definition as a “live” object, wrap it in the built-in
 [`LiveObject`](/docs/api-reference/liveblocks-client#LiveObject) construct, like
@@ -163,7 +163,7 @@ root.set("scientist", new LiveObject({ name: "Marie Curie"; age: 66 }));
 root.set("scientist", { name: "Marie Curie"; age: 66 });
 ```
 
-### Arrays
+## Arrays
 
 Arrays can be defined like this:
 
@@ -183,7 +183,7 @@ root.set("animals", ["🦁", "🦊", "🐵"]));
 root.set("animals", [1, 2, 2]);
 ```
 
-### LiveList
+## LiveList
 
 To use a “live” array instead of a normal array, wrap your item type in a
 [`LiveList`](/docs/api-reference/liveblocks-client#LiveList) when you reference
@@ -208,7 +208,7 @@ root.set("animals", new LiveList(["🦁", "🦊", "🐵"]));
 root.set("animals", ["🦁", "🦊", "🐵"]); // `animals` should be a `LiveList`
 ```
 
-### LiveMap
+## LiveMap
 
 It’s also possible to define a
 [`LiveMap`](/docs/api-reference/liveblocks-client#LiveMap) in your schema.

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -126,8 +126,8 @@
         "path": "/guides/schema-validation",
         "routes": [
           {
-            "title": "Schema language",
-            "path": "/guides/schema-validation/language"
+            "title": "Syntax",
+            "path": "/guides/schema-validation/syntax"
           }
         ]
       }


### PR DESCRIPTION
Hi! This morning, while checking the schema docs, I got an idea for slightly restructuring them, and to stop referring to the concept of a "schema language" or "language specification", because I think it may sound a bit too daunting for what it really is. What I would want to avoid is interested people thinking "Oh god, do I need to learn a new language for this? Nevermind."

Here is a small proposal to rename the doc structure. What do you think?

# Before vs after (main guide)

![Screen Shot 2023-02-10 at 12 22 05@2x](https://user-images.githubusercontent.com/83844/218082303-a59e671b-a308-4d97-82a8-f0f3d2d366a5.png)

![Screen Shot 2023-02-10 at 12 22 22@2x](https://user-images.githubusercontent.com/83844/218082340-ed219532-e5be-4677-b667-793d535ffc5b.png)

# Before vs after (syntax)

![Screen Shot 2023-02-10 at 12 23 37@2x](https://user-images.githubusercontent.com/83844/218083253-22f1a661-eff0-42a3-a45b-8d362cf4a733.png)

![Screen Shot 2023-02-10 at 12 24 04@2x](https://user-images.githubusercontent.com/83844/218083259-95f6e556-8f85-4367-a1e3-367b9b182e1d.png)

