### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/pages/tutorials/collaborative-to-do-list/react.mdx
+++ b/docs/pages/tutorials/collaborative-to-do-list/react.mdx
@@ -487,7 +487,7 @@ import { createClient, LiveList } from "@liveblocks/client";
 // ...
 
 type Storage = {
-  todos: new LiveList<{ text: string }>;
+  todos: LiveList<{ text: string }>;
 };
 
 export const {


### PR DESCRIPTION
Fixes a reported typo in our todo list tutorial.