### PR TITLE
Add `$ref` to 401 response for storage initialization openapi documentation

### DIFF
--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -550,7 +550,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "$ref": "#/components/responses/401"
           },
           "403": {
             "$ref": "#/components/responses/403"


### PR DESCRIPTION
Fixes https://github.com/liveblocks/liveblocks.io/issues/1143#issue-1699752443

> Clicking on Status 401 on the Initialize Storage section on the Rest API documentation causes the corresponding responses section to disappear until page is refreshed. Here's a screen capture and steps to reproduce:
> 1. Go to https://liveblocks.io/docs/api-reference/rest-api-endpoints#post-rooms-roomId-storage
> 2. On the Responses section, click on the Status dropdown and select 401 .

**Problem:** The code that deals with displaying responses requires a response to have either a `$ref` or `content` property - the `Initialize Storage` OpenAPI documentation only contained a `description` property, hence the disappearing section. 

**Fix:** This PR adds the `$ref` field and removes the `description` field. Doing so means the response section for status code `401` shows the `WRONG_KEY_USED` or `MISSING_SECRET_KEY` error message, which aligns with the result from our API backend too.
