### PR TITLE
Fix bug where `shouldInitiallyConnect` config option would not always work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.2
+
+Fix bug where passing down `shouldInitiallyConnect` connection option would not
+always work.
+
 # v1.0.1
 
 Log stack traces of function calls that resulted in rejected storage mutations

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -57,7 +57,7 @@ export type Client = {
     TRoomEvent extends Json = never
   >(
     roomId: string,
-    options: RoomInitializers<TPresence, TStorage>
+    options: EnterOptions<TPresence, TStorage>
   ): Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
 
   /**

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2489,7 +2489,10 @@ export function createRoom<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 >(
-  options: RoomInitializers<TPresence, TStorage>,
+  options: Omit<
+    RoomInitializers<TPresence, TStorage>,
+    "shouldInitiallyConnect"
+  >,
   config: Config
 ): InternalRoom<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const { initialPresence, initialStorage } = options;

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -186,7 +186,7 @@ export function createRoomContext<
           initialPresence: frozen.initialPresence,
           initialStorage: frozen.initialStorage,
           unstable_batchedUpdates: frozen.unstable_batchedUpdates,
-          withoutConnecting: frozen.shouldInitiallyConnect,
+          shouldInitiallyConnect: frozen.shouldInitiallyConnect,
         } as RoomInitializers<TPresence, TStorage>)
       );
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -12,7 +12,7 @@ import type {
   User,
 } from "@liveblocks/client";
 import { shallow } from "@liveblocks/client";
-import type { RoomInitializers, ToImmutable } from "@liveblocks/core";
+import type { ToImmutable } from "@liveblocks/core";
 import {
   asArrayWithLegacyMethods,
   deprecateIf,
@@ -175,9 +175,9 @@ export function createRoomContext<
       client.enter(roomId, {
         initialPresence: frozen.initialPresence,
         initialStorage: frozen.initialStorage,
-        unstable_batchedUpdates: frozen.unstable_batchedUpdates,
         shouldInitiallyConnect: frozen.shouldInitiallyConnect,
-      } as RoomInitializers<TPresence, TStorage>)
+        unstable_batchedUpdates: frozen.unstable_batchedUpdates,
+      })
     );
 
     React.useEffect(() => {
@@ -185,9 +185,9 @@ export function createRoomContext<
         client.enter(roomId, {
           initialPresence: frozen.initialPresence,
           initialStorage: frozen.initialStorage,
-          unstable_batchedUpdates: frozen.unstable_batchedUpdates,
           shouldInitiallyConnect: frozen.shouldInitiallyConnect,
-        } as RoomInitializers<TPresence, TStorage>)
+          unstable_batchedUpdates: frozen.unstable_batchedUpdates,
+        })
       );
 
       return () => {


### PR DESCRIPTION
We forgot to update the old `withoutConnecting` name in the useEffect callback. In this case, the bug would only get surfaced in React Strict Mode, where an application using `<RoomProvider id="abc" shouldInitiallyConnect={false}>...</RoomProvider>` would _still_ connect eventually (on the second render, as triggered by React Strict Mode).

This has been a search & replace overlook, and TypeScript didn't catch it for us because we were annotating the type manually instead of using inference 🙈 