### PR TITLE
Update example READMEs with `create-liveblocks-app` instructions

### DIFF
--- a/docs/pages/guides/nextjs-starter-kit.mdx
+++ b/docs/pages/guides/nextjs-starter-kit.mdx
@@ -42,7 +42,7 @@ The Next.js Starter Kit includes the following
 
 You can get started by running the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --next
 ```
 

--- a/examples/javascript-live-cursors/README.md
+++ b/examples/javascript-live-cursors/README.md
@@ -39,6 +39,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `static/index.html` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/javascript-live-cursors/README.md
+++ b/examples/javascript-live-cursors/README.md
@@ -27,7 +27,7 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example javascript-live-cursors --no-api-key --no-vercel
 ```
 
@@ -62,7 +62,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example javascript-live-cursors --vercel
 ```
 

--- a/examples/javascript-live-cursors/README.md
+++ b/examples/javascript-live-cursors/README.md
@@ -25,8 +25,52 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example javascript-live-cursors --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`app.js`](./app.js) with your **public** key
+- Run `npm run build` and open `static/index.html` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`app.ts`](./app.ts) by your **public** key
+- Replace `pk_YOUR_PUBLIC_KEY` in [`app.ts`](./app.ts) with your **public** key
 - Run `npm run build` and open `static/index.html` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example javascript-live-cursors --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`app.js`](./app.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `static/index.html` in your browser
+
+</details>

--- a/examples/javascript-todo-list/README.md
+++ b/examples/javascript-todo-list/README.md
@@ -32,7 +32,7 @@ also be able to see who else is currently online and when a user is typing.
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example javascript-todo-list --no-api-key --no-vercel
 ```
 
@@ -67,7 +67,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example javascript-todo-list --vercel
 ```
 

--- a/examples/javascript-todo-list/README.md
+++ b/examples/javascript-todo-list/README.md
@@ -30,12 +30,65 @@ also be able to see who else is currently online and when a user is typing.
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example javascript-todo-list --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`app.js`](./app.js) with your **public** key
+- Run `npm run build` and open `static/index.html` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the
-  [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`app.ts`](./app.ts) by your **public** key
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`app.js`](./app.js) with your **public** key
 - Run `npm run build` and open `static/index.html` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example javascript-todo-list --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`app.js`](./app.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `static/index.html` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/javascript-todo-list) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>
 
 ### Tutorial
 

--- a/examples/javascript-todo-list/README.md
+++ b/examples/javascript-todo-list/README.md
@@ -44,6 +44,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `static/index.html` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-3d-builder/README.md
+++ b/examples/nextjs-3d-builder/README.md
@@ -29,7 +29,7 @@ This example shows how to build a collaborative 3D builder with [Liveblocks](htt
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-3d-builder --api-key
 ```
 
@@ -59,7 +59,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-3d-builder --vercel
 ```
 

--- a/examples/nextjs-3d-builder/README.md
+++ b/examples/nextjs-3d-builder/README.md
@@ -27,12 +27,51 @@ This example shows how to build a collaborative 3D builder with [Liveblocks](htt
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-3d-builder --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-3d-builder --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-3d-builder) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-3d-builder/README.md
+++ b/examples/nextjs-3d-builder/README.md
@@ -36,6 +36,7 @@ npx create-liveblocks-app@latest --example nextjs-3d-builder --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-block-text-editor-advanced/README.md
+++ b/examples/nextjs-block-text-editor-advanced/README.md
@@ -36,6 +36,7 @@ npx create-liveblocks-app@latest --example nextjs-block-text-editor-advanced --a
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-block-text-editor-advanced/README.md
+++ b/examples/nextjs-block-text-editor-advanced/README.md
@@ -29,7 +29,7 @@ This example shows how to build a collaborative block text editor with
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-block-text-editor-advanced --api-key
 ```
 
