### PR TITLE
Fix token expiry bug

### DIFF
--- a/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
@@ -28,10 +28,19 @@ describe("isTokenExpired", () => {
     expect(isTokenExpired(expiredToken)).toBe(true);
   });
 
-  test("future token is invalid", () => {
+  test("near-future token is valid", () => {
     const futureToken: JwtMetadata = {
-      iat: (Date.now() + 15 * MINUTES) / 1000,
+      iat: (Date.now() + 4 * MINUTES) / 1000,
       exp: (Date.now() + 1 * DAYS) / 1000,
+    };
+
+    expect(isTokenExpired(futureToken)).toBe(false);
+  });
+
+  test("far-future token is invalid", () => {
+    const futureToken: JwtMetadata = {
+      iat: (Date.now() + 90 * DAYS) / 1000,
+      exp: (Date.now() + 91 * DAYS) / 1000,
     };
 
     expect(isTokenExpired(futureToken)).toBe(true);

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -52,7 +52,7 @@ function hasJwtMeta(data: unknown): data is JwtMetadata {
 
 export function isTokenExpired(token: JwtMetadata): boolean {
   const now = Date.now() / 1000;
-  return now > token.exp - 300 || now < token.iat + 300;
+  return now > token.exp - 300 || now < token.iat - 300;
 }
 
 function isStringList(value: unknown): value is string[] {

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -52,7 +52,8 @@ function hasJwtMeta(data: unknown): data is JwtMetadata {
 
 export function isTokenExpired(token: JwtMetadata): boolean {
   const now = Date.now() / 1000;
-  return now > token.exp - 300 || now < token.iat - 300;
+  const valid = now <= token.exp - 300 && now >= token.iat - 300;
+  return !valid;
 }
 
 function isStringList(value: unknown): value is string[] {


### PR DESCRIPTION
This fixes the bug in token expiry. The original intent for this was to allow near-future tokens to be considered valid, in case a user's system clock would not be in sync with the server clock.

This PR adds an explicit unit test for the edge case where this bug happened (❌), and fixes the bug (✅). I also rewrote the code using DeMorgan to make the condition a positive one, because they're much easier to read mentally.

## Future Work
This isn't really the proper way to fix this. What we should do instead, is as soon as we receive the new token from the server, convert the `exp` values to the "local" clock (using `localExp = (Date.now() / 1000) + (exp - iat)`), and use that value to decide on the client side to proactively know when the server will reject the token. That way it works, even if the user's system clock is way off. (Not tackled in this PR.)
