### PR TITLE
fix: use PATCH instead of DELETE when passing body

### DIFF
--- a/starter-kits/nextjs-starter-kit/lib/client/documents/removeGroupAccess.ts
+++ b/starter-kits/nextjs-starter-kit/lib/client/documents/removeGroupAccess.ts
@@ -26,7 +26,7 @@ export async function removeGroupAccess({
   };
 
   return fetchApiEndpoint<DocumentGroup[]>(url, {
-    method: "DELETE",
+    method: "PATCH",
     body: JSON.stringify(request),
   });
 }

--- a/starter-kits/nextjs-starter-kit/lib/client/documents/removeUserAccess.ts
+++ b/starter-kits/nextjs-starter-kit/lib/client/documents/removeUserAccess.ts
@@ -26,7 +26,7 @@ export async function removeUserAccess({
   };
 
   return fetchApiEndpoint<DocumentUser[]>(url, {
-    method: "DELETE",
+    method: "PATCH",
     body: JSON.stringify(request),
   });
 }

--- a/starter-kits/nextjs-starter-kit/pages/api/liveblocks/documents/[documentId]/groups.ts
+++ b/starter-kits/nextjs-starter-kit/pages/api/liveblocks/documents/[documentId]/groups.ts
@@ -62,7 +62,7 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
 }
 
 /**
- * DELETE Groups - Used in /lib/client/removeGroupAccess.ts
+ * PATCH Groups - Used in /lib/client/removeGroupAccess.ts
  *
  * Remove a group from a document
  * Only allow if authorized with NextAuth and is added as a userId on usersAccesses
@@ -74,7 +74,7 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
  * @param req.body.groupId - The removed group's id
  * @param res
  */
-async function DELETE(req: NextApiRequest, res: NextApiResponse) {
+async function PATCH(req: NextApiRequest, res: NextApiResponse) {
   const documentId = req.query.documentId as string;
   const { groupId }: RemoveGroupRequest = JSON.parse(req.body);
 
@@ -99,14 +99,14 @@ export default async function groups(
       return await GET(req, res);
     case "POST":
       return await POST(req, res);
-    case "DELETE":
-      return await DELETE(req, res);
+    case "PATCH":
+      return await PATCH(req, res);
     default:
       return res.status(405).json({
         error: {
           code: 405,
           message: "Method Not Allowed",
-          suggestion: "Only GET, POST, AND DELETE are available from this API",
+          suggestion: "Only GET, POST, AND PATCH are available from this API",
         },
       });
   }

--- a/starter-kits/nextjs-starter-kit/pages/api/liveblocks/documents/[documentId]/users.ts
+++ b/starter-kits/nextjs-starter-kit/pages/api/liveblocks/documents/[documentId]/users.ts
@@ -62,7 +62,7 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
 }
 
 /**
- * DELETE Users - Used in /lib/client/removeUserAccess.ts
+ * PATCH Users - Used in /lib/client/removeUserAccess.ts
  *
  * Remove a collaborator from a document
  * Only allow if authorized with NextAuth and is added as a userId on usersAccesses
@@ -74,7 +74,7 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
  * @param req.body.userId - The removed user's id
  * @param res
  */
-async function DELETE(req: NextApiRequest, res: NextApiResponse) {
+async function PATCH(req: NextApiRequest, res: NextApiResponse) {
   const documentId = req.query.documentId as string;
   const { userId }: RemoveUserRequest = JSON.parse(req.body);
 
@@ -96,14 +96,14 @@ export default async function users(req: NextApiRequest, res: NextApiResponse) {
       return await GET(req, res);
     case "POST":
       return await POST(req, res);
-    case "DELETE":
-      return await DELETE(req, res);
+    case "PATCH":
+      return await PATCH(req, res);
     default:
       return res.status(405).json({
         error: {
           code: 405,
           message: "Method Not Allowed",
-          suggestion: "Only GET, POST, and DELETE are available from this API",
+          suggestion: "Only GET, POST, and PATCH are available from this API",
         },
       });
   }


### PR DESCRIPTION
<!-- We appreciate your efforts in opening a PR! Your contribution means a lot.
In order to ensure a seamless handling of your PR, we kindly ask you to refer to the checklist sections provided below.
Please select the appropriate checklist that corresponds to the changes you are making:

## For Contributors

### Fixing a bug

Hello, when trying to remove a group access from a document, I have this error:

```
- error Error [SyntaxError]: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at DELETE (webpack-internal:///(api)/./pages/api/liveblocks/documents/[documentId]/teams.ts:45:31)
    at groups (webpack-internal:///(api)/./pages/api/liveblocks/documents/[documentId]/teams.ts:64:26)
    at ...
}
  41 |   const documentId = req.query.documentId as string;
  42 |   console.log("DELETE ", documentId);
> 43 |   const { groupId }: RemoveGroupRequest = JSON.parse(req.body);
     |                                               ^
  44 | 
  45 |   const { data, error } = await removeGroupAccess(req, res, {
  46 |     documentId,
```

I think it's because we're passing a body with a method `DELETE`, which doesn't support.
Using `PATCH` instead fixes it.