@@ -59,7 +59,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-block-text-editor-advanced --vercel
 ```
 

--- a/examples/nextjs-block-text-editor-advanced/README.md
+++ b/examples/nextjs-block-text-editor-advanced/README.md
@@ -27,17 +27,51 @@ This example shows how to build a collaborative block text editor with
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-block-text-editor-advanced --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **secret** key from the
-  [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env.local` file and add your **secret** key as the
-  `LIVEBLOCKS_SECRET_KEY` environment variable
+- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
 
-After forking
-[this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-block-text-editor-advanced)
-on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment
-variable as a [secret](https://codesandbox.io/docs/secrets).
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-block-text-editor-advanced --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-block-text-editor-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-form/README.md
+++ b/examples/nextjs-form/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-form --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-form/README.md
+++ b/examples/nextjs-form/README.md
@@ -28,7 +28,7 @@ This example shows how to build a collaborative form with [Liveblocks](https://l
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-form --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-form --vercel
 ```
 

--- a/examples/nextjs-form/README.md
+++ b/examples/nextjs-form/README.md
@@ -26,12 +26,51 @@ This example shows how to build a collaborative form with [Liveblocks](https://l
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-form --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-form --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-form) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -36,6 +36,7 @@ npx create-liveblocks-app@latest --example nextjs-live-avatars-advanced --api-ke
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -27,19 +27,6 @@ This example shows how to build an advanced live avatar stack with [Liveblocks](
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
-
-### CodeSandbox
-
-After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-avatars-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -36,3 +36,55 @@ This example shows how to build an advanced live avatar stack with [Liveblocks](
 ### CodeSandbox
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-avatars-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-avatars-advanced --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
+- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-avatars-advanced --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-avatars-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -29,7 +29,7 @@ This example shows how to build an advanced live avatar stack with [Liveblocks](
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-avatars-advanced --api-key
 ```
 
@@ -59,7 +59,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-avatars-advanced --vercel
 ```
 

--- a/examples/nextjs-live-avatars/README.md
+++ b/examples/nextjs-live-avatars/README.md
@@ -26,12 +26,51 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-avatars --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-avatars --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-avatars) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-avatars/README.md
+++ b/examples/nextjs-live-avatars/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-live-avatars --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-avatars/README.md
+++ b/examples/nextjs-live-avatars/README.md
@@ -28,7 +28,7 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-avatars --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-avatars --vercel
 ```
 

--- a/examples/nextjs-live-cursors-advanced/README.md
+++ b/examples/nextjs-live-cursors-advanced/README.md
@@ -27,12 +27,51 @@ This example shows how to build advanced live cursors with [Liveblocks](https://
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors-advanced --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors-advanced --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-cursors-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-cursors-advanced/README.md
+++ b/examples/nextjs-live-cursors-advanced/README.md
@@ -29,7 +29,7 @@ This example shows how to build advanced live cursors with [Liveblocks](https://
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors-advanced --api-key
 ```
 
@@ -59,7 +59,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors-advanced --vercel
 ```
 

--- a/examples/nextjs-live-cursors-advanced/README.md
+++ b/examples/nextjs-live-cursors-advanced/README.md
@@ -36,6 +36,7 @@ npx create-liveblocks-app@latest --example nextjs-live-cursors-advanced --api-ke
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-cursors-chat/README.md
+++ b/examples/nextjs-live-cursors-chat/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-live-cursors-chat --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-cursors-chat/README.md
+++ b/examples/nextjs-live-cursors-chat/README.md
@@ -28,7 +28,7 @@ This example shows how to build live cursors along chat and reactions with [Live
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors-chat --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors-chat --vercel
 ```
 

--- a/examples/nextjs-live-cursors-chat/README.md
+++ b/examples/nextjs-live-cursors-chat/README.md
@@ -26,12 +26,51 @@ This example shows how to build live cursors along chat and reactions with [Live
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors-chat --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors-chat --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-cursors-chat) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-cursors-scroll/README.md
+++ b/examples/nextjs-live-cursors-scroll/README.md
@@ -28,7 +28,7 @@ This example shows how to build live cursors within a responsive scrollable page
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors-scroll --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors-scroll --vercel
 ```
 

--- a/examples/nextjs-live-cursors-scroll/README.md
+++ b/examples/nextjs-live-cursors-scroll/README.md
@@ -26,12 +26,51 @@ This example shows how to build live cursors within a responsive scrollable page
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors-scroll --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors-scroll --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-cursors-scroll) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-cursors-scroll/README.md
+++ b/examples/nextjs-live-cursors-scroll/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-live-cursors-scroll --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-cursors/README.md
+++ b/examples/nextjs-live-cursors/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-live-cursors --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-cursors/README.md
+++ b/examples/nextjs-live-cursors/README.md
@@ -28,7 +28,7 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-cursors --vercel
 ```
 

--- a/examples/nextjs-live-cursors/README.md
+++ b/examples/nextjs-live-cursors/README.md
@@ -26,12 +26,51 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-cursors --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-cursors) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-form-selection/README.md
+++ b/examples/nextjs-live-form-selection/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-live-form-selection --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-live-form-selection/README.md
+++ b/examples/nextjs-live-form-selection/README.md
@@ -26,12 +26,51 @@ This example shows how to build live selection on a form with [Liveblocks](https
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-form-selection --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-live-form-selection --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-live-form-selection) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-live-form-selection/README.md
+++ b/examples/nextjs-live-form-selection/README.md
@@ -28,7 +28,7 @@ This example shows how to build live selection on a form with [Liveblocks](https
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-form-selection --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-live-form-selection --vercel
 ```
 

--- a/examples/nextjs-spreadsheet-advanced/README.md
+++ b/examples/nextjs-spreadsheet-advanced/README.md
@@ -25,7 +25,7 @@ This example shows how to build an advanced collaborative spreadsheet with [Live
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-spreadsheet-advanced --api-key
 ```
 
@@ -55,7 +55,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-spreadsheet-advanced --vercel
 ```
 

--- a/examples/nextjs-spreadsheet-advanced/README.md
+++ b/examples/nextjs-spreadsheet-advanced/README.md
@@ -23,12 +23,51 @@ This example shows how to build an advanced collaborative spreadsheet with [Live
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-spreadsheet-advanced --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-spreadsheet-advanced --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-spreadsheet-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-spreadsheet-advanced/README.md
+++ b/examples/nextjs-spreadsheet-advanced/README.md
@@ -32,6 +32,7 @@ npx create-liveblocks-app@latest --example nextjs-spreadsheet-advanced --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-todo-list/README.md
+++ b/examples/nextjs-todo-list/README.md
@@ -25,19 +25,6 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
-
-### CodeSandbox
-
-After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-todo-list) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/nextjs-todo-list/README.md
+++ b/examples/nextjs-todo-list/README.md
@@ -34,6 +34,7 @@ npx create-liveblocks-app@latest --example nextjs-todo-list --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-todo-list/README.md
+++ b/examples/nextjs-todo-list/README.md
@@ -27,7 +27,7 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-todo-list --api-key
 ```
 
@@ -57,7 +57,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-todo-list --vercel
 ```
 

--- a/examples/nextjs-todo-list/README.md
+++ b/examples/nextjs-todo-list/README.md
@@ -34,3 +34,55 @@ As users edit the list, changes will be automatically persisted and synced—all
 ### CodeSandbox
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-todo-list) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-todo-list --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Create an `.env.local` file and add your **public** key as the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable
+- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-todo-list --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-todo-list) on CodeSandbox, create the `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-whiteboard-advanced/README.md
+++ b/examples/nextjs-whiteboard-advanced/README.md
@@ -44,8 +44,8 @@ Alternatively, you can set up your project manually:
 
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **REPLACE_TYPE** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env.local` file and add your **REPLACE_TYPE** key as the `REPLACE_KEY` environment variable
+- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
 </details>
@@ -72,6 +72,6 @@ This will download the example and ask permission to open your browser, enabling
 
 <p></p>
 
-After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-whiteboard-advanced) on CodeSandbox, create the `REPLACE_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-whiteboard-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
 
 </details>

--- a/examples/nextjs-whiteboard-advanced/README.md
+++ b/examples/nextjs-whiteboard-advanced/README.md
@@ -35,3 +35,55 @@ This example shows how to build an advanced collaborative whiteboard with [Liveb
 ### CodeSandbox
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-whiteboard-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-whiteboard-advanced --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **REPLACE_TYPE** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Create an `.env.local` file and add your **REPLACE_TYPE** key as the `REPLACE_KEY` environment variable
+- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nextjs-whiteboard-advanced --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-whiteboard-advanced) on CodeSandbox, create the `REPLACE_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nextjs-whiteboard-advanced/README.md
+++ b/examples/nextjs-whiteboard-advanced/README.md
@@ -28,7 +28,7 @@ This example shows how to build an advanced collaborative whiteboard with [Liveb
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-whiteboard-advanced --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nextjs-whiteboard-advanced --vercel
 ```
 

--- a/examples/nextjs-whiteboard-advanced/README.md
+++ b/examples/nextjs-whiteboard-advanced/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nextjs-whiteboard-advanced --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nextjs-whiteboard-advanced/README.md
+++ b/examples/nextjs-whiteboard-advanced/README.md
@@ -26,19 +26,6 @@ This example shows how to build an advanced collaborative whiteboard with [Liveb
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
-
-### CodeSandbox
-
-After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nextjs-whiteboard-advanced) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/nuxtjs-live-avatars/README.md
+++ b/examples/nuxtjs-live-avatars/README.md
@@ -26,12 +26,51 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example nuxtjs-live-avatars --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
+- Create an `.env.local` file and add your **secret** key as the `LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example nuxtjs-live-avatars --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/nuxtjs-live-avatars) on CodeSandbox, create the `LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/nuxtjs-live-avatars/README.md
+++ b/examples/nuxtjs-live-avatars/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example nuxtjs-live-avatars --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/nuxtjs-live-avatars/README.md
+++ b/examples/nuxtjs-live-avatars/README.md
@@ -28,7 +28,7 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nuxtjs-live-avatars --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example nuxtjs-live-avatars --vercel
 ```
 

--- a/examples/react-dashboard/README.md
+++ b/examples/react-dashboard/README.md
@@ -27,7 +27,7 @@ This example shows how to build collaborative data visualization with [Liveblock
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-dashboard --no-api-key --no-vercel
 ```
 
@@ -62,7 +62,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-dashboard --vercel
 ```
 

--- a/examples/react-dashboard/README.md
+++ b/examples/react-dashboard/README.md
@@ -39,6 +39,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/react-dashboard/README.md
+++ b/examples/react-dashboard/README.md
@@ -25,8 +25,52 @@ This example shows how to build collaborative data visualization with [Liveblock
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example react-dashboard --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) by your **public** key
-- Run `npm run start` and and go to [http://localhost:3000](http://localhost:3000)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example react-dashboard --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>

--- a/examples/react-native-todo-list/README.md
+++ b/examples/react-native-todo-list/README.md
@@ -21,9 +21,55 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example react-native-todo-list --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.ts`](./liveblocks.config.ts) with your **public** key
+- For iOS, run `cd ios && pod install` then `npm run ios`
+- For Android, run `npm run android`
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.ts`](./liveblocks.config.ts) by your **public** key
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.ts`](./liveblocks.config.ts) with your **public** key
 - For iOS, run `cd ios && pod install` then `npm run ios`
 - For Android, run `npm run android`
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example react-native-todo-list --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.ts`](./liveblocks.config.ts) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- For iOS, run `cd ios && pod install` then `npm run ios`
+- For Android, run `npm run android`
+
+</details>

--- a/examples/react-native-todo-list/README.md
+++ b/examples/react-native-todo-list/README.md
@@ -36,6 +36,7 @@ This will download the example and install the example. Next, you must:
 - For Android, run `npm run android`
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/react-native-todo-list/README.md
+++ b/examples/react-native-todo-list/README.md
@@ -23,7 +23,7 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-native-todo-list --no-api-key --no-vercel
 ```
 
@@ -60,7 +60,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-native-todo-list --vercel
 ```
 

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -29,7 +29,7 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-todo-list --no-api-key --no-vercel
 ```
 
@@ -64,7 +64,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-todo-list --vercel
 ```
 

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -41,6 +41,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -27,11 +27,65 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example react-todo-list --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) by your **public** key
-- Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example react-todo-list --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/react-todo-list) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>
 
 ### Tutorial
 

