### PR TITLE
Tighten ESLint checks

### DIFF
--- a/packages/liveblocks-core/.eslintrc.js
+++ b/packages/liveblocks-core/.eslintrc.js
@@ -48,6 +48,13 @@ module.exports = {
       rules: {
         "no-restricted-syntax": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
+
+        // Ideally, we should remove these overrides, since they are still
+        // useful to catch bugs
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
       },
     },
   ],

--- a/packages/liveblocks-core/.eslintrc.js
+++ b/packages/liveblocks-core/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     // Overrides from default rule config used in all other projects!
     // ----------------------------------------------------------------------
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/unbound-method": "off",
 
     // ----------------------------------------------------------------------
     // Extra rules for this project specifically

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -533,7 +533,7 @@ export async function prepareDisconnectedStorageUpdateTest<
   };
 }
 
-export async function reconnect<
+export function reconnect<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,

--- a/packages/liveblocks-core/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-core/src/__tests__/client.node.test.ts
@@ -3,7 +3,7 @@
  */
 
 // We're using node-fetch 2.X because 3+ only support ESM and jest is a pain to use with ESM
-import { Response } from "node-fetch";
+import { Response as NodeFetchResponse } from "node-fetch";
 
 import type { ClientOptions } from "../client";
 import { createClient } from "../client";
@@ -13,12 +13,14 @@ const token =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2Nywicm9vbUlkIjoiazV3bWgwRjlVTGxyek1nWnRTMlpfIiwiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJhY3RvciI6MCwic2NvcGVzIjpbIndlYnNvY2tldDpwcmVzZW5jZSIsIndlYnNvY2tldDpzdG9yYWdlIiwicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.IQFyw54-b4F6P0MTSzmBVwdZi2pwPaxZwzgkE2l0Mi4";
 
 const fetchMock = (async () =>
-  new Response(JSON.stringify({ token }))) as unknown as typeof fetch;
+  Promise.resolve(
+    new NodeFetchResponse(JSON.stringify({ token })) as unknown as Response
+  )) as typeof fetch;
 
