### PR TITLE
Avoid interactive prompts during the publish script when run from CI

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -105,8 +105,8 @@ for pkgdir in ${PACKAGE_DIRS[@]}; do
             npm dist-tag add "$pkgname@$VERSION" "${TAG:-latest}"
             break
         else
-            err "I can't find $pkgname @ $VERSION on NPM under the 'private' tag yet..."
-            read
+            err "I can't find $pkgname@$VERSION on NPM under the 'private' tag yet..."
+            sleep 3
         fi
     done
 done


### PR DESCRIPTION
This will now sleep for 3 seconds before probing NPM again. This was relying on `read`, which prompts for a user to hit Enter to retry, but since we're in a non-interactive environment, this will fail.