### PR TITLE
Release `create-liveblocks-app` with other packages

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -9,6 +9,7 @@ PACKAGE_DIRS=(
     "packages/liveblocks-react"
     "packages/liveblocks-redux"
     "packages/liveblocks-zustand"
+    "packages/create-liveblocks-app"
 )
 PRIMARY_PKG=${PACKAGE_DIRS[0]}
 

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -9,6 +9,7 @@ PACKAGE_DIRS=(
     "packages/liveblocks-react"
     "packages/liveblocks-redux"
     "packages/liveblocks-zustand"
+    "packages/create-liveblocks-app"
 )
 
 err () {

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
         description:
-          "Git tag to create (e.g. v1.0.2-test7). See also
+          "Git tag to create (e.g. v1.2.3-test4). See also
           https://github.com/liveblocks/liveblocks/blob/main/CONTRIBUTING.MD#releasing"
 
 jobs:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
         description:
-          "github release tag (ex: v1.0.2-test0), doc:
+          "Git tag to create (e.g. v1.0.2-test7). See also
           https://github.com/liveblocks/liveblocks/blob/main/CONTRIBUTING.MD#releasing"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.3
+
+## Internal changes
+
+- Release `create-liveblocks-app` along with other Liveblocks packages, using the same versioning scheme.
+
 # v1.0.2
 
 Fix bug where passing down `shouldInitiallyConnect` connection option would not


### PR DESCRIPTION
This puts the `create-liveblocks-app` project on the same release schedule/cadance as the rest of our packages when we publish them to NPM. Tackles part 1 of #831.
