### PR TITLE
Skip over `"authenticating"` connection state

### DIFF
--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -15,7 +15,6 @@ import type {
 // TODO DRY this type up with the ConnectionStatus type in room.ts
 export type PublicConnectionStatus =
   | "closed" // Room hasn't been entered, or has left already
-  | "authenticating" // Authentication has started, but not finished yet
   | "connecting" // Authentication succeeded, now attempting to connect to a room
   | "open" // Successful room connection, on the happy path
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
@@ -35,8 +34,6 @@ function toPublicConnectionStatus(state: State): PublicConnectionStatus {
 
     case "@auth.busy":
     case "@auth.backoff":
-      return "authenticating";
-
     case "@connecting.busy":
       return "connecting";
 

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -15,7 +15,7 @@ import type {
 // TODO DRY this type up with the ConnectionStatus type in room.ts
 export type PublicConnectionStatus =
   | "closed" // Room hasn't been entered, or has left already
-  | "connecting" // Authentication succeeded, now attempting to connect to a room
+  | "connecting" // In the process of authenticating and establishing a WebSocket connection
   | "open" // Successful room connection, on the happy path
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
   | "failed"; // Connection failed and we won't retry automatically (e.g. unauthorized)

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -73,14 +73,12 @@ export type Connection =
       sessionInfo?: never;
       lastSessionInfo: SessionInfo | null;
     }
-  /* Authentication has started, but not finished yet */
-  | {
-      status: "authenticating";
-      sessionInfo?: never;
-      lastSessionInfo: SessionInfo | null;
-    }
   /* Authentication succeeded, now attempting to connect to a room */
-  | { status: "connecting"; sessionInfo: SessionInfo; lastSessionInfo?: never }
+  | {
+      status: "connecting";
+      sessionInfo: SessionInfo | null;
+      lastSessionInfo?: never;
+    }
   /* Successful room connection, on the happy path */
   | { status: "open"; sessionInfo: SessionInfo; lastSessionInfo?: never }
   /* Connection lost unexpectedly, considered a temporary hiccup, will retry */
@@ -894,14 +892,13 @@ export function createRoom<
         }
       : null;
 
-    if (newStatus === "open" || newStatus === "connecting") {
+    if (newStatus === "open") {
       if (sessionInfo === null) {
         throw new Error("Unexpected missing session info");
       }
-      context.connection.set({
-        status: newStatus,
-        sessionInfo,
-      });
+      context.connection.set({ status: newStatus, sessionInfo });
+    } else if (newStatus === "connecting") {
+      context.connection.set({ status: newStatus, sessionInfo });
     } else {
       context.connection.set({
         status: newStatus,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -73,7 +73,7 @@ export type Connection =
       sessionInfo?: never;
       lastSessionInfo: SessionInfo | null;
     }
-  /* Authentication succeeded, now attempting to connect to a room */
+  /* In the process of authenticating and establishing a WebSocket connection */
   | {
       status: "connecting";
       sessionInfo: SessionInfo | null;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -630,18 +630,12 @@ function makeIdFactory(connectionId: number): IdFactory {
   return () => `${connectionId}:${count++}`;
 }
 
-function hasSessionInfo(connection: Connection): boolean {
-  return (
-    connection.status === "open" ||
-    connection.status === "connecting" ||
-    connection.lastSessionInfo !== null
-  );
+function getSessionInfo(connection: Connection): SessionInfo | null {
+  return connection.sessionInfo ?? connection.lastSessionInfo ?? null;
 }
 
-function getSessionInfo(connection: Connection): SessionInfo | null {
-  return connection.status === "open" || connection.status === "connecting"
-    ? connection.sessionInfo
-    : connection.lastSessionInfo;
+function hasSessionInfo(connection: Connection): boolean {
+  return getSessionInfo(connection) !== null;
 }
 
 type HistoryOp<TPresence extends JsonObject> =


### PR DESCRIPTION
> **Warning** Stacked on top of #926, both of which are intended to land in the `beta` branch.

In preparation of making implementation of the new higher-level `Status` values (from [this RFC](https://github.com/liveblocks/liveblocks/issues/878)) easier, this PR makes the room's internal stop using the explicit `"authenticating"` state. This will make implementating the new/proposed connection states a lot easier.

Turns out the `"authenticating"` state was not really carrying any meaning anymore after the state machine rewrite anyway.


### Before (1.0 and lower)
Before this PR, the `connection` state changes would look like this for the happy path:
`closed` -> `authenticating` -> `connecting` -> `open`

### After (soon 1.1 and higher)
After this PR, the `connection` state changes will look like this for the happy path:
`closed` -> `connecting` -> `open`

After this PR, `room.getConnectionState()` will never be `"authenticating"` anymore. In cases where it previously was `"authenticating"` it will now be `"connecting"` instead. There was no behavior coupled to this state, so it's a nice cleanup, and it will allow us to map the new states more cleanly.
