### PR TITLE
Naming cleanup of test helpers

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_updatesUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_updatesUtils.ts
@@ -51,6 +51,10 @@ export type JsonLiveMapUpdate<TKey extends string, TValue extends Lson> = {
   updates: { [key: string]: UpdateDelta };
 };
 
+it("Always passes", () => {
+  /* This bogus test just makes Jest less naggy about this module missing any tests */
+});
+
 export function liveListUpdateToJson<TItem extends Lson>(
   update: LiveListUpdates<TItem>
 ): JsonLiveListUpdate<TItem> {

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -242,7 +242,7 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
     ws,
     expectStorage: (data: ToImmutable<TStorage>) =>
       expect(storage.root.toImmutable()).toEqual(data),
-    assertMessagesSent: (messages: ClientMsg<JsonObject, Json>[]) => {
+    expectMessagesSent: (messages: ClientMsg<JsonObject, Json>[]) => {
       expect(messagesSent).toEqual(messages);
     },
     applyRemoteOperations: (ops: Op[]) =>

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -449,7 +449,7 @@ export function prepareStorageUpdateTest<
     batch: (fn: () => void) => void;
     root: LiveObject<TStorage>;
     machine: Machine<TPresence, TStorage, TUserMeta, TRoomEvent>;
-    assert: (updates: JsonStorageUpdate[][]) => void;
+    expectUpdates: (updates: JsonStorageUpdate[][]) => void;
   }) => Promise<void>
 ): () => Promise<void> {
   return async () => {
@@ -494,7 +494,7 @@ export function prepareStorageUpdateTest<
       { isDeep: true }
     );
 
-    function assert(updates: JsonStorageUpdate[][]) {
+    function expectUpdatesInBothClients(updates: JsonStorageUpdate[][]) {
       expect(jsonUpdates).toEqual(updates);
       expect(refJsonUpdates).toEqual(updates);
     }
@@ -503,7 +503,7 @@ export function prepareStorageUpdateTest<
       batch: machine.batch,
       root: storage.root,
       machine,
-      assert,
+      expectUpdates: expectUpdatesInBothClients,
     });
   };
 }
@@ -522,7 +522,7 @@ export function prepareDisconnectedStorageUpdateTest<
     batch: (fn: () => void) => void;
     root: LiveObject<TStorage>;
     machine: Machine<TPresence, TStorage, TUserMeta, TRoomEvent>;
