### PR TITLE
Extend todo list demo app with ability to cross off items

### DIFF
--- a/examples/nextjs-todo-list/liveblocks.config.ts
+++ b/examples/nextjs-todo-list/liveblocks.config.ts
@@ -22,6 +22,7 @@ type Storage = {
 
 type Todo = {
   text: string;
+  checked?: boolean;
 };
 
 // Optionally, UserMeta represents static/readonly metadata on each User, as

--- a/examples/nextjs-todo-list/liveblocks.config.ts
+++ b/examples/nextjs-todo-list/liveblocks.config.ts
@@ -1,4 +1,4 @@
-import { createClient, LiveList } from "@liveblocks/client";
+import { createClient, LiveList, LiveObject } from "@liveblocks/client";
 import { createRoomContext } from "@liveblocks/react";
 
 const client = createClient({
@@ -17,7 +17,7 @@ type Presence = {
 // LiveList, LiveMap, LiveObject instances, for which updates are
 // automatically persisted and synced to all connected clients.
 type Storage = {
-  todos: LiveList<Todo>;
+  todos: LiveList<LiveObject<Todo>>;
 };
 
 type Todo = {

--- a/examples/nextjs-todo-list/pages/index.tsx
+++ b/examples/nextjs-todo-list/pages/index.tsx
@@ -7,7 +7,7 @@ import {
   useMutation,
 } from "../liveblocks.config";
 import "@liveblocks/react";
-import { LiveList } from "@liveblocks/client";
+import { LiveList, LiveObject } from "@liveblocks/client";
 import { useRouter } from "next/router";
 import { ClientSideSuspense } from "@liveblocks/react";
 
@@ -37,7 +37,7 @@ function Example() {
   const todos = useStorage((root) => root.todos);
 
   const addTodo = useMutation(({ storage }, text) => {
-    storage.get("todos").push({ text });
+    storage.get("todos").push(new LiveObject({ text }));
   }, []);
 
   const deleteTodo = useMutation(({ storage }, index) => {

--- a/examples/nextjs-todo-list/pages/index.tsx
+++ b/examples/nextjs-todo-list/pages/index.tsx
@@ -40,6 +40,11 @@ function Example() {
     storage.get("todos").push(new LiveObject({ text }));
   }, []);
 
+  const toggleTodo = useMutation(({ storage }, index) => {
+    const todo = storage.get("todos").get(index);
+    todo?.set("checked", !todo.get("checked"));
+  }, []);
+
   const deleteTodo = useMutation(({ storage }, index) => {
     storage.get("todos").delete(index);
   }, []);
@@ -68,7 +73,16 @@ function Example() {
       {todos.map((todo, index) => {
         return (
           <div key={index} className="todo_container">
-            <div className="todo">{todo.text}</div>
+            <div className="todo" onClick={() => toggleTodo(index)}>
+              <span
+                style={{
+                  cursor: "pointer",
+                  textDecoration: todo.checked ? "line-through" : undefined,
+                }}
+              >
+                {todo.text}
+              </span>
+            </div>
             <button className="delete_button" onClick={() => deleteTodo(index)}>
               ✕
             </button>

--- a/examples/nextjs-todo-list/pages/index.tsx
+++ b/examples/nextjs-todo-list/pages/index.tsx
@@ -102,7 +102,7 @@ function Loading() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-todo-list");
+  const roomId = useOverrideRoomId("nextjs-todo-list-v2");
 
   return (
     <RoomProvider

--- a/examples/nextjs-todo-list/pages/index.tsx
+++ b/examples/nextjs-todo-list/pages/index.tsx
@@ -61,7 +61,7 @@ function Example() {
           updateMyPresence({ isTyping: true });
         }}
         onKeyDown={(e) => {
-          if (e.key === "Enter") {
+          if (draft && e.key === "Enter") {
             updateMyPresence({ isTyping: false });
             addTodo(draft);
             setDraft("");


### PR DESCRIPTION
Here is a slightly modified version of our Todo list example app, with the ability to cross items off. I've done this to facilitate a simpler demo for schema validation to record for Taylor, and this app can be used as a foundation to show how to make the `checked` property required.

The app is improved in such a way that I think it's a better demo app anyway, even without schema validation in mind.

Here is the new behavior, see:

https://user-images.githubusercontent.com/83844/228759143-f62e34c7-f371-4bc0-ab05-73b7c32ed604.mp4

The updates:

1. Makes every todo list item a `LiveObject`, rather than a JSON object (more idiomatic Liveblocks)
2. Adds an optional `checked` boolean on there that gets toggled on click

I've also fixed a bug where submitting the empty text was possible. (You could hold down Enter in the previous version to create thousands of items per second 😬)
