### PR TITLE
Fix minor position edge case test

### DIFF
--- a/packages/liveblocks-core/src/lib/__tests__/position.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/position.test.ts
@@ -250,7 +250,7 @@ describe("after / before", () => {
         genUnverifiedPos(),
 
         (pos) => {
-          if (!(pos === ONE || pos[0] === ZERO)) {
+          if (!(pos === ONE || asPos(pos)[0] === ZERO)) {
             expect(before(pos).length).toBe(1); // Always generates a single-digit
           }
         }

--- a/packages/liveblocks-core/src/lib/__tests__/position.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/position.test.ts
@@ -254,7 +254,12 @@ describe("after / before", () => {
             expect(before(pos).length).toBe(1); // Always generates a single-digit
           }
         }
-      )
+      ),
+
+      {
+        // Counter-examples that where found in the past by fast-check
+        examples: [["\u0000x"]],
+      }
     );
   });
 


### PR DESCRIPTION
Fast-check found this small counter-example. It was a false alarm. The property does not hold for this edge case, so let's exclude such counter-examples from the precondition.