### PR TITLE
Prepare for formalization of state machine

### DIFF
--- a/e2e/next-sandbox/pages/offline/index.tsx
+++ b/e2e/next-sandbox/pages/offline/index.tsx
@@ -51,7 +51,7 @@ function generateRandomNumber(max: number, ignore?: number) {
 function Sandbox() {
   const [status, setStatus] = useState("connected");
   const room = useRoom();
-  const internals = (room as any).__INTERNAL_DO_NOT_USE as Internal;
+  const internals = (room as any).__internal as Internal;
   const list = useList("items");
   const me = useSelf();
   const undo = useUndo();

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -150,18 +150,24 @@ export const THIRD_POSITION = makePosition(SECOND_POSITION);
 export const FOURTH_POSITION = makePosition(THIRD_POSITION);
 export const FIFTH_POSITION = makePosition(FOURTH_POSITION);
 
-const defaultMachineConfig = {
-  roomId: "room-id",
-  throttleDelay: -1, // No throttle for standard storage test
-  liveblocksServer: "wss://live.liveblocks.io/v6",
-  authentication: {
-    type: "private",
-    url: "/api/auth",
-  } as Authentication,
-  polyfills: {
-    WebSocket: MockWebSocket as any,
-  },
-};
+function makeMachineConfig<
+  TPresence extends JsonObject,
+  TRoomEvent extends Json
+>(mockedEffects: Effects<TPresence, TRoomEvent>) {
+  return {
+    roomId: "room-id",
+    throttleDelay: -1, // No throttle for standard storage test
+    liveblocksServer: "wss://live.liveblocks.io/v6",
+    authentication: {
+      type: "private",
+      url: "/api/auth",
+    } as Authentication,
+    polyfills: {
+      WebSocket: MockWebSocket as any,
+    },
+    mockedEffects,
+  };
+}
 
 export async function prepareRoomWithStorage<
   TPresence extends JsonObject,
@@ -186,8 +192,7 @@ export async function prepareRoomWithStorage<
   >({} as TPresence, defaultStorage || ({} as TStorage));
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
     state,
-    defaultMachineConfig,
-    effects
+    makeMachineConfig(effects)
   );
   const ws = new MockWebSocket("");
 

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -191,8 +191,8 @@ export async function prepareRoomWithStorage<
     TRoomEvent
   >({} as TPresence, defaultStorage || ({} as TStorage));
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
-    state,
-    makeMachineConfig(effects)
+    makeMachineConfig(effects),
+    state
   );
   const ws = new MockWebSocket("");
 

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -193,6 +193,7 @@ export async function prepareRoomWithStorage<
   machine.authenticationSuccess(makeRoomToken(actor, scopes), ws as any);
   ws.open();
 
+  // Start getting the storage, but don't await the promise just yet!
   const getStoragePromise = machine.getStorage();
 
   const clonedItems = deepClone(items);
@@ -204,7 +205,6 @@ export async function prepareRoomWithStorage<
   );
 
   const storage = await getStoragePromise;
-
   return {
     storage,
     machine,

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -26,10 +26,7 @@ import type {
   _private_Effects as Effects,
   _private_Machine as Machine,
 } from "../room";
-import {
-  _private_defaultMachineContext as defaultMachineContext,
-  _private_makeStateMachine as makeStateMachine,
-} from "../room";
+import { _private_makeStateMachine as makeStateMachine } from "../room";
 import type { JsonStorageUpdate } from "./_updatesUtils";
 import { serializeUpdateToJson } from "./_updatesUtils";
 
@@ -184,15 +181,10 @@ export async function prepareRoomWithStorage<
   const effects = mockEffects();
   (effects.send as jest.MockedFunction<any>).mockImplementation(onSend);
 
-  const state = defaultMachineContext<
-    TPresence,
-    TStorage,
-    TUserMeta,
-    TRoomEvent
-  >({} as TPresence, defaultStorage || ({} as TStorage));
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
     makeMachineConfig(effects),
-    state
+    {} as TPresence,
+    defaultStorage || ({} as TStorage)
   );
   const ws = new MockWebSocket("");
 

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -27,7 +27,7 @@ import type {
   _private_Machine as Machine,
 } from "../room";
 import {
-  _private_defaultState as defaultState,
+  _private_defaultMachineContext as defaultMachineContext,
   _private_makeStateMachine as makeStateMachine,
 } from "../room";
 import type { JsonStorageUpdate } from "./_updatesUtils";
@@ -150,7 +150,7 @@ export const THIRD_POSITION = makePosition(SECOND_POSITION);
 export const FOURTH_POSITION = makePosition(THIRD_POSITION);
 export const FIFTH_POSITION = makePosition(FOURTH_POSITION);
 
-const defaultContext = {
+const defaultMachineConfig = {
   roomId: "room-id",
   throttleDelay: -1, // No throttle for standard storage test
   liveblocksServer: "wss://live.liveblocks.io/v6",
@@ -178,13 +178,15 @@ export async function prepareRoomWithStorage<
   const effects = mockEffects();
   (effects.send as jest.MockedFunction<any>).mockImplementation(onSend);
 
-  const state = defaultState<TPresence, TStorage, TUserMeta, TRoomEvent>(
-    {} as TPresence,
-    defaultStorage || ({} as TStorage)
-  );
+  const state = defaultMachineContext<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TRoomEvent
+  >({} as TPresence, defaultStorage || ({} as TStorage));
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
     state,
-    defaultContext,
+    defaultMachineConfig,
     effects
   );
   const ws = new MockWebSocket("");

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -73,14 +73,9 @@ export async function prepareStorageImmutableTest<
   state = lsonToJson(storage.root) as ToJson<TStorage>;
   refState = lsonToJson(refStorage.root) as ToJson<TStorage>;
 
-  const root = refStorage.root;
-  refMachine.subscribe(
-    root,
-    () => {
-      refState = lsonToJson(refStorage.root) as ToJson<TStorage>;
-    },
-    { isDeep: true }
-  );
+  refMachine.events.storage.subscribe(() => {
+    refState = lsonToJson(refStorage.root) as ToJson<TStorage>;
+  });
 
   function expectStorageAndStateInBothClients(
     data: ToJson<TStorage>,
@@ -111,8 +106,6 @@ export async function prepareStorageImmutableTest<
     refStorage,
     expectStorageAndState: expectStorageAndStateInBothClients,
     expectStorage: expectStorageInBothClients,
-    subscribe: machine.subscribe,
-    refSubscribe: refMachine.subscribe,
     state,
   };
 }

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -21,6 +21,7 @@ import type { _private_Effects as Effects } from "../room";
 import {
   _private_makeStateMachine as makeStateMachine,
   createRoom,
+  makeClassicSubscribeFn,
 } from "../room";
 import type { Others } from "../types/Others";
 import { WebsocketCloseCodes } from "../types/WebsocketCloseCodes";
