### PR TITLE
Expose assert helper from '@liveblocks/core'

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -30,7 +30,7 @@ export {
   lsonToJson,
   patchLiveObjectKey,
 } from "./immutable";
-export { assertNever, nn } from "./lib/assert";
+export { assert, assertNever, nn } from "./lib/assert";
 export {
   deprecate,
   deprecateIf,


### PR DESCRIPTION
Exposes the `assert` helper from `@liveblocks/core`