### PR TITLE
Improve WebSocket mock

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -133,7 +133,7 @@ export class MockWebSocket {
   // SIMULATION APIS
   //
 
-  open() {
+  simulateOpen() {
     this.#readyState = this.OPEN;
     for (const callback of this.#openListeners) {
       callback({ type: "open" });
@@ -143,7 +143,7 @@ export class MockWebSocket {
   /**
    * Simulates a close of the connection by the server.
    */
-  closeFromBackend(event: IWebSocketCloseEvent) {
+  simulateCloseFromServer(event: IWebSocketCloseEvent) {
     this.#readyState = this.CLOSED;
     for (const callback of this.#closeListeners) {
       callback(event);
@@ -209,7 +209,7 @@ export async function prepareRoomWithStorage<
 
   room.__internal.connect();
   room.__internal.authenticationSuccess(makeRoomToken(actor, scopes), ws);
-  ws.open();
+  ws.simulateOpen();
 
   // Start getting the storage, but don't await the promise just yet!
   const getStoragePromise = room.getStorage();
@@ -393,7 +393,7 @@ export async function prepareStorageTest<
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(makeRoomToken(actor, []), ws);
-    ws.open();
+    ws.simulateOpen();
 
     // Mock server messages for Presence.
     // Other user in the room (refRoom) recieves a "USER_JOINED" message.
@@ -566,7 +566,7 @@ export async function reconnect<
   const ws = new MockWebSocket();
   room.__internal.connect();
   room.__internal.authenticationSuccess(makeRoomToken(actor, []), ws);
-  ws.open();
+  ws.simulateOpen();
 
   room.__internal.onMessage(
     serverMessage({

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -134,6 +134,12 @@ export class MockWebSocket {
   //
 
   simulateOpen() {
+    if (this.readyState > this.CONNECTING) {
+      throw new Error(
+        "Cannot open a WebSocket that has already advanced beyond the CONNECTING state"
+      );
+    }
+
     this.#readyState = this.OPEN;
     for (const callback of this.#openListeners) {
       callback({ type: "open" });

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1575,8 +1575,11 @@ describe("room", () => {
       room.reconnect();
       expect(room.getConnectionState()).toBe("authenticating");
 
-      room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.simulateOpen();
+      const ws2 = new MockWebSocket();
+      room.__internal.authenticationSuccess(defaultRoomToken, ws2);
+      expect(room.getConnectionState()).toBe("connecting");
+
+      ws2.simulateOpen();
       expect(room.getConnectionState()).toBe("open");
     });
   });

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -267,7 +267,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     expect(effects.send).toHaveBeenCalledWith([
       { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },
@@ -281,7 +281,7 @@ describe("room", () => {
     room.updatePresence({ x: 0 });
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     expect(effects.send).toHaveBeenCalledWith([
       { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },
@@ -294,7 +294,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     expect(effects.send).toHaveBeenCalledWith([
       { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
@@ -310,7 +310,7 @@ describe("room", () => {
 
     const now = new Date(2021, 1, 1, 0, 0, 0, 0).getTime();
 
-    withDateNow(now, () => ws.open());
+    withDateNow(now, () => ws.simulateOpen());
 
     withDateNow(now + 30, () => room.updatePresence({ x: 1 }));
 
@@ -351,7 +351,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.__internal.onMessage(
       serverMessage({
@@ -387,7 +387,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.__internal.onMessage(
       serverMessage({
@@ -423,7 +423,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.__internal.onMessage(
       serverMessage({
@@ -459,7 +459,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.__internal.onMessage(
       serverMessage({
@@ -510,7 +510,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.__internal.onMessage(
       serverMessage({
@@ -577,7 +577,7 @@ describe("room", () => {
 
       const now = new Date(2021, 1, 1, 0, 0, 0, 0).getTime();
 
-      withDateNow(now, () => ws.open());
+      withDateNow(now, () => ws.simulateOpen());
 
       expect(effects.send).nthCalledWith(1, [
         { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} },
@@ -613,7 +613,7 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
@@ -634,7 +634,7 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
       expect(effects.send).toBeCalledTimes(1);
       expect(effects.send).toHaveBeenCalledWith([
@@ -650,7 +650,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     const getStoragePromise = room.getStorage();
 
@@ -672,7 +672,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     expect(room.__internal.buffer.me).toEqual(null);
     room.updatePresence({ x: 0 }, { addToHistory: true });
@@ -727,7 +727,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     const getStoragePromise = room.getStorage();
 
@@ -761,7 +761,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
     room.updatePresence({ x: 1 }, { addToHistory: true });
@@ -782,7 +782,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.updatePresence({ x: 0 });
     room.updatePresence({ x: 1 });
@@ -798,7 +798,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
     expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
@@ -832,7 +832,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
 
@@ -856,7 +856,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     const getStoragePromise = room.getStorage();
 
@@ -897,7 +897,7 @@ describe("room", () => {
     const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
-    ws.open();
+    ws.simulateOpen();
 
     const getStoragePromise = room.getStorage();
 
@@ -963,7 +963,7 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
       const getStoragePromise = room.getStorage();
 
@@ -1204,7 +1204,7 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
       let others: Others<P, never> | undefined;
 
@@ -1255,7 +1255,7 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
       const callback = jest.fn();
       room.events.customEvent.subscribe(callback);
@@ -1325,7 +1325,7 @@ describe("room", () => {
         items: ["A", "C"],
       });
 
-      ws.closeFromBackend(
+      ws.simulateCloseFromServer(
         new CloseEvent("close", {
           code: WebsocketCloseCodes.CLOSE_ABNORMAL,
           wasClean: false,
@@ -1421,7 +1421,7 @@ describe("room", () => {
 
       room.updatePresence({ x: 1 });
 
-      ws.closeFromBackend(
+      ws.simulateCloseFromServer(
         new CloseEvent("close", {
           code: WebsocketCloseCodes.CLOSE_ABNORMAL,
           wasClean: false,
@@ -1465,7 +1465,7 @@ describe("room", () => {
 
       room.events.storageStatus.subscribe(storageStatusCallback);
 
-      ws.closeFromBackend(
+      ws.simulateCloseFromServer(
         new CloseEvent("close", {
           code: WebsocketCloseCodes.CLOSE_ABNORMAL,
           wasClean: false,
@@ -1520,9 +1520,9 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
-      ws.closeFromBackend(
+      ws.simulateCloseFromServer(
         new CloseEvent("close", {
           code: 1006,
           wasClean: false,
@@ -1542,9 +1542,9 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
-      ws.closeFromBackend(
+      ws.simulateCloseFromServer(
         new CloseEvent("close", {
           code: 4002,
           wasClean: false,
@@ -1569,14 +1569,14 @@ describe("room", () => {
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       expect(room.getConnectionState()).toBe("connecting");
 
-      ws.open();
+      ws.simulateOpen();
       expect(room.getConnectionState()).toBe("open");
 
       room.reconnect();
       expect(room.getConnectionState()).toBe("authenticating");
 
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
       expect(room.getConnectionState()).toBe("open");
     });
   });
@@ -1593,7 +1593,7 @@ describe("room", () => {
       const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
-      ws.open();
+      ws.simulateOpen();
 
       let others: Others<P, M> | undefined;
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -256,7 +256,7 @@ describe("room", () => {
     const { room } = setupStateMachine({});
     room.__internal.authenticationSuccess(
       defaultRoomToken,
-      new MockWebSocket("")
+      new MockWebSocket()
     );
     expect(room.getConnectionState()).toBe("connecting");
   });
@@ -264,7 +264,7 @@ describe("room", () => {
   test("initial presence should be sent once the connection is open", () => {
     const { room, effects } = setupStateMachine({ x: 0 });
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -277,7 +277,7 @@ describe("room", () => {
   test("if presence has been updated before the connection, it should be sent when the connection is ready", () => {
     const { room, effects } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.updatePresence({ x: 0 });
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
@@ -291,7 +291,7 @@ describe("room", () => {
   test("if no presence has been set before the connection is open, an empty presence should be sent", () => {
     const { room, effects } = setupStateMachine({} as never);
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -304,7 +304,7 @@ describe("room", () => {
   test("initial presence followed by updatePresence should delay sending the second presence event", () => {
     const { room, effects } = setupStateMachine({ x: 0 });
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
 
@@ -348,7 +348,7 @@ describe("room", () => {
   test("others should be iterable", () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -384,7 +384,7 @@ describe("room", () => {
   test("others should be iterable", () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -420,7 +420,7 @@ describe("room", () => {
   test("others should be read-only when associated scopes are received", () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -456,7 +456,7 @@ describe("room", () => {
   test("should clear users when socket close", () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -507,7 +507,7 @@ describe("room", () => {
 
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -571,7 +571,7 @@ describe("room", () => {
     test("should send event to other users", () => {
       const { room, effects } = setupStateMachine({});
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
 
@@ -610,7 +610,7 @@ describe("room", () => {
 
       expect(effects.send).not.toHaveBeenCalled();
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -631,7 +631,7 @@ describe("room", () => {
 
       expect(effects.send).not.toHaveBeenCalled();
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -647,7 +647,7 @@ describe("room", () => {
   test("storage should be initialized properly", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -669,7 +669,7 @@ describe("room", () => {
   test("undo redo with presence", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -724,7 +724,7 @@ describe("room", () => {
   test("if presence is not added to history during a batch, it should not impact the undo/stack", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -758,7 +758,7 @@ describe("room", () => {
   test("if nothing happened while the history was paused, the undo stack should not be impacted", () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -779,7 +779,7 @@ describe("room", () => {
   test("undo redo with presence that do not impact presence", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -795,7 +795,7 @@ describe("room", () => {
   test("pause / resume history", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -829,7 +829,7 @@ describe("room", () => {
   test("undo while history is paused", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -853,7 +853,7 @@ describe("room", () => {
   test("undo redo with presence + storage", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -894,7 +894,7 @@ describe("room", () => {
   test("batch without changes should not erase redo stack", async () => {
     const { room } = setupStateMachine({});
 
-    const ws = new MockWebSocket("");
+    const ws = new MockWebSocket();
     room.__internal.connect();
     room.__internal.authenticationSuccess(defaultRoomToken, ws);
     ws.open();
@@ -960,7 +960,7 @@ describe("room", () => {
     test("batch storage and presence", async () => {
       const { room } = setupStateMachine({});
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -1201,7 +1201,7 @@ describe("room", () => {
 
       const { room } = setupStateMachine<P, never, never, never>({});
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -1252,7 +1252,7 @@ describe("room", () => {
     test("event", () => {
       const { room } = setupStateMachine({});
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -1517,7 +1517,7 @@ describe("room", () => {
     test("when error code 1006", () => {
       const { room } = setupStateMachine({ x: 0 });
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -1539,7 +1539,7 @@ describe("room", () => {
     test("when error code 4002", () => {
       const { room } = setupStateMachine({ x: 0 });
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();
@@ -1562,7 +1562,7 @@ describe("room", () => {
       const { room } = setupStateMachine({ x: 0 });
       expect(room.getConnectionState()).toBe("closed");
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       expect(room.getConnectionState()).toBe("authenticating");
 
@@ -1590,7 +1590,7 @@ describe("room", () => {
 
       const { room } = setupStateMachine<P, S, M, E>({});
 
-      const ws = new MockWebSocket("");
+      const ws = new MockWebSocket();
       room.__internal.connect();
       room.__internal.authenticationSuccess(defaultRoomToken, ws);
       ws.open();


### PR DESCRIPTION
This PR simplifies our `MockWebSocket` class in our unit tests. It only implements the bare minimum that's needed for the now required `IWebSocket` interface, and ensures that it's always assignable to it. I've removed all the cruft from the mock that wasn't used or needed, and tweaked a few things to make it behave more closely to a real `WebSocket` implementation.

I've also renamed the `.open()` method to `.simulateOpen()` to make it more obvious that this isn't a method that is part of the WebSocket API.

One bug I found is that you could call `ws.simulateOpen()` multiple times for a connection, which should never happen in practice, so I'm now [forbidding that explicitly](https://github.com/liveblocks/liveblocks/commit/b04fa2671dd7e062cd2c00e3aa671dc15f0311c4). Doing so [revealed a bug](https://github.com/liveblocks/liveblocks/actions/runs/4872579293/jobs/8690953670#step:7:85) in our unit test, where we were asserting a property on the wrong instance of a WebSocket. I've [fixed this unit test](https://github.com/liveblocks/liveblocks/commit/c30894fdf335b821b62dc83789e8806604d01558) to more accurately test what should be tested: that the _second instance_ of the WebSocket will move to "open" state correctly. (The unit test only passed because the old instance remained in "open" state previously.)
