### PR TITLE
Allow explicitly _not_ transitioning

### DIFF
--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -450,6 +450,34 @@ describe("finite state machine", () => {
     expect(fsm.context).toEqual({ x: 3, y: 13 });
   });
 
+  test("explicitly *not* transitioning", () => {
+    let n = 0;
+
+    const fsm = new FSM({ x: 13, y: 13 })
+      .addState("one")
+      .addState("two")
+      .addTransitions("one", { GO: "two" })
+      .addTransitions("two", {
+        GO: () =>
+          n++ % 2 === 0
+            ? "one" // Transition if n is even
+            : null, // Otherwise, do nothing
+      })
+      .start();
+
+    expect(fsm.currentState).toEqual("one");
+    fsm.send({ type: "GO" });
+    expect(fsm.currentState).toEqual("two");
+    fsm.send({ type: "GO" });
+    expect(fsm.currentState).toEqual("one");
+    fsm.send({ type: "GO" });
+    expect(fsm.currentState).toEqual("two");
+    fsm.send({ type: "GO" });
+    expect(fsm.currentState).toEqual("two"); // Did *not* transition!
+    fsm.send({ type: "GO" });
+    expect(fsm.currentState).toEqual("one");
+  });
+
   describe("time-based transitions", () => {
     test("time-based transitions", () => {
       jest.useFakeTimers();

--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -453,7 +453,7 @@ describe("finite state machine", () => {
   test("explicitly *not* transitioning", () => {
     let n = 0;
 
-    const fsm = new FSM({ x: 13, y: 13 })
+    const fsm = new FSM({})
       .addState("one")
       .addState("two")
       .addTransitions("one", { GO: "two" })


### PR DESCRIPTION
While implementing the connection manager, I discovered a missing feature: being able to _not_ transitioning, based on a condition in the event. This PR adds that simple feature to the abstract state machine.