### PR TITLE
Add generic async cache

### DIFF
--- a/packages/liveblocks-core/src/lib/AsyncCache.ts
+++ b/packages/liveblocks-core/src/lib/AsyncCache.ts
@@ -46,6 +46,9 @@ export type AsyncCacheItem<TData = any, TError = any> = Observable<
   get(): Promise<AsyncResolvedState<TData, TError>>;
   getState(): AsyncState<TData, TError>;
   invalidate(options?: InvalidateOptions): void;
+  revalidate(
+    options?: InvalidateOptions
+  ): Promise<AsyncResolvedState<TData, TError>>;
 };
 
 export type AsyncCache<TData = any, TError = any> = {
@@ -53,6 +56,10 @@ export type AsyncCache<TData = any, TError = any> = {
   get(key: string): Promise<AsyncResolvedState<TData, TError>>;
   getState(key: string): AsyncState<TData, TError> | undefined;
   invalidate(key: string, options?: InvalidateOptions): void;
+  revalidate(
+    key: string,
+    options?: InvalidateOptions
+  ): Promise<AsyncResolvedState<TData, TError>>;
   subscribe(
     key: string,
     callback: Callback<AsyncState<TData, TError>>
@@ -168,6 +175,12 @@ function createCacheItem<TData = any, TError = any>(
     return getState() as AsyncResolvedState<TData, TError>;
   }
 
+  function revalidate(options?: InvalidateOptions) {
+    invalidate(options);
+
+    return get();
+  }
+
   function getState() {
     return {
       isLoading: context.isLoading,
@@ -181,6 +194,7 @@ function createCacheItem<TData = any, TError = any>(
     get,
     getState,
     invalidate,
+    revalidate,
   };
 }
 
@@ -207,7 +221,7 @@ export function createAsyncCache<TData = any, TError = any>(
     return cacheItem;
   }
 
-  async function get(key: string) {
+  function get(key: string) {
     return create(key).get();
   }
 
@@ -217,6 +231,10 @@ export function createAsyncCache<TData = any, TError = any>(
 
   function invalidate(key: string, options?: InvalidateOptions) {
     cache.get(key)?.invalidate(options);
+  }
+
+  function revalidate(key: string, options?: InvalidateOptions) {
+    return create(key).revalidate(options);
   }
 
   function subscribe(
@@ -239,6 +257,7 @@ export function createAsyncCache<TData = any, TError = any>(
     get,
     getState,
     invalidate,
+    revalidate,
     subscribe,
     has,
     clear,

--- a/packages/liveblocks-core/src/lib/AsyncCache.ts
+++ b/packages/liveblocks-core/src/lib/AsyncCache.ts
@@ -137,7 +137,7 @@ function createCacheItem<TData = any, TError = any>(
   function invalidate(options?: InvalidateOptions) {
     if (context.promise) {
       context.hasScheduledInvalidation = true;
-    } else if (!context.hasScheduledInvalidation) {
+    } else if (!context.hasScheduledInvalidation && !context.error) {
       const keepPreviousData = options?.keepPreviousData ?? false;
       context.isInvalid = true;
       context.error = undefined;

--- a/packages/liveblocks-core/src/lib/AsyncCache.ts
+++ b/packages/liveblocks-core/src/lib/AsyncCache.ts
@@ -53,6 +53,7 @@ export type AsyncCache<TData = any, TError = any> = {
     key: string,
     callback: Callback<AsyncState<TData, TError>>
   ): UnsubscribeCallback;
+  clear(): void;
 };
 
 const noop = () => {};
@@ -167,11 +168,16 @@ export function createAsyncCache<TData = any, TError = any>(
     return cache.get(key)?.subscribe(callback) ?? noop;
   }
 
+  function clear() {
+    cache.clear();
+  }
+
   return {
     create,
     get,
     getState,
     revalidate,
     subscribe,
+    clear,
   };
 }

--- a/packages/liveblocks-core/src/lib/AsyncCache.ts
+++ b/packages/liveblocks-core/src/lib/AsyncCache.ts
@@ -1,0 +1,177 @@
+import type { Callback, Observable, UnsubscribeCallback } from "./EventSource";
+import { makeEventSource } from "./EventSource";
+
+type AsyncFunction<T, A extends any[] = any[]> = (...args: A) => Promise<T>;
+
+export type AsyncState<TData = any, TError = any> =
+  | {
+      status: "idle" | "loading";
+      data?: TData;
+      error?: TError;
+    }
+  | {
+      status: "error";
+      data: undefined;
+      error: TError;
+    }
+  | {
+      status: "success";
+      data: TData;
+      error: undefined;
+    };
+
+type AsyncCacheItemContext<TData, TError> = AsyncState<TData, TError> & {
+  promise?: Promise<TData>;
+};
+
+export type AsyncCacheItem<TData = any, TError = any> = Observable<
+  AsyncState<TData, TError>
+> & {
+  get(): Promise<
+    Extract<
+      AsyncState<TData, TError>,
+      { status: "success" } | { status: "error" }
+    >
+  >;
+  getState(): AsyncState<TData, TError>;
+  revalidate(): Promise<void>;
+};
+
+export type AsyncCache<TData = any, TError = any> = {
+  create(key: string): AsyncCacheItem<TData, TError>;
+  get(
+    key: string
+  ): Promise<
+    Extract<
+      AsyncState<TData, TError>,
+      { status: "success" } | { status: "error" }
+    >
+  >;
+  getState(key: string): AsyncState<TData, TError> | undefined;
+  revalidate(key: string): Promise<void>;
+  subscribe(
+    key: string,
+    callback: Callback<AsyncState<TData, TError>>
+  ): UnsubscribeCallback;
+};
+
+const noop = () => {};
+
+function createCacheItem<TData = any, TError = any>(
+  key: string,
+  asyncFunction: AsyncFunction<TData>
+): AsyncCacheItem<TData, TError> {
+  const context: AsyncCacheItemContext<TData, TError> = {
+    status: "idle",
+  };
+  const eventSource = makeEventSource<AsyncState<TData, TError>>();
+
+  function notify() {
+    eventSource.notify(getState());
+  }
+
+  function setSuccess(data: TData) {
+    context.status = "success";
+    context.data = data;
+    context.error = undefined;
+    notify();
+  }
+
+  function setError(error: TError) {
+    context.status = "error";
+    context.data = undefined;
+    context.error = error;
+    notify();
+  }
+
+  function execute() {
+    context.error = undefined;
+    context.status = "loading";
+    context.promise = asyncFunction(key);
+    notify();
+  }
+
+  async function revalidate() {
+    try {
+      if (context.status !== "loading") {
+        execute();
+      }
+
+      setSuccess(await (context.promise as Promise<TData>));
+    } catch (error) {
+      setError(error as TError);
+    }
+  }
+
+  async function get() {
+    if (!context.data) {
+      await revalidate();
+    }
+
+    return getState() as Extract<
+      AsyncState<TData, TError>,
+      { status: "success" } | { status: "error" }
+    >;
+  }
+
+  function getState(): AsyncState<TData, TError> {
+    return {
+      data: context.data,
+      error: context.error,
+      status: context.status,
+    } as AsyncState<TData, TError>;
+  }
+
+  return {
+    ...eventSource.observable,
+    get,
+    getState,
+    revalidate,
+  };
+}
+
+export function createAsyncCache<TData = any, TError = any>(
+  asyncFunction: AsyncFunction<TData, [string]>
+): AsyncCache<TData, TError> {
+  const cache = new Map<string, AsyncCacheItem<TData, TError>>();
+
+  function create(key: string) {
+    let cacheItem = cache.get(key);
+
+    if (cacheItem) {
+      return cacheItem;
+    }
+
+    cacheItem = createCacheItem(key, asyncFunction);
+    cache.set(key, cacheItem);
+
+    return cacheItem;
+  }
+
+  async function get(key: string) {
+    return create(key).get();
+  }
+
+  function getState(key: string) {
+    return cache.get(key)?.getState();
+  }
+
+  async function revalidate(key: string) {
+    await cache.get(key)?.revalidate();
+  }
+
+  function subscribe(
+    key: string,
+    callback: Callback<AsyncState<TData, TError>>
+  ) {
+    return cache.get(key)?.subscribe(callback) ?? noop;
+  }
+
+  return {
+    create,
+    get,
+    getState,
+    revalidate,
+    subscribe,
+  };
+}

--- a/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
@@ -372,7 +372,7 @@ describe("AsyncCache", () => {
     expect(mock).toHaveBeenCalledTimes(2);
   });
 
-  test("clearing the cache while running", async () => {
+  test("clearing the cache while pending", async () => {
     const mock = createAsyncMock();
     const cache = createAsyncCache(mock, {
       deduplicationInterval: 0,
@@ -564,7 +564,7 @@ describe("AsyncCache", () => {
     );
   });
 
-  test("subscribing and invalidating while running", async () => {
+  test("subscribing and invalidating while pending", async () => {
     const mock = createAsyncMock();
     const cache = createAsyncCache(mock, {
       deduplicationInterval: 0,

--- a/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
@@ -206,6 +206,24 @@ describe("AsyncCache", () => {
     expect(mock).toHaveBeenCalledTimes(2);
   });
 
+  test("revalidating", async () => {
+    const mock = createAsyncMock();
+    const cache = createAsyncCache(mock, { deduplicationInterval: 0 });
+
+    // 🚀 Called
+    await cache.get(KEY_ABC);
+
+    // 🗑️ Clears the cache for "abc" and 🚀 called again because invalidated
+    expect(await cache.revalidate(KEY_ABC)).toMatchObject<
+      AsyncStateDataError<string>
+    >({
+      data: KEY_ABC,
+      error: undefined,
+    });
+
+    expect(mock).toHaveBeenCalledTimes(2);
+  });
+
   test("clearing the cache", async () => {
     const mock = createAsyncMock();
     const cache = createAsyncCache(mock, {

--- a/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
@@ -181,6 +181,23 @@ describe("AsyncCache", () => {
     expect(subscribeCallback).not.toHaveBeenCalled();
   });
 
+  test("clearing the cache", async () => {
+    const asyncFunction = jest.fn(async (key: string) => {
+      await sleep(REQUEST_DELAY);
+
+      return key;
+    });
+    const asyncCache = createAsyncCache(asyncFunction);
+
+    await asyncCache.get(KEY_ABC);
+
+    asyncCache.clear();
+
+    await asyncCache.get(KEY_ABC);
+
+    expect(asyncFunction).toHaveBeenCalledTimes(2);
+  });
+
   test("statuses", async () => {
     let index = 0;
     const asyncFunction = jest.fn(async () => {

--- a/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
@@ -1,0 +1,231 @@
+import type { AsyncState } from "../AsyncCache";
+import { createAsyncCache } from "../AsyncCache";
+
+const REQUEST_DELAY = 100;
+const KEY_ABC = "abc";
+const KEY_XYZ = "xyz";
+const ERROR_MESSAGE = "error";
+
+async function sleep(ms: number): Promise<42> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(42);
+    }, ms);
+  });
+}
+
+describe("AsyncCache", () => {
+  test("getting the same key", async () => {
+    const asyncFunction = jest.fn(async (key: string) => {
+      await sleep(REQUEST_DELAY);
+
+      return key;
+    });
+    const cache = createAsyncCache(asyncFunction);
+
+    const successState: AsyncState<string> = {
+      status: "success",
+      data: KEY_ABC,
+      error: undefined,
+    };
+
+    expect(await cache.get(KEY_ABC)).toMatchObject(successState);
+    expect(await cache.get(KEY_ABC)).toMatchObject(successState);
+    expect(await cache.get(KEY_ABC)).toMatchObject(successState);
+
+    expect(asyncFunction).toHaveBeenCalledTimes(1);
+    expect(asyncFunction).toHaveBeenCalledWith(KEY_ABC);
+  });
+
+  test("getting multiple keys", async () => {
+    const asyncFunction = jest.fn(async (key: string) => {
+      await sleep(REQUEST_DELAY);
+
+      return key;
+    });
+    const asyncCache = createAsyncCache(asyncFunction);
+
+    const abc = await asyncCache.get(KEY_ABC);
+    const xyz = await asyncCache.get(KEY_XYZ);
+
+    expect(abc.data).toEqual(KEY_ABC);
+    expect(xyz.data).toEqual(KEY_XYZ);
+    expect(asyncFunction).toHaveBeenCalledTimes(2);
+  });
+
+  test("getting an error then a success", async () => {
+    let index = 0;
+    const asyncFunction = jest.fn(async (key: string) => {
+      const isError = index === 0;
+      index += 1;
+
+      await sleep(REQUEST_DELAY);
+
+      if (isError) {
+        throw new Error(ERROR_MESSAGE);
+      } else {
+        return key;
+      }
+    });
+    const asyncCache = createAsyncCache<string, Error>(asyncFunction);
+
+    const firstState = await asyncCache.get(KEY_ABC);
+    expect(firstState).toMatchObject({
+      status: "error",
+      data: undefined,
+      error: new Error(ERROR_MESSAGE),
+    });
+
+    const secondState = await asyncCache.get(KEY_ABC);
+    expect(secondState).toMatchObject({
+      status: "success",
+      data: KEY_ABC,
+      error: undefined,
+    });
+
+    expect(asyncFunction).toHaveBeenCalledTimes(2);
+  });
+
+  test("getting a success then an error", async () => {
+    let index = 0;
+    const asyncFunction = jest.fn(async (key: string) => {
+      const isError = index > 0;
+      index += 1;
+
+      await sleep(REQUEST_DELAY);
+
+      if (isError) {
+        throw new Error(ERROR_MESSAGE);
+      } else {
+        return key;
+      }
+    });
+
+    const asyncCache = createAsyncCache<string, Error>(asyncFunction);
+
+    const firstState = await asyncCache.get(KEY_ABC);
+    expect(firstState).toMatchObject({
+      status: "success",
+      data: KEY_ABC,
+      error: undefined,
+    });
+
+    await asyncCache.revalidate(KEY_ABC);
+
+    // TODO: Option to hold onto the last success state if there's an error?
+    const secondState = await asyncCache.get(KEY_ABC);
+    expect(secondState).toMatchObject({
+      status: "error",
+      data: undefined,
+      error: new Error(ERROR_MESSAGE),
+    });
+
+    expect(asyncFunction).toHaveBeenCalledTimes(3);
+  });
+
+  test("subscribing to a key", async () => {
+    const asyncFunction = jest.fn(async (key: string) => {
+      await sleep(REQUEST_DELAY);
+
+      return key;
+    });
+    const asyncCache = createAsyncCache(asyncFunction);
+    const subscribeCallback = jest.fn();
+
+    const cacheItem = asyncCache.create(KEY_ABC);
+    const unsubscribe = cacheItem.subscribe(subscribeCallback);
+
+    await cacheItem.get();
+
+    unsubscribe();
+
+    await cacheItem.revalidate();
+
+    expect(subscribeCallback).toHaveBeenCalledTimes(2);
+    expect(subscribeCallback).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        status: "loading",
+        data: undefined,
+        error: undefined,
+      })
+    );
+    expect(subscribeCallback).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        status: "success",
+        data: KEY_ABC,
+        error: undefined,
+      })
+    );
+  });
+
+  test("statuses", async () => {
+    let index = 0;
+    const asyncFunction = jest.fn(async () => {
+      const isError = index === 0;
+      index += 1;
+
+      await sleep(REQUEST_DELAY);
+
+      if (isError) {
+        throw new Error(ERROR_MESSAGE);
+      } else {
+        return index;
+      }
+    });
+    const asyncCache = createAsyncCache(asyncFunction);
+
+    const cacheItem = asyncCache.create(KEY_ABC);
+
+    expect(asyncFunction).not.toHaveBeenCalled();
+    expect(cacheItem.getState()).toMatchObject({
+      status: "idle",
+      data: undefined,
+      error: undefined,
+    });
+
+    void cacheItem.get();
+
+    expect(cacheItem.getState()).toMatchObject({
+      status: "loading",
+      data: undefined,
+      error: undefined,
+    });
+
+    await sleep(REQUEST_DELAY);
+
+    expect(cacheItem.getState()).toMatchObject({
+      status: "error",
+      data: undefined,
+      error: new Error(ERROR_MESSAGE),
+    });
+
+    // Will revalidate because there's no data yet
+    await cacheItem.get();
+
+    expect(cacheItem.getState()).toMatchObject({
+      status: "success",
+      data: 2,
+      error: undefined,
+    });
+
+    // Will not revalidate because there's data
+    await cacheItem.get();
+
+    expect(cacheItem.getState()).toMatchObject({
+      status: "success",
+      data: 2,
+      error: undefined,
+    });
+
+    // Will revalidate even if there's data already
+    await cacheItem.revalidate();
+
+    expect(cacheItem.getState()).toMatchObject({
+      status: "success",
+      data: 3,
+      error: undefined,
+    });
+  });
+});

--- a/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
@@ -160,6 +160,27 @@ describe("AsyncCache", () => {
     );
   });
 
+  test("using a non-existing key", async () => {
+    const asyncFunction = jest.fn(async (key: string) => {
+      await sleep(REQUEST_DELAY);
+
+      return key;
+    });
+    const asyncCache = createAsyncCache(asyncFunction);
+    const subscribeCallback = jest.fn();
+
+    const unsubscribe = asyncCache.subscribe(KEY_ABC, subscribeCallback);
+    expect(unsubscribe).toEqual(expect.any(Function));
+
+    await asyncCache.revalidate(KEY_ABC);
+
+    expect(asyncCache.getState(KEY_ABC)).toBeUndefined();
+
+    await asyncCache.get(KEY_ABC);
+
+    expect(subscribeCallback).not.toHaveBeenCalled();
+  });
+
   test("statuses", async () => {
     let index = 0;
     const asyncFunction = jest.fn(async () => {

--- a/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/AsyncCache.test.ts
@@ -1,11 +1,10 @@
 import type { AsyncState } from "../AsyncCache";
-import { createAsyncCache, isStateEqual } from "../AsyncCache";
+import { createAsyncCache, isDifferentState } from "../AsyncCache";
 
 const REQUEST_DELAY = 20;
 const KEY_ABC = "abc";
 const KEY_XYZ = "xyz";
-const ERROR_MESSAGE = "error";
-const ERROR = new Error(ERROR_MESSAGE);
+const ERROR = new Error("error");
 
 type AsyncStateDataError<TData = any, TError = any> = Pick<
   AsyncState<TData, TError>,
@@ -515,8 +514,8 @@ describe("AsyncCache", () => {
   });
 });
 
-describe.only("isStateEqual", () => {
-  test("loading or not", () => {
+describe("isDifferentState", () => {
+  test("loading", () => {
     const a: AsyncState = {
       isLoading: false,
       data: undefined,
@@ -533,13 +532,29 @@ describe.only("isStateEqual", () => {
       error: undefined,
     };
 
-    expect(isStateEqual(a, b)).toBe(false);
-    expect(isStateEqual(b, a)).toBe(false);
-    expect(isStateEqual(a, c)).toBe(true);
-    expect(isStateEqual(c, a)).toBe(true);
+    expect(isDifferentState(a, b)).toBe(true);
+    expect(isDifferentState(b, a)).toBe(true);
+    expect(isDifferentState(a, c)).toBe(false);
+    expect(isDifferentState(c, a)).toBe(false);
   });
 
-  test("error or not", () => {
+  test("data", () => {
+    const a: AsyncState = {
+      isLoading: false,
+      data: undefined,
+      error: undefined,
+    };
+    const b: AsyncState = {
+      isLoading: false,
+      data: { key: KEY_ABC },
+      error: undefined,
+    };
+
+    expect(isDifferentState(a, b)).toBe(true);
+    expect(isDifferentState(b, a)).toBe(true);
+  });
+
+  test("error", () => {
     const a: AsyncState = {
       isLoading: false,
       data: undefined,
@@ -551,69 +566,7 @@ describe.only("isStateEqual", () => {
       error: ERROR,
     };
 
-    expect(isStateEqual(a, b)).toBe(false);
-    expect(isStateEqual(b, a)).toBe(false);
-  });
-
-  test("error", () => {
-    const a: AsyncState = {
-      isLoading: false,
-      data: undefined,
-      error: new Error(ERROR_MESSAGE),
-    };
-    const b: AsyncState = {
-      isLoading: false,
-      data: undefined,
-      error: new Error(ERROR_MESSAGE),
-    };
-    const c: AsyncState = {
-      isLoading: false,
-      data: undefined,
-      error: new Error("c"),
-    };
-
-    expect(isStateEqual(a, b)).toBe(true);
-    expect(isStateEqual(b, a)).toBe(true);
-    expect(isStateEqual(a, c)).toBe(false);
-    expect(isStateEqual(c, a)).toBe(false);
-  });
-
-  test("data or not", () => {
-    const a: AsyncState = {
-      isLoading: false,
-      data: undefined,
-      error: undefined,
-    };
-    const b: AsyncState = {
-      isLoading: false,
-      data: { key: KEY_ABC },
-      error: undefined,
-    };
-
-    expect(isStateEqual(a, b)).toBe(false);
-    expect(isStateEqual(b, a)).toBe(false);
-  });
-
-  test("data", () => {
-    const a: AsyncState = {
-      isLoading: false,
-      data: { key: KEY_ABC },
-      error: undefined,
-    };
-    const b: AsyncState = {
-      isLoading: false,
-      data: { key: KEY_ABC },
-      error: undefined,
-    };
-    const c: AsyncState = {
-      isLoading: false,
-      data: [{ key: KEY_ABC }],
-      error: undefined,
-    };
-
-    expect(isStateEqual(a, b)).toBe(true);
-    expect(isStateEqual(b, a)).toBe(true);
-    expect(isStateEqual(a, c)).toBe(false);
-    expect(isStateEqual(c, a)).toBe(false);
+    expect(isDifferentState(a, b)).toBe(true);
+    expect(isDifferentState(b, a)).toBe(true);
   });
 });


### PR DESCRIPTION
This PR adds a generic async cache system called `AsyncCache` which handles things like caching, deduplication, invalidation, and even revalidation with optimistic data. It is not used anywhere yet.

This system's raison d'être is that we have various use cases (present and future) in our packages with very similar shared requirements (a form of cached state and request deduplication). It is meant as a private utility that we can use as a foundation while adding use case-specific logic around it (e.g. a token system will invalidate based on expiration and will never return stale data, a comments system will use optimistic data when revalidating after submitting a new comment, etc).

In a future PR, I'll make a React wrapper for it (that's the main reason it has subscription methods) so that we can also use it within `@liveblocks/react`, possibly even while sharing the same caches between `@liveblocks/client` and `@liveblocks/react` (e.g. `client.resolveUser(userId)` and `useUser(userId)` would both share the same `AsyncCache` instance).