### PR TITLE
Remove the `scheduleFlush` effect

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -635,7 +635,6 @@ export function mockEffects<
   return {
     authenticateAndConnect: jest.fn(),
     send: jest.fn(),
-    scheduleFlush: jest.fn(),
     scheduleReconnect: jest.fn(),
     startHeartbeatInterval: jest.fn(),
     schedulePongTimeout: jest.fn(),

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -277,26 +277,40 @@ describe("room", () => {
     ]);
   });
 
-  test("initial presence followed by updatePresence should delay sending the second presence event", () => {
+  test("initial presence followed by updatePresence should delay sending the second presence event", async () => {
+    jest.useFakeTimers();
+
     const { room, effects } = createTestableRoom({ x: 0 });
 
     const ws = new MockWebSocket();
     room.__internal.send.connect();
     room.__internal.send.authSuccess(defaultRoomToken, ws);
 
-    const now = new Date(2021, 1, 1, 0, 0, 0, 0).getTime();
+    const now = Date.now();
 
-    withDateNow(now, () => ws.simulateOpen());
-
-    withDateNow(now + 30, () => room.updatePresence({ x: 1 }));
-
-    expect(effects.scheduleFlush).toBeCalledWith(
-      makeRoomConfig().throttleDelay - 30
-    );
-    expect(effects.send).toHaveBeenCalledWith([
+    expect(effects.send).toHaveBeenCalledTimes(0);
+    ws.simulateOpen();
+    expect(effects.send).toHaveBeenCalledTimes(1);
+    expect(effects.send).toHaveBeenLastCalledWith([
       { type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: { x: 0 } },
     ]);
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 1 });
+
+    // Forward the system clock by 30 millis
+    jest.setSystemTime(now + 30);
+    room.updatePresence({ x: 1 });
+    jest.setSystemTime(now + 35);
+    room.updatePresence({ x: 2 }); // These calls should get batched and flushed later
+
+    expect(effects.send).toHaveBeenCalledTimes(1);
+    expect(room.__internal.buffer.me?.data).toEqual({ x: 2 });
+
+    // Forwarding time by the flush threshold will trigger the future flush
+    await jest.advanceTimersByTimeAsync(makeRoomConfig().throttleDelay);
+
+    expect(effects.send).toHaveBeenCalledTimes(2);
+    expect(effects.send).toHaveBeenLastCalledWith([
+      { type: ClientMsgCode.UPDATE_PRESENCE, data: { x: 2 } },
+    ]);
   });
 
   test("should replace current presence and set flushData presence when connection is closed", () => {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -728,7 +728,6 @@ type Effects<TPresence extends JsonObject, TRoomEvent extends Json> = {
     createWebSocket: (token: RichToken) => IWebSocketInstance
   ): void;
   send(messages: ClientMsg<TPresence, TRoomEvent>[]): void;
-  scheduleFlush(delay: number): TimeoutID;
   scheduleReconnect(delay: number): TimeoutID;
   startHeartbeatInterval(): IntervalID;
   schedulePongTimeout(): TimeoutID;
@@ -1015,7 +1014,6 @@ export function createRoom<
       }
     },
 
-    scheduleFlush: (delay: number) => setTimeout(tryFlushing, delay),
     scheduleReconnect: (delay: number) => setTimeout(handleConnect, delay),
     startHeartbeatInterval: () => setInterval(heartbeat, HEARTBEAT_INTERVAL),
     schedulePongTimeout: () => setTimeout(pongTimeout, PONG_TIMEOUT),
@@ -1944,7 +1942,8 @@ export function createRoom<
     } else {
       // Or schedule the flush a few millis into the future
       clearTimeout(context.timers.flush);
-      context.timers.flush = effects.scheduleFlush(
+      context.timers.flush = setTimeout(
+        tryFlushing,
         config.throttleDelay - elapsedMillis
       );
     }


### PR DESCRIPTION
Removes the `scheduleFlush` effect that is configured in the current testing setup. The goal here is to get rid of the effects and rely less on testing implementation details, and try to treat the room under test more as a black box. All the other effects (except `send()`) will be removed in the upcoming connection manager PR which I'll open soon, since those effects are all responsibility of the connection manager instead of the room soon.
