### PR TITLE
Prep DevTools for new statuses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17992,7 +17992,7 @@
     },
     "packages/liveblocks-devtools": {
       "name": "@liveblocks/devtools",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@liveblocks/core": "*",
         "@plasmohq/storage": "^0.14.0",

--- a/packages/liveblocks-devtools/package.json
+++ b/packages/liveblocks-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/devtools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "displayName": "Liveblocks DevTools",
   "description": "A browser extension that lets you inspect Liveblocks real-time collaborative experiences. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",

--- a/packages/liveblocks-devtools/src/devtools/components/RoomStatus.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/RoomStatus.tsx
@@ -28,15 +28,19 @@ export function RoomStatus({ className, ...props }: ComponentProps<"div">) {
   const currentStatus = useStatus();
   const statusContent = useMemo(() => {
     switch (currentStatus) {
-      case "open":
+      case "connected":
+      case "open": // Sent by old clients (prior to 1.1)
         return <Ping className="text-green-500 dark:text-green-400" />;
 
       case "connecting":
-      case "authenticating":
+      case "reconnecting":
+      case "authenticating": // Sent by old clients (prior to 1.1)
+      case "unavailable": // Sent by old clients (prior to 1.1)
         return <Ping className="text-orange-500 dark:text-orange-400" />;
 
-      case "closed":
-      case "failed":
+      case "disconnected":
+      case "closed": // Sent by old clients (prior to 1.1)
+      case "failed": // Sent by old clients (prior to 1.1)
         return (
           <Ping className="text-red-500 dark:text-red-400" animate={false} />
         );

--- a/packages/liveblocks-devtools/src/devtools/contexts/CurrentRoom.tsx
+++ b/packages/liveblocks-devtools/src/devtools/contexts/CurrentRoom.tsx
@@ -16,9 +16,20 @@ import { makeEventSource } from "../../lib/EventSource";
 import { onMessage, sendMessage } from "../port";
 import type { FullBackgroundToPanelMessage } from "../protocol";
 
+// We can remove this type definition by importing it from @liveblocks/core
+// once the 1.1 beta has landed
+type FutureConnectionStatus =
+  | "initial"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected";
+
+type Status = ConnectionStatus | FutureConnectionStatus;
+
 type Room = {
   readonly roomId: string;
-  status: ConnectionStatus | null;
+  status: Status | null;
   storage: readonly DevTools.LsonTreeNode[] | null;
   me: DevTools.UserTreeNode | null;
   others: readonly DevTools.UserTreeNode[];
@@ -319,7 +330,7 @@ export function useRoomIds(): string[] {
   return useSyncExternalStore(onRoomCountChanged.subscribe, () => allRoomIds);
 }
 
-export function useStatus(): ConnectionStatus | null {
+export function useStatus(): Status | null {
   const currentRoomId = useCurrentRoomId();
   return useSyncExternalStore(
     getSubscribe(currentRoomId, "onStatus") ?? nosub,


### PR DESCRIPTION
With the new connection statuses in the making, [as formulated here](https://github.com/liveblocks/liveblocks/issues/878), this PR prepares the Liveblocks DevTools to be able to handle both old and new client statuses being streamed to the DevTools, so we can properly display the correct circle colors for those new statuses too.

Without this change, the new statuses would be "unknown" to the DevTools, and the status color indicator would remain gray when used with newer Liveblocks versions.

Note that no clients sending the newer statuses exists in the wild yet, but that will start to change once the 1.1 beta release lands.

The idea is to add support for old _and_ new status codes to the DevTools, and publish the new version of the Liveblocks DevTools to all the extension stores, so that they're ready for the new status codes before those are being used in the wild.