### PR TITLE
Limit builds to the relevant packages only when publishing

### DIFF
--- a/.github/workflows/publish-devtools.yml
+++ b/.github/workflows/publish-devtools.yml
@@ -28,10 +28,10 @@ jobs:
           restore-keys: turbo-cache-@liveblocks/devtools-bust
 
       - name: Build for Chromium
-        run: npm run build -- --filter devtools
+        run: npm run build -- --filter=@liveblocks/devtools
 
       - name: Build for Firefox
-        run: npm run build:firefox -- --filter devtools
+        run: npm run build:firefox -- --filter=@liveblocks/devtools
 
       - name: Browser Platform Publish
         uses: PlasmoHQ/bpp@v3

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -76,7 +76,8 @@ jobs:
         run: ./.github/scripts/release.sh -V "$VERSION"
 
       - name: Build all packages
-        run: npm run build
+        run: |
+          npm run build -- --filter='./packages/*' --filter='!@liveblocks/devtools'
 
       - name: Publish packages
         env:


### PR DESCRIPTION
The `npm run build` at the top-level will build all packages in the Turborepo, even the ones we're not trying to publish. This is a waste and not necessary. This scopes the builds to the correct packages only.

![Screen Shot 2023-04-25 at 11 33 59@2x](https://user-images.githubusercontent.com/83844/234239483-584b43c6-e77e-4663-b629-d394889b5194.png)
