### PR TITLE
Prepare for formalization of state machine (continued)

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -620,11 +620,11 @@ export function mockEffects<
 >(): Effects<TPresence, TRoomEvent> {
   return {
     authenticate: jest.fn(),
-    delayFlush: jest.fn(),
     send: jest.fn(),
-    schedulePongTimeout: jest.fn(),
-    startHeartbeatInterval: jest.fn(),
+    scheduleFlush: jest.fn(),
     scheduleReconnect: jest.fn(),
+    startHeartbeatInterval: jest.fn(),
+    schedulePongTimeout: jest.fn(),
   };
 }
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -318,7 +318,7 @@ describe("room", () => {
 
     withDateNow(now + 30, () => machine.updatePresence({ x: 1 }));
 
-    expect(effects.delayFlush).toBeCalledWith(
+    expect(effects.scheduleFlush).toBeCalledWith(
       makeMachineConfig().throttleDelay - 30
     );
     expect(effects.send).toHaveBeenCalledWith([

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1540,7 +1540,7 @@ describe("room", () => {
         "Connection to Liveblocks websocket server closed (code: 1006). Retrying in 250ms."
       );
 
-      expect(state.numberOfRetry).toEqual(1);
+      expect(state.numRetries).toEqual(1);
     });
 
     test("when error code 4002", () => {
@@ -1562,7 +1562,7 @@ describe("room", () => {
         "Connection to websocket server closed. Reason:  (code: 4002). Retrying in 2000ms."
       );
 
-      expect(state.numberOfRetry).toEqual(1);
+      expect(state.numRetries).toEqual(1);
     });
 
     test("manual reconnection", () => {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1507,6 +1507,8 @@ function makeStateMachine<
     }
   }
 
+  function canUndo() { return context.undoStack.length > 0; } // prettier-ignore
+  function canRedo() { return context.redoStack.length > 0; } // prettier-ignore
   function onHistoryChange(batchedUpdatesWrapper: (cb: () => void) => void) {
     batchedUpdatesWrapper(() => {
       eventHub.history.notify({ canUndo: canUndo(), canRedo: canRedo() });
@@ -2066,10 +2068,6 @@ function makeStateMachine<
     tryFlushing();
   }
 
-  function canUndo() {
-    return context.undoStack.length > 0;
-  }
-
   function redo() {
     if (context.activeBatch) {
       throw new Error("redo is not allowed during a batch");
@@ -2095,10 +2093,6 @@ function makeStateMachine<
       }
     }
     tryFlushing();
-  }
-
-  function canRedo() {
-    return context.redoStack.length > 0;
   }
 
   function batch<T>(callback: () => T): T {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1898,6 +1898,7 @@ function makeStateMachine<
     const elapsedMillis = now - context.buffer.lastFlushedAt;
 
     if (elapsedMillis > config.throttleDelay) {
+      // Flush the buffer right now
       const messagesToFlush = serializeBuffer();
       if (messagesToFlush.length === 0) {
         return;
@@ -1911,6 +1912,7 @@ function makeStateMachine<
         me: null,
       };
     } else {
+      // Or schedule the flush a few millis into the future
       if (context.timers.flush !== null) {
         clearTimeout(context.timers.flush);
       }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -685,7 +685,13 @@ type MachineContext<
     readonly raw: string;
     readonly parsed: RoomAuthToken & JwtMetadata;
   } | null;
-  lastConnectionId: number | null; // TODO: Move into Connection type members?
+
+  /**
+   * Remembers the last successful connection ID. This gets assigned as soon as
+   * the connection status switched from "connecting" to "open".
+   */
+  lastConnectionId: number | null; // TODO Do we really need to separately track this, or can we derive this from the last known token?
+
   socket: WebSocket | null;
 
   /**

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -930,17 +930,17 @@ function makeStateMachine<
       if (process.env.NODE_ENV !== "production") {
         const stackTrace = captureStackTrace("Storage mutation", this.dispatch);
         if (stackTrace) {
-          ops.forEach((op) => {
+          for (const op of ops) {
             if (op.opId) {
               nn(context.opStackTraces).set(op.opId, stackTrace);
             }
-          });
+          }
         }
       }
 
       if (activeBatch) {
         activeBatch.ops.push(...ops);
-        storageUpdates.forEach((value, key) => {
+        for (const [key, value] of storageUpdates) {
           activeBatch.updates.storageUpdates.set(
             key,
             mergeStorageUpdates(
@@ -948,7 +948,7 @@ function makeStateMachine<
               value
             )
           );
-        });
+        }
         activeBatch.reverseOps.unshift(...reverse);
       } else {
         batchUpdates(() => {
@@ -1092,9 +1092,9 @@ function makeStateMachine<
     }
 
     const currentItems: NodeMap = new Map();
-    context.nodes.forEach((node, id) => {
+    for (const [id, node] of context.nodes) {
       currentItems.set(id, node._serialize());
-    });
+    }
 
     // Get operations that represent the diff between 2 states.
     const ops = getTreesDiffOperations(currentItems, new Map(items));
@@ -1650,13 +1650,12 @@ function makeStateMachine<
           // Write event
           case ServerMsgCode.UPDATE_STORAGE: {
             const applyResult = applyOps(message.ops, false);
-            applyResult.updates.storageUpdates.forEach((value, key) => {
+            for (const [key, value] of applyResult.updates.storageUpdates) {
               updates.storageUpdates.set(
                 key,
                 mergeStorageUpdates(updates.storageUpdates.get(key), value)
               );
-            });
-
+            }
             break;
           }
 
@@ -1878,11 +1877,10 @@ function makeStateMachine<
 
   function tryFlushing() {
     const storageOps = context.buffer.storageOperations;
-
     if (storageOps.length > 0) {
-      storageOps.forEach((op) => {
+      for (const op of storageOps) {
         context.unacknowledgedOps.set(nn(op.opId), op);
-      });
+      }
       notifyStorageStatus();
     }
 
@@ -1982,7 +1980,9 @@ function makeStateMachine<
       notify({ others: [{ type: "reset" }] }, doNotBatchUpdates);
 
       // Clear all event listeners
-      Object.values(eventHub).forEach((eventSource) => eventSource.clear());
+      for (const eventSource of Object.values(eventHub)) {
+        eventSource.clear();
+      }
     });
   }
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1862,13 +1862,13 @@ function makeStateMachine<
       context.socket = null;
     }
 
+    clearTimeout(context.timers.flush);
+    clearTimeout(context.timers.reconnect);
+    clearInterval(context.timers.heartbeat);
+    clearTimeout(context.timers.pongTimeout);
+
     batchUpdates(() => {
       updateConnection({ status: "closed" }, doNotBatchUpdates);
-
-      clearTimeout(context.timers.flush);
-      clearTimeout(context.timers.reconnect);
-      clearInterval(context.timers.heartbeat);
-      clearTimeout(context.timers.pongTimeout);
 
       context.others.clearOthers();
       notify({ others: [{ type: "reset" }] }, doNotBatchUpdates);
@@ -1890,12 +1890,12 @@ function makeStateMachine<
       context.socket = null;
     }
 
-    updateConnection({ status: "unavailable" }, batchUpdates);
-
     clearTimeout(context.timers.flush);
     clearTimeout(context.timers.reconnect);
     clearInterval(context.timers.heartbeat);
     clearTimeout(context.timers.pongTimeout);
+
+    updateConnection({ status: "unavailable" }, batchUpdates);
 
     connect();
   }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -723,7 +723,7 @@ type MachineContext<
 
   clock: number;
   opClock: number;
-  nodes: Map<string, LiveNode>;
+  readonly nodes: Map<string, LiveNode>;
   root: LiveObject<TStorage> | undefined;
 
   undoStack: HistoryOp<TPresence>[][];
@@ -739,7 +739,7 @@ type MachineContext<
    * Place to collect all mutations during a batch. Ops will be sent over the
    * wire after the batch is ended.
    */
-  activeBatch: null | {
+  activeBatch: {
     ops: Op[];
     reverseOps: HistoryOp<TPresence>[];
     updates: {
@@ -747,14 +747,14 @@ type MachineContext<
       presence: boolean;
       storageUpdates: Map<string, StorageUpdate>;
     };
-  };
+  } | null;
 
   // A registry of yet-unacknowledged Ops. These Ops have already been
   // submitted to the server, but have not yet been acknowledged.
-  unacknowledgedOps: Map<string, Op>;
+  readonly unacknowledgedOps: Map<string, Op>;
 
   // Stack traces of all pending Ops. Used for debugging in non-production builds
-  opStackTraces?: Map<string, string>;
+  readonly opStackTraces?: Map<string, string>;
 };
 
 /** @internal */

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1872,12 +1872,12 @@ function makeStateMachine<
 
       context.others.clearOthers();
       notify({ others: [{ type: "reset" }] }, doNotBatchUpdates);
-
-      // Clear all event listeners
-      for (const eventSource of Object.values(eventHub)) {
-        eventSource.clear();
-      }
     });
+
+    // Clear all event listeners
+    for (const eventSource of Object.values(eventHub)) {
+      eventSource.clear();
+    }
   }
 
   function reconnect() {


### PR DESCRIPTION
More of the same stuff that #828 is made of. Again, this only contains pure refactorings. This is a continuation of cleaning up the room's internals in order to simplify them and document them, so that making the real refactoring will soon be much easier. This is likely not the last one. I'll keep doing this until the switch to a more formal state machine is less daunting to make, and we can do so with more confidence. (In the spirit of Kent Beck: _"First make the change easy, then make the easy change"_.)