-    assert: (updates: JsonStorageUpdate[][]) => void;
+    expectUpdates: (updates: JsonStorageUpdate[][]) => void;
   }) => Promise<void>
 ): () => Promise<void> {
   return async () => {
@@ -533,23 +533,23 @@ export function prepareDisconnectedStorageUpdateTest<
       TRoomEvent
     >(items, -1);
 
-    const jsonUpdates: JsonStorageUpdate[][] = [];
+    const receivedUpdates: JsonStorageUpdate[][] = [];
 
     machine.subscribe(
       storage.root,
-      (updates) => jsonUpdates.push(updates.map(serializeUpdateToJson)),
+      (updates) => receivedUpdates.push(updates.map(serializeUpdateToJson)),
       { isDeep: true }
     );
 
-    function assert(updates: JsonStorageUpdate[][]) {
-      expect(jsonUpdates).toEqual(updates);
+    function expectUpdates(updates: JsonStorageUpdate[][]) {
+      expect(receivedUpdates).toEqual(updates);
     }
 
     await callback({
       batch: machine.batch,
       root: storage.root,
       machine,
-      assert,
+      expectUpdates,
     });
   };
 }

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -240,7 +240,7 @@ export async function prepareIsolatedStorageTest<TStorage extends LsonObject>(
     undo: machine.undo,
     redo: machine.redo,
     ws,
-    assert: (data: ToImmutable<TStorage>) =>
+    expectStorage: (data: ToImmutable<TStorage>) =>
       expect(storage.root.toImmutable()).toEqual(data),
     assertMessagesSent: (messages: ClientMsg<JsonObject, Json>[]) => {
       expect(messagesSent).toEqual(messages);
@@ -344,32 +344,31 @@ export async function prepareStorageTest<
 
   const states: ToImmutable<TStorage>[] = [];
 
-  function assertState(data: ToImmutable<TStorage>) {
-    const imm = storage.root.toImmutable();
-    expect(imm).toEqual(data);
+  function expectBothClientStoragesToEqual(data: ToImmutable<TStorage>) {
+    expect(storage.root.toImmutable()).toEqual(data);
     expect(refStorage.root.toImmutable()).toEqual(data);
     expect(machine.getItemsCount()).toBe(refMachine.getItemsCount());
   }
 
-  function assert(data: ToImmutable<TStorage>) {
+  function expectStorage(data: ToImmutable<TStorage>) {
     states.push(data);
-    assertState(data);
+    expectBothClientStoragesToEqual(data);
   }
 
   function assertUndoRedo() {
     for (let i = 0; i < states.length - 1; i++) {
       machine.undo();
-      assertState(states[states.length - 2 - i]);
+      expectBothClientStoragesToEqual(states[states.length - 2 - i]);
     }
 
     for (let i = 0; i < states.length - 1; i++) {
       machine.redo();
-      assertState(states[i + 1]);
+      expectBothClientStoragesToEqual(states[i + 1]);
     }
 
     for (let i = 0; i < states.length - 1; i++) {
       machine.undo();
-      assertState(states[states.length - 2 - i]);
+      expectBothClientStoragesToEqual(states[states.length - 2 - i]);
     }
   }
 
@@ -412,7 +411,7 @@ export async function prepareStorageTest<
     operations,
     storage,
     refStorage,
-    assert,
+    expectStorage,
     assertUndoRedo,
     updatePresence: machine.updatePresence,
     getUndoStack: machine.getUndoStack,

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -87,7 +87,7 @@ export async function prepareStorageImmutableTest<
     itemsCount?: number,
     storageOpsCount?: number
   ) {
-    assertStorage(data);
+    expectStorageInBothClients(data);
 
     if (itemsCount !== undefined) {
       expect(machine.getItemsCount()).toBe(itemsCount);
@@ -100,7 +100,7 @@ export async function prepareStorageImmutableTest<
     }
   }
 
-  function assertStorage(data: ToJson<TStorage>) {
+  function expectStorageInBothClients(data: ToJson<TStorage>) {
     const json = lsonToJson(storage.root);
     expect(json).toEqual(data);
     expect(lsonToJson(refStorage.root)).toEqual(data);
@@ -110,7 +110,7 @@ export async function prepareStorageImmutableTest<
     storage,
     refStorage,
     assert,
-    assertStorage,
+    expectStorage: expectStorageInBothClients,
     subscribe: machine.subscribe,
     refSubscribe: refMachine.subscribe,
     state,
@@ -659,7 +659,7 @@ describe("2 ways tests with two clients", () => {
     });
 
     test("new state contains a function", async () => {
-      const { storage, state, assertStorage } =
+      const { storage, state, expectStorage } =
         await prepareStorageImmutableTest<{ syncObj: { a: any } }>(
           [
             createSerializedObject("0:0", {}),
@@ -683,7 +683,7 @@ describe("2 ways tests with two clients", () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
 
-      assertStorage({ syncObj: { a: 0 } });
+      expectStorage({ syncObj: { a: 0 } });
     });
 
     test("Production env - new state contains a function", async () => {

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -82,7 +82,7 @@ export async function prepareStorageImmutableTest<
     { isDeep: true }
   );
 
-  function assert(
+  function expectStorageAndStateInBothClients(
     data: ToJson<TStorage>,
     itemsCount?: number,
     storageOpsCount?: number
@@ -109,7 +109,7 @@ export async function prepareStorageImmutableTest<
   return {
     storage,
     refStorage,
-    assert,
+    expectStorageAndState: expectStorageAndStateInBothClients,
     expectStorage: expectStorageInBothClients,
     subscribe: machine.subscribe,
     refSubscribe: refMachine.subscribe,
@@ -158,9 +158,10 @@ describe("patchLiveObjectKey", () => {
 describe("2 ways tests with two clients", () => {
   describe("Object/LiveObject", () => {
     test("create object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a: number };
-      }>([createSerializedObject("0:0", {})], 1);
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncObj: { a: number };
+        }>([createSerializedObject("0:0", {})], 1);
 
       expect(state).toEqual({});
 
@@ -175,19 +176,20 @@ describe("2 ways tests with two clients", () => {
         newState["syncObj"]
       );
 
-      assert({ syncObj: { a: 1 } }, 2, 1);
+      expectStorageAndState({ syncObj: { a: 1 } }, 2, 1);
     });
 
     test("update object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a: number };
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncObj: { a: number };
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
+          ],
+          1
+        );
 
       expect(state).toEqual({ syncObj: { a: 0 } });
 
@@ -202,19 +204,20 @@ describe("2 ways tests with two clients", () => {
         newState["syncObj"]
       );
 
-      assert({ syncObj: { a: 1 } }, 2, 1);
+      expectStorageAndState({ syncObj: { a: 1 } }, 2, 1);
     });
 
     test("add nested object", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a: any };
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncObj: { a: any };
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
+          ],
+          1
+        );
 
       expect(state).toEqual({ syncObj: { a: 0 } });
 
@@ -229,19 +232,20 @@ describe("2 ways tests with two clients", () => {
         newState["syncObj"]
       );
 
-      assert({ syncObj: { a: { subA: "ok" } } }, 3, 1);
+      expectStorageAndState({ syncObj: { a: { subA: "ok" } } }, 3, 1);
     });
 
     test("create LiveList with one LiveRegister item in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        doc: any;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", {}, "0:0", "doc"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          doc: any;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", {}, "0:0", "doc"),
+          ],
+          1
+        );
 
       expect(state).toEqual({ doc: {} });
 
@@ -251,19 +255,20 @@ describe("2 ways tests with two clients", () => {
 
       patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
 
-      assert({ doc: { sub: [0] } }, 4, 2);
+      expectStorageAndState({ doc: { sub: [0] } }, 4, 2);
     });
 
     test("create nested LiveList with one LiveObject item in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        doc: any;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", {}, "0:0", "doc"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          doc: any;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", {}, "0:0", "doc"),
+          ],
+          1
+        );
 
       expect(state).toEqual({ doc: {} });
 
@@ -273,19 +278,20 @@ describe("2 ways tests with two clients", () => {
 
       patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
 
-      assert({ doc: { sub: { subSub: [{ a: 1 }] } } }, 5, 3);
+      expectStorageAndState({ doc: { sub: { subSub: [{ a: 1 }] } } }, 5, 3);
     });
 
     test("Add nested objects in same batch", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        doc: any;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", {}, "0:0", "doc"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          doc: any;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", {}, "0:0", "doc"),
+          ],
+          1
+        );
 
       expect(state).toEqual({ doc: {} });
 
@@ -295,19 +301,20 @@ describe("2 ways tests with two clients", () => {
 
       patchLiveObjectKey(storage.root, "doc", oldState["doc"], newState["doc"]);
 
-      assert({ doc: { pos: { a: { b: 1 } } } }, 4, 2);
+      expectStorageAndState({ doc: { pos: { a: { b: 1 } } } }, 4, 2);
     });
 
     test("delete object key", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncObj: { a?: number };
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncObj: { a?: number };
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", { a: 0 }, "0:0", "syncObj"),
+          ],
+          1
+        );
 
       expect(state).toEqual({ syncObj: { a: 0 } });
 
@@ -322,24 +329,25 @@ describe("2 ways tests with two clients", () => {
         newState["syncObj"]
       );
 
-      assert({ syncObj: {} }, 2, 1);
+      expectStorageAndState({ syncObj: {} }, 2, 1);
     });
   });
 
   describe("Array/LiveList", () => {
     test("replace array of 3 elements to 1 element", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<number>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, 1),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, 1),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, 1),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<number>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, 1),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, 1),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, 1),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList = [2];
@@ -352,19 +360,20 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: [2] });
+      expectStorageAndState({ syncList: [2] });
     });
 
     test("add item to array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList.push("a");
@@ -377,22 +386,23 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["a"] }, 3, 1);
+      expectStorageAndState({ syncList: ["a"] }, 3, 1);
     });
 
     test("replace first item in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        list: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "list"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          list: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "list"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.list[0] = "D";
@@ -400,22 +410,23 @@ describe("2 ways tests with two clients", () => {
 
       patchLiveObject(storage.root, oldState, newState);
 
-      assert({ list: ["D", "B", "C"] }, 5, 1);
+      expectStorageAndState({ list: ["D", "B", "C"] }, 5, 1);
     });
 
     test("replace last item in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        list: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "list"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          list: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "list"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.list[2] = "D";
@@ -423,20 +434,21 @@ describe("2 ways tests with two clients", () => {
 
       patchLiveObject(storage.root, oldState, newState);
 
-      assert({ list: ["A", "B", "D"] }, 5, 1);
+      expectStorageAndState({ list: ["A", "B", "D"] }, 5, 1);
     });
 
     test("insert item at beginning of array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList.unshift("b");
@@ -449,23 +461,24 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["b", "a"] }, 4, 1);
+      expectStorageAndState({ syncList: ["b", "a"] }, 4, 1);
     });
 
     test("swap items in array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
-          createSerializedRegister("0:5", "0:1", FOURTH_POSITION, "d"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
+            createSerializedRegister("0:5", "0:1", FOURTH_POSITION, "d"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList = ["d", "b", "c", "a"];
@@ -478,20 +491,21 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["d", "b", "c", "a"] }, 6, 4);
+      expectStorageAndState({ syncList: ["d", "b", "c", "a"] }, 6, 4);
     });
 
     test("array of objects", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<LiveObject<{ a: number }>>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedObject("0:2", { a: 1 }, "0:1", FIRST_POSITION),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<LiveObject<{ a: number }>>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedObject("0:2", { a: 1 }, "0:1", FIRST_POSITION),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList[0].a = 2;
@@ -504,21 +518,22 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: [{ a: 2 }] }, 3, 1);
+      expectStorageAndState({ syncList: [{ a: 2 }] }, 3, 1);
     });
 
     test("remove first item from array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList.shift();
@@ -531,21 +546,22 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["b"] }, 3, 1);
+      expectStorageAndState({ syncList: ["b"] }, 3, 1);
     });
 
     test("remove last item from array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList.pop();
@@ -558,22 +574,23 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["a"] }, 3, 1);
+      expectStorageAndState({ syncList: ["a"] }, 3, 1);
     });
 
     test("remove all elements of array except first", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList = ["a"];
@@ -586,21 +603,22 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["a"] }, 3, 2);
+      expectStorageAndState({ syncList: ["a"] }, 3, 2);
     });
     test("remove all elements of array except last", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList = ["c"];
@@ -613,21 +631,22 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: ["c"] }, 3, 2);
+      expectStorageAndState({ syncList: ["c"] }, 3, 2);
     });
     test("remove all elements of array", async () => {
-      const { storage, state, assert } = await prepareStorageImmutableTest<{
-        syncList: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "syncList"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
-        ],
-        1
-      );
+      const { storage, state, expectStorageAndState } =
+        await prepareStorageImmutableTest<{
+          syncList: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "syncList"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "c"),
+          ],
+          1
+        );
 
       const { oldState, newState } = applyStateChanges(state, () => {
         state.syncList = [];
@@ -640,7 +659,7 @@ describe("2 ways tests with two clients", () => {
         newState["syncList"]
       );
 
-      assert({ syncList: [] }, 2, 3);
+      expectStorageAndState({ syncList: [] }, 2, 3);
     });
   });
 

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -89,13 +89,13 @@ export async function prepareStorageImmutableTest<
   ) {
     assertStorage(data);
 
-    if (itemsCount) {
+    if (itemsCount !== undefined) {
       expect(machine.getItemsCount()).toBe(itemsCount);
     }
     expect(state).toEqual(refState);
     expect(state).toEqual(data);
 
-    if (storageOpsCount) {
+    if (storageOpsCount !== undefined) {
       expect(totalStorageOps).toEqual(storageOpsCount);
     }
   }

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1652,7 +1652,7 @@ describe("room", () => {
 
   describe("initial storage", () => {
     test("initialize room with initial storage should send operation only once", async () => {
-      const { expectStorage, assertMessagesSent } =
+      const { expectStorage, expectMessagesSent } =
         await prepareIsolatedStorageTest<{
           items: LiveList<string>;
         }>([createSerializedObject("0:0", {})], 1, { items: new LiveList() });
@@ -1661,7 +1661,7 @@ describe("room", () => {
         items: [],
       });
 
-      assertMessagesSent([
+      expectMessagesSent([
         { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
         { type: ClientMsgCode.FETCH_STORAGE },
         {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -676,7 +676,7 @@ describe("room", () => {
         createSerializedList("0:1", "0:0", "items"),
         createSerializedObject("0:2", {}, "0:1", FIRST_POSITION),
       ],
-      async ({ assert, batch, root, machine }) => {
+      async ({ expectUpdates, batch, root, machine }) => {
         const items = root.get("items");
         batch(() => {
           nn(items.get(0)).set("a", 1);
@@ -690,7 +690,7 @@ describe("room", () => {
         machine.redo();
 
         expect(items.toImmutable()).toEqual([{ a: 2 }]);
-        assert([
+        expectUpdates([
           [listUpdate([{ a: 2 }], [listUpdateSet(0, { a: 2 })])],
           [listUpdate([{}], [listUpdateSet(0, {})])],
           [listUpdate([{ a: 2 }], [listUpdateSet(0, { a: 2 })])],
@@ -1122,7 +1122,7 @@ describe("room", () => {
           createSerializedObject("0:2", {}, "0:1", FIRST_POSITION),
           createSerializedList("0:3", "0:2", "names"),
         ],
-        async ({ assert, root, batch, machine }) => {
+        async ({ expectUpdates: expectUpdates, root, batch, machine }) => {
           let receivedUpdates: StorageUpdate[] = [];
 
           machine.subscribe(root, (updates) => (receivedUpdates = updates), {
@@ -1143,7 +1143,7 @@ describe("room", () => {
             items.push(new LiveObject({ names: new LiveList(["James Doe"]) }));
           });
 
-          assert([
+          expectUpdates([
             [
               listUpdate(
                 [

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -127,12 +127,12 @@ describe("LiveList", () => {
             createSerializedObject("0:0", {}),
             createSerializedList("0:1", "0:0", "items"),
           ],
-          async ({ root, assert, machine }) => {
+          async ({ root, expectUpdates, machine }) => {
             root.get("items").push("a");
             machine.undo();
             machine.redo();
 
-            assert([
+            expectUpdates([
               [listUpdate(["a"], [listUpdateInsert(0, "a")])],
               [listUpdate([], [listUpdateDelete(0)])],
               [listUpdate(["a"], [listUpdateInsert(0, "a")])],
@@ -268,12 +268,12 @@ describe("LiveList", () => {
             createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
             createSerializedRegister("0:3", "0:1", SECOND_POSITION, "C"),
           ],
-          async ({ root, assert, machine }) => {
+          async ({ root, expectUpdates, machine }) => {
             root.get("items").insert("B", 1);
             machine.undo();
             machine.redo();
 
-            assert([
+            expectUpdates([
               [listUpdate(["A", "B", "C"], [listUpdateInsert(1, "B")])],
               [listUpdate(["A", "C"], [listUpdateDelete(1)])],
               [listUpdate(["A", "B", "C"], [listUpdateInsert(1, "B")])],
@@ -341,12 +341,12 @@ describe("LiveList", () => {
             createSerializedList("0:1", "0:0", "items"),
             createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
           ],
-          async ({ root, assert, machine }) => {
+          async ({ root, expectUpdates, machine }) => {
             root.get("items").delete(0);
             machine.undo();
             machine.redo();
 
-            assert([
+            expectUpdates([
               [listUpdate([], [listUpdateDelete(0)])],
               [listUpdate(["A"], [listUpdateInsert(0, "A")])],
               [listUpdate([], [listUpdateDelete(0)])],
@@ -442,12 +442,12 @@ describe("LiveList", () => {
             createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
             createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
           ],
-          async ({ root, assert, machine }) => {
+          async ({ root, expectUpdates, machine }) => {
             root.get("items").move(0, 1);
             machine.undo();
             machine.redo();
 
-            assert([
+            expectUpdates([
               [listUpdate(["B", "A"], [listUpdateMove(0, 1, "A")])],
               [listUpdate(["A", "B"], [listUpdateMove(1, 0, "A")])],
               [listUpdate(["B", "A"], [listUpdateMove(0, 1, "A")])],
@@ -568,12 +568,12 @@ describe("LiveList", () => {
             createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
             createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
           ],
-          async ({ root, assert, machine }) => {
+          async ({ root, expectUpdates, machine }) => {
             root.get("items").clear();
             machine.undo();
             machine.redo();
 
-            assert([
+            expectUpdates([
               [listUpdate([], [listUpdateDelete(0), listUpdateDelete(0)])],
               [
                 listUpdate(

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -69,20 +69,20 @@ describe("LiveList", () => {
 
   describe("deserialization", () => {
     it("create document with list in root", async () => {
-      const { assert } = await prepareIsolatedStorageTest<{
+      const { expectStorage } = await prepareIsolatedStorageTest<{
         items: LiveList<never>;
       }>([
         createSerializedObject("0:0", {}),
         createSerializedList("0:1", "0:0", "items"),
       ]);
 
-      assert({
+      expectStorage({
         items: [],
       });
     });
 
     it("init list with items", async () => {
-      const { assert } = await prepareIsolatedStorageTest<{
+      const { expectStorage } = await prepareIsolatedStorageTest<{
         items: LiveList<LiveObject<{ a: number }>>;
       }>([
         createSerializedObject("0:0", {}),
@@ -92,7 +92,7 @@ describe("LiveList", () => {
         createSerializedObject("0:4", { a: 2 }, "0:1", THIRD_POSITION),
       ]);
 
-      assert({
+      expectStorage({
         items: [{ a: 0 }, { a: 1 }, { a: 2 }],
       });
     });
@@ -143,26 +143,27 @@ describe("LiveList", () => {
     });
 
     it("push LiveObject on empty list", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<LiveObject<{ a: number }>>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+          ],
+          1
+        );
 
       const root = storage.root;
       const items = root.get("items");
 
-      assert({
+      expectStorage({
         items: [],
       });
 
       items.push(new LiveObject({ a: 0 }));
 
-      assert({
+      expectStorage({
         items: [{ a: 0 }],
       });
 
@@ -170,46 +171,48 @@ describe("LiveList", () => {
     });
 
     it("push number on empty list", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<number>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<number>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+          ],
+          1
+        );
 
       const root = storage.root;
       const items = root.toObject().items;
 
-      assert({ items: [] });
+      expectStorage({ items: [] });
 
       items.push(0);
-      assert({ items: [0] });
+      expectStorage({ items: [0] });
 
       assertUndoRedo();
     });
 
     it("push LiveMap on empty list", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveMap<string, number>>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<LiveMap<string, number>>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+          ],
+          1
+        );
 
       const root = storage.root;
       const items = root.get("items");
 
-      assert({ items: [] });
+      expectStorage({ items: [] });
 
       items.push(new LiveMap([["first", 0]]));
 
-      assert({ items: [new Map([["first", 0]])] });
+      expectStorage({ items: [new Map([["first", 0]])] });
 
       assertUndoRedo();
     });
@@ -281,18 +284,19 @@ describe("LiveList", () => {
     });
 
     it("insert LiveObject at position 0", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedObject("0:2", { a: 1 }, "0:1", FIRST_POSITION),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<LiveObject<{ a: number }>>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedObject("0:2", { a: 1 }, "0:1", FIRST_POSITION),
+          ],
+          1
+        );
 
-      assert({
+      expectStorage({
         items: [{ a: 1 }],
       });
 
@@ -301,7 +305,7 @@ describe("LiveList", () => {
 
       items.insert(new LiveObject({ a: 0 }), 0);
 
-      assert({ items: [{ a: 0 }, { a: 1 }] });
+      expectStorage({ items: [{ a: 0 }, { a: 1 }] });
 
       assertUndoRedo();
     });
@@ -353,25 +357,26 @@ describe("LiveList", () => {
     });
 
     it("delete first item", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>([
-        createSerializedObject("0:0", {}),
-        createSerializedList("0:1", "0:0", "items"),
-        createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-        createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-      ]);
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>([
+          createSerializedObject("0:0", {}),
+          createSerializedList("0:1", "0:0", "items"),
+          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+        ]);
 
       const root = storage.root;
       const items = root.toObject().items;
 
-      assert({
+      expectStorage({
         items: ["A", "B"],
       });
 
       items.delete(0);
 
-      assert({
+      expectStorage({
         items: ["B"],
       });
 
@@ -379,7 +384,7 @@ describe("LiveList", () => {
     });
 
     it("delete should remove descendants", async () => {
-      const { storage, assert, assertUndoRedo, getItemsCount } =
+      const { storage, expectStorage, assertUndoRedo, getItemsCount } =
         await prepareStorageTest<{
           items: LiveList<LiveObject<{ child: LiveObject<{ a: number }> }>>;
         }>([
@@ -389,13 +394,13 @@ describe("LiveList", () => {
           createSerializedObject("0:3", { a: 0 }, "0:2", "child"),
         ]);
 
-      assert({
+      expectStorage({
         items: [{ child: { a: 0 } }],
       });
 
       storage.root.toObject().items.delete(0);
 
-      assert({
+      expectStorage({
         items: [],
       });
 
@@ -453,17 +458,18 @@ describe("LiveList", () => {
     });
 
     it("move after current position", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>([
-        createSerializedObject("0:0", {}),
-        createSerializedList("0:1", "0:0", "items"),
-        createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-        createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-        createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-      ]);
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>([
+          createSerializedObject("0:0", {}),
+          createSerializedList("0:1", "0:0", "items"),
+          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+        ]);
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
@@ -471,33 +477,34 @@ describe("LiveList", () => {
       const items = root.toObject().items;
       items.move(0, 1);
 
-      assert({ items: ["B", "A", "C"] });
+      expectStorage({ items: ["B", "A", "C"] });
 
       assertUndoRedo();
     });
 
     it("move before current position", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+          ],
+          1
+        );
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
       const items = storage.root.get("items");
 
       items.move(0, 1);
-      assert({
+      expectStorage({
         items: ["B", "A", "C"],
       });
 
@@ -505,17 +512,18 @@ describe("LiveList", () => {
     });
 
     it("move at the end of the list", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>([
-        createSerializedObject("0:0", {}),
-        createSerializedList("0:1", "0:0", "items"),
-        createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-        createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-        createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-      ]);
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>([
+          createSerializedObject("0:0", {}),
+          createSerializedList("0:1", "0:0", "items"),
+          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+        ]);
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
@@ -523,7 +531,7 @@ describe("LiveList", () => {
       const items = root.toObject().items;
       items.move(0, 2);
 
-      assert({
+      expectStorage({
         items: ["B", "C", "A"],
       });
 
@@ -582,28 +590,29 @@ describe("LiveList", () => {
     });
 
     it("clear should delete all items", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+          ],
+          1
+        );
 
       const root = storage.root;
       const items = root.get("items");
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
       items.clear();
-      assert({
+      expectStorage({
         items: [],
       });
 
@@ -613,7 +622,7 @@ describe("LiveList", () => {
 
   describe("batch", () => {
     it("batch multiple inserts", async () => {
-      const { storage, assert, assertUndoRedo, batch } =
+      const { storage, expectStorage, assertUndoRedo, batch } =
         await prepareStorageTest<{
           items: LiveList<string>;
         }>(
@@ -626,14 +635,14 @@ describe("LiveList", () => {
 
       const items = storage.root.get("items");
 
-      assert({ items: [] });
+      expectStorage({ items: [] });
 
       batch(() => {
         items.push("A");
         items.push("B");
       });
 
-      assert(
+      expectStorage(
         { items: ["A", "B"] }
         // Updates are not tested here because undo/redo is not symetric
       );
@@ -678,52 +687,54 @@ describe("LiveList", () => {
     });
 
     it("set register", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
-          createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "A"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "B"),
+            createSerializedRegister("0:4", "0:1", THIRD_POSITION, "C"),
+          ],
+          1
+        );
 
       const root = storage.root;
       const items = root.toObject().items;
 
-      assert({ items: ["A", "B", "C"] });
+      expectStorage({ items: ["A", "B", "C"] });
 
       items.set(0, "D");
-      assert({ items: ["D", "B", "C"] });
+      expectStorage({ items: ["D", "B", "C"] });
 
       items.set(1, "E");
-      assert({ items: ["D", "E", "C"] });
+      expectStorage({ items: ["D", "E", "C"] });
 
       assertUndoRedo();
     });
 
     it("set nested object", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<LiveObject<{ a: number }>>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedObject("0:2", { a: 1 }, "0:1", FIRST_POSITION),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<LiveObject<{ a: number }>>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedObject("0:2", { a: 1 }, "0:1", FIRST_POSITION),
+          ],
+          1
+        );
 
       const root = storage.root;
       const items = root.toObject().items;
 
-      assert({ items: [{ a: 1 }] });
+      expectStorage({ items: [{ a: 1 }] });
 
       items.set(0, new LiveObject({ a: 2 }));
-      assert({ items: [{ a: 2 }] });
+      expectStorage({ items: [{ a: 2 }] });
 
       assertUndoRedo();
     });
@@ -731,7 +742,7 @@ describe("LiveList", () => {
 
   describe("conflict", () => {
     it("list conflicts", async () => {
-      const { root, assert, applyRemoteOperations } =
+      const { root, expectStorage, applyRemoteOperations } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
@@ -755,7 +766,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["1", "0"],
       });
 
@@ -768,13 +779,13 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["1", "0"],
       });
     });
 
     it("list conflicts 2", async () => {
-      const { root, applyRemoteOperations, assert } =
+      const { root, applyRemoteOperations, expectStorage } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
@@ -799,7 +810,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["y0", "x0", "x1"],
       });
 
@@ -814,7 +825,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["y0", "x0", "y1", "x1"],
       });
 
@@ -826,7 +837,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["y0", "y1", "x0", "x1"],
       });
 
@@ -838,13 +849,13 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["y0", "y1", "x0", "x1"],
       });
     });
 
     it("list conflicts with offline", async () => {
-      const { root, assert, applyRemoteOperations, machine } =
+      const { root, expectStorage, applyRemoteOperations, machine } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
@@ -865,7 +876,7 @@ describe("LiveList", () => {
       // Register id = 1:0
       items.push("0");
 
-      assert({
+      expectStorage({
         items: ["0"],
       });
 
@@ -875,7 +886,7 @@ describe("LiveList", () => {
         createSerializedRegister("2:0", "0:1", FIRST_POSITION, "1"),
       ]);
 
-      assert({
+      expectStorage({
         items: ["1", "0"],
       });
 
@@ -888,13 +899,13 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["1", "0"],
       });
     });
 
     it("list conflicts with undo redo and remote change", async () => {
-      const { root, assert, applyRemoteOperations, machine } =
+      const { root, expectStorage, applyRemoteOperations, machine } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
@@ -914,13 +925,13 @@ describe("LiveList", () => {
 
       items.push("0");
 
-      assert({
+      expectStorage({
         items: ["0"],
       });
 
       machine.undo();
 
-      assert({
+      expectStorage({
         items: [],
       });
 
@@ -936,13 +947,13 @@ describe("LiveList", () => {
 
       machine.redo();
 
-      assert({
+      expectStorage({
         items: ["1", "0"],
       });
     });
 
     it("list conflicts - move", async () => {
-      const { root, assert, applyRemoteOperations } =
+      const { root, expectStorage, applyRemoteOperations } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("0:0", {}),
@@ -960,13 +971,13 @@ describe("LiveList", () => {
       // Register id = 1:2
       items.push("C");
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
       items.move(0, 2);
 
-      assert({
+      expectStorage({
         items: ["B", "C", "A"],
       });
 
@@ -978,7 +989,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["C", "B", "A"],
       });
 
@@ -990,13 +1001,13 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["C", "B", "A"],
       });
     });
 
     it("list conflicts - ack has different position that local item", async () => {
-      const { root, assert, applyRemoteOperations } =
+      const { root, expectStorage, applyRemoteOperations } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("root", {}),
@@ -1009,7 +1020,7 @@ describe("LiveList", () => {
 
       items.push("B");
 
-      assert({
+      expectStorage({
         items: ["B"],
       });
 
@@ -1035,7 +1046,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["B"], // "B" is at SECOND_POSITION
       });
 
@@ -1051,7 +1062,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["B"], // "B" should at FIRST_POSITION
       });
 
@@ -1067,13 +1078,13 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["B", "C"],
       });
     });
 
     it("list conflicts - ack has different position that local and ack position is used", async () => {
-      const { root, assert, applyRemoteOperations } =
+      const { root, expectStorage, applyRemoteOperations } =
         await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedObject("root", {}),
@@ -1086,7 +1097,7 @@ describe("LiveList", () => {
 
       items.push("B");
 
-      assert({
+      expectStorage({
         items: ["B"],
       });
 
@@ -1123,7 +1134,7 @@ describe("LiveList", () => {
         },
       ]);
 
-      assert({
+      expectStorage({
         items: ["B", "C"], // C position is shifted
       });
     });
@@ -1131,16 +1142,17 @@ describe("LiveList", () => {
 
   describe("subscriptions", () => {
     test("batch multiple actions", async () => {
-      const { storage, subscribe, batch, assert } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-        ],
-        1
-      );
+      const { storage, subscribe, batch, expectStorage } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+          ],
+          1
+        );
 
       const callback = jest.fn();
 
@@ -1155,7 +1167,7 @@ describe("LiveList", () => {
         liveList.push("c");
       });
 
-      assert({ items: ["a", "b", "c"] });
+      expectStorage({ items: ["a", "b", "c"] });
 
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith([
@@ -1171,16 +1183,17 @@ describe("LiveList", () => {
     });
 
     test("batch multiple inserts", async () => {
-      const { storage, subscribe, batch, assert } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-        ],
-        1
-      );
+      const { storage, subscribe, batch, expectStorage } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+          ],
+          1
+        );
 
       const callback = jest.fn();
 
@@ -1195,7 +1208,7 @@ describe("LiveList", () => {
         liveList.insert("c", 2);
       });
 
-      assert({ items: ["a", "b", "c"] });
+      expectStorage({ items: ["a", "b", "c"] });
 
       expect(callback).toHaveBeenCalledTimes(1);
     });
@@ -1203,16 +1216,17 @@ describe("LiveList", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-        ],
-        1
-      );
+      const { expectStorage, machine, root } =
+        await prepareIsolatedStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+          ],
+          1
+        );
 
       const rootCallback = jest.fn();
       const rootDeepCallback = jest.fn();
@@ -1224,7 +1238,7 @@ describe("LiveList", () => {
       machine.subscribe(root, rootDeepCallback, { isDeep: true });
       machine.subscribe(listItems, listCallback);
 
-      assert({ items: ["a"] });
+      expectStorage({ items: ["a"] });
 
       machine.onClose(
         new CloseEvent("close", {
@@ -1258,13 +1272,13 @@ describe("LiveList", () => {
 
       reconnect(machine, 3, newInitStorage);
 
-      assert({
+      expectStorage({
         items: ["a", "b"],
       });
 
       listItems.push("c");
 
-      assert({
+      expectStorage({
         items: ["a", "b", "c"],
       });
 
@@ -1290,17 +1304,18 @@ describe("LiveList", () => {
     });
 
     test("Register moved in list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-        ],
-        1
-      );
+      const { expectStorage, machine, root } =
+        await prepareIsolatedStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+          ],
+          1
+        );
 
       const rootCallback = jest.fn();
       const rootDeepCallback = jest.fn();
@@ -1312,7 +1327,7 @@ describe("LiveList", () => {
       machine.subscribe(root, rootDeepCallback, { isDeep: true });
       machine.subscribe(listItems, listCallback);
 
-      assert({ items: ["a", "b"] });
+      expectStorage({ items: ["a", "b"] });
 
       machine.onClose(
         new CloseEvent("close", {
@@ -1346,7 +1361,7 @@ describe("LiveList", () => {
 
       reconnect(machine, 3, newInitStorage);
 
-      assert({
+      expectStorage({
         items: ["b", "a"],
       });
 
@@ -1366,17 +1381,18 @@ describe("LiveList", () => {
     });
 
     test("Register deleted from list", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-          createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
-          createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
-        ],
-        1
-      );
+      const { expectStorage, machine, root } =
+        await prepareIsolatedStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+            createSerializedRegister("0:2", "0:1", FIRST_POSITION, "a"),
+            createSerializedRegister("0:3", "0:1", SECOND_POSITION, "b"),
+          ],
+          1
+        );
 
       const rootCallback = jest.fn();
       const rootDeepCallback = jest.fn();
@@ -1388,7 +1404,7 @@ describe("LiveList", () => {
       machine.subscribe(root, rootDeepCallback, { isDeep: true });
       machine.subscribe(listItems, listCallback);
 
-      assert({ items: ["a", "b"] });
+      expectStorage({ items: ["a", "b"] });
 
       machine.onClose(
         new CloseEvent("close", {
@@ -1413,7 +1429,7 @@ describe("LiveList", () => {
 
       reconnect(machine, 3, newInitStorage);
 
-      assert({
+      expectStorage({
         items: ["a"],
       });
 
@@ -1473,7 +1489,7 @@ describe("LiveList", () => {
 
     describe("apply CreateRegister", () => {
       it('with intent "set" should replace existing item', async () => {
-        const { assert, applyRemoteOperations } =
+        const { expectStorage, applyRemoteOperations } =
           await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
             [
               createSerializedObject("root", {}),
@@ -1483,7 +1499,7 @@ describe("LiveList", () => {
             1
           );
 
-        assert({
+        expectStorage({
           items: ["A"],
         });
 
@@ -1498,7 +1514,7 @@ describe("LiveList", () => {
           },
         ]);
 
-        assert({
+        expectStorage({
           items: ["B"],
         });
       });
@@ -1541,7 +1557,7 @@ describe("LiveList", () => {
       });
 
       it('with intent "set" should insert item if conflict with a delete operation', async () => {
-        const { root, assert, applyRemoteOperations } =
+        const { root, expectStorage, applyRemoteOperations } =
           await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
             [
               createSerializedObject("root", {}),
@@ -1553,13 +1569,13 @@ describe("LiveList", () => {
 
         const items = root.get("items");
 
-        assert({
+        expectStorage({
           items: ["A"],
         });
 
         items.delete(0);
 
-        assert({
+        expectStorage({
           items: [],
         });
 
@@ -1574,7 +1590,7 @@ describe("LiveList", () => {
           },
         ]);
 
-        assert({
+        expectStorage({
           items: ["B"],
         });
       });
@@ -1618,7 +1634,7 @@ describe("LiveList", () => {
       });
 
       it("on existing position should give the right update", async () => {
-        const { root, assert, applyRemoteOperations, subscribe } =
+        const { root, expectStorage, applyRemoteOperations, subscribe } =
           await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
             [
               createSerializedObject("0:0", {}),
@@ -1632,7 +1648,7 @@ describe("LiveList", () => {
         // Register id = 1:0
         items.push("0");
 
-        assert({
+        expectStorage({
           items: ["0"],
         });
 
@@ -1650,7 +1666,7 @@ describe("LiveList", () => {
           },
         ]);
 
-        assert({
+        expectStorage({
           items: ["1", "0"],
         });
 

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveMap.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveMap.test.ts
@@ -94,7 +94,7 @@ describe("LiveMap", () => {
   });
 
   it("create document with map in root", async () => {
-    const { storage, assert } = await prepareStorageTest<{
+    const { storage, expectStorage } = await prepareStorageTest<{
       map: LiveMap<string, LiveObject<{ a: number }>>;
     }>([
       createSerializedObject("0:0", {}),
@@ -104,7 +104,7 @@ describe("LiveMap", () => {
     const root = storage.root;
     const map = root.toObject().map;
     expect(Array.from(map.entries())).toEqual([]);
-    assert({ map: new Map() });
+    expectStorage({ map: new Map() });
   });
 
   it("set throws on read-only", async () => {
@@ -126,7 +126,7 @@ describe("LiveMap", () => {
   });
 
   it("init map with items", async () => {
-    const { storage, assert } = await prepareStorageTest<{
+    const { storage, expectStorage } = await prepareStorageTest<{
       map: LiveMap<string, LiveObject<{ a: number }>>;
     }>([
       createSerializedObject("0:0", {}),
@@ -147,7 +147,7 @@ describe("LiveMap", () => {
       ["third", { a: 2 }],
     ]);
 
-    assert({
+    expectStorage({
       map: new Map([
         ["first", { a: 0 }],
         ["second", { a: 1 }],
@@ -157,28 +157,29 @@ describe("LiveMap", () => {
   });
 
   it("map.set object", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, number>;
-    }>(
-      [
-        createSerializedObject("0:0", {}),
-        createSerializedMap("0:1", "0:0", "map"),
-      ],
-      1
-    );
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map: LiveMap<string, number>;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedMap("0:1", "0:0", "map"),
+        ],
+        1
+      );
 
     const root = storage.root;
     const map = root.toObject().map;
 
-    assert({ map: new Map() });
+    expectStorage({ map: new Map() });
 
     map.set("first", 0);
-    assert({
+    expectStorage({
       map: new Map([["first", 0]]),
     });
 
     map.set("second", 1);
-    assert({
+    expectStorage({
       map: new Map([
         ["first", 0],
         ["second", 1],
@@ -186,7 +187,7 @@ describe("LiveMap", () => {
     });
 
     map.set("third", 2);
-    assert({
+    expectStorage({
       map: new Map([
         ["first", 0],
         ["second", 1],
@@ -217,20 +218,21 @@ describe("LiveMap", () => {
     });
 
     it("should delete LiveObject", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        map: LiveMap<string, number>;
-      }>([
-        createSerializedObject("0:0", {}),
-        createSerializedMap("0:1", "0:0", "map"),
-        createSerializedRegister("0:2", "0:1", "first", 0),
-        createSerializedRegister("0:3", "0:1", "second", 1),
-        createSerializedRegister("0:4", "0:1", "third", 2),
-      ]);
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          map: LiveMap<string, number>;
+        }>([
+          createSerializedObject("0:0", {}),
+          createSerializedMap("0:1", "0:0", "map"),
+          createSerializedRegister("0:2", "0:1", "first", 0),
+          createSerializedRegister("0:3", "0:1", "second", 1),
+          createSerializedRegister("0:4", "0:1", "third", 2),
+        ]);
 
       const root = storage.root;
       const map = root.toObject().map;
 
-      assert({
+      expectStorage({
         map: new Map([
           ["first", 0],
           ["second", 1],
@@ -239,7 +241,7 @@ describe("LiveMap", () => {
       });
 
       map.delete("first");
-      assert({
+      expectStorage({
         map: new Map([
           ["second", 1],
           ["third", 2],
@@ -247,12 +249,12 @@ describe("LiveMap", () => {
       });
 
       map.delete("second");
-      assert({
+      expectStorage({
         map: new Map([["third", 2]]),
       });
 
       map.delete("third");
-      assert({
+      expectStorage({
         map: new Map(),
       });
 
@@ -260,7 +262,7 @@ describe("LiveMap", () => {
     });
 
     it("should remove nested data structure from cache", async () => {
-      const { storage, assert, assertUndoRedo, getItemsCount } =
+      const { storage, expectStorage, assertUndoRedo, getItemsCount } =
         await prepareStorageTest<{
           map: LiveMap<string, LiveObject<{ a: number }>>;
         }>(
@@ -272,7 +274,7 @@ describe("LiveMap", () => {
           1
         );
 
-      assert({
+      expectStorage({
         map: new Map([["first", { a: 0 }]]),
       });
 
@@ -283,7 +285,7 @@ describe("LiveMap", () => {
       expect(map.delete("first")).toBe(true);
       expect(getItemsCount()).toBe(2);
 
-      assert({
+      expectStorage({
         map: new Map(),
       });
 
@@ -291,7 +293,7 @@ describe("LiveMap", () => {
     });
 
     it("should delete live list", async () => {
-      const { storage, assert, assertUndoRedo, getItemsCount } =
+      const { storage, expectStorage, assertUndoRedo, getItemsCount } =
         await prepareStorageTest<{ map: LiveMap<string, LiveList<number>> }>(
           [
             createSerializedObject("0:0", {}),
@@ -302,7 +304,7 @@ describe("LiveMap", () => {
           1
         );
 
-      assert({
+      expectStorage({
         map: new Map([["first", [0]]]),
       });
 
@@ -313,7 +315,7 @@ describe("LiveMap", () => {
       expect(map.delete("first")).toBe(true);
       expect(getItemsCount()).toBe(2);
 
-      assert({
+      expectStorage({
         map: new Map(),
       });
 
@@ -396,25 +398,26 @@ describe("LiveMap", () => {
   });
 
   it("map.set live object", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>(
-      [
-        createSerializedObject("0:0", {}),
-        createSerializedMap("0:1", "0:0", "map"),
-      ],
-      1
-    );
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map: LiveMap<string, LiveObject<{ a: number }>>;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedMap("0:1", "0:0", "map"),
+        ],
+        1
+      );
 
     const root = storage.root;
     const map = root.toObject().map;
-    assert({
+    expectStorage({
       map: new Map(),
     });
 
     map.set("first", new LiveObject({ a: 0 }));
 
-    assert({
+    expectStorage({
       map: new Map([["first", { a: 0 }]]),
     });
 
@@ -452,18 +455,19 @@ describe("LiveMap", () => {
   });
 
   it("map.set live object on existing key", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveObject<{ a: number }>>;
-    }>(
-      [
-        createSerializedObject("0:0", {}),
-        createSerializedMap("0:1", "0:0", "map"),
-        createSerializedObject("0:2", { a: 0 }, "0:1", "first"),
-      ],
-      1
-    );
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map: LiveMap<string, LiveObject<{ a: number }>>;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedMap("0:1", "0:0", "map"),
+          createSerializedObject("0:2", { a: 0 }, "0:1", "first"),
+        ],
+        1
+      );
 
-    assert({
+    expectStorage({
       map: new Map([["first", { a: 0 }]]),
     });
 
@@ -472,7 +476,7 @@ describe("LiveMap", () => {
 
     map.set("first", new LiveObject({ a: 1 }));
 
-    assert({
+    expectStorage({
       map: new Map([["first", { a: 1 }]]),
     });
 
@@ -480,15 +484,16 @@ describe("LiveMap", () => {
   });
 
   it("attach map with items to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map?: LiveMap<string, { a: number }>;
-    }>([createSerializedObject("0:0", {})], 1);
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map?: LiveMap<string, { a: number }>;
+      }>([createSerializedObject("0:0", {})], 1);
 
-    assert({});
+    expectStorage({});
 
     storage.root.set("map", new LiveMap([["first", { a: 0 }]]));
 
-    assert({
+    expectStorage({
       map: new Map([["first", { a: 0 }]]),
     });
 
@@ -496,15 +501,16 @@ describe("LiveMap", () => {
   });
 
   it("attach map with live objects to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map?: LiveMap<string, LiveObject<{ a: number }>>;
-    }>([createSerializedObject("0:0", {})], 1);
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map?: LiveMap<string, LiveObject<{ a: number }>>;
+      }>([createSerializedObject("0:0", {})], 1);
 
-    assert({});
+    expectStorage({});
 
     storage.root.set("map", new LiveMap([["first", new LiveObject({ a: 0 })]]));
 
-    assert({
+    expectStorage({
       map: new Map([["first", { a: 0 }]]),
     });
 
@@ -512,15 +518,16 @@ describe("LiveMap", () => {
   });
 
   it("attach map with objects to root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map?: LiveMap<string, { a: number }>;
-    }>([createSerializedObject("0:0", {})], 1);
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map?: LiveMap<string, { a: number }>;
+      }>([createSerializedObject("0:0", {})], 1);
 
-    assert({});
+    expectStorage({});
 
     storage.root.set("map", new LiveMap([["first", { a: 0 }]]));
 
-    assert({
+    expectStorage({
       map: new Map([["first", { a: 0 }]]),
     });
 
@@ -528,22 +535,23 @@ describe("LiveMap", () => {
   });
 
   it("add list in map", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveList<string>>;
-    }>(
-      [
-        createSerializedObject("0:0", {}),
-        createSerializedMap("0:1", "0:0", "map"),
-      ],
-      1
-    );
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map: LiveMap<string, LiveList<string>>;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedMap("0:1", "0:0", "map"),
+        ],
+        1
+      );
 
-    assert({ map: new Map() });
+    expectStorage({ map: new Map() });
 
     const map = storage.root.get("map");
     map.set("list", new LiveList(["itemA", "itemB", "itemC"]));
 
-    assert({
+    expectStorage({
       map: new Map([["list", ["itemA", "itemB", "itemC"]]]),
     });
 
@@ -551,22 +559,23 @@ describe("LiveMap", () => {
   });
 
   it("add map in map", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      map: LiveMap<string, LiveMap<string, string>>;
-    }>(
-      [
-        createSerializedObject("0:0", {}),
-        createSerializedMap("0:1", "0:0", "map"),
-      ],
-      1
-    );
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        map: LiveMap<string, LiveMap<string, string>>;
+      }>(
+        [
+          createSerializedObject("0:0", {}),
+          createSerializedMap("0:1", "0:0", "map"),
+        ],
+        1
+      );
 
-    assert({ map: new Map() });
+    expectStorage({ map: new Map() });
 
     const map = storage.root.get("map");
     map.set("map", new LiveMap([["first", "itemA"]]));
 
-    assert({
+    expectStorage({
       map: new Map([["map", new Map([["first", "itemA"]])]]),
     });
 
@@ -639,16 +648,17 @@ describe("LiveMap", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to map", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        map: LiveMap<string, string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedMap("0:1", "0:0", "map"),
-          createSerializedRegister("0:2", "0:1", "first", "a"),
-        ],
-        1
-      );
+      const { expectStorage, machine, root } =
+        await prepareIsolatedStorageTest<{
+          map: LiveMap<string, string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedMap("0:1", "0:0", "map"),
+            createSerializedRegister("0:2", "0:1", "first", "a"),
+          ],
+          1
+        );
 
       const rootDeepCallback = jest.fn();
       const mapCallback = jest.fn();
@@ -658,7 +668,7 @@ describe("LiveMap", () => {
       machine.subscribe(root, rootDeepCallback, { isDeep: true });
       machine.subscribe(listItems, mapCallback);
 
-      assert({ map: new Map([["first", "a"]]) });
+      expectStorage({ map: new Map([["first", "a"]]) });
 
       machine.onClose(
         new CloseEvent("close", {
@@ -692,7 +702,7 @@ describe("LiveMap", () => {
 
       reconnect(machine, 3, newInitStorage);
 
-      assert({
+      expectStorage({
         map: new Map([
           ["first", "a"],
           ["second", "b"],

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
@@ -52,14 +52,14 @@ describe("LiveObject", () => {
   });
 
   it("update non existing property", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest([
-      createSerializedObject("0:0", {}),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } = await prepareStorageTest(
+      [createSerializedObject("0:0", {})]
+    );
 
-    assert({});
+    expectStorage({});
 
     storage.root.update({ a: 1 });
-    assert({
+    expectStorage({
       a: 1,
     });
 
@@ -67,14 +67,14 @@ describe("LiveObject", () => {
   });
 
   it("update non existing property with null", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest([
-      createSerializedObject("0:0", {}),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } = await prepareStorageTest(
+      [createSerializedObject("0:0", {})]
+    );
 
-    assert({});
+    expectStorage({});
 
     storage.root.update({ a: null });
-    assert({
+    expectStorage({
       a: null,
     });
 
@@ -94,14 +94,14 @@ describe("LiveObject", () => {
   });
 
   it("update existing property", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest([
-      createSerializedObject("0:0", { a: 0 }),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } = await prepareStorageTest(
+      [createSerializedObject("0:0", { a: 0 })]
+    );
 
-    assert({ a: 0 });
+    expectStorage({ a: 0 });
 
     storage.root.update({ a: 1 });
-    assert({
+    expectStorage({
       a: 1,
     });
 
@@ -109,14 +109,14 @@ describe("LiveObject", () => {
   });
 
   it("update existing property with null", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest([
-      createSerializedObject("0:0", { a: 0 }),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } = await prepareStorageTest(
+      [createSerializedObject("0:0", { a: 0 })]
+    );
 
-    assert({ a: 0 });
+    expectStorage({ a: 0 });
 
     storage.root.update({ a: null });
-    assert({
+    expectStorage({
       a: null,
     });
 
@@ -124,21 +124,21 @@ describe("LiveObject", () => {
   });
 
   it("update root", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest([
-      createSerializedObject("0:0", { a: 0 }),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } = await prepareStorageTest(
+      [createSerializedObject("0:0", { a: 0 })]
+    );
 
-    assert({
+    expectStorage({
       a: 0,
     });
 
     storage.root.update({ a: 1 });
-    assert({
+    expectStorage({
       a: 1,
     });
 
     storage.root.update({ b: 1 });
-    assert({
+    expectStorage({
       a: 1,
       b: 1,
     });
@@ -159,7 +159,7 @@ describe("LiveObject", () => {
   });
 
   it("update with LiveObject", async () => {
-    const { storage, assert, operations, assertUndoRedo, getUndoStack } =
+    const { storage, expectStorage, operations, assertUndoRedo, getUndoStack } =
       await prepareStorageTest<{ child: LiveObject<{ a: number }> | null }>(
         [createSerializedObject("0:0", { child: null })],
         1
@@ -167,13 +167,13 @@ describe("LiveObject", () => {
 
     const root = storage.root;
 
-    assert({
+    expectStorage({
       child: null,
     });
 
     root.set("child", new LiveObject({ a: 0 }));
 
-    assert({
+    expectStorage({
       child: {
         a: 0,
       },
@@ -202,7 +202,7 @@ describe("LiveObject", () => {
 
     root.set("child", null);
 
-    assert({
+    expectStorage({
       child: null,
     });
     expect(getUndoStack()[1]).toEqual([
@@ -219,7 +219,7 @@ describe("LiveObject", () => {
   });
 
   it("remove nested grand child record with update", async () => {
-    const { storage, assert, assertUndoRedo, getItemsCount } =
+    const { storage, expectStorage, assertUndoRedo, getItemsCount } =
       await prepareStorageTest<{
         a: number;
         child: LiveObject<{
@@ -232,7 +232,7 @@ describe("LiveObject", () => {
         createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
       ]);
 
-    assert({
+    expectStorage({
       a: 0,
       child: {
         b: 0,
@@ -244,7 +244,7 @@ describe("LiveObject", () => {
 
     storage.root.update({ child: null });
 
-    assert({
+    expectStorage({
       a: 0,
       child: null,
     });
@@ -254,7 +254,7 @@ describe("LiveObject", () => {
   });
 
   it("remove nested child record with update", async () => {
-    const { storage, assert, assertUndoRedo, getItemsCount } =
+    const { storage, expectStorage, assertUndoRedo, getItemsCount } =
       await prepareStorageTest<{
         a: number;
         child: LiveObject<{ b: number }> | null;
@@ -263,7 +263,7 @@ describe("LiveObject", () => {
         createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
       ]);
 
-    assert({
+    expectStorage({
       a: 0,
       child: {
         b: 0,
@@ -272,7 +272,7 @@ describe("LiveObject", () => {
 
     storage.root.update({ child: null });
 
-    assert({
+    expectStorage({
       a: 0,
       child: null,
     });
@@ -282,16 +282,16 @@ describe("LiveObject", () => {
   });
 
   it("add nested record with update", async () => {
-    const { storage, assert, assertUndoRedo, getItemsCount } =
+    const { storage, expectStorage, assertUndoRedo, getItemsCount } =
       await prepareStorageTest([createSerializedObject("0:0", {})], 1);
 
-    assert({});
+    expectStorage({});
 
     storage.root.update({
       child: new LiveObject({ a: 0 }),
     });
 
-    assert({
+    expectStorage({
       child: {
         a: 0,
       },
@@ -303,16 +303,16 @@ describe("LiveObject", () => {
   });
 
   it("replace nested record with update", async () => {
-    const { storage, assert, assertUndoRedo, getItemsCount } =
+    const { storage, expectStorage, assertUndoRedo, getItemsCount } =
       await prepareStorageTest([createSerializedObject("0:0", {})], 1);
 
-    assert({});
+    expectStorage({});
 
     storage.root.update({
       child: new LiveObject({ a: 0 }),
     });
 
-    assert({
+    expectStorage({
       child: {
         a: 0,
       },
@@ -322,7 +322,7 @@ describe("LiveObject", () => {
       child: new LiveObject({ a: 1 }),
     });
 
-    assert({
+    expectStorage({
       child: {
         a: 1,
       },
@@ -334,18 +334,19 @@ describe("LiveObject", () => {
   });
 
   it("update nested record", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      a: number;
-      child: LiveObject<{ b: number }>;
-    }>([
-      createSerializedObject("0:0", { a: 0 }),
-      createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        a: number;
+        child: LiveObject<{ b: number }>;
+      }>([
+        createSerializedObject("0:0", { a: 0 }),
+        createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
+      ]);
 
     const root = storage.root;
     const child = root.toObject().child;
 
-    assert({
+    expectStorage({
       a: 0,
       child: {
         b: 0,
@@ -353,7 +354,7 @@ describe("LiveObject", () => {
     });
 
     child.update({ b: 1 });
-    assert({
+    expectStorage({
       a: 0,
       child: {
         b: 1,
@@ -364,16 +365,17 @@ describe("LiveObject", () => {
   });
 
   it("update deeply nested record", async () => {
-    const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-      a: number;
-      child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
-    }>([
-      createSerializedObject("0:0", { a: 0 }),
-      createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
-      createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
-    ]);
+    const { storage, expectStorage, assertUndoRedo } =
+      await prepareStorageTest<{
+        a: number;
+        child: LiveObject<{ b: number; grandChild: LiveObject<{ c: number }> }>;
+      }>([
+        createSerializedObject("0:0", { a: 0 }),
+        createSerializedObject("0:1", { b: 0 }, "0:0", "child"),
+        createSerializedObject("0:2", { c: 0 }, "0:1", "grandChild"),
+      ]);
 
-    assert({
+    expectStorage({
       a: 0,
       child: {
         b: 0,
@@ -393,7 +395,7 @@ describe("LiveObject", () => {
     grandChild.update({ c: 1 });
     expect(grandChild.toObject()).toMatchObject({ c: 1 });
 
-    assert({
+    expectStorage({
       a: 0,
       child: {
         b: 0,
@@ -456,17 +458,17 @@ describe("LiveObject", () => {
 
     describe("should ignore incoming updates if the current op has not been acknowledged", () => {
       test("when value is not a crdt", async () => {
-        const { root, assert, applyRemoteOperations } =
+        const { root, expectStorage, applyRemoteOperations } =
           await prepareIsolatedStorageTest<{ a: number }>(
             [createSerializedObject("0:0", { a: 0 })],
             1
           );
 
-        assert({ a: 0 });
+        expectStorage({ a: 0 });
 
         root.set("a", 1);
 
-        assert({ a: 1 });
+        expectStorage({ a: 1 });
 
         applyRemoteOperations([
           {
@@ -477,12 +479,14 @@ describe("LiveObject", () => {
           },
         ]);
 
-        assert({ a: 1 });
+        expectStorage({ a: 1 });
       });
 
       it("when value is a LiveObject", async () => {
-        const { root, assert, applyRemoteOperations } =
-          await prepareIsolatedStorageTest<{ a: LiveObject<{ subA: number }> }>(
+        const { root, expectStorage, applyRemoteOperations } =
+          await prepareIsolatedStorageTest<{
+            a: LiveObject<{ subA: number }>;
+          }>(
             [
               createSerializedObject("0:0", {}),
               createSerializedObject("0:1", { subA: 0 }, "0:0", "a"),
@@ -490,11 +494,11 @@ describe("LiveObject", () => {
             1
           );
 
-        assert({ a: { subA: 0 } });
+        expectStorage({ a: { subA: 0 } });
 
         root.set("a", new LiveObject({ subA: 1 }));
 
-        assert({ a: { subA: 1 } });
+        expectStorage({ a: { subA: 1 } });
 
         applyRemoteOperations([
           {
@@ -507,11 +511,11 @@ describe("LiveObject", () => {
           },
         ]);
 
-        assert({ a: { subA: 1 } });
+        expectStorage({ a: { subA: 1 } });
       });
 
       it("when value is a LiveList with LiveObjects", async () => {
-        const { root, assert, applyRemoteOperations } =
+        const { root, expectStorage, applyRemoteOperations } =
           await prepareIsolatedStorageTest<{
             a: LiveList<LiveObject<{ b: number }>>;
           }>(
@@ -522,13 +526,13 @@ describe("LiveObject", () => {
             1
           );
 
-        assert({ a: [] });
+        expectStorage({ a: [] });
 
         const newList = new LiveList<LiveObject<{ b: number }>>();
         newList.push(new LiveObject({ b: 1 }));
         root.set("a", newList);
 
-        assert({ a: [{ b: 1 }] });
+        expectStorage({ a: [{ b: 1 }] });
 
         applyRemoteOperations([
           {
@@ -540,7 +544,7 @@ describe("LiveObject", () => {
           },
         ]);
 
-        assert({ a: [{ b: 1 }] });
+        expectStorage({ a: [{ b: 1 }] });
       });
     });
   });
@@ -570,29 +574,31 @@ describe("LiveObject", () => {
     });
 
     it("should delete property from the object", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        a?: number;
-      }>([createSerializedObject("0:0", { a: 0 })]);
-      assert({ a: 0 });
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          a?: number;
+        }>([createSerializedObject("0:0", { a: 0 })]);
+      expectStorage({ a: 0 });
 
       storage.root.delete("a");
-      assert({});
+      expectStorage({});
 
       assertUndoRedo();
     });
 
     it("should delete nested crdt", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        child?: LiveObject<{ a: number }>;
-      }>([
-        createSerializedObject("0:0", {}),
-        createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
-      ]);
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          child?: LiveObject<{ a: number }>;
+        }>([
+          createSerializedObject("0:0", {}),
+          createSerializedObject("0:1", { a: 0 }, "0:0", "child"),
+        ]);
 
-      assert({ child: { a: 0 } });
+      expectStorage({ child: { a: 0 } });
 
       storage.root.delete("child");
-      assert({});
+      expectStorage({});
 
       assertUndoRedo();
     });
@@ -902,15 +908,16 @@ describe("LiveObject", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("LiveObject updated", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        obj: LiveObject<{ a: number }>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
-        ],
-        1
-      );
+      const { expectStorage, machine, root } =
+        await prepareIsolatedStorageTest<{
+          obj: LiveObject<{ a: number }>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
+          ],
+          1
+        );
 
       const rootDeepCallback = jest.fn();
       const liveObjectCallback = jest.fn();
@@ -918,7 +925,7 @@ describe("LiveObject", () => {
       machine.subscribe(root, rootDeepCallback, { isDeep: true });
       machine.subscribe(root.get("obj"), liveObjectCallback);
 
-      assert({ obj: { a: 1 } });
+      expectStorage({ obj: { a: 1 } });
 
       machine.onClose(
         new CloseEvent("close", {
@@ -942,7 +949,7 @@ describe("LiveObject", () => {
 
       reconnect(machine, 3, newInitStorage);
 
-      assert({
+      expectStorage({
         obj: { a: 2 },
       });
 
@@ -960,15 +967,16 @@ describe("LiveObject", () => {
     });
 
     test("LiveObject updated nested", async () => {
-      const { assert, machine, root } = await prepareIsolatedStorageTest<{
-        obj: LiveObject<{ a: number; subObj?: LiveObject<{ b: number }> }>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
-        ],
-        1
-      );
+      const { expectStorage, machine, root } =
+        await prepareIsolatedStorageTest<{
+          obj: LiveObject<{ a: number; subObj?: LiveObject<{ b: number }> }>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedObject("0:1", { a: 1 }, "0:0", "obj"),
+          ],
+          1
+        );
 
       const rootDeepCallback = jest.fn();
       const liveObjectCallback = jest.fn();
@@ -976,7 +984,7 @@ describe("LiveObject", () => {
       machine.subscribe(root, rootDeepCallback, { isDeep: true });
       machine.subscribe(root.get("obj"), liveObjectCallback);
 
-      assert({ obj: { a: 1 } });
+      expectStorage({ obj: { a: 1 } });
 
       machine.onClose(
         new CloseEvent("close", {
@@ -1009,7 +1017,7 @@ describe("LiveObject", () => {
 
       reconnect(machine, 3, newInitStorage);
 
-      assert({
+      expectStorage({
         obj: { a: 1, subObj: { b: 1 } },
       });
 
@@ -1031,21 +1039,21 @@ describe("LiveObject", () => {
 
   describe("undo apply update", () => {
     test("subscription should gives the right update", async () => {
-      const { root, assert, subscribe, undo } =
+      const { root, expectStorage, subscribe, undo } =
         await prepareIsolatedStorageTest<{ a: number }>(
           [createSerializedObject("0:0", { a: 0 })],
           1
         );
 
-      assert({ a: 0 });
+      expectStorage({ a: 0 });
       root.set("a", 1);
-      assert({ a: 1 });
+      expectStorage({ a: 1 });
 
       const callback = jest.fn();
       subscribe(root, callback, { isDeep: true });
 
       undo();
-      assert({ a: 0 });
+      expectStorage({ a: 0 });
 
       expect(callback).toHaveBeenCalledWith([
         { type: "LiveObject", node: root, updates: { a: { type: "update" } } },

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
@@ -418,7 +418,7 @@ describe("LiveObject", () => {
           createSerializedObject("0:0", {}),
           createSerializedObject("0:1", { a: "B" }, "0:0", "items"),
         ],
-        async ({ assert, batch, root, machine }) => {
+        async ({ expectUpdates, batch, root, machine }) => {
           const items = root.get("items");
           batch(() => {
             items.set("a", "A");
@@ -426,7 +426,7 @@ describe("LiveObject", () => {
           });
 
           expect(items.toObject()).toEqual({ a: "A", b: "A" });
-          assert([
+          expectUpdates([
             [
               objectUpdate(
                 { a: "A", b: "A" },
@@ -438,7 +438,7 @@ describe("LiveObject", () => {
           machine.undo();
 
           expect(items.toObject()).toEqual({ a: "B" });
-          assert([
+          expectUpdates([
             [
               objectUpdate(
                 { a: "A", b: "A" },

--- a/packages/liveblocks-core/src/crdts/__tests__/doc.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/doc.test.ts
@@ -232,15 +232,16 @@ describe("Storage", () => {
 
   describe("batching", () => {
     it("batching and undo", async () => {
-      const { storage, assert, undo, redo, batch } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-        ],
-        1
-      );
+      const { storage, expectStorage, undo, redo, batch } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+          ],
+          1
+        );
 
       const items = storage.root.get("items");
 
@@ -250,33 +251,34 @@ describe("Storage", () => {
         items.push("C");
       });
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
       undo();
 
-      assert({
+      expectStorage({
         items: [],
       });
 
       redo();
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
     });
 
     it("nesting batches makes inner batches a no-op", async () => {
-      const { storage, assert, undo, redo, batch } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-        ],
-        1
-      );
+      const { storage, expectStorage, undo, redo, batch } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+          ],
+          1
+        );
 
       const items = storage.root.get("items");
 
@@ -300,19 +302,19 @@ describe("Storage", () => {
         });
       });
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
 
       undo();
 
-      assert({
+      expectStorage({
         items: [],
       });
 
       redo();
 
-      assert({
+      expectStorage({
         items: ["A", "B", "C"],
       });
     });
@@ -366,27 +368,28 @@ describe("Storage", () => {
 
   describe("undo / redo", () => {
     it("list.push", async () => {
-      const { storage, assert, assertUndoRedo } = await prepareStorageTest<{
-        items: LiveList<string>;
-      }>(
-        [
-          createSerializedObject("0:0", {}),
-          createSerializedList("0:1", "0:0", "items"),
-        ],
-        1
-      );
+      const { storage, expectStorage, assertUndoRedo } =
+        await prepareStorageTest<{
+          items: LiveList<string>;
+        }>(
+          [
+            createSerializedObject("0:0", {}),
+            createSerializedList("0:1", "0:0", "items"),
+          ],
+          1
+        );
 
       const items = storage.root.get("items");
 
-      assert({ items: [] });
+      expectStorage({ items: [] });
 
       items.push("A");
-      assert({
+      expectStorage({
         items: ["A"],
       });
 
       items.push("B");
-      assert({
+      expectStorage({
         items: ["A", "B"],
       });
 
@@ -394,13 +397,13 @@ describe("Storage", () => {
     });
 
     it("max undo-redo stack", async () => {
-      const { storage, assert, undo } = await prepareStorageTest<{
+      const { storage, expectStorage, undo } = await prepareStorageTest<{
         a: number;
       }>([createSerializedObject("0:0", { a: 0 })], 1);
 
       for (let i = 0; i < 100; i++) {
         storage.root.set("a", i + 1);
-        assert({
+        expectStorage({
           a: i + 1,
         });
       }
@@ -409,13 +412,13 @@ describe("Storage", () => {
         undo();
       }
 
-      assert({
+      expectStorage({
         a: 50,
       });
     });
 
     it("storage operation should clear redo stack", async () => {
-      const { storage, assert, undo, redo } = await prepareStorageTest<{
+      const { storage, expectStorage, undo, redo } = await prepareStorageTest<{
         items: LiveList<string>;
       }>(
         [
@@ -427,23 +430,23 @@ describe("Storage", () => {
 
       const items = storage.root.get("items");
 
-      assert({ items: [] });
+      expectStorage({ items: [] });
 
       items.insert("A", 0);
-      assert({
+      expectStorage({
         items: ["A"],
       });
 
       undo();
 
       items.insert("B", 0);
-      assert({
+      expectStorage({
         items: ["B"],
       });
 
       redo();
 
-      assert({
+      expectStorage({
         items: ["B"],
       });
     });


### PR DESCRIPTION
Renames a few of our exposed `assert` methods, to be more clear in call sites. What "assert" means depends on which prep function was used.

This PR is just a naming cleanup. I want to make more fundamental changes to our test setup, but that's not the point of this PR just yet.