--- a/examples/react-whiteboard/README.md
+++ b/examples/react-whiteboard/README.md
@@ -26,10 +26,62 @@ This example shows how to build a collaborative whiteboard with
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example react-whiteboard --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the
-  [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in
-  [`liveblocks.config.js`](./liveblocks.config.js) by your **public** key
-- Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example react-whiteboard --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/react-whiteboard) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/react-whiteboard/README.md
+++ b/examples/react-whiteboard/README.md
@@ -28,7 +28,7 @@ This example shows how to build a collaborative whiteboard with
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-whiteboard --no-api-key --no-vercel
 ```
 
@@ -63,7 +63,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example react-whiteboard --vercel
 ```
 

--- a/examples/react-whiteboard/README.md
+++ b/examples/react-whiteboard/README.md
@@ -40,6 +40,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/redux-todo-list/README.md
+++ b/examples/redux-todo-list/README.md
@@ -34,6 +34,71 @@ As users edit the list, changes will be automatically persisted and synced—all
 - Replace `pk_YOUR_PUBLIC_KEY` in [`store.js`](./src/store.js) by your **public** key
 - Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
 
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example redux-todo-list --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example redux-todo-list --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/redux-todo-list) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>
+
 ### Tutorial
 
 Follow our [step by step tutorial](https://liveblocks.io/docs/tutorials/collaborative-to-do-list/react-redux) to build it from scratch.
+
+

--- a/examples/redux-todo-list/README.md
+++ b/examples/redux-todo-list/README.md
@@ -30,7 +30,7 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example redux-todo-list --no-api-key --no-vercel
 ```
 
@@ -65,7 +65,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example redux-todo-list --vercel
 ```
 

--- a/examples/redux-todo-list/README.md
+++ b/examples/redux-todo-list/README.md
@@ -28,15 +28,6 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`store.js`](./src/store.js) by your **public** key
-- Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/redux-todo-list/README.md
+++ b/examples/redux-todo-list/README.md
@@ -51,6 +51,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/redux-whiteboard/README.md
+++ b/examples/redux-whiteboard/README.md
@@ -42,6 +42,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/redux-whiteboard/README.md
+++ b/examples/redux-whiteboard/README.md
@@ -30,7 +30,7 @@ This example shows how to build a collaborative whiteboard with
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example redux-whiteboard --no-api-key --no-vercel
 ```
 
@@ -65,7 +65,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example redux-whiteboard --vercel
 ```
 

