### PR TITLE
Fix exported `Pos` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.7
+
+- Private API changes only.
+
 # v1.0.6
 
 ## Internal changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -17681,7 +17681,7 @@
       }
     },
     "packages/create-liveblocks-app": {
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -17868,10 +17868,10 @@
     },
     "packages/liveblocks-client": {
       "name": "@liveblocks/client",
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "1.0.6"
+        "@liveblocks/core": "1.0.7-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -17884,7 +17884,7 @@
     },
     "packages/liveblocks-core": {
       "name": "@liveblocks/core",
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -18049,7 +18049,7 @@
     },
     "packages/liveblocks-node": {
       "name": "@liveblocks/node",
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^2.6.1"
@@ -18063,11 +18063,11 @@
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.0.6",
-        "@liveblocks/core": "1.0.6",
+        "@liveblocks/client": "1.0.7-test1",
+        "@liveblocks/core": "1.0.7-test1",
         "use-sync-external-store": "^1.2.0"
       },
       "devDependencies": {
@@ -18386,11 +18386,11 @@
     },
     "packages/liveblocks-redux": {
       "name": "@liveblocks/redux",
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.0.6",
-        "@liveblocks/core": "1.0.6"
+        "@liveblocks/client": "1.0.7-test1",
+        "@liveblocks/core": "1.0.7-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -18519,11 +18519,11 @@
     },
     "packages/liveblocks-zustand": {
       "name": "@liveblocks/zustand",
-      "version": "1.0.6",
+      "version": "1.0.7-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.0.6",
-        "@liveblocks/core": "1.0.6"
+        "@liveblocks/client": "1.0.7-test1",
+        "@liveblocks/core": "1.0.7-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -18692,6 +18692,11 @@
         "@liveblocks/jest-config": "*",
         "@types/pluralize": "^0.0.29"
       }
