### PR TITLE
Small FSM tweak

### DIFF
--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -640,8 +640,7 @@ describe("finite state machine", () => {
     });
   });
 
-  // TODO Nice to have, no need to fix this right now yet
-  test.skip("wildcards cannot overwrite existing transitions", () => {
+  test("wildcards cannot overwrite existing transitions", () => {
     const fsm = new FSM({})
       .addState("foo.start")
       .addState("foo.mid")

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -386,6 +386,7 @@ export class FSM<
       throw new Error("Already started");
     }
 
+    const isPattern = nameOrPattern.endsWith("*");
     for (const srcState of this.getStatesMatching(nameOrPattern)) {
       let map = this.allowedTransitions.get(srcState);
       if (map === undefined) {
@@ -400,10 +401,13 @@ export class FSM<
           | undefined;
         this.knownEventTypes.add(type);
 
-        if (target != null) {
-          // TODO Disallow overwriting when using a wildcard pattern!
-          const targetFn = typeof target === "function" ? target : () => target;
-          map.set(type, targetFn);
+        if (target !== undefined && target !== null) {
+          // Disallow overwriting when using a wildcard pattern!
+          if (!isPattern || !map.has(type)) {
+            const targetFn =
+              typeof target === "function" ? target : () => target;
+            map.set(type, targetFn);
+          }
         }
       }
     }

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -401,7 +401,7 @@ export class FSM<
           | undefined;
         this.knownEventTypes.add(type);
 
-        if (target !== undefined && target !== null) {
+        if (target !== undefined) {
           // Disallow overwriting when using a wildcard pattern!
           if (!isPattern || !map.has(type)) {
             const targetFn =


### PR DESCRIPTION
This PR fixes an open TODO I left but forgot about when implementing the FSM.

This change prevents using wildcards if state transitions already exist. It's not something we actually use, but I wanted to fix it proactively before it becomes someone's footgun.

### Context
For context, this:

```ts
fsm
  .addTransitions('one', { ... })
  .addTransitions('two', { ... })
  .addTransitions('three', { ... })
  .addTransitions('*', { GO: 'three' })
```

This would be a "shorthand" for:

```ts
fsm
  .addTransitions('one', { GO: 'three', ... })
  .addTransitions('two', { GO: 'three', ... })
  .addTransitions('three', { GO: 'three', ... })
```

### Problem case
However, if an explicit state transition already exists, like:

```ts
fsm
  .addTransitions('one', { GO: 'two' })
  .addTransitions('two', { ... })
  .addTransitions('three', { GO: null /* prevent explicitly */ })
  .addTransitions('*', { GO: 'three' })
```

### Previous behavior
Then, previously this would become:

```ts
fsm
  .addTransitions('one', { GO: 'three' })  // ❌ Overridden!
  .addTransitions('two', { GO: 'three' })
  .addTransitions('three', { GO: 'three' }) // ❌ Overridden!
```

### New behavior
The call to `.addTransitions('*')` will fail if it would override anything, to catch accidental misconfigurations:

```ts
// ⚡ Trying to set transition "GO" on "one" (via "*"), but a transition already exists there.
fsm.addTransitions('*', { GO: 'three' })
```
