### PR TITLE
Better API for patching contexts in the state machine

### DIFF
--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -174,6 +174,9 @@ enum LogLevel {
   ERROR,
 }
 
+/**
+ * Generic "log" effect. Use it in `effect` handlers of state transitions.
+ */
 function log(level: LogLevel, message: string) {
   const logger =
     level === LogLevel.ERROR

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -506,12 +506,12 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
   };
 
   machine
-    .onEnter("@ok.*", (ctx) => {
+    .onEnter("@ok.*", () => {
       // Do nothing on entering...
 
       // ...but when *leaving* OK state, always tear down the old socket. It's
       // no longer valid.
-      return () => {
+      return (ctx) => {
         teardownSocket(ctx.socket);
         (ctx as any).socket = null;
         //   ^^^^^^

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -2,8 +2,8 @@ import { assertNever } from "./lib/assert";
 import type { Observable } from "./lib/EventSource";
 import { makeEventSource } from "./lib/EventSource";
 import * as console from "./lib/fancy-console";
-import type { BuiltinEvent, Target } from "./lib/fsm";
-import { FSM, Patchable } from "./lib/fsm";
+import type { BuiltinEvent, Patchable, Target } from "./lib/fsm";
+import { FSM } from "./lib/fsm";
 import type {
   IWebSocketCloseEvent,
   IWebSocketEvent,
@@ -703,7 +703,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * Call this method to try to connect to a WebSocket. This only has an effect
    * if the machine is idle at the moment, otherwise this is a no-op.
    */
-  public connect() {
+  public connect(): void {
     this.machine.send({ type: "CONNECT" });
   }
 
@@ -711,7 +711,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * If idle, will try to connect. Otherwise, it will attempt to reconnect to
    * the socket, potentially obtaining a new token first, if needed.
    */
-  public reconnect() {
+  public reconnect(): void {
     this.machine.send({ type: "RECONNECT" });
   }
 
@@ -719,7 +719,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * Call this method to disconnect from the current WebSocket. Is going to be
    * a no-op if there is no active connection.
    */
-  public disconnect() {
+  public disconnect(): void {
     this.machine.send({ type: "DISCONNECT" });
   }
 
@@ -728,7 +728,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * calling destroy(), you can no longer use this instance. Call this before
    * letting the instance get garbage collected.
    */
-  public destroy() {
+  public destroy(): void {
     this.machine.stop();
 
     let cleanup: (() => void) | undefined;
@@ -741,7 +741,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * Safely send a message to the current WebSocket connection. Will emit a log
    * message if this is somehow impossible.
    */
-  public send(data: string) {
+  public send(data: string): void {
     const socket = this.machine.context?.socket;
     if (socket === null) {
       console.warn("Cannot send: not connected yet", data);
@@ -756,7 +756,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * NOTE: Used by the E2E app only, to simulate explicit events.
    * Not ideal to keep exposed :(
    */
-  public _privateSend(event: Event) {
-    return this.machine.send(event);
+  public _privateSend(event: Event): void {
+    this.machine.send(event);
   }
 }

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -252,11 +252,8 @@ function defineConnectivityEvents(machine: FSM<Context, Event, State>) {
   };
 }
 
-const assign = (patch: Partial<Context>) => {
-  return (ctx: Patchable<Context>) => {
-    ctx.patch(patch);
-  };
-};
+const assign = (patch: Partial<Context>) => (ctx: Patchable<Context>) =>
+  ctx.patch(patch);
 
 function createConnectionStateMachine<T extends BaseAuthResult>(
   delegates: Delegates<T>

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -365,9 +365,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
               target: "@idle.failed",
               effect: log(
                 LogLevel.ERROR,
-                `Unauthorized: ${
-                  (failedEvent.reason as UnauthorizedError).message
-                }`
+                `Unauthorized: ${failedEvent.reason.message}`
               ),
             }
           : {

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -46,12 +46,6 @@ export type TargetFn<
   context: Readonly<TContext>
 ) => TState | TargetConfig<TContext, TEvent, TState> | null;
 
-export type Assigner<TContext> = (patch: Partial<TContext>) => void;
-
-export type AssignConfig<TContext extends object, TEvent extends BaseEvent> =
-  | Partial<TContext>
-  | ((context: Patchable<TContext>, event: TEvent) => void);
-
 export type Effect<TContext, TEvent extends BaseEvent> = (
   context: Patchable<TContext>,
   event: TEvent
@@ -63,14 +57,6 @@ export type TargetConfig<
   TState extends string
 > = {
   target: TState;
-
-  // /**
-  //  * Specify an object that will be used to "patch" the current context as soon
-  //  * as the transition is taken. The context will be updated before the new
-  //  * state is entered.
-  //  */
-  // assign?: AssignConfig<TContext, TEvent>;
-  assign?: never;
 
   /**
    * Emit a side effect (other than assigning to the context) when this
@@ -590,7 +576,6 @@ export class FSM<
     const targetFn = typeof target === "function" ? target : () => target;
     const nextTarget = targetFn(event, this.currentContext.current);
     let nextState: TState;
-    // let assign: AssignConfig<TContext, E> | undefined = undefined;
     let effects: Effect<TContext, E>[] | undefined = undefined;
     if (nextTarget === null) {
       // Do not transition
@@ -602,7 +587,6 @@ export class FSM<
       nextState = nextTarget;
     } else {
       nextState = nextTarget.target;
-      // assign = nextTarget.assign;
       effects =
         nextTarget.effect !== undefined
           ? Array.isArray(nextTarget.effect)

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -62,7 +62,7 @@ export type TargetConfig<
    * Emit a side effect (other than assigning to the context) when this
    * transition is taken.
    */
-  effect?: Effect<TContext, TEvent> | Effect<TContext, TEvent>[];
+  effect: Effect<TContext, TEvent> | Effect<TContext, TEvent>[];
 };
 
 export type Target<

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -28,10 +28,10 @@ export type AsyncErrorEvent = {
 export type BaseEvent = { readonly type: string };
 export type BuiltinEvent = TimerEvent | AsyncOKEvent<unknown> | AsyncErrorEvent;
 
-export type CleanupFn = () => void;
+export type CleanupFn<TContext> = (context: Readonly<TContext>) => void;
 export type EnterFn<TContext> = (
   context: Readonly<TContext>
-) => void | CleanupFn;
+) => void | CleanupFn<TContext>;
 
 export type TargetFn<
   TContext,
@@ -191,7 +191,7 @@ export class FSM<
   // will contain the exit handler for `foo.bar.qux` (at the top), then
   // `foo.bar.*`, then `foo.*`, and finally, `*`.
   //
-  private cleanupStack: (CleanupFn | null)[];
+  private cleanupStack: (CleanupFn<TContext> | null)[];
 
   private enterFns: Map<TState | Wildcard<TState>, EnterFn<TContext>>;
 
@@ -469,7 +469,7 @@ export class FSM<
 
     levels = levels ?? this.cleanupStack.length;
     for (let i = 0; i < levels; i++) {
-      this.cleanupStack.pop()?.();
+      this.cleanupStack.pop()?.(this.currentContext);
     }
   }
 

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -588,12 +588,9 @@ export class FSM<
       nextState = nextTarget;
     } else {
       nextState = nextTarget.target;
-      effects =
-        nextTarget.effect !== undefined
-          ? Array.isArray(nextTarget.effect)
-            ? nextTarget.effect
-            : [nextTarget.effect]
-          : undefined;
+      effects = Array.isArray(nextTarget.effect)
+        ? nextTarget.effect
+        : [nextTarget.effect];
     }
 
     if (!this.states.has(nextState)) {

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -142,6 +142,7 @@ class SafeContext<TContext extends object> {
    * of this window.
    */
   allowPatching(callback: (context: Patchable<TContext>) => void): void {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     let allowed = true;
 


### PR DESCRIPTION
This PR improves the API for patching the context as a side-effect, as part of a transition or in an onEnter/onExit handler. It unifies the previously-separate `assign` and `effect` APIs into a single `effect`. An `assign` is now considered just a special case of a side-effect, namely one that happens to mutate the `context`. Mutating the context is perfectly fine during a transition or during onEnter/onExit (but not at any other time!).

This change allows us to unify the API for safely mutating the context from an onEnter/onExit handler as well. In both situations, the `context` that is received allows for patching the context, like so:

```ts
// Only a side-effect
.addTransitions('one', {
  GO: {
    target: 'two',
    effect: () => console.log('Wheee'),
}})

// Only a context assignment
.addTransitions('one', {
  GO: {
    target: 'two',
    effect: (ctx) => ctx.patch({ x: 1 }),
    //                   ^^^^^ ✨ The new API ✨
}})

// Both
.addTransitions('one', {
  GO: {
    target: 'two',
    effect: [
      () => console.log('Wheee'),
      (ctx) => ctx.patch({ x: 1 })
    ],
}})
```

Because of this unified API, we can now also call `.patch()` in onEnter/onExit handlers, too:

```ts
// Only a side-effect
.onEnter('two', (ctx) => {
  ctx.patch({ x: 1 });
  return () => { /* cleanup */ };
});
```

These `.patch()` handlers are guarded, so they can only be used when called from a "safe window"—they will throw if you try to hold on to them and call them later, like so:

```ts
// Only a side-effect
.onEnter('two', (ctx) => {
  setTimeout(() => ctx.patch({ x: 1 }), 1000);  // Won't work!
  return () => { /* cleanup */ };
});
```
