### PR TITLE
Fix "ghosting bug"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17886,6 +17886,9 @@
       "name": "@liveblocks/core",
       "version": "1.0.2",
       "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
@@ -20461,6 +20464,7 @@
         "@types/ws": "^8.5.3",
         "dotenv": "^16.0.3",
         "eslint-plugin-rulesdir": "^0.2.1",
+        "lodash": "^4.17.21",
         "msw": "^0.47.4",
         "ws": "^8.5.0"
       },

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -44,5 +44,8 @@
     "url": "https://github.com/liveblocks/liveblocks.git",
     "directory": "packages/liveblocks-core"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
 }

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -52,7 +52,7 @@ export enum OpSource {
   LOCAL,
 
   /* Incoming Op, originally from this client, but echoed back by the server to acknowledge unmodified */
-  ACK,
+  PURE_ACK,
 
   /* Incoming Op, originally from this client, but modified by the server after conflict resolution */
   PATCHED_ACK,

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -48,7 +48,7 @@ export interface ManagedPool {
 }
 
 export enum OpSource {
-  UNDOREDO_RECONNECT,
+  LOCAL,
   REMOTE,
   ACK,
 }

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -51,11 +51,11 @@ export enum OpSource {
   /* Applied locally in the client (optimistically). Could be from an undo/redo operation, or a reconnect (?) */
   LOCAL,
 
-  /* Incoming Op, originating from a different client */
-  REMOTE,
-
   /* Incoming Op, originally from this client, but echoed back by the server to acknowledge unmodified */
   ACK,
+
+  /* Incoming Op, originating from a different client */
+  REMOTE,
 }
 
 // TODO Temporary helper to help convert from AbstractCrdt -> LiveNode, only

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -54,6 +54,9 @@ export enum OpSource {
   /* Incoming Op, originally from this client, but echoed back by the server to acknowledge unmodified */
   ACK,
 
+  /* Incoming Op, originally from this client, but modified by the server after conflict resolution */
+  PATCHED_ACK,
+
   /* Incoming Op, originating from a different client */
   REMOTE,
 }

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -48,8 +48,13 @@ export interface ManagedPool {
 }
 
 export enum OpSource {
+  /* Applied locally in the client (optimistically). Could be from an undo/redo operation, or a reconnect (?) */
   LOCAL,
+
+  /* Incoming Op, originating from a different client */
   REMOTE,
+
+  /* Incoming Op, originally from this client, but echoed back by the server to acknowledge unmodified */
   ACK,
 }
 

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -599,7 +599,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         return this._applySetRemote(op);
       } else if (source === OpSource.ACK) {
         return this._applySetAck(op);
-      } else if (source === OpSource.UNDOREDO_RECONNECT) {
+      } else if (source === OpSource.LOCAL) {
         return this._applySetUndoRedo(op);
       } else {
         // Should never happen
@@ -610,7 +610,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         return this._applyRemoteInsert(op);
       } else if (source === OpSource.ACK) {
         return this._applyInsertAck(op);
-      } else if (source === OpSource.UNDOREDO_RECONNECT) {
+      } else if (source === OpSource.LOCAL) {
         return this._applyInsertUndoRedo(op);
       } else {
         // Should never happen

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -597,7 +597,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     if (op.intent === "set") {
       if (source === OpSource.REMOTE) {
         return this._applySetRemote(op);
-      } else if (source === OpSource.PURE_ACK) {
+      } else if (
+        source === OpSource.PURE_ACK ||
+        source === OpSource.PATCHED_ACK
+      ) {
         return this._applySetAck(op);
       } else if (source === OpSource.LOCAL) {
         return this._applySetUndoRedo(op);
@@ -608,7 +611,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     } else {
       if (source === OpSource.REMOTE) {
         return this._applyRemoteInsert(op);
-      } else if (source === OpSource.PURE_ACK) {
+      } else if (
+        source === OpSource.PURE_ACK ||
+        source === OpSource.PATCHED_ACK
+      ) {
         return this._applyInsertAck(op);
       } else if (source === OpSource.LOCAL) {
         return this._applyInsertUndoRedo(op);
@@ -845,7 +851,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   _setChildKey(newKey: string, child: LiveNode, source: OpSource): ApplyResult {
     if (source === OpSource.REMOTE) {
       return this._applySetChildKeyRemote(newKey, child);
-    } else if (source === OpSource.PURE_ACK) {
+    } else if (
+      source === OpSource.PURE_ACK ||
+      source === OpSource.PATCHED_ACK
+    ) {
       return this._applySetChildKeyAck(newKey, child);
     } else {
       return this._applySetChildKeyUndoRedo(newKey, child);

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -597,7 +597,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     if (op.intent === "set") {
       if (source === OpSource.REMOTE) {
         return this._applySetRemote(op);
-      } else if (source === OpSource.ACK) {
+      } else if (source === OpSource.PURE_ACK) {
         return this._applySetAck(op);
       } else if (source === OpSource.LOCAL) {
         return this._applySetUndoRedo(op);
@@ -608,7 +608,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     } else {
       if (source === OpSource.REMOTE) {
         return this._applyRemoteInsert(op);
-      } else if (source === OpSource.ACK) {
+      } else if (source === OpSource.PURE_ACK) {
         return this._applyInsertAck(op);
       } else if (source === OpSource.LOCAL) {
         return this._applyInsertUndoRedo(op);
@@ -845,7 +845,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   _setChildKey(newKey: string, child: LiveNode, source: OpSource): ApplyResult {
     if (source === OpSource.REMOTE) {
       return this._applySetChildKeyRemote(newKey, child);
-    } else if (source === OpSource.ACK) {
+    } else if (source === OpSource.PURE_ACK) {
       return this._applySetChildKeyAck(newKey, child);
     } else {
       return this._applySetChildKeyUndoRedo(newKey, child);

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -153,7 +153,7 @@ export class LiveMap<
       return { modified: false };
     }
 
-    if (source === OpSource.PURE_ACK) {
+    if (source === OpSource.PURE_ACK || source === OpSource.PATCHED_ACK) {
       const lastUpdateOpId = this.unacknowledgedSet.get(key);
       if (lastUpdateOpId === opId) {
         // Acknowlegment from local operation

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -153,7 +153,7 @@ export class LiveMap<
       return { modified: false };
     }
 
-    if (source === OpSource.ACK) {
+    if (source === OpSource.PURE_ACK) {
       const lastUpdateOpId = this.unacknowledgedSet.get(key);
       if (lastUpdateOpId === opId) {
         // Acknowlegment from local operation

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -189,7 +189,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       return { modified: false };
     }
 
-    if (source === OpSource.UNDOREDO_RECONNECT) {
+    if (source === OpSource.LOCAL) {
       this._propToLastUpdate.set(key, nn(opId));
     } else if (this._propToLastUpdate.get(key) === undefined) {
       // Remote operation with no local change => apply operation

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -1,8 +1,3 @@
-import { RoomScope } from "../../protocol/AuthToken";
-import { OpCode } from "../../protocol/Op";
-import type { IdTuple, SerializedCrdt } from "../../protocol/SerializedCrdt";
-import { CrdtType } from "../../protocol/SerializedCrdt";
-import { WebsocketCloseCodes } from "../../types/WebsocketCloseCodes";
 import {
   listUpdate,
   listUpdateDelete,
@@ -25,6 +20,11 @@ import {
   SECOND_POSITION,
   THIRD_POSITION,
 } from "../../__tests__/_utils";
+import { RoomScope } from "../../protocol/AuthToken";
+import { OpCode } from "../../protocol/Op";
+import type { IdTuple, SerializedCrdt } from "../../protocol/SerializedCrdt";
+import { CrdtType } from "../../protocol/SerializedCrdt";
+import { WebsocketCloseCodes } from "../../types/WebsocketCloseCodes";
 import { LiveList } from "../LiveList";
 import { LiveMap } from "../LiveMap";
 import { LiveObject } from "../LiveObject";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1222,7 +1222,7 @@ function makeStateMachine<
         }
 
         const applyOpResult = applyOp(op, source);
-        if (applyOpResult.modified) {
+        if (applyOpResult.modified && source !== OpSource.ACK) {
           const nodeId = applyOpResult.modified.node._id;
 
           // If the modified node is not the root (undefined) and was created in the same batch, we don't want to notify

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1218,11 +1218,11 @@ function makeStateMachine<
           }
 
           const deleted = state.unacknowledgedOps.delete(opId);
-          source = deleted ? OpSource.ACK : OpSource.REMOTE;
+          source = deleted ? OpSource.PURE_ACK : OpSource.REMOTE;
         }
 
         const applyOpResult = applyOp(op, source);
-        if (applyOpResult.modified && source !== OpSource.ACK) {
+        if (applyOpResult.modified && source !== OpSource.PURE_ACK) {
           const nodeId = applyOpResult.modified.node._id;
 
           // If the modified node is not the root (undefined) and was created in the same batch, we don't want to notify

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1210,7 +1210,7 @@ function makeStateMachine<
         let source: OpSource;
 
         if (isLocal) {
-          source = OpSource.UNDOREDO_RECONNECT;
+          source = OpSource.LOCAL;
         } else {
           const opId = nn(op.opId);
           if (process.env.NODE_ENV !== "production") {
@@ -1279,7 +1279,7 @@ function makeStateMachine<
           return { modified: false };
         }
 
-        return node._apply(op, source === OpSource.UNDOREDO_RECONNECT);
+        return node._apply(op, source === OpSource.LOCAL);
       }
 
       case OpCode.SET_PARENT_KEY: {


### PR DESCRIPTION
There is a bug where a specific succession of quickly sent events can cause too many storage update events to get fired. While the updates ultimately lead to the correct end result, the in-between states that happen cause the storage state to temporarily be incorrect in the client. This bug manifests in an application as something described as "ghosting". The application seems to "flicker" or jump to incorrect state and quickly recover afterwards.

It addresses the symptoms described by Fermat on the customer call we had with them last week. Bug reports #628 and #731 seem to be incarnations of the same bug.

Commit eefca593aa8d3fd56784a811755291110272e17c adds a unit test, to try to capture the issue in a failing unit test. This is mostly the work of Eric, but I adjusted it a bit to be a little more explicit, and to capture another case.

Next, commit 70ccf3df317834aa8c10930c8cd25ddcb5c5d56c is a potential fix that I tried to make the tests pass. However, I'm not sure if this is the correct fix. ~While the unit tests all pass,~ Hmm, nevermind 🤔 The E2E suite definitely fails, fortunately! (I hadn't been running those locally, because they're so slow.)

Definitely shows I haven't found the fix yet.

---

## How should this be manually tested?

To see the weird behavior yourself, do this:

1. Check out this PR
2. `cd examples/nextjs-block-text-editor-advanced`
3. Run `link-example-locally.sh` (this will create a temporary local commit, please remove this local commit when you're done testing)
4. Run `turbo dev` to run the example locally (built against the version of `@liveblocks/client` from this PR)
