### PR TITLE
Schema: Import PlainLson types from @liveblocks/core

### DIFF
--- a/schema-lang/infer-schema/src/field.ts
+++ b/schema-lang/infer-schema/src/field.ts
@@ -1,9 +1,10 @@
+import type { PlainLsonFields } from "@liveblocks/core";
 import { AST } from "@liveblocks/schema";
 import { string } from "decoders";
 
 import type { ChildContext, MergeContext } from "./inference";
 import { invalidFieldName } from "./naming";
-import type { JsonObject, PlainLsonFields } from "./plainLson";
+import type { NonLiveJsonObject } from "./plainLson";
 import type { InferredSchema } from "./schema";
 import type { InferredTypeReference } from "./typeReference";
 import {
@@ -30,7 +31,7 @@ const propertyKeyDecoder = string
   );
 
 export function inferLsonFields(
-  fields: PlainLsonFields | JsonObject,
+  fields: PlainLsonFields | NonLiveJsonObject,
   ctx: Omit<ChildContext, "field">
 ): InferredFields {
   const fieldEntries = Object.entries(fields)

--- a/schema-lang/infer-schema/src/index.ts
+++ b/schema-lang/infer-schema/src/index.ts
@@ -1,17 +1,8 @@
+import type { PlainLsonObject } from "@liveblocks/core";
 import { prettify } from "@liveblocks/schema";
 
 import { inferStorageType } from "./inference";
-import type { PlainLsonObject } from "./plainLson";
 import { buildSchema, inferredSchemaToAst } from "./schema";
-
-export type {
-  Json,
-  JsonObject,
-  JsonScalar,
-  PlainLsonList,
-  PlainLsonMap,
-  PlainLsonObject,
-} from "./plainLson";
 
 export function inferSchema(storageValue: PlainLsonObject): string {
   const storageType = inferStorageType(storageValue);

--- a/schema-lang/infer-schema/src/inference.ts
+++ b/schema-lang/infer-schema/src/inference.ts
@@ -1,3 +1,5 @@
+import type { JsonScalar, PlainLson, PlainLsonObject } from "@liveblocks/core";
+
 import { inferLsonFields } from "./field";
 import type { InferredObjectType } from "./object";
 import {
@@ -5,7 +7,6 @@ import {
   isInferredObjectType,
   mergeInferredObjectTypes,
 } from "./object";
-import type { JsonScalar, PlainLson, PlainLsonObject } from "./plainLson";
 import type { InferredScalarType } from "./scalar";
 import {
   inferScalarType,

--- a/schema-lang/infer-schema/src/object.ts
+++ b/schema-lang/infer-schema/src/object.ts
@@ -1,3 +1,4 @@
+import type { PlainLsonObject } from "@liveblocks/core";
 import { AST } from "@liveblocks/schema";
 
 import type { InferredFields } from "./field";
@@ -9,7 +10,7 @@ import {
 import type { ChildContext, InferredType, MergeContext } from "./inference";
 import type { ScoredNames } from "./naming";
 import { generateNames, mergeScoredNames } from "./naming";
-import type { JsonObject, PlainLsonObject } from "./plainLson";
+import type { NonLiveJsonObject } from "./plainLson";
 import type { InferredSchema } from "./schema";
 import { invariant } from "./utils/invariant";
 import { isNotUndefined } from "./utils/typeGuards";
@@ -24,7 +25,7 @@ export type InferredObjectType = {
 };
 
 export function inferObjectType(
-  value: JsonObject | PlainLsonObject,
+  value: NonLiveJsonObject | PlainLsonObject,
   ctx: ChildContext
 ): InferredObjectType {
   const isLive = value.liveblocksType === "LiveObject";

--- a/schema-lang/infer-schema/src/plainLson.ts
+++ b/schema-lang/infer-schema/src/plainLson.ts
@@ -1,30 +1,3 @@
-import type {
-  JsonArray,
-  JsonObject as BaseJsonObject,
-  JsonScalar,
-} from "@liveblocks/core";
+import type { JsonObject } from "@liveblocks/core";
 
-export type PlainLsonFields = Record<string, PlainLson> & {
-  liveblocksType?: never;
-};
-
-export type PlainLsonObject = {
-  liveblocksType: "LiveObject";
-  data: PlainLsonFields;
-};
-
-export type PlainLsonMap = {
-  liveblocksType: "LiveMap";
-  data: PlainLsonFields;
-};
-
-export type PlainLsonList = {
-  liveblocksType: "LiveList";
-  data: PlainLson[];
-};
-
-export type JsonObject = BaseJsonObject & { liveblocksType?: never };
-export type { JsonArray, JsonScalar } from "@liveblocks/core";
-export type Json = JsonScalar | JsonArray | JsonObject;
-
-export type PlainLson = PlainLsonObject | PlainLsonMap | PlainLsonList | Json;
+export type NonLiveJsonObject = JsonObject & { liveblocksType?: never };

--- a/schema-lang/infer-schema/src/scalar.ts
+++ b/schema-lang/infer-schema/src/scalar.ts
@@ -1,9 +1,9 @@
+import type { JsonScalar } from "@liveblocks/core";
 import { AST } from "@liveblocks/schema";
 
 import type { ChildContext, InferredType } from "./inference";
 import type { ScoredNames } from "./naming";
 import { generateNames, mergeScoredNames } from "./naming";
-import type { JsonScalar } from "./plainLson";
 import type { InferredSchema } from "./schema";
 
 export type InferredStringType = {

--- a/schema-lang/infer-schema/src/tests/inferSchema.test.ts
+++ b/schema-lang/infer-schema/src/tests/inferSchema.test.ts
@@ -1,7 +1,7 @@
+import type { PlainLsonObject } from "@liveblocks/core";
 import { parse } from "@liveblocks/schema";
 import fc from "fast-check";
 
-import type { PlainLsonObject } from "..";
 import { inferSchema } from "..";
 import { plainLsonArbitraries } from "./arbitraries";
 import {

--- a/schema-lang/infer-schema/src/tests/testData.ts
+++ b/schema-lang/infer-schema/src/tests/testData.ts
@@ -1,4 +1,4 @@
-import type { PlainLsonObject } from "../plainLson";
+import type { PlainLsonObject } from "@liveblocks/core";
 
 export const EMPTY: PlainLsonObject = {
   liveblocksType: "LiveObject",

--- a/schema-lang/infer-schema/src/typeReference.ts
+++ b/schema-lang/infer-schema/src/typeReference.ts
@@ -1,9 +1,9 @@
+import type { PlainLson } from "@liveblocks/core";
 import { AST } from "@liveblocks/schema";
 
 import type { ChildContext, InferredType, MergeContext } from "./inference";
 import { inferType, mergeInferredTypes } from "./inference";
 import { isInferredObjectType } from "./object";
-import type { PlainLson } from "./plainLson";
 import { inferredScalarTypeToAst, isInferredScalarType } from "./scalar";
 import type { InferredSchema } from "./schema";
 import { invariant } from "./utils/invariant";


### PR DESCRIPTION
## What does this PR do?

This PR deduplicates `PlainLson` types used in `@liveblocks/infer-schema` by importing them from `@liveblocks/core`.