### PR TITLE
fix navigation link in zustand package per user feedback

### DIFF
--- a/docs/pages/api-reference/liveblocks-zustand.mdx
+++ b/docs/pages/api-reference/liveblocks-zustand.mdx
@@ -126,7 +126,7 @@ const {
 } = useStore();
 ```
 
-### room [#liveblocks-state-others]
+### others [#liveblocks-state-others]
 
 Other users in the room. Empty when no room is currently synced.
 


### PR DESCRIPTION
This PR just updates a anchor link in the zustand package, as it was incorrectly referenced and a user pointed it out. 