### PR TITLE
Show a union of string literals in the example

### DIFF
--- a/docs/pages/guides/schema-validation/syntax.mdx
+++ b/docs/pages/guides/schema-validation/syntax.mdx
@@ -220,7 +220,7 @@ For example:
 type Shape {
   x: number
   y: number
-  fill: string
+  fill: "red" | "yellow" | "blue"
 }
 
 type Storage {


### PR DESCRIPTION
Update one of the examples in the Schema Validation syntax guide to show an example of a literal type. Without adding a whole new section and calling much attention to it, I think this will be familiar enough for people to understand they can use this feature.
