### PR TITLE
Update Discord links in documebntation

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -10,7 +10,7 @@
   <a href="https://twitter.com/liveblocks">
     <img src="https://img.shields.io/badge/liveblocks-message?style=flat&logo=twitter&color=555&logoColor=fff" alt="Twitter" />
   </a>
-  <a href="https://discord.gg/X4YWJuH9VY">
+  <a href="https://liveblocks.io/discord">
     <img src="https://img.shields.io/discord/913109211746009108?style=flat&label=discord&logo=discord&color=85f&logoColor=fff" alt="Discord" />
   </a>
     <a href="https://www.youtube.com/channel/UCDXT5skWxzOorIQrWG5OT2w">

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://twitter.com/liveblocks">
     <img src="https://img.shields.io/badge/liveblocks-message?style=flat&logo=twitter&color=555&logoColor=fff" alt="Twitter" />
   </a>
-  <a href="https://discord.gg/X4YWJuH9VY">
+  <a href="https://liveblocks.io/discord">
     <img src="https://img.shields.io/discord/913109211746009108?style=flat&label=discord&logo=discord&color=85f&logoColor=fff" alt="Discord" />
   </a>
     <a href="https://www.youtube.com/channel/UCDXT5skWxzOorIQrWG5OT2w">
@@ -61,7 +61,8 @@ to help you get started.
 
 ## Releases
 