--- a/examples/redux-whiteboard/README.md
+++ b/examples/redux-whiteboard/README.md
@@ -28,13 +28,65 @@ This example shows how to build a collaborative whiteboard with
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example redux-whiteboard --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the
-  [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`store.js`](./src/store.js) by your
-  **public** key
-- Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example redux-whiteboard --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/redux-whiteboard) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>
 
 ### Tutorial
 

--- a/examples/solidjs-live-avatars/README.md
+++ b/examples/solidjs-live-avatars/README.md
@@ -28,7 +28,7 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example solidjs-live-avatars --no-api-key --no-vercel
 ```
 
@@ -63,7 +63,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example solidjs-live-avatars --vercel
 ```
 

--- a/examples/solidjs-live-avatars/README.md
+++ b/examples/solidjs-live-avatars/README.md
@@ -26,8 +26,62 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example solidjs-live-avatars --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`index.jsx`](./src/index.jsx) with your **public** key
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example solidjs-live-avatars --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/solidjs-live-avatars) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/solidjs-live-avatars/README.md
+++ b/examples/solidjs-live-avatars/README.md
@@ -40,6 +40,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -28,7 +28,7 @@ This example shows how to build a live cursors with [Liveblocks](https://liveblo
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example solidjs-live-cursors --no-api-key --no-vercel
 ```
 
@@ -63,7 +63,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example solidjs-live-cursors --vercel
 ```
 

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -31,3 +31,66 @@ This example shows how to build a live cursors with [Liveblocks](https://liveblo
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`index.jsx`](./src/index.jsx) with your **public** key
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example solidjs-live-cursors --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example solidjs-live-cursors --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/solidjs-live-cursors) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -26,15 +26,6 @@ This example shows how to build a live cursors with [Liveblocks](https://liveblo
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`index.jsx`](./src/index.jsx) with your **public** key
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -40,6 +40,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/sveltekit-live-avatars/README.md
+++ b/examples/sveltekit-live-avatars/README.md
@@ -26,12 +26,51 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example sveltekit-live-avatars --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Create an `.env.local` file and add your **secret** key as the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable
 - Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
 
