### PR TITLE
Remove prefixes in titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,40 +1,40 @@
 ---
 name: Bug report
 about: Create a report to help us improve Liveblocks
-title: "[BUG]"
 labels: bug, triage needed
-assignees: ''
+assignees: ""
 ---
 
 **Describe the bug**
 
-A clear and concise description of what the bug is.
-Ex: The storage block is getting out of synchronization when resuming my internet connection.
-When getting back online, I don't see any changes.
+A clear and concise description of what the bug is. Ex: The storage block is
+getting out of synchronization when resuming my internet connection. When
+getting back online, I don't see any changes.
 
 **To Reproduce**
 
 Steps to reproduce the behavior:
+
 1. Initialize storage
 2. Stop internet connection
-3. Mutate the storage using another user 
+3. Mutate the storage using another user
 4. Restore internet connection
 5. The storage is not in sync
 
 **Expected behavior**
 
-A clear and concise description of what you expected to happen.
-Ex: I should see the updates performed on storage while I was disconnected. 
+A clear and concise description of what you expected to happen. Ex: I should see
+the updates performed on storage while I was disconnected.
 
 **Illustrations**
 
 If applicable, add screenshots or video recordings to help explain your problem.
 Upload your file with a drag and drop on the text area.
 
-
 **Environment (please complete the following information):**
 
-- Liveblocks packages and packages version [e.g. @liveblocks/react@0.15.1 @liveblocks/client@0.15.1]
+- Liveblocks packages and packages version [e.g. @liveblocks/react@0.15.1
+  @liveblocks/client@0.15.1]
 - Browser's version [e.g. chrome v99.0.4, safari]
 - [...]
 

--- a/.github/ISSUE_TEMPLATE/docs-request-for-an-update-or-improvement.md
+++ b/.github/ISSUE_TEMPLATE/docs-request-for-an-update-or-improvement.md
@@ -1,19 +1,20 @@
 ---
 name: Docs Request for an Update or Improvement
 about: A request to update or improve Liveblocks documentation
-title: "[DOC_REQUEST]"
 labels: documentation, enhancement, triage needed
-assignees: ''
+assignees: ""
 ---
 
 **What is the improvement or update you wish to see?**
 
-Ex. I would like to see more examples of how to use the `updateMyPresence`  React Hook. 
+Ex. I would like to see more examples of how to use the `updateMyPresence` 
+React Hook.
 
 **Is there any context that might help us understand?**
 
-Ex. Can I call the `updateMyPresence` function with other parameters than cursors position?  
-  
+Ex. Can I call the `updateMyPresence` function with other parameters than
+cursors position?
+
 **Does the docs page already exist? Please link to it.**
 
 Ex. [https://liveblocks.io/docs/api-reference/liveblocks-react](https://liveblocks.io/docs/api-reference/liveblocks-react)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,16 +1,17 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE_REQUEST]"
 labels: feature request
-assignees: ''
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**
 
 A clear and concise description of what the problem is.
 
-Ex. Can `id` be exposed on `Room`? In situations where our app switches from room to room but reuses context, it would be helpful to be able to distinguish between rooms.
+Ex. Can `id` be exposed on `Room`? In situations where our app switches from
+room to room but reuses context, it would be helpful to be able to distinguish
+between rooms.
 
 **Describe the solution you'd like**
 


### PR DESCRIPTION
### Description

The goal of this PR is to remove the prefix that is automatically added to any new issue:
- `[BUG]` for Bug report
- `[DOC_REQUEST]` for Docs Request for an Update or Improvement 
- `[FEATURE_REQUEST]` for Feature request 

The reason is that it was creating too much noise when looking at the backlog, and we want to simplify this view for our community. To spot bugs or feature request, they can rely on there labels

#### How to test it

To properly test this PR, you'd have to create a private repo and use the files submitted to see it works perfectly int heir expected flow. Otherwise, the markdown can be previewed from Github
