### PR TITLE
fix exponential update size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # vNEXT (not released yet)
 
+### `@liveblocks/core`
+
+- Fix a bug where undo/redo on `LiveObject` creates exponentially larger deltas
+
 # v1.0.10
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -547,15 +547,38 @@ export async function prepareStorageTest<
   }
 
   function assertUndoRedo() {
+    // this is what the last undo item looked like before we undo
+    const before = JSON.parse(
+      JSON.stringify(
+        room.__internal.undoStack[room.__internal.undoStack.length - 1]
+      ) //,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      //(key, value) => (key === "opId" ? undefined : value)
+    );
+
+    // this will undo the whole stack
     for (let i = 0; i < states.length - 1; i++) {
       room.history.undo();
       expectBothClientStoragesToEqual(states[states.length - 2 - i]);
     }
 
+    // this will redo the whole stack
     for (let i = 0; i < states.length - 1; i++) {
       room.history.redo();
       expectBothClientStoragesToEqual(states[i + 1]);
     }
+
+    // this is what the last undo item looks like after redoing everything
+    const after = JSON.parse(
+      JSON.stringify(
+        room.__internal.undoStack[room.__internal.undoStack.length - 1]
+      ) //,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      //(key, value) => (key === "opId" ? undefined : value)
+    );
+
+    // It should be identical before/after
+    expect(before).toEqual(after);
 
     for (let i = 0; i < states.length - 1; i++) {
       room.history.undo();

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -375,7 +375,6 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       id,
       data: {},
     };
-    reverse.push(reverseUpdate);
 
     for (const key in op.data as Partial<O>) {
       const oldValue = this._map.get(key);


### PR DESCRIPTION
### Description

An inadvertent double push to the reverse op array caused the history op size to double. Once this size reaches 1mb the client will be stuck in a reconnect loop. 

#### How to test it

- Check websocket message size when undoing and redoing in the next whiteboard advanced example.

#### Related issue(s)

https://github.com/liveblocks/liveblocks/issues/900

