### PR TITLE
Update Vercel "should deploy" script

### DIFF
--- a/scripts/should-example-rebuild-on-vercel.sh
+++ b/scripts/should-example-rebuild-on-vercel.sh
@@ -48,12 +48,12 @@ shift $(($OPTIND - 1))
 
 if [ "$#" -lt 1 ]; then
     usage
-    exit 2
+    exit 3
 elif [ "$#" -gt 1 ]; then
     shift 1
     err "Superfluous arguments: $@"
     usage
-    exit 2
+    exit 4
 fi
 
 EXAMPLE="${1%/}"
@@ -62,14 +62,14 @@ if [ ! -d "examples/$EXAMPLE" ]; then
     err "Unknown example: $EXAMPLE"
     err "Valid examples are:"
     ls examples/ | cat >&2
-    exit 2
+    exit 5
 fi
 
 get_all_changed_files () {
     if [ ! -f "changed-files.txt" ]; then
         if [ -z "$GITHUB_ACCESS_TOKEN" ]; then
             err "Please set the GITHUB_ACCESS_TOKEN env var for this Vercel project for this to work."
-            exit 2
+            exit 6
         fi
 
         # If this is a check on the main branch, then compare the latest commit


### PR DESCRIPTION
This updates the Vercel "should deploy" script to fail with different exit codes for different errors, so we can see which one is failing. All we know is that it's [failing with exit code 2](https://vercel.com/liveblocks/examples-nextjs-whiteboard/3xViCNVWjC9HDneZdVV7HDsXXisz) now, which is not that useful.