@@ -98,7 +99,14 @@ function setupStateMachine<
     initialPresence,
     undefined // no initialStorage
   );
-  return { machine, state: machine.state, effects };
+  return {
+    machine: {
+      ...machine,
+      subscribe: makeClassicSubscribeFn(machine),
+    },
+    state: machine.state,
+    effects,
+  };
 }
 
 describe("room / auth", () => {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -18,7 +18,7 @@ import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
 import { ServerMsgCode } from "../protocol/ServerMsg";
 import {
-  _private_defaultState as defaultState,
+  _private_defaultMachineContext as defaultMachineContext,
   _private_makeStateMachine as makeStateMachine,
   createRoom,
 } from "../room";
@@ -67,7 +67,12 @@ function setupStateMachine<
   TRoomEvent extends Json
 >(initialPresence: TPresence) {
   const effects = mockEffects<TPresence, TRoomEvent>();
-  const state = defaultState<TPresence, TStorage, TUserMeta, TRoomEvent>(
+  const state = defaultMachineContext<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TRoomEvent
+  >(
     initialPresence,
     undefined // no initialStorage
   );

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -17,11 +17,11 @@ import { ClientMsgCode } from "../protocol/ClientMsg";
 import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
 import { ServerMsgCode } from "../protocol/ServerMsg";
+import type { _private_Effects as Effects } from "../room";
 import {
   _private_makeStateMachine as makeStateMachine,
   createRoomMachine,
 } from "../room";
-import type { _private_Effects as Effects } from "../room";
 import type { Others } from "../types/Others";
 import { WebsocketCloseCodes } from "../types/WebsocketCloseCodes";
 import { listUpdate, listUpdateInsert, listUpdateSet } from "./_updatesUtils";

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -20,7 +20,7 @@ import { ServerMsgCode } from "../protocol/ServerMsg";
 import type { _private_Effects as Effects } from "../room";
 import {
   _private_makeStateMachine as makeStateMachine,
-  createRoomMachine,
+  createRoom,
 } from "../room";
 import type { Others } from "../types/Others";
 import { WebsocketCloseCodes } from "../types/WebsocketCloseCodes";
@@ -42,14 +42,14 @@ import {
   withDateNow,
 } from "./_utils";
 
-function createTestableRoom(...args: Parameters<typeof createRoomMachine>): {
+function createTestableRoom(...args: Parameters<typeof createRoom>): {
   // room: ReturnType<typeof createRoom>;
   connect: () => void;
   disconnect: () => void;
   onNavigatorOnline: () => void;
   onVisibilityChange: (visibilityState: DocumentVisibilityState) => void;
 } {
-  const room = createRoomMachine(...args);
+  const room = createRoom(...args);
   return {
     // room,
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -20,7 +20,7 @@ import { ServerMsgCode } from "../protocol/ServerMsg";
 import {
   _private_defaultMachineContext as defaultMachineContext,
   _private_makeStateMachine as makeStateMachine,
-  createRoom,
+  createRoomMachine,
 } from "../room";
 import type { Others } from "../types/Others";
 import { WebsocketCloseCodes } from "../types/WebsocketCloseCodes";
@@ -122,7 +122,7 @@ describe("room / auth", () => {
   test.each([{ notAToken: "" }, undefined, null, ""])(
     "custom authentication with missing token in callback response should throw",
     async (response) => {
-      const room = createRoom(
+      const room = createRoomMachine(
         { initialPresence: {} as never },
         {
           ...defaultContext,
@@ -150,7 +150,7 @@ describe("room / auth", () => {
   );
 
   test("private authentication with 403 status should throw", async () => {
-    const room = createRoom(
+    const room = createRoomMachine(
       { initialPresence: {} as never },
       {
         ...defaultContext,
@@ -173,7 +173,7 @@ describe("room / auth", () => {
   });
 
   test("private authentication that does not returns json should throw", async () => {
-    const room = createRoom(
+    const room = createRoomMachine(
       { initialPresence: {} as never },
       {
         ...defaultContext,
@@ -196,7 +196,7 @@ describe("room / auth", () => {
   });
 
   test("private authentication that does not returns json should throw", async () => {
-    const room = createRoom(
+    const room = createRoomMachine(
       { initialPresence: {} as never },
       {
         ...defaultContext,

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -42,6 +42,26 @@ import {
   withDateNow,
 } from "./_utils";
 
+function createTestableRoom(...args: Parameters<typeof createRoomMachine>): {
+  // room: ReturnType<typeof createRoom>;
+  connect: () => void;
+  disconnect: () => void;
+  onNavigatorOnline: () => void;
+  onVisibilityChange: (visibilityState: DocumentVisibilityState) => void;
+} {
+  const room = createRoomMachine(...args);
+  return {
+    // room,
+
+    // Expose the internal methods that provide control over the room's state
+    // machine directly, for convenience in unit tests.
+    connect: room.__internal.connect,
+    disconnect: room.__internal.disconnect,
+    onNavigatorOnline: room.__internal.onNavigatorOnline,
+    onVisibilityChange: room.__internal.onVisibilityChange,
+  };
+}
+
 function makeMachineConfig<
   TPresence extends JsonObject,
   TRoomEvent extends Json
@@ -119,7 +139,7 @@ describe("room / auth", () => {
   test.each([{ notAToken: "" }, undefined, null, ""])(
     "custom authentication with missing token in callback response should throw",
     async (response) => {
-      const room = createRoomMachine(
+      const controlledRoom = createTestableRoom(
         { initialPresence: {} as never },
         {
           ...makeMachineConfig(),
@@ -134,9 +154,9 @@ describe("room / auth", () => {
         }
       );
 
-      room.connect();
+      controlledRoom.connect();
       await waitFor(() => consoleErrorSpy.mock.calls.length > 0);
-      room.disconnect();
+      controlledRoom.disconnect();
 
       expect(consoleErrorSpy.mock.calls[0][1]).toEqual(
         new Error(
@@ -147,7 +167,7 @@ describe("room / auth", () => {
   );
 
   test("private authentication with 403 status should throw", async () => {
-    const room = createRoomMachine(
+    const controlledRoom = createTestableRoom(
       { initialPresence: {} as never },
       {
         ...makeMachineConfig(),
@@ -158,9 +178,9 @@ describe("room / auth", () => {
       }
     );
 
-    room.connect();
+    controlledRoom.connect();
     await waitFor(() => consoleErrorSpy.mock.calls.length > 0);
-    room.disconnect();
+    controlledRoom.disconnect();
 
     expect(consoleErrorSpy.mock.calls[0][1]).toEqual(
       new Error(
@@ -170,7 +190,7 @@ describe("room / auth", () => {
   });
 
   test("private authentication that does not returns json should throw", async () => {
-    const room = createRoomMachine(
+    const controlledRoom = createTestableRoom(
       { initialPresence: {} as never },
       {
         ...makeMachineConfig(),
@@ -181,9 +201,9 @@ describe("room / auth", () => {
       }
     );
 
-    room.connect();
+    controlledRoom.connect();
     await waitFor(() => consoleErrorSpy.mock.calls.length > 0);
-    room.disconnect();
+    controlledRoom.disconnect();
 
     expect(consoleErrorSpy.mock.calls[0][1]).toEqual(
       new Error(
@@ -193,7 +213,7 @@ describe("room / auth", () => {
   });
 
   test("private authentication that does not returns json should throw", async () => {
-    const room = createRoomMachine(
+    const controlledRoom = createTestableRoom(
       { initialPresence: {} as never },
       {
         ...makeMachineConfig(),
@@ -204,9 +224,9 @@ describe("room / auth", () => {
       }
     );
 
-    room.connect();
+    controlledRoom.connect();
     await waitFor(() => consoleErrorSpy.mock.calls.length > 0);
-    room.disconnect();
+    controlledRoom.disconnect();
 
     expect(consoleErrorSpy.mock.calls[0][1]).toEqual(
       new Error(

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1432,7 +1432,7 @@ describe("room", () => {
 
       reconnect(2);
 
-      const refMachineOthers = refMachine.getOthers().toArray();
+      const refMachineOthers = refMachine.getOthers();
 
       expect(refMachineOthers).toEqual([
         {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -18,7 +18,6 @@ import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
 import { ServerMsgCode } from "../protocol/ServerMsg";
 import {
-  _private_defaultMachineContext as defaultMachineContext,
   _private_makeStateMachine as makeStateMachine,
   createRoomMachine,
 } from "../room";
@@ -74,20 +73,12 @@ function setupStateMachine<
   TRoomEvent extends Json
 >(initialPresence: TPresence) {
   const effects = mockEffects<TPresence, TRoomEvent>();
-  const state = defaultMachineContext<
-    TPresence,
-    TStorage,
-    TUserMeta,
-    TRoomEvent
-  >(
+  const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
+    makeMachineConfig(effects),
     initialPresence,
     undefined // no initialStorage
   );
-  const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
-    makeMachineConfig(effects),
-    state
-  );
-  return { machine, state, effects };
+  return { machine, state: machine.state, effects };
 }
 
 describe("room / auth", () => {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -84,8 +84,8 @@ function setupStateMachine<
     undefined // no initialStorage
   );
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
-    state,
-    makeMachineConfig(effects)
+    makeMachineConfig(effects),
+    state
   );
   return { machine, state, effects };
 }

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -68,7 +68,8 @@ function setupStateMachine<
 >(initialPresence: TPresence) {
   const effects = mockEffects<TPresence, TRoomEvent>();
   const state = defaultState<TPresence, TStorage, TUserMeta, TRoomEvent>(
-    initialPresence
+    initialPresence,
+    undefined // no initialStorage
   );
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
     state,

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -218,23 +218,23 @@ describe("room", () => {
   test("connect should transition to authenticating if closed and execute authenticate", () => {
     const { machine, state, effects } = setupStateMachine({});
     machine.connect();
-    expect(state.connection.current.state).toEqual("authenticating");
+    expect(state.connection.current.status).toEqual("authenticating");
     expect(effects.authenticate).toHaveBeenCalled();
   });
 
   test("connect should stay authenticating if connect is called multiple times and call authenticate only once", () => {
     const { machine, state, effects } = setupStateMachine({});
     machine.connect();
-    expect(state.connection.current.state).toEqual("authenticating");
+    expect(state.connection.current.status).toEqual("authenticating");
     machine.connect();
-    expect(state.connection.current.state).toEqual("authenticating");
+    expect(state.connection.current.status).toEqual("authenticating");
     expect(effects.authenticate).toHaveBeenCalledTimes(1);
   });
 
   test("authentication success should transition to connecting", () => {
     const { machine, state } = setupStateMachine({});
     machine.authenticationSuccess(defaultRoomToken, new MockWebSocket(""));
-    expect(state.connection.current.state).toBe("connecting");
+    expect(state.connection.current.status).toBe("connecting");
   });
 
   test("initial presence should be sent once the connection is open", () => {

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -6,7 +6,7 @@ import type { Resolve } from "./lib/Resolve";
 import type { Authentication } from "./protocol/Authentication";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { Polyfills, Room, RoomInitializers } from "./room";
-import { createRoomMachine } from "./room";
+import { createRoom } from "./room";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1000;
@@ -161,12 +161,7 @@ export function createClient(options: ClientOptions): Client {
       "Please provide an initial presence value for the current user when entering the room."
     );
 
-    const newRoom = createRoomMachine<
-      TPresence,
-      TStorage,
-      TUserMeta,
-      TRoomEvent
-    >(
+    const newRoom = createRoom<TPresence, TStorage, TUserMeta, TRoomEvent>(
       {
         initialPresence: options.initialPresence ?? {},
         initialStorage: options.initialStorage,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -186,13 +186,8 @@ export function createClient(options: ClientOptions): Client {
       {
         roomId,
         throttleDelay,
-
         polyfills: clientOptions.polyfills,
-        WebSocketPolyfill: clientOptions.WebSocketPolyfill, // Backward-compatible API for setting polyfills
-        fetchPolyfill: clientOptions.fetchPolyfill, // Backward-compatible API for setting polyfills
-
         unstable_batchedUpdates: options?.unstable_batchedUpdates,
-
         liveblocksServer:
           // TODO Patch this using public but marked internal fields?
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -5,7 +5,7 @@ import type { Json, JsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
 import type { Authentication } from "./protocol/Authentication";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
-import type { RoomMachine, Polyfills, Room, RoomInitializers } from "./room";
+import type { Polyfills, Room, RoomInitializers, RoomMachine } from "./room";
 import { createRoomMachine } from "./room";
 
 const MIN_THROTTLE = 16;

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -5,8 +5,8 @@ import type { Json, JsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
 import type { Authentication } from "./protocol/Authentication";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
-import type { InternalRoom, Polyfills, Room, RoomInitializers } from "./room";
-import { createRoom } from "./room";
+import type { RoomMachine, Polyfills, Room, RoomInitializers } from "./room";
+import { createRoomMachine } from "./room";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1000;
@@ -124,7 +124,7 @@ export function createClient(options: ClientOptions): Client {
 
   const rooms = new Map<
     string,
-    InternalRoom<JsonObject, LsonObject, BaseUserMeta, Json>
+    RoomMachine<JsonObject, LsonObject, BaseUserMeta, Json>
   >();
 
   function getRoom<
@@ -154,7 +154,7 @@ export function createClient(options: ClientOptions): Client {
     options: EnterOptions<TPresence, TStorage>
   ): Room<TPresence, TStorage, TUserMeta, TRoomEvent> {
     let internalRoom = rooms.get(roomId) as
-      | InternalRoom<TPresence, TStorage, TUserMeta, TRoomEvent>
+      | RoomMachine<TPresence, TStorage, TUserMeta, TRoomEvent>
       | undefined;
     if (internalRoom) {
       return internalRoom.room as unknown as Room<
@@ -173,7 +173,12 @@ export function createClient(options: ClientOptions): Client {
       "Please provide an initial presence value for the current user when entering the room."
     );
 
-    internalRoom = createRoom<TPresence, TStorage, TUserMeta, TRoomEvent>(
+    internalRoom = createRoomMachine<
+      TPresence,
+      TStorage,
+      TUserMeta,
+      TRoomEvent
+    >(
       {
         initialPresence: options.initialPresence ?? {},
         initialStorage: options.initialStorage,
@@ -199,7 +204,7 @@ export function createClient(options: ClientOptions): Client {
 
     rooms.set(
       roomId,
-      internalRoom as unknown as InternalRoom<
+      internalRoom as unknown as RoomMachine<
         JsonObject,
         LsonObject,
         BaseUserMeta,

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -1127,7 +1127,7 @@ describe("LiveList", () => {
 
   describe("subscriptions", () => {
     test("batch multiple actions", async () => {
-      const { storage, subscribe, batch, expectStorage } =
+      const { machine, storage, batch, expectStorage } =
         await prepareStorageTest<{
           items: LiveList<string>;
         }>(
@@ -1140,12 +1140,10 @@ describe("LiveList", () => {
         );
 
       const callback = jest.fn();
+      machine.events.storage.subscribe(callback);
 
       const root = storage.root;
-
       const liveList = root.get("items");
-
-      subscribe(liveList, callback, { isDeep: true });
 
       batch(() => {
         liveList.push("b");
@@ -1168,7 +1166,7 @@ describe("LiveList", () => {
     });
 
     test("batch multiple inserts", async () => {
-      const { storage, subscribe, batch, expectStorage } =
+      const { machine, storage, batch, expectStorage } =
         await prepareStorageTest<{
           items: LiveList<string>;
         }>(
@@ -1181,12 +1179,10 @@ describe("LiveList", () => {
         );
 
       const callback = jest.fn();
+      machine.events.storage.subscribe(callback);
 
       const root = storage.root;
-
       const liveList = root.get("items");
-
-      subscribe(liveList, callback, { isDeep: true });
 
       batch(() => {
         liveList.insert("b", 1);
@@ -1201,7 +1197,7 @@ describe("LiveList", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to list", async () => {
-      const { expectStorage, machine, root } =
+      const { expectStorage, machine, subscribe, root } =
         await prepareIsolatedStorageTest<{
           items: LiveList<string>;
         }>(
@@ -1219,9 +1215,9 @@ describe("LiveList", () => {
 
       const listItems = root.get("items");
 
-      machine.subscribe(root, rootCallback);
-      machine.subscribe(root, rootDeepCallback, { isDeep: true });
-      machine.subscribe(listItems, listCallback);
+      subscribe(root, rootCallback);
+      subscribe(root, rootDeepCallback, { isDeep: true });
+      subscribe(listItems, listCallback);
 
       expectStorage({ items: ["a"] });
 
@@ -1289,7 +1285,7 @@ describe("LiveList", () => {
     });
 
     test("Register moved in list", async () => {
-      const { expectStorage, machine, root } =
+      const { expectStorage, machine, subscribe, root } =
         await prepareIsolatedStorageTest<{
           items: LiveList<string>;
         }>(
@@ -1308,9 +1304,9 @@ describe("LiveList", () => {
 
       const listItems = root.get("items");
 
-      machine.subscribe(root, rootCallback);
-      machine.subscribe(root, rootDeepCallback, { isDeep: true });
-      machine.subscribe(listItems, listCallback);
+      subscribe(root, rootCallback);
+      subscribe(root, rootDeepCallback, { isDeep: true });
+      subscribe(listItems, listCallback);
 
       expectStorage({ items: ["a", "b"] });
 
@@ -1366,7 +1362,7 @@ describe("LiveList", () => {
     });
 
     test("Register deleted from list", async () => {
-      const { expectStorage, machine, root } =
+      const { expectStorage, machine, subscribe, root } =
         await prepareIsolatedStorageTest<{
           items: LiveList<string>;
         }>(
@@ -1385,9 +1381,9 @@ describe("LiveList", () => {
 
       const listItems = root.get("items");
 
-      machine.subscribe(root, rootCallback);
-      machine.subscribe(root, rootDeepCallback, { isDeep: true });
-      machine.subscribe(listItems, listCallback);
+      subscribe(root, rootCallback);
+      subscribe(root, rootDeepCallback, { isDeep: true });
+      subscribe(listItems, listCallback);
 
       expectStorage({ items: ["a", "b"] });
 
@@ -1505,7 +1501,7 @@ describe("LiveList", () => {
       });
 
       it('with intent "set" should notify with a "set" update', async () => {
-        const { root, applyRemoteOperations, subscribe } =
+        const { machine, root, applyRemoteOperations } =
           await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
             [
               createSerializedObject("root", {}),
@@ -1518,8 +1514,7 @@ describe("LiveList", () => {
         const items = root.get("items");
 
         const callback = jest.fn();
-
-        subscribe(items, callback, { isDeep: true });
+        machine.events.storage.subscribe(callback);
 
         applyRemoteOperations([
           {
@@ -1581,7 +1576,7 @@ describe("LiveList", () => {
       });
 
       it('with intent "set" should notify with a "insert" update if no item exists at this position', async () => {
-        const { root, applyRemoteOperations, subscribe } =
+        const { root, subscribe, applyRemoteOperations } =
           await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
             [
               createSerializedObject("root", {}),
@@ -1595,7 +1590,6 @@ describe("LiveList", () => {
         items.delete(0);
 
         const callback = jest.fn();
-
         subscribe(items, callback, { isDeep: true });
 
         applyRemoteOperations([
@@ -1638,7 +1632,6 @@ describe("LiveList", () => {
         });
 
         const callback = jest.fn();
-
         subscribe(items, callback, { isDeep: true });
 
         applyRemoteOperations([

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveMap.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveMap.test.ts
@@ -648,7 +648,7 @@ describe("LiveMap", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("Register added to map", async () => {
-      const { expectStorage, machine, root } =
+      const { expectStorage, machine, subscribe, root } =
         await prepareIsolatedStorageTest<{
           map: LiveMap<string, string>;
         }>(
@@ -665,8 +665,8 @@ describe("LiveMap", () => {
 
       const listItems = root.get("map");
 
-      machine.subscribe(root, rootDeepCallback, { isDeep: true });
-      machine.subscribe(listItems, mapCallback);
+      subscribe(root, rootDeepCallback, { isDeep: true });
+      subscribe(listItems, mapCallback);
 
       expectStorage({ map: new Map([["first", "a"]]) });
 

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
@@ -905,7 +905,7 @@ describe("LiveObject", () => {
 
   describe("reconnect with remote changes and subscribe", () => {
     test("LiveObject updated", async () => {
-      const { expectStorage, machine, root } =
+      const { expectStorage, machine, root, subscribe } =
         await prepareIsolatedStorageTest<{
           obj: LiveObject<{ a: number }>;
         }>(
@@ -919,8 +919,8 @@ describe("LiveObject", () => {
       const rootDeepCallback = jest.fn();
       const liveObjectCallback = jest.fn();
 
-      machine.subscribe(root, rootDeepCallback, { isDeep: true });
-      machine.subscribe(root.get("obj"), liveObjectCallback);
+      subscribe(root, rootDeepCallback, { isDeep: true });
+      subscribe(root.get("obj"), liveObjectCallback);
 
       expectStorage({ obj: { a: 1 } });
 
@@ -964,7 +964,7 @@ describe("LiveObject", () => {
     });
 
     test("LiveObject updated nested", async () => {
-      const { expectStorage, machine, root } =
+      const { expectStorage, machine, root, subscribe } =
         await prepareIsolatedStorageTest<{
           obj: LiveObject<{ a: number; subObj?: LiveObject<{ b: number }> }>;
         }>(
@@ -978,8 +978,8 @@ describe("LiveObject", () => {
       const rootDeepCallback = jest.fn();
       const liveObjectCallback = jest.fn();
 
-      machine.subscribe(root, rootDeepCallback, { isDeep: true });
-      machine.subscribe(root.get("obj"), liveObjectCallback);
+      subscribe(root, rootDeepCallback, { isDeep: true });
+      subscribe(root.get("obj"), liveObjectCallback);
 
       expectStorage({ obj: { a: 1 } });
 

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -267,18 +267,11 @@ function mergeListStorageUpdates<T extends Lson>(
   };
 }
 
-// prettier-ignore
-export function mergeStorageUpdates<T extends StorageUpdate>(first: undefined, second: T): T;
-
-// prettier-ignore
-export function mergeStorageUpdates<K1 extends string, V1 extends Lson, K2 extends string, V2 extends Lson>(first: LiveMapUpdates<K1, V1>, second: LiveMapUpdates<K2, V2>): LiveMapUpdates<K1 | K2, V1 | V2>;
-
-// prettier-ignore
-export function mergeStorageUpdates<T extends Lson>(first: LiveListUpdates<Lson>, second: LiveListUpdates<T>): LiveListUpdates<T>;
-
-// prettier-ignore
-export function mergeStorageUpdates(first: StorageUpdate | undefined, second: StorageUpdate): StorageUpdate {
-  if (!first) {
+export function mergeStorageUpdates(
+  first: StorageUpdate | undefined,
+  second: StorageUpdate
+): StorageUpdate {
+  if (first === undefined) {
     return second;
   }
 

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -138,7 +138,7 @@ function partialSyncStorage(
 }
 
 function partialSyncMe(room: Room<JsonObject, LsonObject, BaseUserMeta, Json>) {
-  const me = room.getSelf_forDevTools();
+  const me = room.__internal.getSelf_forDevTools();
   if (me) {
     sendToPanel({
       msg: "room::sync::partial",
@@ -152,7 +152,7 @@ function partialSyncOthers(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>
 ) {
   // Any time others updates, send the new storage root to the dev panel
-  const others = room.getOthers_forDevTools();
+  const others = room.__internal.getOthers_forDevTools();
   if (others) {
     sendToPanel({
       msg: "room::sync::partial",
@@ -164,8 +164,8 @@ function partialSyncOthers(
 
 function fullSync(room: Room<JsonObject, LsonObject, BaseUserMeta, Json>) {
   const root = room.getStorageSnapshot();
-  const me = room.getSelf_forDevTools();
-  const others = room.getOthers_forDevTools();
+  const me = room.__internal.getSelf_forDevTools();
+  const others = room.__internal.getOthers_forDevTools();
   sendToPanel({
     msg: "room::sync::full",
     roomId: room.id,

--- a/packages/liveblocks-core/src/devtools/protocol.ts
+++ b/packages/liveblocks-core/src/devtools/protocol.ts
@@ -1,4 +1,4 @@
-import type { ConnectionState } from "../room";
+import type { ConnectionStatus } from "../room";
 import type * as DevTools from "../types/DevToolsTreeNode";
 
 /**
@@ -75,7 +75,7 @@ export type ClientToPanelMessage =
   | {
       msg: "room::sync::full";
       roomId: string;
-      status: ConnectionState;
+      status: ConnectionStatus;
       storage: readonly DevTools.LsonTreeNode[] | null;
       me: DevTools.UserTreeNode | null;
       others: readonly DevTools.UserTreeNode[];
@@ -87,7 +87,7 @@ export type ClientToPanelMessage =
   | {
       msg: "room::sync::partial";
       roomId: string;
-      status?: ConnectionState;
+      status?: ConnectionStatus;
       storage?: readonly DevTools.LsonTreeNode[];
       me?: DevTools.UserTreeNode;
       others?: readonly DevTools.UserTreeNode[];

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -106,7 +106,7 @@ export type {
 export { ServerMsgCode } from "./protocol/ServerMsg";
 export type {
   BroadcastOptions,
-  ConnectionState,
+  ConnectionStatus,
   History,
   Room,
   RoomInitializers,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -567,18 +567,6 @@ export type Room<
   };
 };
 
-export function isRoomEventName(value: string): value is RoomEventName {
-  return (
-    value === "my-presence" ||
-    value === "others" ||
-    value === "event" ||
-    value === "error" ||
-    value === "connection" ||
-    value === "history" ||
-    value === "storage-status"
-  );
-}
-
 type Machine<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
@@ -2545,6 +2533,18 @@ export function makeClassicSubscribeFn<
   }
 
   return subscribe;
+}
+
+function isRoomEventName(value: string): value is RoomEventName {
+  return (
+    value === "my-presence" ||
+    value === "others" ||
+    value === "event" ||
+    value === "error" ||
+    value === "connection" ||
+    value === "history" ||
+    value === "storage-status"
+  );
 }
 
 class LiveblocksError extends Error {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2391,7 +2391,6 @@ function makeStateMachine<
 
   return {
     // Internal
-    // XXX Rename to `context` eventually
     get state() {
       return context;
     },

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -550,13 +550,11 @@ export type Room<
       wasClean: boolean;
       reason: string;
     }): void;
+
+    /** For DevTools support */
+    getSelf_forDevTools(): DevTools.UserTreeNode | null;
+    getOthers_forDevTools(): readonly DevTools.UserTreeNode[];
   };
-
-  /** @internal - For DevTools support */
-  getSelf_forDevTools(): DevTools.UserTreeNode | null;
-
-  /** @internal - For DevTools support */
-  getOthers_forDevTools(): readonly DevTools.UserTreeNode[];
 };
 
 export function isRoomEventName(value: string): value is RoomEventName {
@@ -2537,12 +2535,13 @@ export function createRoom<
       disconnect: machine.disconnect,
       onNavigatorOnline: machine.onNavigatorOnline,
       onVisibilityChange: machine.onVisibilityChange,
+
       simulateCloseWebsocket: machine.simulateSocketClose,
       simulateSendCloseEvent: machine.simulateSendCloseEvent,
-    },
 
-    getSelf_forDevTools: machine.getSelf_forDevTools,
-    getOthers_forDevTools: machine.getOthers_forDevTools,
+      getSelf_forDevTools: machine.getSelf_forDevTools,
+      getOthers_forDevTools: machine.getOthers_forDevTools,
+    },
   };
 
   return room;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -761,6 +761,7 @@ type MachineContext<
   opStackTraces?: Map<string, string>;
 };
 
+/** @internal */
 type Effects<TPresence extends JsonObject, TRoomEvent extends Json> = {
   authenticate(
     auth: AuthCallback,
@@ -801,7 +802,8 @@ export type RoomInitializers<
   shouldInitiallyConnect?: boolean;
 }>;
 
-type MachineConfig = {
+/** @internal */
+type MachineConfig<TPresence extends JsonObject, TRoomEvent extends Json> = {
   roomId: string;
   throttleDelay: number;
   authentication: Authentication;
@@ -828,6 +830,8 @@ type MachineConfig = {
    * Backward-compatible way to set `polyfills.WebSocket`.
    */
   WebSocketPolyfill?: Polyfills["WebSocket"];
+
+  mockedEffects?: Effects<TPresence, TRoomEvent>;
 };
 
 function userToTreeNode(
@@ -850,8 +854,7 @@ function makeStateMachine<
 >(
   // XXX Rename to `context`. This represents the "infinite state" part of the Finite State Machine.
   state: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
-  config: MachineConfig,
-  mockedEffects?: Effects<TPresence, TRoomEvent>
+  config: MachineConfig<TPresence, TRoomEvent>
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const doNotBatchUpdates = (cb: () => void): void => cb();
   const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;
@@ -933,7 +936,7 @@ function makeStateMachine<
     storageStatus: makeEventSource<StorageStatus>(),
   };
 
-  const effects: Effects<TPresence, TRoomEvent> = mockedEffects || {
+  const effects: Effects<TPresence, TRoomEvent> = config.mockedEffects || {
     authenticate(
       auth: AuthCallback,
       createWebSocket: (token: string) => WebSocket
@@ -2499,7 +2502,7 @@ export function createRoomMachine<
     RoomInitializers<TPresence, TStorage>,
     "shouldInitiallyConnect"
   >,
-  config: MachineConfig
+  config: MachineConfig<TPresence, TRoomEvent>
 ): RoomMachine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const { initialPresence, initialStorage } = options;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2466,20 +2466,6 @@ function makeStateMachine<
   };
 }
 
-/** @internal */
-export type RoomMachine<
-  TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
-> = {
-  room: Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
-  connect: () => void;
-  disconnect: () => void;
-  onNavigatorOnline: () => void;
-  onVisibilityChange: (visibilityState: DocumentVisibilityState) => void;
-};
-
 export function createRoomMachine<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
@@ -2491,7 +2477,7 @@ export function createRoomMachine<
     "shouldInitiallyConnect"
   >,
   config: MachineConfig<TPresence, TRoomEvent>
-): RoomMachine<TPresence, TStorage, TUserMeta, TRoomEvent> {
+): Room<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const { initialPresence, initialStorage } = options;
 
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
@@ -2555,13 +2541,7 @@ export function createRoomMachine<
     getOthers_forDevTools: machine.getOthers_forDevTools,
   };
 
-  return {
-    connect: room.__internal.connect,
-    disconnect: room.__internal.disconnect,
-    onNavigatorOnline: room.__internal.onNavigatorOnline,
-    onVisibilityChange: room.__internal.onVisibilityChange,
-    room,
-  };
+  return room;
 }
 
 class LiveblocksError extends Error {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -852,9 +852,9 @@ function makeStateMachine<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 >(
+  config: MachineConfig<TPresence, TRoomEvent>,
   // XXX Rename to `context`. This represents the "infinite state" part of the Finite State Machine.
-  state: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
-  config: MachineConfig<TPresence, TRoomEvent>
+  state: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const doNotBatchUpdates = (cb: () => void): void => cb();
   const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;
@@ -2521,8 +2521,8 @@ export function createRoomMachine<
   );
 
   const machine = makeStateMachine<TPresence, TStorage, TUserMeta, TRoomEvent>(
-    state,
-    config
+    config,
+    state
   );
 
   const room: Room<TPresence, TStorage, TUserMeta, TRoomEvent> = {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -532,9 +532,13 @@ export type Room<
   reconnect(): void;
 
   /**
-   * @internal Utilities only used for unit testing.
+   * @internal
+   * Private methods to directly control the underlying state machine for this
+   * room. Used in the core internals and for unit testing, but as a user of
+   * Liveblocks, NEVER USE ANY OF THESE METHODS DIRECTLY, because bad things
+   * will probably happen if you do.
    */
-  readonly __INTERNAL_DO_NOT_USE: {
+  readonly __internal: {
     connect(): void;
     disconnect(): void;
     onNavigatorOnline(): void;
@@ -2538,7 +2542,7 @@ export function createRoomMachine<
       resume: machine.resumeHistory,
     },
 
-    __INTERNAL_DO_NOT_USE: {
+    __internal: {
       connect: machine.connect,
       disconnect: machine.disconnect,
       onNavigatorOnline: machine.onNavigatorOnline,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -58,6 +58,9 @@ import type { Others, OthersEvent } from "./types/Others";
 import type { User } from "./types/User";
 import { WebsocketCloseCodes } from "./types/WebsocketCloseCodes";
 
+type TimeoutID = ReturnType<typeof setTimeout>;
+type IntervalID = ReturnType<typeof setInterval>;
+
 type CustomEvent<TRoomEvent extends Json> = {
   connectionId: number;
   event: TRoomEvent;
@@ -710,12 +713,12 @@ type MachineContext<
     storageOperations: Op[];
   };
   timeoutHandles: {
-    flush: number | null;
-    reconnect: number;
-    pongTimeout: number;
+    flush: TimeoutID | undefined;
+    reconnect: TimeoutID | undefined;
+    pongTimeout: TimeoutID | undefined;
   };
   intervalHandles: {
-    heartbeat: number;
+    heartbeat: IntervalID | undefined;
   };
 
   readonly connection: ValueRef<Connection>;
@@ -769,10 +772,10 @@ type Effects<TPresence extends JsonObject, TRoomEvent extends Json> = {
     createWebSocket: (token: string) => WebSocket
   ): void;
   send(messages: ClientMsg<TPresence, TRoomEvent>[]): void;
-  delayFlush(delay: number): number;
-  startHeartbeatInterval(): number;
-  schedulePongTimeout(): number;
-  scheduleReconnect(delay: number): number;
+  delayFlush(delay: number): TimeoutID;
+  startHeartbeatInterval(): IntervalID;
+  schedulePongTimeout(): TimeoutID;
+  scheduleReconnect(delay: number): TimeoutID;
 };
 
 export type Polyfills = {
@@ -858,9 +861,9 @@ function makeStateMachine<
     numberOfRetry: 0,
     lastFlushTime: 0,
     timeoutHandles: {
-      flush: null,
-      reconnect: 0,
-      pongTimeout: 0,
+      flush: undefined,
+      reconnect: undefined,
+      pongTimeout: undefined,
     },
     buffer: {
       me:
@@ -873,7 +876,7 @@ function makeStateMachine<
       storageOperations: [],
     },
     intervalHandles: {
-      heartbeat: 0,
+      heartbeat: undefined,
     },
 
     connection: new ValueRef<Connection>({ status: "closed" }),
@@ -1023,16 +1026,16 @@ function makeStateMachine<
       context.socket.send(JSON.stringify(messageOrMessages));
     },
     delayFlush(delay: number) {
-      return setTimeout(tryFlushing, delay) as any;
+      return setTimeout(tryFlushing, delay);
     },
     startHeartbeatInterval() {
-      return setInterval(heartbeat, HEARTBEAT_INTERVAL) as any;
+      return setInterval(heartbeat, HEARTBEAT_INTERVAL);
     },
     schedulePongTimeout() {
-      return setTimeout(pongTimeout, PONG_TIMEOUT) as any;
+      return setTimeout(pongTimeout, PONG_TIMEOUT);
     },
     scheduleReconnect(delay: number) {
-      return setTimeout(connect, delay) as any;
+      return setTimeout(connect, delay);
     },
   };
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1364,10 +1364,6 @@ function makeStateMachine<
     }
   }
 
-  function getConnectionState() {
-    return context.connection.current.status;
-  }
-
   function connect() {
     if (
       context.connection.current.status !== "closed" &&
@@ -2021,14 +2017,6 @@ function makeStateMachine<
     });
   }
 
-  function getPresence(): Readonly<TPresence> {
-    return context.me.current;
-  }
-
-  function getOthers(): Others<TPresence, TUserMeta> {
-    return context.others.current;
-  }
-
   function broadcastEvent(
     event: TRoomEvent,
     options: BroadcastOptions = {
@@ -2326,13 +2314,13 @@ function makeStateMachine<
     },
 
     // Core
-    getConnectionState,
+    getConnectionState: () => context.connection.current.status,
     isSelfAware: () => isConnectionSelfAware(context.connection.current),
     getSelf: () => self.current,
 
     // Presence
-    getPresence,
-    getOthers,
+    getPresence: () => context.me.current,
+    getOthers: () => context.others.current,
 
     // Support for the Liveblocks browser extension
     getSelf_forDevTools: () => selfAsTreeNode.current,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -861,8 +861,6 @@ function defaultMachineContext<
     others.map((other, index) => userToTreeNode(`Other ${index}`, other))
   );
 
-  const connection = new ValueRef<Connection>({ status: "closed" });
-
   return {
     token: null,
     lastConnectionId: null,
@@ -888,7 +886,7 @@ function defaultMachineContext<
       heartbeat: 0,
     },
 
-    connection,
+    connection: new ValueRef<Connection>({ status: "closed" }),
     me: new MeRef(initialPresence),
     others,
     others_forDevTools,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2406,7 +2406,7 @@ function defaultState<
   TRoomEvent extends Json
 >(
   initialPresence: TPresence,
-  initialStorage?: TStorage
+  initialStorage: TStorage | undefined
 ): State<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const others = new OthersRef<TPresence, TUserMeta>();
   const others_forDevTools = new DerivedRef(others, (others) =>

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -843,7 +843,10 @@ function makeStateMachine<
   initialPresence: TPresence,
   initialStorage: TStorage | undefined
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
-  // The "context" is the "infinite state" part of this Finite State Machine.
+  // The "context" is the machine's stateful extended context, also sometimes
+  // known as the "extended state" of a finite state machine. The context
+  // maintains state beyond the inherent state that are the finite states
+  // themselves.
   const context: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent> = {
     token: null,
     lastConnectionId: null,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2466,6 +2466,10 @@ function makeStateMachine<
   };
 }
 
+/**
+ * Initializes a new Room state machine, and returns its public API to observe
+ * and control it.
+ */
 export function createRoom<
   TPresence extends JsonObject,
   TStorage extends LsonObject,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2476,7 +2476,7 @@ function defaultMachineContext<
 }
 
 /** @internal */
-export type InternalRoom<
+export type RoomMachine<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -2489,7 +2489,7 @@ export type InternalRoom<
   onVisibilityChange: (visibilityState: DocumentVisibilityState) => void;
 };
 
-export function createRoom<
+export function createRoomMachine<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -2500,7 +2500,7 @@ export function createRoom<
     "shouldInitiallyConnect"
   >,
   config: MachineConfig
-): InternalRoom<TPresence, TStorage, TUserMeta, TRoomEvent> {
+): RoomMachine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const { initialPresence, initialStorage } = options;
 
   const state = defaultMachineContext<

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -818,16 +818,6 @@ type MachineConfig<TPresence extends JsonObject, TRoomEvent extends Json> = {
    */
   unstable_batchedUpdates?: (cb: () => void) => void;
 
-  /**
-   * Backward-compatible way to set `polyfills.fetch`.
-   */
-  fetchPolyfill?: Polyfills["fetch"];
-
-  /**
-   * Backward-compatible way to set `polyfills.WebSocket`.
-   */
-  WebSocketPolyfill?: Polyfills["WebSocket"];
-
   mockedEffects?: Effects<TPresence, TRoomEvent>;
 };
 
@@ -1497,11 +1487,11 @@ function makeStateMachine<
 
     const auth = prepareAuthEndpoint(
       config.authentication,
-      config.polyfills?.fetch ?? config.fetchPolyfill
+      config.polyfills?.fetch
     );
     const createWebSocket = prepareCreateWebSocket(
       config.liveblocksServer,
-      config.polyfills?.WebSocket ?? config.WebSocketPolyfill
+      config.polyfills?.WebSocket
     );
 
     updateConnection({ status: "authenticating" }, batchUpdates);

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -535,6 +535,11 @@ export type Room<
    * @internal Utilities only used for unit testing.
    */
   readonly __INTERNAL_DO_NOT_USE: {
+    connect(): void;
+    disconnect(): void;
+    onNavigatorOnline(): void;
+    onVisibilityChange(visibilityState: DocumentVisibilityState): void;
+
     simulateCloseWebsocket(): void;
     simulateSendCloseEvent(event: {
       code: number;
@@ -2534,6 +2539,10 @@ export function createRoomMachine<
     },
 
     __INTERNAL_DO_NOT_USE: {
+      connect: machine.connect,
+      disconnect: machine.disconnect,
+      onNavigatorOnline: machine.onNavigatorOnline,
+      onVisibilityChange: machine.onVisibilityChange,
       simulateCloseWebsocket: machine.simulateSocketClose,
       simulateSendCloseEvent: machine.simulateSendCloseEvent,
     },
@@ -2543,10 +2552,10 @@ export function createRoomMachine<
   };
 
   return {
-    connect: machine.connect,
-    disconnect: machine.disconnect,
-    onNavigatorOnline: machine.onNavigatorOnline,
-    onVisibilityChange: machine.onVisibilityChange,
+    connect: room.__internal.connect,
+    disconnect: room.__internal.disconnect,
+    onNavigatorOnline: room.__internal.onNavigatorOnline,
+    onVisibilityChange: room.__internal.onVisibilityChange,
     room,
   };
 }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -21,7 +21,7 @@ import { isJsonArray, isJsonObject } from "./lib/Json";
 import type { Resolve } from "./lib/Resolve";
 import { compact, isPlainObject, tryParseJson } from "./lib/utils";
 import type { Authentication } from "./protocol/Authentication";
-import type { RoomAuthToken, JwtMetadata } from "./protocol/AuthToken";
+import type { JwtMetadata, RoomAuthToken } from "./protocol/AuthToken";
 import {
   isTokenExpired,
   parseRoomAuthToken,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -847,7 +847,7 @@ function userToTreeNode(
 }
 
 /** @internal */
-function defaultMachineContext<
+function makeInitialContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -929,7 +929,7 @@ function makeStateMachine<
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   // XXX Rename to `context`. This represents the "infinite state" part of the Finite State Machine.
   const state: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent> =
-    defaultMachineContext(initialPresence, initialStorage);
+    makeInitialContext(initialPresence, initialStorage);
 
   const doNotBatchUpdates = (cb: () => void): void => cb();
   const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2466,7 +2466,7 @@ function makeStateMachine<
   };
 }
 
-export function createRoomMachine<
+export function createRoom<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -847,7 +847,7 @@ function userToTreeNode(
 }
 
 /** @internal */
-function makeInitialContext<
+function defaultMachineContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -929,7 +929,7 @@ function makeStateMachine<
 ): Machine<TPresence, TStorage, TUserMeta, TRoomEvent> {
   // XXX Rename to `context`. This represents the "infinite state" part of the Finite State Machine.
   const state: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent> =
-    makeInitialContext(initialPresence, initialStorage);
+    defaultMachineContext(initialPresence, initialStorage);
 
   const doNotBatchUpdates = (cb: () => void): void => cb();
   const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -943,7 +943,7 @@ function makeStateMachine<
           activeBatch.updates.storageUpdates.set(
             key,
             mergeStorageUpdates(
-              activeBatch.updates.storageUpdates.get(key) as any, // FIXME
+              activeBatch.updates.storageUpdates.get(key),
               value
             )
           );
@@ -1286,9 +1286,7 @@ function makeStateMachine<
             output.storageUpdates.set(
               nn(applyOpResult.modified.node._id),
               mergeStorageUpdates(
-                output.storageUpdates.get(
-                  nn(applyOpResult.modified.node._id)
-                ) as any, // FIXME
+                output.storageUpdates.get(nn(applyOpResult.modified.node._id)),
                 applyOpResult.modified
               )
             );
@@ -1693,10 +1691,7 @@ function makeStateMachine<
             applyResult.updates.storageUpdates.forEach((value, key) => {
               updates.storageUpdates.set(
                 key,
-                mergeStorageUpdates(
-                  updates.storageUpdates.get(key) as any, // FIXME
-                  value
-                )
+                mergeStorageUpdates(updates.storageUpdates.get(key), value)
               );
             });
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2426,6 +2426,10 @@ export function createRoom<
   return room;
 }
 
+/**
+ * This recreates the classic single `.subscribe()` method for the Room API, as
+ * documented here https://liveblocks.io/docs/api-reference/liveblocks-client#Room.subscribe(storageItem)
+ */
 export function makeClassicSubscribeFn<
   TPresence extends JsonObject,
   TStorage extends LsonObject,


### PR DESCRIPTION
In preparation of #823, I did a few "cleanup" passes over the current state machine implementation. **I haven't changed any functionality here**—all changes here are pure refactorings, like renames, or moving code around that is internal. I've started adopting some of the XState terminology, like using the term `context` for the "extended state" being tracked in the Finite State Machine. I'll continue with this work next week, and then I'll use more terminology from XState, like "invoked actors", "transitions", etc in an effort to further formalize the machine.

The reason I'm opening this PR, is to remove a lot of noise from that PR. This PR should be able to be merged as-is, without any observable changes to the public APIs and/or behavior. Having this PR merged will make reviewing the real changes next week a lot easier / less noisy.
