### PR TITLE
Remove ambiguity from `shouldQueueEventIfNotReady` warning

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -233,14 +233,14 @@ be listened to with [`Room.subscribe("event")`][]. Takes a payload as first
 argument. Should be serializable to JSON.
 
 By default, broadcasting an event acts as a “fire and forget”. If the user is
-not currently in the room, the event is simply discarded. With the option
-`shouldQueueEventIfNotReady` , the event will be queued and sent once the
-connection is established.
+not currently in the room, the event is simply discarded. Passing the
+`shouldQueueEventIfNotReady` option will queue the event, before sending it once
+the connection is established.
 
 <Banner title="Notice">
 
-We are not sure if we want to support this option in the future so it might be
-deprecated to be replaced by something else.
+We’re not sure if we want to support `shouldQueueEventIfNotReady` in the future,
+so it may be deprecated and replaced with something else.
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -228,8 +228,8 @@ for (const { connectionId, id, info, presence, isReadOnly } of others) {
 
 ### Room.broadcastEvent
 
-Broadcast an event to other users in the Room. Event broadcasted to the room can
-be listened with [`Room.subscribe("event")`][]. Takes a payload as first
+Broadcast an event to other users in the Room. Events broadcast to the room can
+be listened to with [`Room.subscribe("event")`][]. Takes a payload as first
 argument. Should be serializable to JSON.
 
 By default, broadcasting an event acts as a “fire and forget”. If the user is


### PR DESCRIPTION
The notice didn't mention `shouldQueueEventIfNotReady` before.

![chrome_U5Sx7o5GfI](https://user-images.githubusercontent.com/33033422/227490015-75b8a4c3-e465-4abe-a3a9-072239308cd4.png)