-async function authEndpointCallback() {
-  return {
+function authEndpointCallback() {
+  return Promise.resolve({
     token,
-  };
+  });
 }
 
 function atobPolyfillMock(data: string): string {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -666,7 +666,7 @@ describe("room", () => {
     expect(storage.root.toObject()).toEqual({ x: 0 });
   });
 
-  test("undo redo with presence", async () => {
+  test("undo redo with presence", () => {
     const { room } = setupStateMachine({});
 
     const ws = new MockWebSocket("");
@@ -776,7 +776,7 @@ describe("room", () => {
     expect(room.getPresence()).toEqual({ x: 0 });
   });
 
-  test("undo redo with presence that do not impact presence", async () => {
+  test("undo redo with presence that do not impact presence", () => {
     const { room } = setupStateMachine({});
 
     const ws = new MockWebSocket("");
@@ -792,7 +792,7 @@ describe("room", () => {
     expect(room.getPresence()).toEqual({ x: 1 });
   });
 
-  test("pause / resume history", async () => {
+  test("pause / resume history", () => {
     const { room } = setupStateMachine({});
 
     const ws = new MockWebSocket("");
@@ -826,7 +826,7 @@ describe("room", () => {
     expect(room.getPresence()).toEqual({ x: 10 });
   });
 
-  test("undo while history is paused", async () => {
+  test("undo while history is paused", () => {
     const { room } = setupStateMachine({});
 
     const ws = new MockWebSocket("");

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -93,6 +93,13 @@ export type ClientOptions = {
   | { publicApiKey?: never; authEndpoint: AuthEndpoint }
 );
 
+function getServerFromClientOptions(clientOptions: ClientOptions) {
+  const rawOptions = clientOptions as Record<string, unknown>;
+  return typeof rawOptions.liveblocksServer === "string"
+    ? rawOptions.liveblocksServer
+    : "wss://api.liveblocks.io/v6";
+}
+
 /**
  * Create a client that will be responsible to communicate with liveblocks servers.
  *
@@ -171,11 +178,7 @@ export function createClient(options: ClientOptions): Client {
         throttleDelay,
         polyfills: clientOptions.polyfills,
         unstable_batchedUpdates: options?.unstable_batchedUpdates,
-        liveblocksServer:
-          // TODO Patch this using public but marked internal fields?
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (clientOptions as any)?.liveblocksServer ||
-          "wss://api.liveblocks.io/v6",
+        liveblocksServer: getServerFromClientOptions(clientOptions),
         authentication: prepareAuthentication(clientOptions, roomId),
       }
     );

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.test.ts
@@ -1076,7 +1076,7 @@ describe("LiveObject", () => {
       const obj = root.get("obj");
       const secondItem = obj.get("b");
 
-      const applyResult = obj._detachChild(secondItem!);
+      const applyResult = obj._detachChild(secondItem);
 
       expect(applyResult).toEqual({
         modified: {

--- a/packages/liveblocks-core/src/devtools/bridge.ts
+++ b/packages/liveblocks-core/src/devtools/bridge.ts
@@ -57,10 +57,11 @@ const eventSource = makeEventSource<DevTools.FullPanelToClientMessage>();
 
 // Define it as a no-op in production environments or when run outside of a browser context
 if (process.env.NODE_ENV !== "production" && typeof window !== "undefined") {
-  window.addEventListener("message", (event) => {
+  window.addEventListener("message", (event: MessageEvent<unknown>) => {
     if (
       event.source === window &&
-      event.data?.source === "liveblocks-devtools-panel"
+      (event.data as Record<string, unknown>)?.source ===
+        "liveblocks-devtools-panel"
     ) {
       // console.log(
       //   "%c[client ← panel] %c%s",
@@ -69,7 +70,7 @@ if (process.env.NODE_ENV !== "production" && typeof window !== "undefined") {
       //   event.data.msg,
       //   event.data
       // );
-      eventSource.notify(event.data);
+      eventSource.notify(event.data as DevTools.FullPanelToClientMessage);
     } else {
       // Message not for us
     }

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -7,7 +7,7 @@ import { activateBridge, onMessageFromPanel, sendToPanel } from "./bridge";
 // prettier-ignore
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore (__PACKAGE_VERSION__ will be injected by the build script)
-const VERSION = typeof __PACKAGE_VERSION__ === "string" ? /* istanbul ignore next */ __PACKAGE_VERSION__ : "dev";
+const VERSION = typeof (__PACKAGE_VERSION__ as unknown) === "string" ? /* istanbul ignore next */ (__PACKAGE_VERSION__ as string) : "dev";
 
 let _devtoolsSetupHasRun = false;
 

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -204,7 +204,9 @@ export function patchLiveObjectKey<
     const nonSerializableValue = findNonSerializableValue(next);
     if (nonSerializableValue) {
       console.error(
-        `New state path: '${nonSerializableValue.path}' value: '${nonSerializableValue.value}' is not serializable.\nOnly serializable value can be synced with Liveblocks.`
+        `New state path: '${nonSerializableValue.path}' value: '${String(
+          nonSerializableValue.value
+        )}' is not serializable.\nOnly serializable value can be synced with Liveblocks.`
       );
       return;
     }

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -11,6 +11,7 @@ import type { LiveNode, Lson, LsonObject, ToJson } from "./crdts/Lson";
 import type { StorageUpdate } from "./crdts/StorageUpdates";
 import * as console from "./lib/fancy-console";
 import type { Json, JsonObject } from "./lib/Json";
+import { isJsonObject } from "./lib/Json";
 import { isPlainObject } from "./lib/utils";
 
 function lsonObjectToJson<O extends LsonObject>(
@@ -304,17 +305,13 @@ function legacy_patchImmutableNode<S extends Json>(
   if (pathItem === undefined) {
     switch (update.type) {
       case "LiveObject": {
-        if (
-          state === null ||
-          typeof state !== "object" ||
-          Array.isArray(state)
-        ) {
+        if (!isJsonObject(state)) {
           throw new Error(
             "Internal: received update on LiveObject but state was not an object"
           );
         }
 
-        const newState = Object.assign({}, state as JsonObject);
+        const newState: JsonObject = Object.assign({}, state);
 
         for (const key in update.updates) {
           if (update.updates[key]?.type === "update") {
@@ -390,16 +387,12 @@ function legacy_patchImmutableNode<S extends Json>(
       }
 
       case "LiveMap": {
-        if (
-          state === null ||
-          typeof state !== "object" ||
-          Array.isArray(state)
-        ) {
+        if (!isJsonObject(state)) {
           throw new Error(
             "Internal: received update on LiveMap but state was not an object"
           );
         }
-        const newState = Object.assign({}, state as JsonObject);
+        const newState: JsonObject = Object.assign({}, state);
 
         for (const key in update.updates) {
           if (update.updates[key]?.type === "update") {
@@ -433,13 +426,14 @@ function legacy_patchImmutableNode<S extends Json>(
     //              FIXME Not completely true, because we could have been
     //              updating indexes from StorageUpdate here that aren't in S,
     //              technically.
-  } else if (state !== null && typeof state === "object") {
+  } else if (isJsonObject(state)) {
     const node = state[pathItem];
     if (node === undefined) {
       return state;
     } else {
+      const stateAsObj: JsonObject = state;
       return {
-        ...(state as JsonObject),
+        ...stateAsObj,
         [pathItem]: legacy_patchImmutableNode(node, path, update),
       } as S;
       //   ^

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -60,7 +60,8 @@ export function lsonToJson(value: Lson): Json {
   } else if (value instanceof LiveMap) {
     return liveMapToJson(value);
   } else if (value instanceof LiveRegister) {
-    return value.data;
+    // NOTE: This branch should never be taken, because LiveRegister isn't a valid Lson value
+    return value.data as Json;
   }
 
   // Then for composite Lson values

--- a/packages/liveblocks-core/src/lib/position.ts
+++ b/packages/liveblocks-core/src/lib/position.ts
@@ -220,9 +220,9 @@ function after(pos: Pos): Pos {
  */
 function between(lo: Pos, hi: Pos): Pos {
   if (lo < hi) {
-    return _between(lo, hi) as Pos;
+    return _between(lo, hi);
   } else if (lo > hi) {
-    return _between(hi, lo) as Pos;
+    return _between(hi, lo);
   } else {
     throw new Error("Cannot compute value between two equal positions");
   }

--- a/packages/liveblocks-core/src/refs/__tests__/ValueRef.test.ts
+++ b/packages/liveblocks-core/src/refs/__tests__/ValueRef.test.ts
@@ -36,14 +36,18 @@ describe("Value ref cache", () => {
           const ref = new ValueRef<unknown>(init);
           expect(ref.current).toStrictEqual(init);
           expect(() => {
-            (ref.current as any).abc = 123;
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            ref.current.abc = 123;
           }).toThrow();
 
           // Freezes in setter
           ref.set(newVal);
           expect(ref.current).toStrictEqual(newVal);
           expect(() => {
-            (ref.current as any).xyz = 456;
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            ref.current.xyz = 456;
           }).toThrow();
         }
       )

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -970,13 +970,6 @@ export function createRoom<
         authenticationSuccess(prevToken.parsed, socket);
         return undefined;
       } else {
-        //
-        // TODO(nvie): May have found a bug here
-        //
-        // This promise was returned before, but never awaited, meaning the
-        // promise might be dangling and get this callback at a later stage,
-        // even when it is no longer expected.
-        //
         void auth(config.roomId)
           .then(({ token }) => {
             if (context.connection.current.status !== "authenticating") {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2020,7 +2020,7 @@ export function createRoom<
       return root;
     } else {
       // Not done loading, kick off the loading (will not do anything if already kicked off)
-      startLoadingStorage();
+      void startLoadingStorage();
       return null;
     }
   }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -970,7 +970,14 @@ export function createRoom<
         authenticationSuccess(prevToken.parsed, socket);
         return undefined;
       } else {
-        return auth(config.roomId)
+        //
+        // TODO(nvie): May have found a bug here
+        //
+        // This promise was returned before, but never awaited, meaning the
+        // promise might be dangling and get this callback at a later stage,
+        // even when it is no longer expected.
+        //
+        void auth(config.roomId)
           .then(({ token }) => {
             if (context.connection.current.status !== "authenticating") {
               return;
@@ -985,6 +992,7 @@ export function createRoom<
               er instanceof Error ? er : new Error(String(er))
             )
           );
+        return undefined;
       }
     },
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2405,7 +2405,7 @@ function makeClassicSubscribeFn<
       }
     }
 
-    throw new Error(`"${first}" is not a valid event name`);
+    throw new Error(`"${String(first)}" is not a valid event name`);
   }
 
   return subscribe;
@@ -2530,7 +2530,9 @@ async function fetchAuthEndpoint(
     data = await (res.json() as Promise<Json>);
   } catch (er) {
     throw new AuthenticationError(
-      `Expected a JSON response when doing a POST request on "${endpoint}". ${er}`
+      `Expected a JSON response when doing a POST request on "${endpoint}". ${String(
+        er
+      )}`
     );
   }
   if (!isPlainObject(data) || typeof data.token !== "string") {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2023,7 +2023,7 @@ export function createRoom<
     if (context.root) {
       // Store has already loaded, so we can resolve it directly
       return Promise.resolve({
-        root: context.root as LiveObject<TStorage>,
+        root: context.root,
       });
     }
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2447,7 +2447,7 @@ function prepareCreateWebSocket(
         // prettier-ignore
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore (__PACKAGE_VERSION__ will be injected by the build script)
-        typeof __PACKAGE_VERSION__ === "string" ? /* istanbul ignore next */ __PACKAGE_VERSION__ : "dev"
+        typeof (__PACKAGE_VERSION__ as unknown) === "string" ? /* istanbul ignore next */ (__PACKAGE_VERSION__ as string) : "dev"
       }`
     );
   };

--- a/packages/liveblocks-devtools/.eslintrc.js
+++ b/packages/liveblocks-devtools/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     // Overrides from default rule config used in all other projects!
     // ----------------------------------------------------------------------
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/unbound-method": "off",
 
     // ----------------------------------------------------------------------
     // Extra rules for this project specifically

--- a/packages/liveblocks-devtools/package.json
+++ b/packages/liveblocks-devtools/package.json
@@ -10,6 +10,7 @@
     "dev:firefox": "plasmo dev --build-path=dist --target=firefox-mv2",
     "build": "tsc && plasmo build --build-path=dist --zip",
     "build:firefox": "tsc && plasmo build --build-path=dist --zip --target=firefox-mv2",
+    "lint": "eslint src/",
     "format": "eslint --fix src/; prettier --write src/"
   },
   "dependencies": {

--- a/packages/liveblocks-devtools/src/background.ts
+++ b/packages/liveblocks-devtools/src/background.ts
@@ -20,12 +20,12 @@ browser.runtime.onConnect.addListener((port) => {
     switch (message.msg) {
       // The panel has requested to reload the current tab.
       case "reload":
-        browser.tabs.reload(message.tabId);
+        void browser.tabs.reload(message.tabId);
         break;
 
       // The panel has requested to open a new tab with a given URL.
       case "open":
-        browser.tabs.create({
+        void browser.tabs.create({
           url: message.url,
         });
         break;
@@ -40,7 +40,7 @@ browser.runtime.onConnect.addListener((port) => {
       case "connect":
         portsByTabId.set(message.tabId, port);
       default: // eslint-disable-line no-fallthrough
-        browser.tabs.sendMessage(message.tabId, message);
+        void browser.tabs.sendMessage(message.tabId, message);
     }
   }
 

--- a/packages/liveblocks-devtools/src/content.ts
+++ b/packages/liveblocks-devtools/src/content.ts
@@ -7,7 +7,7 @@ window.addEventListener("message", (event) => {
     return;
   }
 
-  const message = event.data;
+  const message = event.data as Record<string, unknown>;
   if (message?.source === "liveblocks-devtools-client") {
     // Relay messages from the client to the panel
     void browser.runtime.sendMessage(

--- a/packages/liveblocks-devtools/src/content.ts
+++ b/packages/liveblocks-devtools/src/content.ts
@@ -10,7 +10,7 @@ window.addEventListener("message", (event) => {
   const message = event.data;
   if (message?.source === "liveblocks-devtools-client") {
     // Relay messages from the client to the panel
-    browser.runtime.sendMessage(
+    void browser.runtime.sendMessage(
       message as DevToolsMsg.FullClientToPanelMessage
     );
   }

--- a/packages/liveblocks-devtools/src/devtools/components/ResizablePanel.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/ResizablePanel.tsx
@@ -169,7 +169,9 @@ export function ResizablePanel({
           <Handle
             direction="vertical"
             value={height}
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onValueChange={setRenderHeight}
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onValueApply={setHeight}
             min={MIN_HEIGHT}
             max={MAX_HEIGHT}
@@ -179,6 +181,7 @@ export function ResizablePanel({
             direction="horizontal"
             value={width}
             onValueChange={setRenderWidth}
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onValueApply={setWidth}
             min={MIN_WIDTH}
             max={MAX_WIDTH}

--- a/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
@@ -508,11 +508,7 @@ function LsonNodeRenderer(props: NodeRendererProps<DevTools.LsonTreeNode>) {
     case "LiveMap":
     case "LiveList":
     case "LiveObject":
-      return (
-        <LiveNodeRenderer
-          {...(props as NodeRendererProps<DevTools.LsonTreeNode>)}
-        />
-      );
+      return <LiveNodeRenderer {...props} />;
 
     case "Json":
       return (
@@ -523,11 +519,7 @@ function LsonNodeRenderer(props: NodeRendererProps<DevTools.LsonTreeNode>) {
 
     default:
       // e.g. future LiveXxx types
-      return (
-        <LiveNodeRenderer
-          {...(props as NodeRendererProps<DevTools.LsonTreeNode>)}
-        />
-      );
+      return <LiveNodeRenderer {...props} />;
   }
 }
 

--- a/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
@@ -812,7 +812,7 @@ function collect(
 
       case "LiveList":
       case "LiveObject":
-      case "LiveMap":
+      case "LiveMap": {
         let isIndirectMatch = false;
         for (const childNode of node.payload) {
           if (collect(childNode, pattern, directMatches, indirectMatches)) {
@@ -823,6 +823,7 @@ function collect(
           indirectMatches.add(node.id);
         }
         return isIndirectMatch;
+      }
 
       default:
         // e.g. future LiveXxx types

--- a/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
@@ -91,8 +91,9 @@ type TreeProps<TTreeNode extends DevTools.TreeNode> = Pick<
   ArboristTreeProps<TTreeNode> &
   RefAttributes<TreeApi<TTreeNode> | undefined>;
 
-interface RowProps extends ComponentProps<"div"> {
-  node: NodeApi;
+interface RowProps<TTreeNode extends DevTools.TreeNode>
+  extends ComponentProps<"div"> {
+  node: NodeApi<TTreeNode>;
 }
 
 interface RowHighlightProps extends ComponentProps<"div"> {
@@ -312,7 +313,12 @@ function RowHighlight({ node, className, ...props }: RowHighlightProps) {
   );
 }
 
-function Row({ node, children, className, ...props }: RowProps) {
+function Row<TTreeNode extends DevTools.TreeNode>({
+  node,
+  children,
+  className,
+  ...props
+}: RowProps<TTreeNode>) {
   const isOpen = node.isOpen;
   const isParent = node.isInternal;
   const isSelected = node.isSelected;

--- a/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
@@ -925,8 +925,8 @@ const AutoSizer = forwardRef<HTMLDivElement, AutoSizerProps>(
       <div
         style={
           {
-            "--width": `${width}px`,
-            "--height": `${height}px`,
+            "--width": width !== undefined ? `${width}px` : undefined,
+            "--height": height !== undefined ? `${height}px` : undefined,
             ...autoSizerStyle,
             ...style,
           } as CSSProperties

--- a/packages/liveblocks-devtools/src/devtools/index.tsx
+++ b/packages/liveblocks-devtools/src/devtools/index.tsx
@@ -1,7 +1,7 @@
 import liveblocksPanelHTML from "url:./panel.html";
 import browser from "webextension-polyfill";
 
-browser.devtools.panels.create(
+void browser.devtools.panels.create(
   "Liveblocks",
   "",
   // See: https://github.com/PlasmoHQ/plasmo/issues/106#issuecomment-1188539625

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -43,7 +43,9 @@ export class WebhookHandler {
 
     if (expectedSignatures.includes(signature) === false)
       throw new Error(
-        `Invalid signature, expected one of ${expectedSignatures}, got ${signature}`
+        `Invalid signature, expected one of ${expectedSignatures.join(
+          ", "
+        )}, got ${signature}`
       );
 
     const event: WebhookEvent = JSON.parse(request.rawBody) as WebhookEvent;

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/unbound-method": "off",
 
     // ----------------------------------------------------------------------
     // Extra rules for this project specifically
@@ -25,4 +26,20 @@ module.exports = {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
   },
+
+  overrides: [
+    {
+      files: ["src/**/__tests__/**"],
+
+      rules: {
+        // Ideally, enable these lint rules again later, as they are useful to
+        // catch bugs
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/unbound-method": "off",
+        "@typescript-eslint/no-floating-promises": "off",
+      },
+    },
+  ],
 };

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -399,7 +399,7 @@ describe("useObject", () => {
 });
 
 describe("useStorage", () => {
-  test("return null before storage has loaded", async () => {
+  test("return null before storage has loaded", () => {
     const { result } = renderHook(() => useStorage((root) => root.obj));
     expect(result.current).toBeNull();
   });

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -558,7 +558,7 @@ export function createRoomContext<
       } else {
         const root = rootOrNull;
         const imm = root.toImmutable();
-        return imm as ToImmutable<TStorage>;
+        return imm;
       }
     }, [rootOrNull]);
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -624,8 +624,14 @@ export function createRoomContext<
     return React.useMemo(
       () => {
         return ((...args) =>
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           room.batch(() =>
-            callback(makeMutationContext(room), ...args)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            callback(
+              makeMutationContext(room),
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              ...args
+            )
           )) as OmitFirstArg<F>;
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -21,4 +21,21 @@ module.exports = {
     // ----------------------------------------------------------------------
     /* None yet 😇 ! */
   },
+
+  overrides: [
+    {
+      files: ["src/__tests__/**"],
+
+      // Special config for test files
+      rules: {
+        // Ideally, enable these lint rules again later, as they are useful
+        // to catch bugs
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+      },
+    },
+  ],
 };

--- a/packages/liveblocks-redux/.eslintrc.js
+++ b/packages/liveblocks-redux/.eslintrc.js
@@ -16,26 +16,17 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     eqeqeq: "off",
 
+    // Ideally, enable these lint rules again later, as they are useful
+    // to catch bugs
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+
     // ----------------------------------------------------------------------
     // Extra rules for this project specifically
     // ----------------------------------------------------------------------
     /* None yet 😇 ! */
   },
-
-  overrides: [
-    {
-      files: ["src/__tests__/**"],
-
-      // Special config for test files
-      rules: {
-        // Ideally, enable these lint rules again later, as they are useful
-        // to catch bugs
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-      },
-    },
-  ],
 };

--- a/packages/liveblocks-redux/src/__tests__/index.test.ts
+++ b/packages/liveblocks-redux/src/__tests__/index.test.ts
@@ -119,7 +119,7 @@ const basicStoreReducer = ((
     }
   }
 
-  return state as BasicState;
+  return state;
 }) as Reducer<BasicState>;
 
 const basicInitialState = {

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -233,7 +233,7 @@ const internalEnhancer = <TState>(options: {
           type: ACTION_TYPES.START_LOADING_STORAGE,
         });
 
-        room.getStorage().then(({ root }) => {
+        void room.getStorage().then(({ root }) => {
           const updates: any = {};
 
           room!.batch(() => {

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -156,7 +156,7 @@ const internalEnhancer = <TState>(options: {
 
             if (room) {
               isPatching = true;
-              updatePresence(room!, state, newState, presenceMapping as any);
+              updatePresence(room, state, newState, presenceMapping as any);
 
               room.batch(() => {
                 if (storageRoot) {

--- a/packages/liveblocks-zustand/.eslintrc.js
+++ b/packages/liveblocks-zustand/.eslintrc.js
@@ -21,4 +21,21 @@ module.exports = {
     // ----------------------------------------------------------------------
     /* None yet 😇 ! */
   },
+
+  overrides: [
+    {
+      files: ["src/__tests__/**"],
+
+      // Special config for test files
+      rules: {
+        // Ideally, enable these lint rules again later, as they are useful
+        // to catch bugs
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        // "@typescript-eslint/no-unsafe-call": "off",
+        // "@typescript-eslint/no-unsafe-member-access": "off",
+        // "@typescript-eslint/no-unsafe-return": "off",
+      },
+    },
+  ],
 };

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -202,7 +202,7 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
         })
       );
 
-      room.getStorage().then(({ root }) => {
+      void room.getStorage().then(({ root }) => {
         const updates = {} as Partial<TState>;
 
         room.batch(() => {

--- a/shared/eslint-config/index.js
+++ b/shared/eslint-config/index.js
@@ -12,7 +12,11 @@ module.exports = {
     "eslint-plugin-simple-import-sort",
   ],
 
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+  ],
 
   // Rules that are enabled for _all_ packages by default
   rules: {


### PR DESCRIPTION
This PR tightens our ESLint checks, by enabling the following preset:

    @typescript-eslint/recommended-requiring-type-checking

This complements the `@typescript-eslint/recommended` preset we were already using, but this preset will use static type information from TypeScript to provide even better linting errors. These checks make it much easier to catch issues like implicit `any`s that you can shoot yourself in the foot with, or dangling promises that you aren't awaiting, or functions that are async that don't have to be, or `x as Y` annotations where `x` already is `Y`, so the `as`-clause can be safely removed, etc.

In general: more code hygiene. I've fixed a handful of the issues that popped up, and also ignored some (mostly in our unit tests). For now, at least.

I decided to tighten these checks first, before continuing with my refactoring efforts, which primarily heavily rely on our TypeScript types being accurate and reliable.
