### PR TITLE
Disable code coverage by default on local test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run build -- --filter ${{ matrix.pkg }}
 
       - name: Run unit tests
-        run: npm run test -- --filter ${{ matrix.pkg }}
+        run: npm run test -- --filter ${{ matrix.pkg }} -- --coverage
 
       - name: Run type tests
         run: npm run test:types -- --filter ${{ matrix.pkg }}

--- a/packages/liveblocks-core/jest.config.js
+++ b/packages/liveblocks-core/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
   // Our standard Jest configuration, used by all projects in this monorepo
   ...commonJestConfig,
 
-  // Collect code coverage for this project
-  collectCoverage: true,
+  // Collect code coverage for this project, when using the --coverage flag
   coveragePathIgnorePatterns: ["/__tests__/"],
 };


### PR DESCRIPTION
Still runs code coverage on CI, but locally, don't run it by default. You can still run it using the `--coverage` flag, but don't run them by default. It's pretty annoying to have to silence it when you're actively working on getting tests to pass.
