### PR TITLE
Fix HTTP status code for when `@liveblocks/node` cannot connect to our infra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# vNEXT (not released yet)
+
+### `@liveblocks/node`
+
+- Fix incorrect status code when Liveblocks server cannot be reached temporarily
+
 # v1.0.9
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -101,7 +101,7 @@ export async function authorize(
     };
   } catch (er) {
     return {
-      status: 403,
+      status: 503,
       body: 'Call to "https://api.liveblocks.io/v2/rooms/:roomId/authorize" failed. See "error" for more information.',
       error: er as Error | undefined,
     };

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -25,6 +25,7 @@ type AuthorizeOptions = {
   groupIds?: string[];
 };
 
+/** @internal */
 type AllAuthorizeOptions = AuthorizeOptions & {
   liveblocksAuthorizeEndpoint?: string;
 };
@@ -73,7 +74,7 @@ export async function authorize(
     }
 
     const result = await fetch(
-      buildLiveblocksAuthorizeEndpoint(options as AllAuthorizeOptions, room),
+      buildLiveblocksAuthorizeEndpoint(options, room),
       {
         method: "POST",
         headers: {

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -73,38 +73,35 @@ export async function authorize(
       );
     }
 
-    const result = await fetch(
-      buildLiveblocksAuthorizeEndpoint(options, room),
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${secret}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          userId,
-          userInfo,
-          groupIds,
-        }),
-      }
-    );
+    const resp = await fetch(buildLiveblocksAuthorizeEndpoint(options, room), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        userId,
+        userInfo,
+        groupIds,
+      }),
+    });
 
-    if (result.ok) {
+    if (resp.ok) {
       return {
         status: 200 /* OK */,
-        body: await result.text(),
+        body: await resp.text(),
       };
     }
 
-    if (result.status >= 500) {
+    if (resp.status >= 500) {
       return {
         status: 503 /* Service Unavailable */,
-        body: await result.text(),
+        body: await resp.text(),
       };
     } else {
       return {
         status: 403 /* Unauthorized */,
-        body: await result.text(),
+        body: await resp.text(),
       };
     }
   } catch (er) {

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -91,18 +91,18 @@ export async function authorize(
 
     if (!result.ok) {
       return {
-        status: 403,
+        status: 403 /* Unauthorized */,
         body: await result.text(),
       };
     }
 
     return {
-      status: 200,
+      status: 200 /* OK */,
       body: await result.text(),
     };
   } catch (er) {
     return {
-      status: 503,
+      status: 503 /* Service Unavailable */,
       body: 'Call to "https://api.liveblocks.io/v2/rooms/:roomId/authorize" failed. See "error" for more information.',
       error: er as Error | undefined,
     };

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -89,17 +89,24 @@ export async function authorize(
       }
     );
 
-    if (!result.ok) {
+    if (result.ok) {
+      return {
+        status: 200 /* OK */,
+        body: await result.text(),
+      };
+    }
+
+    if (result.status >= 500) {
+      return {
+        status: 503 /* Service Unavailable */,
+        body: await result.text(),
+      };
+    } else {
       return {
         status: 403 /* Unauthorized */,
         body: await result.text(),
       };
     }
-
-    return {
-      status: 200 /* OK */,
-      body: await result.text(),
-    };
   } catch (er) {
     return {
       status: 503 /* Service Unavailable */,


### PR DESCRIPTION
This PR changes the status code that our `authorize()` helper from `@liveblocks/node` will return when implementing your own auth backend. This is about the case when the user's backend uses this wrapper to try to relay the request to our infra, but somehow this is not possible (network down, infra down, etc). In those cases, we should return a 5xx response back to the clients, not a 4xx response, and certainly no _403_ response, which will soon indicate to the client to stop retrying. We definitely want the client to keep retrying in this case!
