### PR TITLE
Fix issues with publish script

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -100,13 +100,13 @@ echo "Assigning definitive NPM tags"
 for pkgdir in ${PACKAGE_DIRS[@]}; do
     pkgname="$(npm_pkgname "$pkgdir")"
     while true; do
-        if npm dist-tag ls "$pkgname" | grep -qx "private: $VERSION"; then
-            echo "==> Adding tag ${TAG:-latest} to $pkgname @ $VERSION"
+        if npm dist-tag ls "$pkgname" | grep -qEe ": $VERSION\$"; then
+            echo "==> Adding tag ${TAG:-latest} to $pkgname@$VERSION"
             npm dist-tag add "$pkgname@$VERSION" "${TAG:-latest}"
             break
         else
-            err "I can't find $pkgname@$VERSION on NPM under the 'private' tag yet..."
-            sleep 3
+            err "I can't find $pkgname@$VERSION on NPM yet..."
+            sleep 5
         fi
     done
 done
@@ -114,7 +114,7 @@ done
 # Clean up those temporary "private" tags
 for pkgdir in ${PACKAGE_DIRS[@]}; do
     pkgname="$(npm_pkgname "$pkgdir")"
-    npm dist-tag rm "$pkgname@$VERSION" private
+    npm dist-tag rm "$pkgname@$VERSION" private || echo "Continuing despite error..."
 done
 
 echo ""


### PR DESCRIPTION
The current script checks for versions on NPM that are published under the (temporary) `private` tag when looking to assign the final tags. This works on the happy path, but if that flow works and then later down the line something fails (like… say… not being able to push the commits to GitHub), then on the next retry of the same version, the `private` tag no longer exists, and this script couldn't find those versions again anymore.

This PR fixes that, by not looking for the existence of the `private` tag, but instead look for the existence of the _version_ we're trying to deploy (indepently of which tag that version has at the moment the script runs). This makes it more robust and makes the script work under more circumstances.