### PR TITLE
Updated 128 kB limits docs

### DIFF
--- a/docs/pages/guides/limits.mdx
+++ b/docs/pages/guides/limits.mdx
@@ -37,5 +37,4 @@ characters once serialized to JSON.
 
 ### Storage
 
-The value of a `LiveObject`, `LiveList`, and `LiveMap` storage item cannot
-exceed 128 kB. This limit can be increased on the Enterprise plan.
+The `LiveObject` data structure and JSON values in storage cannot exceed 128 kB.

--- a/docs/pages/guides/limits.mdx
+++ b/docs/pages/guides/limits.mdx
@@ -37,4 +37,17 @@ characters once serialized to JSON.
 
 ### Storage
 
-The `LiveObject` and JSON values in storage cannot exceed 128 kB.
+Our conflict-free data structures have a limit.
+
+- A `LiveObject` cannot exceed 128 kB when totalling the size of the keys and
+  values.
+- A `LiveMap` can be any size, so long as each individual value does not exceed
+  128kB.
+- A `LiveList` can be any size, so long as each individual value does not exceed
+  128kB.
+
+Note that when one real-time data structure is nested inside another, it does
+not count towards the limit. Only the JSON leaves of your data structure count
+towards the limit. For example, if a `LiveList` is nested inside a `LiveObject`,
+the `LiveList` and its contents do not count towards the `LiveObject`'s data
+limit.

--- a/docs/pages/guides/limits.mdx
+++ b/docs/pages/guides/limits.mdx
@@ -37,8 +37,6 @@ characters once serialized to JSON.
 
 ### Storage
 
-Our conflict-free data structures have a limit.
-
 - A `LiveObject` cannot exceed 128 kB when totalling the size of the keys and
   values.
 - A `LiveMap` can be any size, so long as each individual value does not exceed

--- a/docs/pages/guides/limits.mdx
+++ b/docs/pages/guides/limits.mdx
@@ -37,4 +37,4 @@ characters once serialized to JSON.
 
 ### Storage
 
-The `LiveObject` data structure and JSON values in storage cannot exceed 128 kB.
+The `LiveObject` and JSON values in storage cannot exceed 128 kB.


### PR DESCRIPTION
The limits page on the documentation was misleading.
Only LiveObjects and JSON cannot exceed 128 kB.