-### CodeSandbox
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example sveltekit-live-avatars --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/sveltekit-live-avatars) on CodeSandbox, create the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/sveltekit-live-avatars/README.md
+++ b/examples/sveltekit-live-avatars/README.md
@@ -28,7 +28,7 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example sveltekit-live-avatars --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example sveltekit-live-avatars --vercel
 ```
 

--- a/examples/sveltekit-live-avatars/README.md
+++ b/examples/sveltekit-live-avatars/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example sveltekit-live-avatars --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/sveltekit-live-cursors/README.md
+++ b/examples/sveltekit-live-cursors/README.md
@@ -35,6 +35,7 @@ npx create-liveblocks-app@latest --example sveltekit-live-cursors --api-key
 This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/sveltekit-live-cursors/README.md
+++ b/examples/sveltekit-live-cursors/README.md
@@ -35,3 +35,56 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 ### CodeSandbox
 
 After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/sveltekit-live-cursors) on CodeSandbox, create the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example sveltekit-live-cursors --api-key
+```
+
+This will download the example and ask permission to open your browser, enabling you to automatically get your API key from your [liveblocks.io](https://liveblocks.io) account.
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Create an `.env.local` file and add your **secret** key as the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable
+- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example sveltekit-live-cursors --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel.
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/sveltekit-live-cursors) on CodeSandbox, create the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/sveltekit-live-cursors/README.md
+++ b/examples/sveltekit-live-cursors/README.md
@@ -26,20 +26,6 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Create an `.env.local` file and add your **secret** key as the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
-
-### CodeSandbox
-
-After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/sveltekit-live-cursors) on CodeSandbox, create the `VITE_LIVEBLOCKS_SECRET_KEY` environment variable as a [secret](https://codesandbox.io/docs/secrets).
-
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/sveltekit-live-cursors/README.md
+++ b/examples/sveltekit-live-cursors/README.md
@@ -28,7 +28,7 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example sveltekit-live-cursors --api-key
 ```
 
@@ -58,7 +58,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example sveltekit-live-cursors --vercel
 ```
 

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -30,3 +30,66 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 - Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`App.vue`](./src/App.vue) by your **public** key
 - Run `npm run serve` and go to [http://localhost:8000](http://localhost:8000)
+
+
+## Getting started
+
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example vuejs-live-cursors --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/App.vue`](./src/App.vue) with your **public** key
+- Run `npm run build` and open `http://localhost:8000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
+- Install all dependencies with `npm install`
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/App.vue`](./src/App.vue) with your **public** key
+- Run `npm run build` and open `http://localhost:8000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example vuejs-live-cursors --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/App.vue`](./src/App.vue) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:8000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/vuejs-live-cursors) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -25,15 +25,6 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 ## Getting started
 
-- Install all dependencies with `npm install`
-- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **secret** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`App.vue`](./src/App.vue) by your **public** key
-- Run `npm run serve` and go to [http://localhost:8000](http://localhost:8000)
-
-
-## Getting started
-
 Run the following command to try this example locally:
 
 ```shell

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -27,7 +27,7 @@ This example shows how to build live cursors with [Liveblocks](https://liveblock
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example vuejs-live-cursors --no-api-key --no-vercel
 ```
 
@@ -62,7 +62,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example vuejs-live-cursors --vercel
 ```
 

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -39,6 +39,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:8000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/zustand-todo-list/README.md
+++ b/examples/zustand-todo-list/README.md
@@ -42,6 +42,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/zustand-todo-list/README.md
+++ b/examples/zustand-todo-list/README.md
@@ -30,7 +30,7 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example zustand-todo-list --no-api-key --no-vercel
 ```
 
@@ -65,7 +65,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example zustand-todo-list --vercel
 ```
 

--- a/examples/zustand-todo-list/README.md
+++ b/examples/zustand-todo-list/README.md
@@ -28,11 +28,65 @@ As users edit the list, changes will be automatically persisted and synced—all
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example zustand-todo-list --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`store.ts`](./src/store.ts) by your **public** key
-- Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example zustand-todo-list --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/zustand-todo-list) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>
 
 ### Tutorial
 

--- a/examples/zustand-whiteboard/README.md
+++ b/examples/zustand-whiteboard/README.md
@@ -42,6 +42,7 @@ This will download the example and install the example. Next, you must:
 - Run `npm run build` and open `http://localhost:3000` in your browser
 
 ### Manual setup
+
 <details><summary>Read more</summary>
 
 <p></p>

--- a/examples/zustand-whiteboard/README.md
+++ b/examples/zustand-whiteboard/README.md
@@ -28,13 +28,65 @@ This example shows how to build a collaborative whiteboard with
 
 ## Getting started
 
+Run the following command to try this example locally:
+
+```shell
+npx create-liveblocks-app@latest --example zustand-whiteboard --no-api-key --no-vercel
+```
+
+This will download the example and install the example. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+### Manual setup
+<details><summary>Read more</summary>
+
+<p></p>
+
+Alternatively, you can set up your project manually:
+
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
-- Copy your **public** key from the
-  [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`store.ts`](./src/store.ts) by your
-  **public** key
-- Run `npm run start` and go to [http://localhost:3000](http://localhost:3000)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Deploy on Vercel
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
+
+```shell
+npx create-liveblocks-app@latest --example zustand-whiteboard --vercel
+```
+
+This will download the example and ask permission to open your browser, enabling you to deploy to Vercel. Next, you must:
+
+- Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
+- Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
+- Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
+- Push a commit to update the Vercel demo with the key
+- Run `npm run build` and open `http://localhost:3000` in your browser
+
+</details>
+
+### Develop on CodeSandbox
+
+<details><summary>Read more</summary>
+
+<p></p>
+
+After forking [this example](https://codesandbox.io/s/github/liveblocks/liveblocks/tree/main/examples/zustand-whiteboard) on CodeSandbox, create the `pk_YOUR_PUBLIC_KEY` environment variable as a [public](https://codesandbox.io/docs/secrets).
+
+</details>
 
 ### Tutorial
 

--- a/examples/zustand-whiteboard/README.md
+++ b/examples/zustand-whiteboard/README.md
@@ -30,7 +30,7 @@ This example shows how to build a collaborative whiteboard with
 
 Run the following command to try this example locally:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example zustand-whiteboard --no-api-key --no-vercel
 ```
 
@@ -65,7 +65,7 @@ Alternatively, you can set up your project manually:
 
 To both deploy on [Vercel](https://vercel.com), and run the example locally, use the following command:
 
-```shell
+```bash
 npx create-liveblocks-app@latest --example zustand-whiteboard --vercel
 ```
 


### PR DESCRIPTION
New format for the READMEs containing the installer command. The READMEs vary slightly, depending on whether environment variables are used or not.

---

**How it looks on GitHub** 

![chrome_EA9E86FNPE](https://user-images.githubusercontent.com/33033422/218124475-1c82d716-1e3d-4989-b049-20c0130c9dea.png)

---

**How it looks on examples pages**

![image (2)](https://user-images.githubusercontent.com/33033422/218124612-c3c111f5-3692-4f37-92a8-fc74b1374f6a.png)

---

**TODO**
- [x] Finish all READMEs
- [ ] Merge this: https://github.com/liveblocks/liveblocks.io/pull/909