-See the latest changes [here](https://github.com/liveblocks/liveblocks/releases).
+See the latest changes
+[here](https://github.com/liveblocks/liveblocks/releases).
 
 ## Community
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -75,7 +75,7 @@ be happy to help.
   />
   <DocsCard
     title="Discord"
-    href="https://discord.gg/X4YWJuH9VY"
+    href="https://liveblocks.io/discord"
     description="Join our awesome community of developers on Discord to help and show off what you built."
     visual={<img alt="Discord" src="/images/docs/discord.svg" width={56} />}
     openInNewWindow

--- a/package-lock.json
+++ b/package-lock.json
@@ -16020,7 +16020,7 @@
     },
     "packages/liveblocks-devtools": {
       "name": "@liveblocks/devtools",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@liveblocks/core": "*",
         "@plasmohq/storage": "^0.14.0",

--- a/packages/liveblocks-client/README.md
+++ b/packages/liveblocks-client/README.md
@@ -51,7 +51,7 @@ learn more about
 
 ## Community
 
-- [Discord](https://discord.gg/X4YWJuH9VY) - To get involved with the Liveblocks
+- [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
 - [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
   blog posts, and general Liveblocks tips.

--- a/packages/liveblocks-devtools/README.md
+++ b/packages/liveblocks-devtools/README.md
@@ -43,7 +43,8 @@ Download the extension for your browser:
 1. Run `turbo build --filter @liveblocks/devtools` from the project root to
    build the browser extension
 1. Navigate to [chrome://extensions](chrome://extensions)
-1. Disable the production Liveblocks extension, if you already have it installed (it will conflict with the development version)
+1. Disable the production Liveblocks extension, if you already have it installed
+   (it will conflict with the development version)
 1. Enable "Developer mode"
 1. Click "Load unpacked" and select the outputted `dist/chrome-mv3-prod`
    directory (which contains the `manifest.json` file)
@@ -54,7 +55,8 @@ Download the extension for your browser:
    to build the browser extension
 1. Navigate to
    [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox)
-1. Disable the production Liveblocks extension, if you already have it installed (it will conflict with the development version)
+1. Disable the production Liveblocks extension, if you already have it installed
+   (it will conflict with the development version)
 1. Click "Load temporary add-on..." and select the `manifest.json` file within
    the outputted `dist/firefox-mv2-prod` directory
 
@@ -91,7 +93,7 @@ learn more about
 
 ## Community
 
-- [Discord](https://discord.gg/X4YWJuH9VY) - To get involved with the Liveblocks
+- [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
 - [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
   blog posts, and general Liveblocks tips.

--- a/packages/liveblocks-node/README.md
+++ b/packages/liveblocks-node/README.md
@@ -21,7 +21,8 @@
   </a>
 </p>
 
-A server-side utility that lets you set up a [Liveblocks](https://liveblocks.io) authentication endpoint.
+A server-side utility that lets you set up a [Liveblocks](https://liveblocks.io)
+authentication endpoint.
 
 ## Installation
 
@@ -31,25 +32,33 @@ npm install @liveblocks/node
 
 ## Documentation
 
-Read the [documentation](https://liveblocks.io/docs) for guides and API references.
+Read the [documentation](https://liveblocks.io/docs) for guides and API
+references.
 
 ## Examples
 
-Explore our [collaborative examples](https://liveblocks.io/examples) to help you get started.
+Explore our [collaborative examples](https://liveblocks.io/examples) to help you
+get started.
 
-> All examples are open-source and live in this repository, within [`/examples`](../../examples).
+> All examples are open-source and live in this repository, within
+> [`/examples`](../../examples).
 
 ## Releases
 
-See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or learn more about [upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
+See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or
+learn more about
+[upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
 
 ## Community
 
-- [Discord](https://discord.gg/X4YWJuH9VY) - To get involved with the Liveblocks community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements, blog posts, and general Liveblocks tips.
+- [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
+  community, ask questions and share tips.
+- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
+  blog posts, and general Liveblocks tips.
 
 ## License
 
-Licensed under the Apache License 2.0, Copyright © 2021-present [Liveblocks](https://liveblocks.io).
+Licensed under the Apache License 2.0, Copyright © 2021-present
+[Liveblocks](https://liveblocks.io).
 
 See [LICENSE](../../LICENSE) for more information.

--- a/packages/liveblocks-react/README.md
+++ b/packages/liveblocks-react/README.md
@@ -21,7 +21,8 @@
   </a>
 </p>
 
-A set of [React](https://reactjs.org/) hooks and providers to use [Liveblocks](https://liveblocks.io) declaratively.
+A set of [React](https://reactjs.org/) hooks and providers to use
+[Liveblocks](https://liveblocks.io) declaratively.
 
 ## Installation
 
@@ -31,25 +32,33 @@ npm install @liveblocks/client @liveblocks/react
 
 ## Documentation
 
-Read the [documentation](https://liveblocks.io/docs) for guides and API references.
+Read the [documentation](https://liveblocks.io/docs) for guides and API
+references.
 
 ## Examples
 
-Explore our [collaborative examples](https://liveblocks.io/examples) to help you get started.
+Explore our [collaborative examples](https://liveblocks.io/examples) to help you
+get started.
 
-> All examples are open-source and live in this repository, within [`/examples`](../../examples).
+> All examples are open-source and live in this repository, within
+> [`/examples`](../../examples).
 
 ## Releases
 
-See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or learn more about [upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
+See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or
+learn more about
+[upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
 
 ## Community
 
-- [Discord](https://discord.gg/X4YWJuH9VY) - To get involved with the Liveblocks community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements, blog posts, and general Liveblocks tips.
+- [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
+  community, ask questions and share tips.
+- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
+  blog posts, and general Liveblocks tips.
 
 ## License
 
-Licensed under the Apache License 2.0, Copyright © 2021-present [Liveblocks](https://liveblocks.io).
+Licensed under the Apache License 2.0, Copyright © 2021-present
+[Liveblocks](https://liveblocks.io).
 
 See [LICENSE](../../LICENSE) for more information.

--- a/packages/liveblocks-redux/README.md
+++ b/packages/liveblocks-redux/README.md
@@ -21,7 +21,10 @@
   </a>
 </p>
 
-A [store enhancer](https://redux.js.org/understanding/thinking-in-redux/glossary#store-enhancer) to integrate [Liveblocks](https://liveblocks.io) into [Redux](https://redux-toolkit.js.org/) stores.
+A
+[store enhancer](https://redux.js.org/understanding/thinking-in-redux/glossary#store-enhancer)
+to integrate [Liveblocks](https://liveblocks.io) into
+[Redux](https://redux-toolkit.js.org/) stores.
 
 ## Installation
 
@@ -31,25 +34,33 @@ npm install @liveblocks/client @liveblocks/redux
 
 ## Documentation
 
-Read the [documentation](https://liveblocks.io/docs) for guides and API references.
+Read the [documentation](https://liveblocks.io/docs) for guides and API
+references.
 
 ## Examples
 
-Explore our [collaborative examples](https://liveblocks.io/examples) to help you get started.
+Explore our [collaborative examples](https://liveblocks.io/examples) to help you
+get started.
 
-> All examples are open-source and live in this repository, within [`/examples`](../../examples).
+> All examples are open-source and live in this repository, within
+> [`/examples`](../../examples).
 
 ## Releases
 
-See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or learn more about [upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
+See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or
+learn more about
+[upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
 
 ## Community
 
-- [Discord](https://discord.gg/X4YWJuH9VY) - To get involved with the Liveblocks community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements, blog posts, and general Liveblocks tips.
+- [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
+  community, ask questions and share tips.
+- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
+  blog posts, and general Liveblocks tips.
 
 ## License
 
-Licensed under the Apache License 2.0, Copyright © 2021-present [Liveblocks](https://liveblocks.io).
+Licensed under the Apache License 2.0, Copyright © 2021-present
+[Liveblocks](https://liveblocks.io).
 
 See [LICENSE](../../LICENSE) for more information.

--- a/packages/liveblocks-zustand/README.md
+++ b/packages/liveblocks-zustand/README.md
@@ -21,7 +21,9 @@
   </a>
 </p>
 
-A [middleware](https://github.com/pmndrs/zustand#middleware) to integrate [Liveblocks](https://liveblocks.io) into [Zustand](https://github.com/pmndrs/zustand) stores.
+A [middleware](https://github.com/pmndrs/zustand#middleware) to integrate
+[Liveblocks](https://liveblocks.io) into
+[Zustand](https://github.com/pmndrs/zustand) stores.
 
 ## Installation
 
@@ -31,25 +33,33 @@ npm install @liveblocks/client @liveblocks/zustand
 
 ## Documentation
 
-Read the [documentation](https://liveblocks.io/docs) for guides and API references.
+Read the [documentation](https://liveblocks.io/docs) for guides and API
+references.
 
 ## Examples
 
-Explore our [collaborative examples](https://liveblocks.io/examples) to help you get started.
+Explore our [collaborative examples](https://liveblocks.io/examples) to help you
+get started.
 
-> All examples are open-source and live in this repository, within [`/examples`](../../examples).
+> All examples are open-source and live in this repository, within
+> [`/examples`](../../examples).
 
 ## Releases
 
-See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or learn more about [upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
+See the [latest changes](https://github.com/liveblocks/liveblocks/releases) or
+learn more about
+[upcoming releases](https://github.com/liveblocks/liveblocks/milestones).
 
 ## Community
 
-- [Discord](https://discord.gg/X4YWJuH9VY) - To get involved with the Liveblocks community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements, blog posts, and general Liveblocks tips.
+- [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
+  community, ask questions and share tips.
+- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
+  blog posts, and general Liveblocks tips.
 
 ## License
 
-Licensed under the Apache License 2.0, Copyright © 2021-present [Liveblocks](https://liveblocks.io).
+Licensed under the Apache License 2.0, Copyright © 2021-present
+[Liveblocks](https://liveblocks.io).
 
 See [LICENSE](../../LICENSE) for more information.


### PR DESCRIPTION
As per [this comment on Discord](https://discord.com/channels/913109211746009108/1083419180734369802/1083422053039878236), the links to Discord were broken from the documentation.