### PR TITLE
Only send messages on OPEN sockets

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1016,7 +1016,9 @@ function makeStateMachine<
       if (context.socket === null) {
         throw new Error("Can't send message if socket is null");
       }
-      context.socket.send(JSON.stringify(messageOrMessages));
+      if (context.socket.readyState === context.socket.OPEN) {
+        context.socket.send(JSON.stringify(messageOrMessages));
+      }
     },
     delayFlush(delay: number) {
       return setTimeout(tryFlushing, delay);


### PR DESCRIPTION
Matches the same guard we have in place for sending `ping` socket messages. A socket can be in either of these 4 states during its lifetime:

- `CONNECTING` - ⚠️ Calling `.send()` here can throw ← **This PR fixes that!**
- `OPEN`
- `CLOSING` - Calling `.send()` here won't throw (silently discards)
- `CLOSED` - Calling `.send()` here won't throw (silently discards)

We'll only want to call `.send()` when we have an `OPEN` connection. During the `CONNECTING` phase, calling `socket.send()` can throw an exception.

There is no risk for a race condition here, because once the socket reaches `CLOSING` or `CLOSED` phases, calling `socket.send()` will no longer throw. Instead, those messages won't be received, and we can expect those messages to be re-sent after reconnection, later in the future.