+    },
+    "schema-lang/infer-schema/node_modules/@liveblocks/core": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.0.6.tgz",
+      "integrity": "sha512-0cZy36md9B0OKdTOf7AnoVS2tf+t4keJnZaa3uP1bBR9Emjly0Mx0xv2XH9nkxZNOA5QDxp0r9wKCZvZfIeLzw=="
     },
     "schema-lang/liveblocks-schema": {
       "name": "@liveblocks/schema",
@@ -20416,7 +20421,7 @@
     "@liveblocks/client": {
       "version": "file:packages/liveblocks-client",
       "requires": {
-        "@liveblocks/core": "1.0.6",
+        "@liveblocks/core": "1.0.7-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/ws": "^8.5.3",
@@ -20590,6 +20595,13 @@
         "@types/pluralize": "^0.0.29",
         "decoders": "^2.0.3",
         "pluralize": "^8.0.0"
+      },
+      "dependencies": {
+        "@liveblocks/core": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.0.6.tgz",
+          "integrity": "sha512-0cZy36md9B0OKdTOf7AnoVS2tf+t4keJnZaa3uP1bBR9Emjly0Mx0xv2XH9nkxZNOA5QDxp0r9wKCZvZfIeLzw=="
+        }
       }
     },
     "@liveblocks/jest-config": {
@@ -20640,8 +20652,8 @@
     "@liveblocks/react": {
       "version": "file:packages/liveblocks-react",
       "requires": {
-        "@liveblocks/client": "1.0.6",
-        "@liveblocks/core": "1.0.6",
+        "@liveblocks/client": "1.0.7-test1",
+        "@liveblocks/core": "1.0.7-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -20876,8 +20888,8 @@
     "@liveblocks/redux": {
       "version": "file:packages/liveblocks-redux",
       "requires": {
-        "@liveblocks/client": "1.0.6",
-        "@liveblocks/core": "1.0.6",
+        "@liveblocks/client": "1.0.7-test1",
+        "@liveblocks/core": "1.0.7-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
@@ -21215,8 +21227,8 @@
     "@liveblocks/zustand": {
       "version": "file:packages/liveblocks-zustand",
       "requires": {
-        "@liveblocks/client": "1.0.6",
-        "@liveblocks/core": "1.0.6",
+        "@liveblocks/client": "1.0.7-test1",
+        "@liveblocks/core": "1.0.7-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",

--- a/packages/create-liveblocks-app/package.json
+++ b/packages/create-liveblocks-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-liveblocks-app",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "An installer for Liveblocks projects, including various examples and a Next.js starter kit. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "bin": "dist/index.cjs",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/client",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "A client that lets you interact with Liveblocks servers. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -18,7 +18,7 @@
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"
   },
   "dependencies": {
-    "@liveblocks/core": "1.0.6"
+    "@liveblocks/core": "1.0.7-test1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/core",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "Shared code and foundational internals for Liveblocks",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -1,7 +1,7 @@
 import { nn } from "../lib/assert";
 import { nanoid } from "../lib/nanoid";
 import type { Pos } from "../lib/position";
-import { asPos, comparePosition, makePosition } from "../lib/position";
+import { asPos, makePosition } from "../lib/position";
 import type { CreateChildOp, CreateListOp, CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedList } from "../protocol/SerializedCrdt";
@@ -53,7 +53,9 @@ export type LiveListUpdates<TItem extends Lson> = {
 };
 
 function compareNodePosition(itemA: LiveNode, itemB: LiveNode) {
-  return comparePosition(itemA._parentPos, itemB._parentPos);
+  const posA = itemA._parentPos;
+  const posB = itemB._parentPos;
+  return posA === posB ? 0 : posA < posB ? -1 : 1;
 }
 
 /**

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -41,7 +41,7 @@ export { freeze } from "./lib/freeze";
 export type { Json, JsonArray, JsonObject, JsonScalar } from "./lib/Json";
 export { isJsonArray, isJsonObject, isJsonScalar } from "./lib/Json";
 export { asArrayWithLegacyMethods } from "./lib/LegacyArray";
-export { comparePosition, makePosition } from "./lib/position";
+export { asPos, makePosition } from "./lib/position";
 export type { Resolve } from "./lib/Resolve";
 export { shallow } from "./lib/shallow";
 export { b64decode, isPlainObject, tryParseJson } from "./lib/utils";

--- a/packages/liveblocks-core/src/lib/__tests__/position.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/position.test.ts
@@ -8,7 +8,6 @@ import {
   __nthDigit as nthDigit,
   __NUM_DIGITS as NUM_DIGITS,
   asPos,
-  comparePosition,
   makePosition,
 } from "../position";
 
@@ -168,24 +167,6 @@ describe("position datastructure", () => {
         (s) => {
           expect(asPos(s)).toBe(asPos(asPos(s)));
           expect(asPos(s)).toBe(asPos(asPos(asPos(asPos(s)))));
-        }
-      )
-    );
-  });
-
-  it("position's string representation is also alphabetically sortable", () => {
-    fc.assert(
-      fc.property(
-        genPos(),
-        genPos(),
-
-        (pos1, pos2) => {
-          expect(comparePosition(pos1, pos2) < 0).toEqual(pos1 < pos2);
-          expect(comparePosition(pos1, pos2) > 0).toEqual(pos1 > pos2);
-          expect(comparePosition(pos1, pos2) === 0).toEqual(pos1 === pos2);
-          expect(comparePosition(pos1, pos2) <= 0).toEqual(pos1 <= pos2);
-          expect(comparePosition(pos1, pos2) >= 0).toEqual(pos1 >= pos2);
-          expect(comparePosition(pos1, pos2) !== 0).toEqual(pos1 !== pos2);
         }
       )
     );
@@ -485,36 +466,9 @@ describe("makePosition", () => {
 
 describe("comparePosition", () => {
   it("basics", () => {
-    expect(comparePosition(asPos("1"), asPos("2"))).toBeLessThan(0);
-    expect(comparePosition(asPos("!"), asPos("~~"))).toBeLessThan(0);
-    expect(comparePosition(asPos("11111"), asPos("11"))).toBeGreaterThan(0);
-  });
-
-  it("returns 0 when equal", () => {
-    fc.assert(
-      fc.property(
-        genUnverifiedPos(),
-
-        (pos) => {
-          expect(comparePosition(pos, pos)).toBe(0);
-        }
-      )
-    );
-  });
-
-  it("inverted comparison leads to opposite result", () => {
-    fc.assert(
-      fc.property(
-        genUnverifiedPos(),
-        genUnverifiedPos(),
-
-        (p1, p2) => {
-          if (p1 !== p2) {
-            expect(comparePosition(p1, p2)).toBe(-comparePosition(p2, p1));
-          }
-        }
-      )
-    );
+    expect(asPos("1") < asPos("2")).toBe(true);
+    expect(asPos("!") < asPos("~~")).toBe(true);
+    expect(asPos("11111") > asPos("11")).toBe(true);
   });
 
   it("correct compares output of before/after", () => {
@@ -523,10 +477,10 @@ describe("comparePosition", () => {
         genPos(),
 
         (pos) => {
-          expect(comparePosition(pos, after(pos))).toBe(-1);
-          expect(comparePosition(before(pos), pos)).toBe(-1);
-          expect(comparePosition(after(pos), pos)).toBe(1);
-          expect(comparePosition(pos, before(pos))).toBe(1);
+          expect(pos < after(pos)).toBe(true);
+          expect(before(pos) < pos).toBe(true);
+          expect(after(pos) > pos).toBe(true);
+          expect(pos > before(pos)).toBe(true);
         }
       )
     );
@@ -539,10 +493,10 @@ describe("comparePosition", () => {
 
         ([lo, hi]) => {
           const mid = between(lo, hi);
-          expect(comparePosition(lo, mid)).toBe(-1);
-          expect(comparePosition(mid, hi)).toBe(-1);
-          expect(comparePosition(mid, lo)).toBe(1);
-          expect(comparePosition(hi, mid)).toBe(1);
+          expect(lo < mid).toBe(true);
+          expect(mid < hi).toBe(true);
+          expect(mid > lo).toBe(true);
+          expect(hi > mid).toBe(true);
         }
       )
     );

--- a/packages/liveblocks-core/src/lib/position.ts
+++ b/packages/liveblocks-core/src/lib/position.ts
@@ -330,11 +330,7 @@ function asPos(str: string): Pos {
   return isPos(str) ? str : convertToPos(str);
 }
 
-function comparePosition(posA: Pos, posB: Pos): number {
-  return posA === posB ? 0 : posA < posB ? -1 : 1;
-}
-
-export { asPos, comparePosition, makePosition };
+export { asPos, makePosition };
 
 // For use in unit tests only
 export {

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/node",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "A server-side utility that lets you set up a Liveblocks authentication endpoint. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "A set of React hooks and providers to use Liveblocks declaratively. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -20,8 +20,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.0.6",
-    "@liveblocks/core": "1.0.6",
+    "@liveblocks/client": "1.0.7-test1",
+    "@liveblocks/core": "1.0.7-test1",
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/redux",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "A store enhancer to integrate Liveblocks into Redux stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -18,8 +18,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.0.6",
-    "@liveblocks/core": "1.0.6"
+    "@liveblocks/client": "1.0.7-test1",
+    "@liveblocks/core": "1.0.7-test1"
   },
   "peerDependencies": {
     "redux": "^4"

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "1.0.6",
+  "version": "1.0.7-test1",
   "description": "A middleware to integrate Liveblocks into Zustand stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -19,8 +19,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.0.6",
-    "@liveblocks/core": "1.0.6"
+    "@liveblocks/client": "1.0.7-test1",
+    "@liveblocks/core": "1.0.7-test1"
   },
   "peerDependencies": {
     "zustand": "^4.1.3"


### PR DESCRIPTION
This PR changes the following exported private APIs, which should have been part of #565.

- Removes the `comparePosition` API
- Exposes the `asPos` API

Needed by our backend.
