### PR TITLE
Improve WebSocket mocking in unit tests

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -75,11 +75,20 @@ type Emitters = {
   onError: EventSource<IWebSocketEvent>;
 };
 
+/**
+ * The server side socket of the two-sided connection. It's the opposite end of
+ * the client side socket (aka the MockWebSocket instance).
+ */
 type ServerSocket = {
+  /** Inspect the messages the server end has received as the result of the client side sending it messages. */
   receivedMessages: string[];
+  /** Accept the socket from the server side. The client will receive an "open" event. */
   accept(): void;
+  /** Close the socket from the server side. */
   close(event: IWebSocketCloseEvent): void;
+  /** Send a message from the server side to the client side. */
   message(event: IWebSocketMessageEvent): void;
+  /** Send an error event from the server side to the client side. */
   error(event: IWebSocketEvent): void;
 };
 

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -84,15 +84,15 @@ type LiteServer = {
 };
 
 export class MockWebSocketServer {
-  public last: MockWebSocket | undefined;
+  public current: MockWebSocket | undefined;
   public connections: Map<MockWebSocket, Emitters> = new Map();
   public receivedMessages: string[] = [];
 
-  get current(): MockWebSocket {
-    if (this.last === undefined) {
+  get last(): LiteServer {
+    if (this.current === undefined) {
       throw new Error("No socket instantiated yet");
     }
-    return this.last;
+    return this.current.server;
   }
 
   getEmitters(socket: MockWebSocket): Emitters {
@@ -148,7 +148,7 @@ export class MockWebSocketServer {
     const socket = new MockWebSocket();
     socket.linkToServer(liteServer, publicListeners);
     this.connections.set(socket, emitters);
-    this.last = socket;
+    this.current = socket;
 
     if (callback) {
       callback(socket);

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -268,33 +268,33 @@ export class MockWebSocket {
     return this.#readyState;
   }
 
-  addEventListener(event: "message", listener: MessageListener): void; // prettier-ignore
-  addEventListener(event: "close", listener: CloseListener): void; // prettier-ignore
-  addEventListener(event: "open" | "error", listener: Listener): void; // prettier-ignore
+  addEventListener(type: "message", listener: MessageListener): void; // prettier-ignore
+  addEventListener(type: "close", listener: CloseListener): void; // prettier-ignore
+  addEventListener(type: "open" | "error", listener: Listener): void; // prettier-ignore
   // prettier-ignore
-  addEventListener(event: "open" | "close" | "message" | "error", listener: Listener | MessageListener | CloseListener): void {
-    let unsub;
-    if (event === "open") {
+  addEventListener(type: "open" | "close" | "message" | "error", listener: Listener | MessageListener | CloseListener): void {
+    let unsub: (() => void) | undefined;
+    if (type === "open") {
       unsub = this.listeners.onOpen.subscribe(listener as Listener);
-    } else if (event === "close") {
+    } else if (type === "close") {
       unsub = this.listeners.onClose.subscribe(listener as CloseListener);
-    } else if (event === "message") {
+    } else if (type === "message") {
       unsub = this.listeners.onMessage.subscribe(listener as MessageListener);
-    } else if (event === "error") {
+    } else if (type === "error") {
       unsub = this.listeners.onError.subscribe(listener as Listener);
     }
 
     if (unsub) {
-      this.unsubs[event].set(listener, unsub);
+      this.unsubs[type].set(listener, unsub);
     }
   }
 
-  removeEventListener(event: "message", listener: MessageListener): void; // prettier-ignore
-  removeEventListener(event: "close", listener: CloseListener): void; // prettier-ignore
-  removeEventListener(event: "open" | "error", listener: Listener): void; // prettier-ignore
+  removeEventListener(type: "message", listener: MessageListener): void; // prettier-ignore
+  removeEventListener(type: "close", listener: CloseListener): void; // prettier-ignore
+  removeEventListener(type: "open" | "error", listener: Listener): void; // prettier-ignore
   // prettier-ignore
-  removeEventListener(event: "open" | "close" | "message" | "error", listener: Listener | MessageListener | CloseListener): void {
-    const unsub = this.unsubs[event].get(listener);
+  removeEventListener(type: "open" | "close" | "message" | "error", listener: Listener | MessageListener | CloseListener): void {
+    const unsub = this.unsubs[type].get(listener);
     if (unsub !== undefined) {
       unsub();
     }

--- a/packages/liveblocks-core/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-core/src/__tests__/client.node.test.ts
@@ -31,7 +31,7 @@ function createClientAndEnter(options: ClientOptions) {
   const client = createClient(options);
   client.enter("room", { initialPresence: {} });
 
-  // Entering starts asynchronous jobs in the background (times, promises,
+  // Entering starts asynchronous jobs in the background (timers, promises,
   // etc). Not leaving the room would leave those open handles dangling which
   // doesn't make Jest happy.
   client.leave("room");

--- a/packages/liveblocks-core/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-core/src/__tests__/client.node.test.ts
@@ -30,6 +30,11 @@ function atobPolyfillMock(data: string): string {
 function createClientAndEnter(options: ClientOptions) {
   const client = createClient(options);
   client.enter("room", { initialPresence: {} });
+
+  // Entering starts asynchronous jobs in the background (times, promises,
+  // etc). Not leaving the room would leave those open handles dangling which
+  // doesn't make Jest happy.
+  client.leave("room");
 }
 
 describe("createClient", () => {

--- a/packages/liveblocks-core/src/__tests__/connection.test.ts
+++ b/packages/liveblocks-core/src/__tests__/connection.test.ts
@@ -38,7 +38,7 @@ describe("ManagedSocket", () => {
 
     const mgr = new ManagedSocket({
       authenticate: ALWAYS_SUCCEEDS,
-      createSocket: () => wss.newSocketAndAccept(),
+      createSocket: () => wss.newSocket((socket) => socket.server.accept()),
     });
     mgr.events.didConnect.subscribe(didConnect);
     // mgr.events.didDisconnect.subscribe(didDisconnect);


### PR DESCRIPTION
This PR changes some testing internals around the MockWebSocket helper, to help with making it easier to express unit tests more precisely, and to help observe outside behavior, instead of implementation details.

The main conceptual change made here is that no `MockWebSocket` instance stands on its own. Each such socket instance really is the client end to a _pipe_ with sockets on both ends: the client side and the server side.

Using this API, we can pass the client end to the delegate. It basically acts like a normal WebSocket polyfill. But… we can now control the server's bahavior precisely, for example:

```ts
// ❌ Old way
const ws = new MockWebSocket();

// ✅ New way
const wss = new MockWebSocketServer();
//                           ^^^^^^ ⚠️
const ws1 = wss.newSocket();
const ws2 = wss.newSocket();
```

The benefits are: very precise control over the server behavior in unit tests, and being able to observe the effects of using the client, by inspecting the received server messages (rather than observing which effects the client emits).

```ts
ws1.server.accept();
ws2.server.close(/* close event */);
```

Later, we can use this to implement a better fake Liveblocks server (a lite/fake implementation of our backend), which _relays_ messages between clients in a correct way.
