### PR TITLE
Public doc typos and add

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -666,6 +666,7 @@ Transform the `LiveObject` into a normal JavaScript object.
 
 ```ts
 const liveObject = new LiveObject({ firstName: "Grace", lastName: "Hopper" });
+liveObject.toObject();
 // { firstName: "Grace", lastName: "Hopper" }
 ```
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -38,7 +38,7 @@ will have.
 
 At the very least, you must pass a `userId` and a `roomId`. Optionally,
 `userInfo` can be used to add information about the current user that will not
-change during the session. This information will will be accessible in the
+change during the session. This information will be accessible in the
 client to all other users in [`Room.getOthers`][]. It can be helpful to
 implement avatars or display the user’s name without introducing a potential
 impersonification security issue.

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -38,10 +38,10 @@ will have.
 
 At the very least, you must pass a `userId` and a `roomId`. Optionally,
 `userInfo` can be used to add information about the current user that will not
-change during the session. This information will be accessible in the
-client to all other users in [`Room.getOthers`][]. It can be helpful to
-implement avatars or display the user’s name without introducing a potential
-impersonification security issue.
+change during the session. This information will be accessible in the client to
+all other users in [`Room.getOthers`][]. It can be helpful to implement avatars
+or display the user’s name without introducing a potential impersonification
+security issue.
 
 - `userId` cannot be longer than 128 characters.
 - `userInfo` cannot be longer than 1024 characters once serialized to JSON.
@@ -130,6 +130,14 @@ app.post("/api/auth", (req, res) => {
 ```
 
 ## WebhookHandler [#WebhookHandler]
+
+<Banner title="Need help implementing webhooks?">
+
+Check out the [Webhooks guide](/docs/guides/webhooks), we explain how to use
+them within your product so that you can react to Liveblocks events as they
+happen.
+
+</Banner>
 
 The `WebhookHandler` class is a helper to handle webhook requests from
 Liveblocks.


### PR DESCRIPTION
3 changes:
- Feels like a `liveObject.toObject();` is missing in the code snippet of https://liveblocks.io/docs/api-reference/liveblocks-client#LiveObject.toObject
- Will will typo fixed
- Added a webhooks banner to bring people to the guide from the `@liveblocks/node` page