### PR TITLE
Fix some typos in README instructions

### DIFF
--- a/examples/react-dashboard/README.md
+++ b/examples/react-dashboard/README.md
@@ -72,6 +72,6 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>

--- a/examples/react-dashboard/README.md
+++ b/examples/react-dashboard/README.md
@@ -35,8 +35,8 @@ This will download the example and install the example. Next, you must:
 
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) with your **public** key
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -49,8 +49,8 @@ Alternatively, you can set up your project manually:
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) with your **public** key
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -37,8 +37,8 @@ This will download the example and install the example. Next, you must:
 
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) with your **public** key
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -51,8 +51,8 @@ Alternatively, you can set up your project manually:
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) with your **public** key
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -74,7 +74,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/react-whiteboard/README.md
+++ b/examples/react-whiteboard/README.md
@@ -36,8 +36,8 @@ This will download the example and install the example. Next, you must:
 
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) with your **public** key
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -50,8 +50,8 @@ Alternatively, you can set up your project manually:
 - Install all dependencies with `npm install`
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
-- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./src/liveblocks.config.js) with your **public** key
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/react-whiteboard/README.md
+++ b/examples/react-whiteboard/README.md
@@ -73,7 +73,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`liveblocks.config.js`](./liveblocks.config.js) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/redux-todo-list/README.md
+++ b/examples/redux-todo-list/README.md
@@ -39,7 +39,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -53,7 +53,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 
@@ -75,7 +75,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/redux-whiteboard/README.md
+++ b/examples/redux-whiteboard/README.md
@@ -39,7 +39,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -53,7 +53,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 
@@ -75,7 +75,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.js`](./src/store.js) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/solidjs-live-avatars/README.md
+++ b/examples/solidjs-live-avatars/README.md
@@ -37,7 +37,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run dev` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -51,7 +51,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run dev` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/solidjs-live-avatars/README.md
+++ b/examples/solidjs-live-avatars/README.md
@@ -73,7 +73,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run dev` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -37,7 +37,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run dev` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -51,7 +51,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run dev` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/solidjs-live-cursors/README.md
+++ b/examples/solidjs-live-cursors/README.md
@@ -73,7 +73,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/index.jsx`](./src/index.jsx) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run dev` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -72,7 +72,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/App.vue`](./src/App.vue) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:8000` in your browser
+- Run `npm run serve` and open `http://localhost:8000` in your browser
 
 </details>
 

--- a/examples/vuejs-live-cursors/README.md
+++ b/examples/vuejs-live-cursors/README.md
@@ -36,7 +36,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/App.vue`](./src/App.vue) with your **public** key
-- Run `npm run build` and open `http://localhost:8000` in your browser
+- Run `npm run serve` and open `http://localhost:8000` in your browser
 
 ### Manual setup
 
@@ -50,7 +50,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/App.vue`](./src/App.vue) with your **public** key
-- Run `npm run build` and open `http://localhost:8000` in your browser
+- Run `npm run serve` and open `http://localhost:8000` in your browser
 
 </details>
 

--- a/examples/zustand-todo-list/README.md
+++ b/examples/zustand-todo-list/README.md
@@ -39,7 +39,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -53,7 +53,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 
@@ -75,7 +75,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 

--- a/examples/zustand-whiteboard/README.md
+++ b/examples/zustand-whiteboard/README.md
@@ -39,7 +39,7 @@ This will download the example and install the example. Next, you must:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 ### Manual setup
 
@@ -53,7 +53,7 @@ Alternatively, you can set up your project manually:
 - Create an account on [liveblocks.io](https://liveblocks.io/dashboard)
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 
@@ -75,7 +75,7 @@ This will download the example and ask permission to open your browser, enabling
 - Copy your **public** key from the [dashboard](https://liveblocks.io/dashboard/apikeys)
 - Replace `pk_YOUR_PUBLIC_KEY` in [`src/store.ts`](./src/store.ts) with your **public** key
 - Push a commit to update the Vercel demo with the key
-- Run `npm run build` and open `http://localhost:3000` in your browser
+- Run `npm run start` and open `http://localhost:3000` in your browser
 
 </details>
 


### PR DESCRIPTION
I noticed these while following the instructions. Not sure if the Starter Kit ones use different commands to run them locally, but I don't think so?

Depending on which project type, there is variation between `dev`, `serve`, `start`, and `run` 😬 