### PR TITLE
Make unit tests tests fewer implementation details

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -80,7 +80,7 @@ export class MockWebSocket implements WebSocket {
     public url: string,
     private onSend: (message: string) => void = () => {}
   ) {
-    this.readyState = this.CLOSED;
+    this.readyState = this.CONNECTING;
     MockWebSocket.instances.push(this);
   }
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -578,11 +578,7 @@ type Machine<
 
   // Internal unit testing tools
   simulateSocketClose(): void;
-  simulateSendCloseEvent(event: {
-    code: number;
-    wasClean: boolean;
-    reason: string;
-  }): void;
+  simulateSendCloseEvent(event: { code: number; wasClean: boolean; reason: string; }): void; // prettier-ignore
 
   // onWakeUp,
   onVisibilityChange(visibilityState: DocumentVisibilityState): void;
@@ -595,10 +591,7 @@ type Machine<
   reconnect(): void;
 
   // Presence
-  updatePresence(
-    patch: Partial<TPresence>,
-    options?: { addToHistory: boolean }
-  ): void;
+  updatePresence(patch: Partial<TPresence>, options?: { addToHistory: boolean }): void; // prettier-ignore
   broadcastEvent(event: TRoomEvent, options?: BroadcastOptions): void;
 
   batch<T>(callback: () => T): T;
@@ -609,9 +602,7 @@ type Machine<
   pauseHistory(): void;
   resumeHistory(): void;
 
-  getStorage(): Promise<{
-    root: LiveObject<TStorage>;
-  }>;
+  getStorage(): Promise<{ root: LiveObject<TStorage> }>;
   getStorageSnapshot(): LiveObject<TStorage> | null;
   getStorageStatus(): StorageStatus;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -877,7 +877,7 @@ function makeStateMachine<
       storageOperations: [],
     },
 
-    connection: new ValueRef<Connection>({ status: "closed" }),
+    connection: new ValueRef({ status: "closed" }),
     me: new MeRef(initialPresence),
     others: new OthersRef<TPresence, TUserMeta>(),
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -578,7 +578,6 @@ type Machine<
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
   onMessage(event: MessageEvent<string>): void;
   authenticationSuccess(token: RoomAuthToken, socket: WebSocket): void;
-  heartbeat(): void;
   onNavigatorOnline(): void;
 
   // Internal unit testing tools
@@ -2228,7 +2227,6 @@ function makeStateMachine<
     onClose,
     onMessage,
     authenticationSuccess,
-    heartbeat,
     onNavigatorOnline,
 
     // Internal DevTools

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -568,8 +568,8 @@ type Machine<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 > = {
-  // Internal
-  state: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>;
+  /* Only access these internals in unit tests, to test implementation details */
+  __internal: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>;
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
   onMessage(event: MessageEvent<string>): void;
   authenticationSuccess(token: RoomAuthToken, socket: WebSocket): void;
@@ -2212,10 +2212,12 @@ function makeStateMachine<
   );
 
   return {
-    // Internal
-    get state() {
+    /* NOTE: Exposing __internal here only to allow testing implementation details in unit tests */
+    get __internal() {
       return context;
     },
+
+    // Internal
     onClose,
     onMessage,
     authenticationSuccess,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -569,7 +569,12 @@ type Machine<
   TRoomEvent extends Json
 > = {
   /* Only access these internals in unit tests, to test implementation details */
-  __internal: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>;
+  // prettier-ignore
+  __internal: Pick<
+    MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>,
+    "buffer" | "numRetries"
+  >;
+
   onClose(event: { code: number; wasClean: boolean; reason: string }): void;
   onMessage(event: MessageEvent<string>): void;
   authenticationSuccess(token: RoomAuthToken, socket: WebSocket): void;
@@ -2213,8 +2218,10 @@ function makeStateMachine<
 
   return {
     /* NOTE: Exposing __internal here only to allow testing implementation details in unit tests */
-    get __internal() {
-      return context;
+    // prettier-ignore
+    __internal: {
+      get buffer() { return context.buffer },
+      get numRetries() { return context.numRetries },
     },
 
     // Internal
@@ -2223,9 +2230,11 @@ function makeStateMachine<
     authenticationSuccess,
     heartbeat,
     onNavigatorOnline,
+
     // Internal DevTools
     simulateSocketClose,
     simulateSendCloseEvent,
+
     onVisibilityChange,
     getUndoStack: () => context.undoStack,
     getItemsCount: () => context.nodes.size,


### PR DESCRIPTION
Some minor refactorings, mostly of our test helpers. I have a bunch more local changes that aren't ready to be committed just yet, but these are the ones that should be able to land already. This changes the testing setup a bit, so it's more obvious where we're testing implementation details. Most of the machine's `context` is now hidden away already, the goal is to make it entirely opaque to unit tests and only use publicly observable properties and behavior in those tests.
