### PR TITLE
Refactor internal auth response structures slightly

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -634,7 +634,7 @@ export function mockEffects<
   TRoomEvent extends Json
 >(): Effects<TPresence, TRoomEvent> {
   return {
-    authenticate: jest.fn(),
+    authenticateAndConnect: jest.fn(),
     send: jest.fn(),
     scheduleFlush: jest.fn(),
     scheduleReconnect: jest.fn(),

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -170,10 +170,9 @@ export const THIRD_POSITION = makePosition(SECOND_POSITION);
 export const FOURTH_POSITION = makePosition(THIRD_POSITION);
 export const FIFTH_POSITION = makePosition(FOURTH_POSITION);
 
-function makeMachineConfig<
-  TPresence extends JsonObject,
-  TRoomEvent extends Json
->(mockedEffects: Effects<TPresence, TRoomEvent>) {
+function makeRoomConfig<TPresence extends JsonObject, TRoomEvent extends Json>(
+  mockedEffects: Effects<TPresence, TRoomEvent>
+) {
   return {
     roomId: "room-id",
     throttleDelay: -1, // No throttle for standard storage test
@@ -209,7 +208,7 @@ export async function prepareRoomWithStorage<
       initialPresence: {} as TPresence,
       initialStorage: defaultStorage || ({} as TStorage),
     },
-    makeMachineConfig(effects)
+    makeRoomConfig(effects)
   );
   const ws = new MockWebSocket();
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -62,7 +62,7 @@ const defaultRoomToken: RoomAuthToken = {
   scopes: [],
 };
 
-function setupStateMachine<
+function createTestableRoom<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -216,14 +216,14 @@ describe("room / auth", () => {
 
 describe("room", () => {
   test("connect should transition to authenticating if closed and execute authenticate", () => {
-    const { room, effects } = setupStateMachine({});
+    const { room, effects } = createTestableRoom({});
     room.__internal.send.connect();
     expect(room.getConnectionState()).toEqual("authenticating");
     expect(effects.authenticateAndConnect).toHaveBeenCalled();
   });
 
   test("connect should stay authenticating if connect is called multiple times and call authenticate only once", () => {
-    const { room, effects } = setupStateMachine({});
+    const { room, effects } = createTestableRoom({});
     room.__internal.send.connect();
     expect(room.getConnectionState()).toEqual("authenticating");
     room.__internal.send.connect();
@@ -232,13 +232,13 @@ describe("room", () => {
   });
 
   test("authentication success should transition to connecting", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
     room.__internal.send.authSuccess(defaultRoomToken, new MockWebSocket());
     expect(room.getConnectionState()).toBe("connecting");
   });
 
   test("initial presence should be sent once the connection is open", () => {
-    const { room, effects } = setupStateMachine({ x: 0 });
+    const { room, effects } = createTestableRoom({ x: 0 });
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -251,7 +251,7 @@ describe("room", () => {
   });
 
   test("if presence has been updated before the connection, it should be sent when the connection is ready", () => {
-    const { room, effects } = setupStateMachine({});
+    const { room, effects } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.updatePresence({ x: 0 });
@@ -265,7 +265,7 @@ describe("room", () => {
   });
 
   test("if no presence has been set before the connection is open, an empty presence should be sent", () => {
-    const { room, effects } = setupStateMachine({} as never);
+    const { room, effects } = createTestableRoom({} as never);
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -278,7 +278,7 @@ describe("room", () => {
   });
 
   test("initial presence followed by updatePresence should delay sending the second presence event", () => {
-    const { room, effects } = setupStateMachine({ x: 0 });
+    const { room, effects } = createTestableRoom({ x: 0 });
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -300,7 +300,7 @@ describe("room", () => {
   });
 
   test("should replace current presence and set flushData presence when connection is closed", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     room.updatePresence({ x: 0 });
 
@@ -309,7 +309,7 @@ describe("room", () => {
   });
 
   test("should merge current presence and set flushData presence when connection is closed", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     room.updatePresence({ x: 0 });
 
@@ -322,7 +322,7 @@ describe("room", () => {
   });
 
   test("others should be iterable", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -358,7 +358,7 @@ describe("room", () => {
   });
 
   test("others should be iterable", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -394,7 +394,7 @@ describe("room", () => {
   });
 
   test("others should be read-only when associated scopes are received", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -430,7 +430,7 @@ describe("room", () => {
   });
 
   test("should clear users when socket close", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -481,7 +481,7 @@ describe("room", () => {
     - Client A should remove client B from others.
   */
 
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -545,7 +545,7 @@ describe("room", () => {
 
   describe("broadcast", () => {
     test("should send event to other users", () => {
-      const { room, effects } = setupStateMachine({});
+      const { room, effects } = createTestableRoom({});
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();
@@ -580,7 +580,7 @@ describe("room", () => {
     });
 
     test("should not send event to other users if not connected", () => {
-      const { room, effects } = setupStateMachine({});
+      const { room, effects } = createTestableRoom({});
 
       room.broadcastEvent({ type: "EVENT" });
 
@@ -598,7 +598,7 @@ describe("room", () => {
     });
 
     test("should queue event if socket is not ready and shouldQueueEventsIfNotReady is true", () => {
-      const { room, effects } = setupStateMachine({});
+      const { room, effects } = createTestableRoom({});
 
       room.broadcastEvent(
         { type: "EVENT" },
@@ -621,7 +621,7 @@ describe("room", () => {
   });
 
   test("storage should be initialized properly", async () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -643,7 +643,7 @@ describe("room", () => {
   });
 
   test("undo redo with presence", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -698,7 +698,7 @@ describe("room", () => {
   });
 
   test("if presence is not added to history during a batch, it should not impact the undo/stack", async () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -732,7 +732,7 @@ describe("room", () => {
   });
 
   test("if nothing happened while the history was paused, the undo stack should not be impacted", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -753,7 +753,7 @@ describe("room", () => {
   });
 
   test("undo redo with presence that do not impact presence", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -769,7 +769,7 @@ describe("room", () => {
   });
 
   test("pause / resume history", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -803,7 +803,7 @@ describe("room", () => {
   });
 
   test("undo while history is paused", () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -827,7 +827,7 @@ describe("room", () => {
   });
 
   test("undo redo with presence + storage", async () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -868,7 +868,7 @@ describe("room", () => {
   });
 
   test("batch without changes should not erase redo stack", async () => {
-    const { room } = setupStateMachine({});
+    const { room } = createTestableRoom({});
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
@@ -918,7 +918,7 @@ describe("room", () => {
 
   describe("subscription", () => {
     test("batch my-presence", () => {
-      const { room } = setupStateMachine({});
+      const { room } = createTestableRoom({});
 
       const callback = jest.fn();
 
@@ -934,7 +934,7 @@ describe("room", () => {
     });
 
     test("batch storage and presence", async () => {
-      const { room } = setupStateMachine({});
+      const { room } = createTestableRoom({});
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();
@@ -1142,7 +1142,7 @@ describe("room", () => {
     });
 
     test("batch history", () => {
-      const { room } = setupStateMachine({});
+      const { room } = createTestableRoom({});
 
       const callback = jest.fn();
       room.events.history.subscribe(callback);
@@ -1157,7 +1157,7 @@ describe("room", () => {
     });
 
     test("my-presence", () => {
-      const { room } = setupStateMachine({});
+      const { room } = createTestableRoom({});
 
       const callback = jest.fn();
       const unsubscribe = room.events.me.subscribe(callback);
@@ -1175,7 +1175,7 @@ describe("room", () => {
     test("others", () => {
       type P = { x?: number };
 
-      const { room } = setupStateMachine<P, never, never, never>({});
+      const { room } = createTestableRoom<P, never, never, never>({});
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();
@@ -1226,7 +1226,7 @@ describe("room", () => {
     });
 
     test("event", () => {
-      const { room } = setupStateMachine({});
+      const { room } = createTestableRoom({});
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();
@@ -1253,7 +1253,7 @@ describe("room", () => {
     });
 
     test("history", () => {
-      const { room } = setupStateMachine({});
+      const { room } = createTestableRoom({});
 
       const callback = jest.fn();
       const unsubscribe = room.events.history.subscribe(callback);
@@ -1491,7 +1491,7 @@ describe("room", () => {
     });
 
     test("when error code 1006", () => {
-      const { room } = setupStateMachine({ x: 0 });
+      const { room } = createTestableRoom({ x: 0 });
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();
@@ -1513,7 +1513,7 @@ describe("room", () => {
     });
 
     test("when error code 4002", () => {
-      const { room } = setupStateMachine({ x: 0 });
+      const { room } = createTestableRoom({ x: 0 });
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();
@@ -1535,7 +1535,7 @@ describe("room", () => {
     });
 
     test("manual reconnection", () => {
-      const { room } = setupStateMachine({ x: 0 });
+      const { room } = createTestableRoom({ x: 0 });
       expect(room.getConnectionState()).toBe("closed");
 
       const ws = new MockWebSocket();
@@ -1567,7 +1567,7 @@ describe("room", () => {
       type M = never;
       type E = never;
 
-      const { room } = setupStateMachine<P, S, M, E>({});
+      const { room } = createTestableRoom<P, S, M, E>({});
 
       const ws = new MockWebSocket();
       room.__internal.send.connect();

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -472,7 +472,7 @@ describe("room", () => {
   test("should clear users not present in server message ROOM_STATE", () => {
     /*
     Scenario:
-    - Client A (machine) and Client B (ref machine) are connected to the room.
+    - Client A (room) and Client B (refRoom) are connected to the room.
     - Client A computer goes to sleep, it doesn't properly close. It still has client B in others.
     - Client B computer goes to sleep, it doesn't properly close.
     - After 2 minutes, the server clears client A and B from its list of users.
@@ -1406,9 +1406,9 @@ describe("room", () => {
 
       reconnect(2);
 
-      const refMachineOthers = refRoom.getOthers();
+      const refRoomOthers = refRoom.getOthers();
 
-      expect(refMachineOthers).toEqual([
+      expect(refRoomOthers).toEqual([
         {
           connectionId: 1,
           id: undefined,

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -220,7 +220,7 @@ describe("room", () => {
     const { room, effects } = setupStateMachine({});
     room.__internal.send.connect();
     expect(room.getConnectionState()).toEqual("authenticating");
-    expect(effects.authenticate).toHaveBeenCalled();
+    expect(effects.authenticateAndConnect).toHaveBeenCalled();
   });
 
   test("connect should stay authenticating if connect is called multiple times and call authenticate only once", () => {
@@ -229,7 +229,7 @@ describe("room", () => {
     expect(room.getConnectionState()).toEqual("authenticating");
     room.__internal.send.connect();
     expect(room.getConnectionState()).toEqual("authenticating");
-    expect(effects.authenticate).toHaveBeenCalledTimes(1);
+    expect(effects.authenticateAndConnect).toHaveBeenCalledTimes(1);
   });
 
   test("authentication success should transition to connecting", () => {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -39,10 +39,9 @@ import {
   withDateNow,
 } from "./_utils";
 
-function makeMachineConfig<
-  TPresence extends JsonObject,
-  TRoomEvent extends Json
->(mockedEffects?: Effects<TPresence, TRoomEvent>) {
+function makeRoomConfig<TPresence extends JsonObject, TRoomEvent extends Json>(
+  mockedEffects?: Effects<TPresence, TRoomEvent>
+) {
   return {
     roomId: "room-id",
     throttleDelay: 100,
@@ -75,7 +74,7 @@ function setupStateMachine<
       initialPresence,
       initialStorage: undefined,
     },
-    makeMachineConfig(effects)
+    makeRoomConfig(effects)
   );
   return { room, effects };
 }
@@ -121,7 +120,7 @@ describe("room / auth", () => {
       const room = createRoom(
         { initialPresence: {} as never },
         {
-          ...makeMachineConfig(),
+          ...makeRoomConfig(),
           authentication: {
             type: "custom",
             callback: (_room) =>
@@ -149,7 +148,7 @@ describe("room / auth", () => {
     const room = createRoom(
       { initialPresence: {} as never },
       {
-        ...makeMachineConfig(),
+        ...makeRoomConfig(),
         authentication: {
           type: "private",
           url: "/mocked-api/403",
@@ -172,7 +171,7 @@ describe("room / auth", () => {
     const room = createRoom(
       { initialPresence: {} as never },
       {
-        ...makeMachineConfig(),
+        ...makeRoomConfig(),
         authentication: {
           type: "private",
           url: "/mocked-api/not-json",
@@ -195,7 +194,7 @@ describe("room / auth", () => {
     const room = createRoom(
       { initialPresence: {} as never },
       {
-        ...makeMachineConfig(),
+        ...makeRoomConfig(),
         authentication: {
           type: "private",
           url: "/mocked-api/missing-token",
@@ -292,7 +291,7 @@ describe("room", () => {
     withDateNow(now + 30, () => room.updatePresence({ x: 1 }));
 
     expect(effects.scheduleFlush).toBeCalledWith(
-      makeMachineConfig().throttleDelay - 30
+      makeRoomConfig().throttleDelay - 30
     );
     expect(effects.send).toHaveBeenCalledWith([
       { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },

--- a/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
@@ -1,7 +1,7 @@
 import type { JwtMetadata } from "../../protocol/AuthToken";
 import {
   isTokenExpired,
-  parseRoomAuthToken_,
+  parseRoomAuthToken,
   RoomScope,
 } from "../../protocol/AuthToken";
 
@@ -46,8 +46,8 @@ describe("parseRoomAuthToken", () => {
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2NywiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJzY29wZXMiOlsicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.7Wplt6YV_YbpPAcAFyC8pX8tk5BGNy53GdoH1_u8sjo";
 
   test("should parse a valid token", () => {
-    const parsedToken = parseRoomAuthToken_(roomToken);
-    expect(parsedToken).toEqual({
+    const { parsed } = parseRoomAuthToken(roomToken);
+    expect(parsed).toEqual({
       actor: 87,
       appId: "605a4fd31a36d5ea7a2e08f1",
       exp: 1664570010,
@@ -59,7 +59,7 @@ describe("parseRoomAuthToken", () => {
 
   test("should throw if token is not a room token", () => {
     try {
-      parseRoomAuthToken_(apiToken);
+      parseRoomAuthToken(apiToken);
     } catch (error) {
       expect(error).toEqual(
         new Error(

--- a/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
@@ -1,7 +1,7 @@
 import type { JwtMetadata } from "../../protocol/AuthToken";
 import {
   isTokenExpired,
-  parseRoomAuthToken,
+  parseRoomAuthToken_,
   RoomScope,
 } from "../../protocol/AuthToken";
 
@@ -46,7 +46,7 @@ describe("parseRoomAuthToken", () => {
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2NywiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJzY29wZXMiOlsicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.7Wplt6YV_YbpPAcAFyC8pX8tk5BGNy53GdoH1_u8sjo";
 
   test("should parse a valid token", () => {
-    const parsedToken = parseRoomAuthToken(roomToken);
+    const parsedToken = parseRoomAuthToken_(roomToken);
     expect(parsedToken).toEqual({
       actor: 87,
       appId: "605a4fd31a36d5ea7a2e08f1",
@@ -59,7 +59,7 @@ describe("parseRoomAuthToken", () => {
 
   test("should throw if token is not a room token", () => {
     try {
-      parseRoomAuthToken(apiToken);
+      parseRoomAuthToken_(apiToken);
     } catch (error) {
       expect(error).toEqual(
         new Error(

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -136,9 +136,9 @@ export function parseRoomAuthToken_(
     // If this legacy field is found on the token, pretend it wasn't there,
     // to make all internally used token payloads uniform
     maxConnections: _legacyField,
-    ...token
+    ...parsedToken
   } = data;
-  return token;
+  return parsedToken;
 }
 
 export function parseRoomAuthToken(tokenString: string): RichToken {

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -122,9 +122,7 @@ function parseJwtToken(token: string): JwtMetadata {
   }
 }
 
-export function parseRoomAuthToken_(
-  tokenString: string
-): RoomAuthToken & JwtMetadata {
+export function parseRoomAuthToken(tokenString: string): RichToken {
   const data = parseJwtToken(tokenString);
   if (!(data && isRoomAuthToken(data))) {
     throw new Error(
@@ -138,11 +136,7 @@ export function parseRoomAuthToken_(
     maxConnections: _legacyField,
     ...parsedToken
   } = data;
-  return parsedToken;
-}
 
-export function parseRoomAuthToken(tokenString: string): RichToken {
-  const parsedToken = parseRoomAuthToken_(tokenString);
   return {
     raw: tokenString,
     parsed: parsedToken,

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -126,19 +126,19 @@ export function parseRoomAuthToken_(
   tokenString: string
 ): RoomAuthToken & JwtMetadata {
   const data = parseJwtToken(tokenString);
-  if (data && isRoomAuthToken(data)) {
-    const {
-      // If this legacy field is found on the token, pretend it wasn't there,
-      // to make all internally used token payloads uniform
-      maxConnections: _legacyField,
-      ...token
-    } = data;
-    return token;
-  } else {
+  if (!(data && isRoomAuthToken(data))) {
     throw new Error(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"
     );
   }
+
+  const {
+    // If this legacy field is found on the token, pretend it wasn't there,
+    // to make all internally used token payloads uniform
+    maxConnections: _legacyField,
+    ...token
+  } = data;
+  return token;
 }
 
 export function parseRoomAuthToken(tokenString: string): RichToken {

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -27,6 +27,13 @@ export type RoomAuthToken = {
 
 export type AuthToken = AppOnlyAuthToken | RoomAuthToken;
 
+// The "rich" token is data we obtain by parsing the JWT token and making all
+// metadata on it accessible. It's done right after authorizing in the backend.
+export type RichToken = {
+  readonly raw: string;
+  readonly parsed: RoomAuthToken & JwtMetadata;
+};
+
 export interface JwtMetadata extends JsonObject {
   iat: number;
   exp: number;
@@ -113,7 +120,7 @@ function parseJwtToken(token: string): JwtMetadata {
   }
 }
 
-export function parseRoomAuthToken(
+export function parseRoomAuthToken_(
   tokenString: string
 ): RoomAuthToken & JwtMetadata {
   const data = parseJwtToken(tokenString);
@@ -130,4 +137,12 @@ export function parseRoomAuthToken(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"
     );
   }
+}
+
+export function parseRoomAuthToken(tokenString: string): RichToken {
+  const parsedToken = parseRoomAuthToken_(tokenString);
+  return {
+    raw: tokenString,
+    parsed: parsedToken,
+  };
 }

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -28,10 +28,12 @@ export type RoomAuthToken = {
 export type AuthToken = AppOnlyAuthToken | RoomAuthToken;
 
 // The "rich" token is data we obtain by parsing the JWT token and making all
-// metadata on it accessible. It's done right after authorizing in the backend.
+// metadata on it accessible. It's done right after hitting the backend, but
+// before the promise will get returned, so it's an inherent part of the
+// authentication step.
 export type RichToken = {
-  readonly raw: string;
-  readonly parsed: RoomAuthToken & JwtMetadata;
+  readonly raw: string; // The raw JWT value, unchanged
+  readonly parsed: RoomAuthToken & JwtMetadata; // Rich data on the JWT value
 };
 
 export interface JwtMetadata extends JsonObject {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -66,8 +66,6 @@ type CustomEvent<TRoomEvent extends Json> = {
   event: TRoomEvent;
 };
 
-type AuthCallback = () => Promise<{ token: string }>;
-
 export type Connection =
   /* The initial state, before connecting */
   | { status: "closed" }
@@ -726,7 +724,7 @@ type RoomState<
 /** @internal */
 type Effects<TPresence extends JsonObject, TRoomEvent extends Json> = {
   authenticateAndConnect(
-    auth: AuthCallback,
+    auth: () => Promise<{ token: string }>,
     createWebSocket: (token: string) => IWebSocketInstance
   ): void;
   send(messages: ClientMsg<TPresence, TRoomEvent>[]): void;
@@ -975,7 +973,7 @@ export function createRoom<
 
   const effects: Effects<TPresence, TRoomEvent> = config.mockedEffects || {
     authenticateAndConnect(
-      auth: AuthCallback,
+      auth: () => Promise<{ token: string }>,
       createWebSocket: (token: string) => IWebSocketInstance
     ) {
       // If we already have a parsed token from a previous connection
@@ -2524,7 +2522,8 @@ function makeAuthDelegateForRoom(
   roomId: string,
   authentication: Authentication,
   fetchPolyfill?: typeof window.fetch
-): AuthCallback {
+  // XXX Change this return type
+): () => Promise<{ token: string }> {
   if (authentication.type === "public") {
     if (typeof window === "undefined" && fetchPolyfill === undefined) {
       throw new Error(

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -639,7 +639,7 @@ type RoomState<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 > = {
-  richToken: RichToken | null;
+  token: RichToken | null;
 
   /**
    * Remembers the last successful connection ID. This gets assigned as soon as
@@ -840,7 +840,7 @@ export function createRoom<
 
   // The room's internal stateful context
   const context: RoomState<TPresence, TStorage, TUserMeta, TRoomEvent> = {
-    richToken: null,
+    token: null,
     lastConnectionId: null,
     socket: null,
 
@@ -974,24 +974,24 @@ export function createRoom<
   const effects: Effects<TPresence, TRoomEvent> = config.mockedEffects || {
     authenticateAndConnect(
       auth: () => Promise<RichToken>,
-      createWebSocket: (richToken: RichToken) => IWebSocketInstance
+      createWebSocket: (token: RichToken) => IWebSocketInstance
     ) {
       // If we already have a parsed token from a previous connection
       // in-memory, reuse it
-      const prevToken = context.richToken;
+      const prevToken = context.token;
       if (prevToken !== null && !isTokenExpired(prevToken.parsed)) {
         const socket = createWebSocket(prevToken);
         handleAuthSuccess(prevToken.parsed, socket);
         return undefined;
       } else {
         void auth()
-          .then((richToken) => {
+          .then((token) => {
             if (context.connection.current.status !== "authenticating") {
               return;
             }
-            const socket = createWebSocket(richToken);
-            handleAuthSuccess(richToken.parsed, socket);
-            context.richToken = richToken;
+            const socket = createWebSocket(token);
+            handleAuthSuccess(token.parsed, socket);
+            context.token = token;
           })
           .catch((er: unknown) =>
             authenticationFailure(
@@ -1421,7 +1421,7 @@ export function createRoom<
     if (process.env.NODE_ENV !== "production") {
       console.error("Call to authentication endpoint failed", error);
     }
-    context.richToken = null;
+    context.token = null;
     updateConnection({ status: "unavailable" }, batchUpdates);
     context.numRetries++;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1322,24 +1322,18 @@ export function createRoom<
       return;
     }
 
-    const delegates = {
-      authenticate: prepareAuthEndpoint(
-        config.roomId,
-        config.authentication,
-        config.polyfills?.fetch
-      ),
-
-      createSocket: prepareCreateWebSocket(
-        config.liveblocksServer,
-        config.polyfills?.WebSocket
-      ),
-    };
+    const auth = prepareAuthEndpoint(
+      config.roomId,
+      config.authentication,
+      config.polyfills?.fetch
+    );
+    const createWebSocket = prepareCreateWebSocket(
+      config.liveblocksServer,
+      config.polyfills?.WebSocket
+    );
 
     updateConnection({ status: "authenticating" }, batchUpdates);
-    effects.authenticateAndConnect(
-      delegates.authenticate,
-      delegates.createSocket
-    );
+    effects.authenticateAndConnect(auth, createWebSocket);
   }
 
   function updatePresence(

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -24,7 +24,7 @@ import type { Authentication } from "./protocol/Authentication";
 import type { RichToken, RoomAuthToken } from "./protocol/AuthToken";
 import {
   isTokenExpired,
-  parseRoomAuthToken_,
+  parseRoomAuthToken,
   RoomScope,
 } from "./protocol/AuthToken";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
@@ -989,11 +989,10 @@ export function createRoom<
             if (context.connection.current.status !== "authenticating") {
               return;
             }
-            const parsedToken = parseRoomAuthToken_(token);
-            const socket = createWebSocket(token);
-
-            handleAuthSuccess(parsedToken, socket);
-            context.richToken = { raw: token, parsed: parsedToken };
+            const richToken = parseRoomAuthToken(token);
+            const socket = createWebSocket(richToken.raw);
+            handleAuthSuccess(richToken.parsed, socket);
+            context.richToken = richToken;
           })
           .catch((er: unknown) =>
             authenticationFailure(

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -572,7 +572,7 @@ type PrivateRoomAPI<
   TRoomEvent extends Json
 > = {
   // For introspection in unit tests only
-  buffer: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent>["buffer"]; // prettier-ignore
+  buffer: RoomState<TPresence, TStorage, TUserMeta, TRoomEvent>["buffer"]; // prettier-ignore
   numRetries: number;
   undoStack: readonly (readonly Readonly<HistoryOp<TPresence>>[])[];
   nodeCount: number;
@@ -635,7 +635,7 @@ type HistoryOp<TPresence extends JsonObject> =
 
 type IdFactory = () => string;
 
-type MachineContext<
+type RoomState<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -767,7 +767,7 @@ export type RoomInitializers<
 }>;
 
 /** @internal */
-type MachineConfig<TPresence extends JsonObject, TRoomEvent extends Json> = {
+type RoomConfig<TPresence extends JsonObject, TRoomEvent extends Json> = {
   roomId: string;
   throttleDelay: number;
   authentication: Authentication;
@@ -819,8 +819,7 @@ type FSMEvent =
 
 /**
  * @internal
- * Initializes a new Room state machine, and returns its public API to observe
- * and control it.
+ * Initializes a new Room, and returns its public API.
  */
 export function createRoom<
   TPresence extends JsonObject,
@@ -832,7 +831,7 @@ export function createRoom<
     RoomInitializers<TPresence, TStorage>,
     "shouldInitiallyConnect"
   >,
-  config: MachineConfig<TPresence, TRoomEvent>
+  config: RoomConfig<TPresence, TRoomEvent>
 ): Room<TPresence, TStorage, TUserMeta, TRoomEvent> {
   const initialPresence =
     typeof options.initialPresence === "function"
@@ -843,11 +842,8 @@ export function createRoom<
       ? options.initialStorage(config.roomId)
       : options.initialStorage;
 
-  // The "context" is the machine's stateful extended context, also sometimes
-  // known as the "extended state" of a finite state machine. The context
-  // maintains state beyond the inherent state that are the finite states
-  // themselves.
-  const context: MachineContext<TPresence, TStorage, TUserMeta, TRoomEvent> = {
+  // The room's internal stateful context
+  const context: RoomState<TPresence, TStorage, TUserMeta, TRoomEvent> = {
     token: null,
     lastConnectionId: null,
     socket: null,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1323,13 +1323,13 @@ export function createRoom<
     }
 
     const delegates = {
-      authenticate: makeAuthDelegateForRoom(
+      authenticate: prepareAuthEndpoint(
         config.roomId,
         config.authentication,
         config.polyfills?.fetch
       ),
 
-      createSocket: makeCreateSocketDelegateForRoom(
+      createSocket: prepareCreateWebSocket(
         config.liveblocksServer,
         config.polyfills?.WebSocket
       ),
@@ -2492,7 +2492,7 @@ class LiveblocksError extends Error {
   }
 }
 
-function makeCreateSocketDelegateForRoom(
+function prepareCreateWebSocket(
   liveblocksServer: string,
   WebSocketPolyfill?: IWebSocket
 ) {
@@ -2517,7 +2517,7 @@ function makeCreateSocketDelegateForRoom(
   };
 }
 
-function makeAuthDelegateForRoom(
+function prepareAuthEndpoint(
   roomId: string,
   authentication: Authentication,
   fetchPolyfill?: typeof window.fetch


### PR DESCRIPTION
This PR is a pure prefactoring. Its purpose is to make the internals of the current code base more easy to plug in to the new connection manager that is in the making.

**No behavioral changes.**

It specifically restructures the response of the `auth` + `createWebSocket` delegate pair to their input/output 100% symmetric. Until now, we've been returning `{ token: string }` in the `authenticate` promise, and having take the `createWebSocket` delegate take a `string` directly. This worked, because the client would be controlling things, eating off the `token` value and passing it to the creation function. In fact, it would also use this `{ token: string }` and turn it into a "richer" token, which it would keep itself in memory (for metadata).

With the upcoming separation of responsibilities, the connection manager (the state machine) is going to be a black box, and its requirement is that you provide it this delegate pair that have matching input/output (so they can "just" be chained without the manager itself having to know/care/understand that payload). It's just a value that is needed for authentication.
