### PR TITLE
docs - fix typo in liveblocks-zustand.mdx

### DIFF
--- a/docs/pages/api-reference/liveblocks-zustand.mdx
+++ b/docs/pages/api-reference/liveblocks-zustand.mdx
@@ -126,7 +126,7 @@ const {
 } = useStore();
 ```
 
-### room [#liveblocks-state-others]
+### others [#liveblocks-state-others]
 
 Other users in the room. Empty when no room is currently synced.
 


### PR DESCRIPTION
room -> others
"room" was duplicated