### PR TITLE
Core: `PlainLson` types

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -117,6 +117,13 @@ export type { NodeMap, ParentToChildNodeMap } from "./types/NodeMap";
 export type { Others } from "./types/Others";
 export type { User } from "./types/User";
 export { WebsocketCloseCodes } from "./types/WebsocketCloseCodes";
+export type {
+  PlainLson,
+  PlainLsonFields,
+  PlainLsonList,
+  PlainLsonMap,
+  PlainLsonObject,
+} from "./types/PlainLson";
 
 /**
  * Helper type to help users adopt to Lson types from interface definitions.

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -115,8 +115,6 @@ export type {
 export type { Immutable } from "./types/Immutable";
 export type { NodeMap, ParentToChildNodeMap } from "./types/NodeMap";
 export type { Others } from "./types/Others";
-export type { User } from "./types/User";
-export { WebsocketCloseCodes } from "./types/WebsocketCloseCodes";
 export type {
   PlainLson,
   PlainLsonFields,
@@ -124,6 +122,8 @@ export type {
   PlainLsonMap,
   PlainLsonObject,
 } from "./types/PlainLson";
+export type { User } from "./types/User";
+export { WebsocketCloseCodes } from "./types/WebsocketCloseCodes";
 
 /**
  * Helper type to help users adopt to Lson types from interface definitions.

--- a/packages/liveblocks-core/src/types/PlainLson.ts
+++ b/packages/liveblocks-core/src/types/PlainLson.ts
@@ -1,6 +1,7 @@
 /**
- * "Plain LSON" is a JSON-based format that's used in the API endpoint to let
- * users upload their initial Room storage.
+ * "Plain LSON" is a JSON-based format that's used when serializing Live structures
+ * to send them over HTTP (e.g. in the API endpoint to let users upload their initial
+ * Room storage, in the API endpoint to fetch a Room's storage, ...).
  *
  * In the client, you would typically create LSON values using:
  *

--- a/packages/liveblocks-core/src/types/PlainLson.ts
+++ b/packages/liveblocks-core/src/types/PlainLson.ts
@@ -1,0 +1,68 @@
+/**
+ * "Plain LSON" is a JSON-based format that's used in the API endpoint to let
+ * users upload their initial Room storage.
+ *
+ * In the client, you would typically create LSON values using:
+ *
+ *    new LiveObject({ x: 0, y: 0 })
+ *
+ * But over HTTP, this has to be serialized somehow. The "Plain LSON" format
+ * is what's used in the POST /init-storage-new endpoint, to allow users to
+ * control which parts of their data structure should be considered "Live"
+ * objects, and which parts are "normal" objects.
+ *
+ * So if they have a structure like:
+ *
+ *    { x: 0, y: 0 }
+ *
+ * And want to make it a Live object, they can serialize it by wrapping it in
+ * a special "annotation":
+ *
+ *    {
+ *      "liveblocksType": "LiveObject",
+ *      "data": { x: 0, y: 0 },
+ *    }
+ *
+ * This "Plain LSON" data format defines exactly those wrappings.
+ *
+ * To summarize:
+ *
+ *   LSON value            |  Plain LSON equivalent
+ *   ----------------------+----------------------------------------------
+ *   42                    |  42
+ *   [1, 2, 3]             |  [1, 2, 3]
+ *   { x: 0, y: 0 }        |  { x: 0, y: 0 }
+ *   ----------------------+----------------------------------------------
+ *   new LiveList(...)     |  { liveblocksType: "LiveList",   data: ... }
+ *   new LiveMap(...)      |  { liveblocksType: "LiveMap",    data: ... }
+ *   new LiveObject(...)   |  { liveblocksType: "LiveObject", data: ... }
+ *
+ */
+
+import type { Json } from "../lib/Json";
+
+export type PlainLsonFields = Record<string, PlainLson>;
+
+export type PlainLsonObject = {
+  liveblocksType: "LiveObject";
+  data: PlainLsonFields;
+};
+
+export type PlainLsonMap = {
+  liveblocksType: "LiveMap";
+  data: PlainLsonFields;
+};
+
+export type PlainLsonList = {
+  liveblocksType: "LiveList";
+  data: PlainLson[];
+};
+
+export type PlainLson =
+  | PlainLsonObject
+  | PlainLsonMap
+  | PlainLsonList
+
+  // Any "normal" Json value, as long as it's not an object with
+  // a `liveblocksType` field :)
+  | Json;


### PR DESCRIPTION
This PR adds and exposes `PlainLson` types from `@liveblocks/core` so that they can be shared and used across multiple Liveblocks projects.

@nvie I wasn't exactly sure about the difference between living under `protocol` and `types` in this case (the types are generic but not too much).