### PR TITLE
Higher level status subscriptions API

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -16,6 +16,7 @@ export type {
   LsonObject,
   Others,
   Room,
+  Status,
   StorageStatus,
   StorageUpdate,
   User,

--- a/packages/liveblocks-core/e2e/utils.ts
+++ b/packages/liveblocks-core/e2e/utils.ts
@@ -4,7 +4,8 @@ import fetch from "node-fetch";
 import type { URL } from "url";
 import WebSocket from "ws";
 
-import type { Room, ConnectionStatus } from "../src/room";
+import type { Room } from "../src/room";
+import type { LegacyConnectionStatus } from "../src/connection";
 import type { BaseUserMeta } from "../src/protocol/BaseUserMeta";
 import { withTimeout } from "../src/lib/utils";
 import type { Json, JsonObject } from "../src/lib/Json";
@@ -263,7 +264,7 @@ export function wait(ms: number) {
  */
 async function waitUntilStatus(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>,
-  targetStatus: ConnectionStatus
+  targetStatus: LegacyConnectionStatus
 ): Promise<void> {
   if (room.getConnectionState() === targetStatus) {
     return;

--- a/packages/liveblocks-core/e2e/utils.ts
+++ b/packages/liveblocks-core/e2e/utils.ts
@@ -5,7 +5,7 @@ import type { URL } from "url";
 import WebSocket from "ws";
 
 import type { Room } from "../src/room";
-import type { LegacyConnectionStatus } from "../src/connection";
+import type { Status } from "../src/connection";
 import type { BaseUserMeta } from "../src/protocol/BaseUserMeta";
 import { withTimeout } from "../src/lib/utils";
 import type { Json, JsonObject } from "../src/lib/Json";
@@ -72,7 +72,7 @@ async function initializeRoomForTest<
     roomId,
     { initialPresence, initialStorage }
   );
-  await waitUntilStatus(room, "open");
+  await waitUntilStatus(room, "connected");
 
   return {
     client,
@@ -264,14 +264,14 @@ export function wait(ms: number) {
  */
 async function waitUntilStatus(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>,
-  targetStatus: LegacyConnectionStatus
+  targetStatus: Status
 ): Promise<void> {
-  if (room.getConnectionState() === targetStatus) {
+  if (room.getStatus() === targetStatus) {
     return;
   }
 
   await withTimeout(
-    room.events.connection.waitUntil((status) => status === targetStatus),
+    room.events.status.waitUntil((status) => status === targetStatus),
     5000,
     `Room did not reach connection status "${targetStatus}" within 5s`
   );

--- a/packages/liveblocks-core/src/__tests__/_waitUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_waitUtils.ts
@@ -1,4 +1,4 @@
-import type { LegacyConnectionStatus } from "../connection";
+import type { Status } from "../connection";
 import type { LsonObject } from "../crdts/Lson";
 import type { Json, JsonObject } from "../lib/Json";
 import { withTimeout } from "../lib/utils";
@@ -34,14 +34,14 @@ export async function waitFor(predicate: () => boolean): Promise<void> {
  */
 export async function waitUntilStatus(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>,
-  targetStatus: LegacyConnectionStatus
+  targetStatus: Status
 ): Promise<void> {
-  if (room.getConnectionState() === targetStatus) {
+  if (room.getStatus() === targetStatus) {
     return;
   }
 
   await withTimeout(
-    room.events.connection.waitUntil((status) => status === targetStatus),
+    room.events.status.waitUntil((status) => status === targetStatus),
     1000,
     `Room did not reach connection status "${targetStatus}" within 1s`
   );

--- a/packages/liveblocks-core/src/__tests__/_waitUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_waitUtils.ts
@@ -1,8 +1,9 @@
+import type { LegacyConnectionStatus } from "../connection";
 import type { LsonObject } from "../crdts/Lson";
 import type { Json, JsonObject } from "../lib/Json";
 import { withTimeout } from "../lib/utils";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
-import type { ConnectionStatus, Room } from "../room";
+import type { Room } from "../room";
 
 export function sleep(delay: number) {
   return new Promise((resolve) => setTimeout(resolve, delay));
@@ -33,7 +34,7 @@ export async function waitFor(predicate: () => boolean): Promise<void> {
  */
 export async function waitUntilStatus(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>,
-  targetStatus: ConnectionStatus
+  targetStatus: LegacyConnectionStatus
 ): Promise<void> {
   if (room.getConnectionState() === targetStatus) {
     return;

--- a/packages/liveblocks-core/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-core/src/__tests__/client.node.test.ts
@@ -158,7 +158,7 @@ describe("createClient", () => {
     const room = client.enter("room", { initialPresence: {} });
 
     // Room will fail to connect, and move to "closed" state, basically giving up reconnecting
-    await waitUntilStatus(room, "failed");
+    await waitUntilStatus(room, "disconnected");
 
     expect(spy).toHaveBeenCalledWith(
       "To use Liveblocks client in a non-dom environment with a url as auth endpoint, you need to provide a fetch polyfill."
@@ -180,7 +180,7 @@ describe("createClient", () => {
     const room = client.enter("room", { initialPresence: {} });
 
     // Room will fail to connect, and move to "closed" state, basically giving up reconnecting
-    await waitUntilStatus(room, "failed");
+    await waitUntilStatus(room, "disconnected");
 
     expect(spy).toHaveBeenCalledWith(
       "To use Liveblocks client in a non-dom environment with a publicApiKey, you need to provide a fetch polyfill."
@@ -197,7 +197,7 @@ describe("createClient", () => {
     const room = client.enter("room", { initialPresence: {} });
 
     // Room will fail to connect, and move to "closed" state, basically giving up reconnecting
-    await waitUntilStatus(room, "failed");
+    await waitUntilStatus(room, "disconnected");
 
     expect(spy).toHaveBeenCalledWith(
       "To use Liveblocks client in a non-dom environment, you need to provide a WebSocket polyfill."

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -178,7 +178,7 @@ describe("room / auth", () => {
     );
 
     room.connect();
-    await waitUntilStatus(room, "failed");
+    await waitUntilStatus(room, "disconnected");
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Unauthorized: reason not provided in auth response (403 returned by POST /mocked-api/403)"
     );
@@ -198,7 +198,7 @@ describe("room / auth", () => {
     );
 
     room.connect();
-    await waitUntilStatus(room, "failed");
+    await waitUntilStatus(room, "disconnected");
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Unauthorized: wrong key type (401 returned by POST /mocked-api/401-with-details)"
     );
@@ -281,7 +281,7 @@ describe("room", () => {
     room.connect();
     expect(room.getConnectionState()).toBe("connecting");
     expect(room.getStatus()).toEqual("connecting");
-    await waitUntilStatus(room, "open");
+    await waitUntilStatus(room, "connected");
     expect(room.getConnectionState()).toBe("open"); // This API will be deprecated in the future
     expect(room.getStatus()).toEqual("connected");
   });
@@ -293,7 +293,7 @@ describe("room", () => {
     await waitUntilStatus(room, "connecting");
     expect(wss.receivedMessages).toEqual([]);
 
-    await waitUntilStatus(room, "open");
+    await waitUntilStatus(room, "connected");
     expect(wss.receivedMessages).toEqual([
       [
         {
@@ -310,7 +310,7 @@ describe("room", () => {
     room.updatePresence({ x: 0 });
     room.connect();
 
-    await waitUntilStatus(room, "open");
+    await waitUntilStatus(room, "connected");
     expect(wss.receivedMessages).toEqual([
       [
         {
@@ -326,7 +326,7 @@ describe("room", () => {
     const { room, wss } = createTestableRoom({} as never);
     room.connect();
 
-    await waitUntilStatus(room, "open");
+    await waitUntilStatus(room, "connected");
     expect(wss.receivedMessages).toEqual([
       [{ type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} }],
     ]);
@@ -337,7 +337,7 @@ describe("room", () => {
     room.connect();
 
     expect(wss.receivedMessages).toEqual([]);
-    await waitUntilStatus(room, "open");
+    await waitUntilStatus(room, "connected");
 
     expect(wss.receivedMessages.length).toBe(1);
     expect(wss.receivedMessages[0]).toEqual([
@@ -572,7 +572,7 @@ describe("room", () => {
       const { room, wss } = createTestableRoom({});
       room.connect();
 
-      await waitUntilStatus(room, "open");
+      await waitUntilStatus(room, "connected");
       expect(wss.receivedMessages).toEqual([
         [{ type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} }],
       ]);
@@ -614,7 +614,7 @@ describe("room", () => {
       expect(wss.receivedMessages).toEqual([]);
 
       room.connect();
-      await waitUntilStatus(room, "open");
+      await waitUntilStatus(room, "connected");
 
       expect(wss.receivedMessages).toEqual([
         [{ type: ClientMsgCode.UPDATE_PRESENCE, targetActor: -1, data: {} }],
@@ -631,7 +631,7 @@ describe("room", () => {
       expect(wss.receivedMessages).toEqual([]);
 
       room.connect();
-      await waitUntilStatus(room, "open");
+      await waitUntilStatus(room, "connected");
 
       expect(wss.receivedMessages).toEqual([
         [
@@ -663,7 +663,7 @@ describe("room", () => {
     const { room } = createTestableRoom({ x: -1 });
     room.connect();
 
-    await waitUntilStatus(room, "open");
+    await waitUntilStatus(room, "connected");
     expect(room.__internal.buffer.me).toEqual(null); // Buffer was flushed
     room.updatePresence({ x: 0 }, { addToHistory: true });
     expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
@@ -1157,7 +1157,7 @@ describe("room", () => {
         (ev) => (others = ev.others)
       );
 
-      await waitUntilStatus(room, "open");
+      await waitUntilStatus(room, "connected");
 
       wss.last.send(
         serverMessage({
@@ -1515,7 +1515,7 @@ describe("room", () => {
       jest.useFakeTimers();
       try {
         await jest.advanceTimersByTimeAsync(0);
-        await waitUntilStatus(room, "open");
+        await waitUntilStatus(room, "connected");
         await jest.advanceTimersByTimeAsync(1111);
         expect(consoleWarnSpy).toHaveBeenCalledWith(
           "Connection to Liveblocks websocket server closed (code: 1006). Retrying in 250ms."
@@ -1585,7 +1585,7 @@ describe("room", () => {
       jest.useFakeTimers();
       try {
         await jest.advanceTimersByTimeAsync(0);
-        await waitUntilStatus(room, "open");
+        await waitUntilStatus(room, "connected");
         await jest.advanceTimersByTimeAsync(1111);
         expect(consoleWarnSpy).toHaveBeenCalledWith(
           "Connection to Liveblocks websocket server closed (code: 4002). Retrying in 2000ms."
@@ -1620,7 +1620,7 @@ describe("room", () => {
 
         const ws1 = wss.last;
         ws1.accept();
-        await waitUntilStatus(room, "open");
+        await waitUntilStatus(room, "connected");
         expect(room.getConnectionState()).toBe("open"); // This API will be deprecated in the future
         expect(room.getStatus()).toEqual("connected");
 
@@ -1640,7 +1640,7 @@ describe("room", () => {
         // This "last" one is a new/different socket instance!
         expect(ws1 === ws2).toBe(false);
 
-        await waitUntilStatus(room, "open");
+        await waitUntilStatus(room, "connected");
         expect(room.getConnectionState()).toBe("open");
         expect(room.getStatus()).toEqual("connected");
       } finally {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -254,6 +254,7 @@ describe("room", () => {
     expect(delegates.authenticate).not.toHaveBeenCalled();
     room.connect();
     expect(room.getConnectionState()).toEqual("connecting");
+    expect(room.getStatus()).toEqual("connecting");
     expect(delegates.authenticate).toHaveBeenCalled();
     expect(delegates.createSocket).not.toHaveBeenCalled();
   });
@@ -262,22 +263,27 @@ describe("room", () => {
     const { room, delegates } = createTestableRoom({});
     room.connect();
     expect(room.getConnectionState()).toEqual("connecting");
+    expect(room.getStatus()).toEqual("connecting");
     room.connect();
     room.connect();
     room.connect();
     expect(room.getConnectionState()).toEqual("connecting");
+    expect(room.getStatus()).toEqual("connecting");
     expect(delegates.authenticate).toHaveBeenCalledTimes(1);
     expect(delegates.createSocket).not.toHaveBeenCalled();
   });
 
   test("authentication success should transition to connecting", async () => {
     const { room } = createTestableRoom({});
-    expect(room.getConnectionState()).toBe("closed");
+    expect(room.getConnectionState()).toBe("closed"); // This API will be deprecated in the future
+    expect(room.getStatus()).toEqual("disconnected");
 
     room.connect();
     expect(room.getConnectionState()).toBe("connecting");
+    expect(room.getStatus()).toEqual("connecting");
     await waitUntilStatus(room, "open");
-    expect(room.getConnectionState()).toBe("open");
+    expect(room.getConnectionState()).toBe("open"); // This API will be deprecated in the future
+    expect(room.getStatus()).toEqual("connected");
   });
 
   test("initial presence should be sent once the connection is open", async () => {
@@ -1604,23 +1610,29 @@ describe("room", () => {
           DEFAULT_AUTH,
           MANUAL_SOCKETS // ⚠️  This will let us programmatically control opening the sockets
         );
-        expect(room.getConnectionState()).toBe("closed");
+        expect(room.getConnectionState()).toBe("closed"); // This API will be deprecated in the future
+        expect(room.getStatus()).toEqual("disconnected");
 
         room.connect();
         expect(room.getConnectionState()).toBe("connecting");
+        expect(room.getStatus()).toEqual("connecting");
         await jest.advanceTimersByTimeAsync(0); // Resolve the auth promise, which will then start the socket connection
 
         const ws1 = wss.last;
         ws1.accept();
         await waitUntilStatus(room, "open");
-        expect(room.getConnectionState()).toBe("open");
+        expect(room.getConnectionState()).toBe("open"); // This API will be deprecated in the future
+        expect(room.getStatus()).toEqual("connected");
 
         room.reconnect();
         expect(room.getConnectionState()).toBe("connecting");
+        expect(room.getStatus()).toEqual("connecting");
         await jest.advanceTimersByTimeAsync(0); // There's a backoff delay here!
         expect(room.getConnectionState()).toBe("connecting");
+        expect(room.getStatus()).toEqual("connecting");
         await jest.advanceTimersByTimeAsync(500); // Wait for the increased backoff delay!
-        expect(room.getConnectionState()).toBe("connecting");
+        expect(room.getConnectionState()).toBe("connecting"); // This API will be deprecated in the future
+        expect(room.getStatus()).toEqual("connecting");
 
         const ws2 = wss.last;
         ws2.accept();
@@ -1630,6 +1642,7 @@ describe("room", () => {
 
         await waitUntilStatus(room, "open");
         expect(room.getConnectionState()).toBe("open");
+        expect(room.getStatus()).toEqual("connected");
       } finally {
         jest.useRealTimers();
       }

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -276,7 +276,7 @@ describe("room", () => {
   test("authentication success should transition to connecting", async () => {
     const { room } = createTestableRoom({});
     expect(room.getConnectionState()).toBe("closed"); // This API will be deprecated in the future
-    expect(room.getStatus()).toEqual("disconnected");
+    expect(room.getStatus()).toEqual("initial");
 
     room.connect();
     expect(room.getConnectionState()).toBe("connecting");
@@ -1611,7 +1611,7 @@ describe("room", () => {
           MANUAL_SOCKETS // ⚠️  This will let us programmatically control opening the sockets
         );
         expect(room.getConnectionState()).toBe("closed"); // This API will be deprecated in the future
-        expect(room.getStatus()).toEqual("disconnected");
+        expect(room.getStatus()).toEqual("initial");
 
         room.connect();
         expect(room.getConnectionState()).toBe("connecting");

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -13,23 +13,7 @@ import type {
 } from "./types/IWebSocket";
 
 /**
- * XXX Mark as @deprecated (also... don't mark the _type_ deprecated, just the APIs!)
- * These are old connection statuses. Please rely on the newer
- * Status values instead. We recommend making the following changes
- * if you use these APIs:
- *
- *     OLD APIs                       NEW APIs
- *     .getConnectionState()     -->  .getStatus()
- *     .subscribe('connection')  -->  .subscribe('status')
- *
- *     OLD STATUSES         NEW STATUSES
- *     closed          -->  initial
- *     authenticating  -->  connecting
- *     connecting      -->  connecting
- *     open            -->  connected
- *     unavailable     -->  reconnecting
- *     failed          -->  disconnected
- *
+ * Old connection statuses, here for backward-compatibility reasons only.
  */
 export type LegacyConnectionStatus =
   | "closed" // Room hasn't been entered, or has left already
@@ -38,6 +22,11 @@ export type LegacyConnectionStatus =
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
   | "failed"; // Connection failed and we won't retry automatically (e.g. unauthorized)
 
+/**
+ * Returns a human-readable status indicating the current connection status of
+ * a Room, as returned by `room.getStatus()`. Can be used to implement
+ * a connection status badge.
+ */
 export type Status =
   | "initial"
   | "connecting"

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -281,20 +281,20 @@ function defineConnectivityEvents(machine: FSM<Context, Event, State>) {
   const didConnect = makeEventSource<void>();
   const didDisconnect = makeEventSource<void>();
 
-  let oldPublicStatus: LegacyConnectionStatus | null = null;
+  let lastStatus: LegacyConnectionStatus | null = null;
 
   const unsubscribe = machine.events.didEnterState.subscribe(() => {
-    const newPublicStatus = toLegacyConnectionStatus(machine);
-    if (newPublicStatus !== oldPublicStatus) {
-      statusDidChange.notify(newPublicStatus);
+    const currStatus = toLegacyConnectionStatus(machine);
+    if (currStatus !== lastStatus) {
+      statusDidChange.notify(currStatus);
     }
 
-    if (oldPublicStatus === "open" && newPublicStatus !== "open") {
+    if (lastStatus === "open" && currStatus !== "open") {
       didDisconnect.notify();
-    } else if (oldPublicStatus !== "open" && newPublicStatus === "open") {
+    } else if (lastStatus !== "open" && currStatus === "open") {
       didConnect.notify();
     }
-    oldPublicStatus = newPublicStatus;
+    lastStatus = currStatus;
   });
 
   return {

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -13,7 +13,8 @@ import type {
 } from "./types/IWebSocket";
 
 /**
- * @deprecated These are old connection statuses. Please rely on the newer
+ * XXX Mark as @deprecated
+ * These are old connection statuses. Please rely on the newer
  * Status values instead. We recommend making the following changes
  * if you use these APIs:
  *

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -13,7 +13,7 @@ import type {
 } from "./types/IWebSocket";
 
 /**
- * XXX Mark as @deprecated
+ * XXX Mark as @deprecated (also... don't mark the _type_ deprecated, just the APIs!)
  * These are old connection statuses. Please rely on the newer
  * Status values instead. We recommend making the following changes
  * if you use these APIs:

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -314,12 +314,13 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
   //
   // Configure the @idle.* states
   //
-  machine.addTransitions("@idle.*", {
-    CONNECT: (_, ctx) =>
-      // If we still have a known token, try to reconnect to the socket directly,
-      // otherwise, try to obtain a new token
-      ctx.token !== null ? "@connecting.busy" : "@auth.busy",
-  });
+
+    .addTransitions("@idle.*", {
+      CONNECT: (_, ctx) =>
+        // If we still have a known token, try to reconnect to the socket directly,
+        // otherwise, try to obtain a new token
+        ctx.token !== null ? "@connecting.busy" : "@auth.busy",
+    });
 
   //
   // Configure the @auth.* states

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -843,7 +843,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
     this.cleanups = cleanups;
   }
 
-  get status(): LegacyConnectionStatus {
+  getLegacyStatus(): LegacyConnectionStatus {
     try {
       return toLegacyConnectionStatus(this.machine.currentState);
     } catch {

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -235,7 +235,7 @@ function enableTracing(machine: FSM<Context, Event, State>) {
 }
 
 function defineConnectivityEvents(machine: FSM<Context, Event, State>) {
-  // Emitted whenever a new WebSocket connection attempt suceeds
+  // Emitted whenever a new WebSocket connection attempt succeeds
   const statusDidChange = makeEventSource<PublicConnectionStatus>();
   const didConnect = makeEventSource<void>();
   const didDisconnect = makeEventSource<void>();

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -12,12 +12,37 @@ import type {
   IWebSocketMessageEvent,
 } from "./types/IWebSocket";
 
+/**
+ * @deprecated These are old connection statuses. Please rely on the newer
+ * Status values instead. We recommend making the following changes
+ * if you use these APIs:
+ *
+ *     OLD APIs                       NEW APIs
+ *     .getConnectionState()     -->  .getStatus()
+ *     .subscribe('connection')  -->  .subscribe('status')
+ *
+ *     OLD STATUSES         NEW STATUSES
+ *     closed          -->  initial
+ *     authenticating  -->  connecting
+ *     connecting      -->  connecting
+ *     open            -->  connected
+ *     unavailable     -->  reconnecting
+ *     failed          -->  disconnected
+ *
+ */
 export type LegacyConnectionStatus =
   | "closed" // Room hasn't been entered, or has left already
   | "connecting" // In the process of authenticating and establishing a WebSocket connection
   | "open" // Successful room connection, on the happy path
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
   | "failed"; // Connection failed and we won't retry automatically (e.g. unauthorized)
+
+export type NewConnectionStatus =
+  | "initial"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected";
 
 /**
  * Maps internal machine state to the public connection status API.

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -15,7 +15,6 @@ import type {
 // TODO DRY this type up with the ConnectionStatus type in room.ts
 export type PublicConnectionStatus =
   | "closed" // Room hasn't been entered, or has left already
-  | "authenticating" // Authentication has started, but not finished yet
   | "connecting" // Authentication succeeded, now attempting to connect to a room
   | "open" // Successful room connection, on the happy path
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
@@ -35,8 +34,6 @@ function toPublicConnectionStatus(state: State): PublicConnectionStatus {
 
     case "@auth.busy":
     case "@auth.backoff":
-      return "authenticating";
-
     case "@connecting.busy":
       return "connecting";
 

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -38,7 +38,7 @@ export type LegacyConnectionStatus =
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
   | "failed"; // Connection failed and we won't retry automatically (e.g. unauthorized)
 
-export type NewConnectionStatus =
+export type Status =
   | "initial"
   | "connecting"
   | "connected"
@@ -79,9 +79,7 @@ function toLegacyConnectionStatus(
 /**
  * Maps internal machine state to the public Status API.
  */
-function toNewConnectionStatus(
-  machine: FSM<Context, Event, State>
-): NewConnectionStatus {
+function toNewConnectionStatus(machine: FSM<Context, Event, State>): Status {
   const state = machine.currentState;
   switch (state) {
     case "@ok.connected":
@@ -886,7 +884,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
     }
   }
 
-  getStatus(): NewConnectionStatus {
+  getStatus(): Status {
     try {
       return toNewConnectionStatus(this.machine);
     } catch {

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -15,7 +15,7 @@ import type {
 // TODO DRY this type up with the ConnectionStatus type in room.ts
 export type PublicConnectionStatus =
   | "closed" // Room hasn't been entered, or has left already
-  | "connecting" // Authentication succeeded, now attempting to connect to a room
+  | "connecting" // In the process of authenticating and establishing a WebSocket connection
   | "open" // Successful room connection, on the happy path
   | "unavailable" // Connection lost unexpectedly, considered a temporary hiccup, will retry
   | "failed"; // Connection failed and we won't retry automatically (e.g. unauthorized)

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -908,7 +908,7 @@ describe("LiveList", () => {
           wasClean: false,
         })
       );
-      await waitUntilStatus(room, "open");
+      await waitUntilStatus(room, "connected");
 
       const items = root.get("items");
 

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -120,7 +120,7 @@ function partialSyncConnection(
   sendToPanel({
     msg: "room::sync::partial",
     roomId: room.id,
-    status: room.getConnectionState(),
+    status: room.getConnectionState(), // XXX How to best handle the new statuses in DevTools? Probably just make it support all (legacy + new) statuses?
   });
 }
 
@@ -169,7 +169,7 @@ function fullSync(room: Room<JsonObject, LsonObject, BaseUserMeta, Json>) {
   sendToPanel({
     msg: "room::sync::full",
     roomId: room.id,
-    status: room.getConnectionState(),
+    status: room.getConnectionState(), // XXX How to best handle the new statuses in DevTools? Probably just make it support all (legacy + new) statuses?
     storage: root?.toTreeNode("root").payload ?? null,
     me,
     others,

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -100,7 +100,7 @@ function startSyncStream(
 
   unsubsByRoomId.set(room.id, [
     // When the connection status changes
-    room.events.connection.subscribe(() => partialSyncConnection(room)),
+    room.events.status.subscribe(() => partialSyncConnection(room)),
 
     // When storage initializes, send the update
     room.events.storageDidLoad.subscribeOnce(() => partialSyncStorage(room)),
@@ -120,7 +120,7 @@ function partialSyncConnection(
   sendToPanel({
     msg: "room::sync::partial",
     roomId: room.id,
-    status: room.getConnectionState(), // XXX How to best handle the new statuses in DevTools? Probably just make it support all (legacy + new) statuses?
+    status: room.getStatus(),
   });
 }
 
@@ -169,7 +169,7 @@ function fullSync(room: Room<JsonObject, LsonObject, BaseUserMeta, Json>) {
   sendToPanel({
     msg: "room::sync::full",
     roomId: room.id,
-    status: room.getConnectionState(), // XXX How to best handle the new statuses in DevTools? Probably just make it support all (legacy + new) statuses?
+    status: room.getStatus(),
     storage: root?.toTreeNode("root").payload ?? null,
     me,
     others,

--- a/packages/liveblocks-core/src/devtools/protocol.ts
+++ b/packages/liveblocks-core/src/devtools/protocol.ts
@@ -1,4 +1,4 @@
-import type { LegacyConnectionStatus } from "../connection";
+import type { Status } from "../connection";
 import type * as DevTools from "../types/DevToolsTreeNode";
 
 /**
@@ -75,7 +75,7 @@ export type ClientToPanelMessage =
   | {
       msg: "room::sync::full";
       roomId: string;
-      status: LegacyConnectionStatus;
+      status: Status;
       storage: readonly DevTools.LsonTreeNode[] | null;
       me: DevTools.UserTreeNode | null;
       others: readonly DevTools.UserTreeNode[];
@@ -87,7 +87,7 @@ export type ClientToPanelMessage =
   | {
       msg: "room::sync::partial";
       roomId: string;
-      status?: LegacyConnectionStatus;
+      status?: Status;
       storage?: readonly DevTools.LsonTreeNode[];
       me?: DevTools.UserTreeNode;
       others?: readonly DevTools.UserTreeNode[];

--- a/packages/liveblocks-core/src/devtools/protocol.ts
+++ b/packages/liveblocks-core/src/devtools/protocol.ts
@@ -1,4 +1,4 @@
-import type { ConnectionStatus } from "../room";
+import type { LegacyConnectionStatus } from "../connection";
 import type * as DevTools from "../types/DevToolsTreeNode";
 
 /**
@@ -75,7 +75,7 @@ export type ClientToPanelMessage =
   | {
       msg: "room::sync::full";
       roomId: string;
-      status: ConnectionStatus;
+      status: LegacyConnectionStatus;
       storage: readonly DevTools.LsonTreeNode[] | null;
       me: DevTools.UserTreeNode | null;
       others: readonly DevTools.UserTreeNode[];
@@ -87,7 +87,7 @@ export type ClientToPanelMessage =
   | {
       msg: "room::sync::partial";
       roomId: string;
-      status?: ConnectionStatus;
+      status?: LegacyConnectionStatus;
       storage?: readonly DevTools.LsonTreeNode[];
       me?: DevTools.UserTreeNode;
       others?: readonly DevTools.UserTreeNode[];

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -14,6 +14,10 @@
 export type { Client } from "./client";
 export { createClient } from "./client";
 export type { BaseAuthResult, Delegates } from "./connection";
+export type {
+  LegacyConnectionStatus as ConnectionStatus,
+  NewConnectionStatus as Status,
+} from "./connection";
 export { LiveList } from "./crdts/LiveList";
 export { LiveMap } from "./crdts/LiveMap";
 export { LiveObject } from "./crdts/LiveObject";
@@ -117,7 +121,6 @@ export type {
 export { ServerMsgCode } from "./protocol/ServerMsg";
 export type {
   BroadcastOptions,
-  ConnectionStatus,
   History,
   Room,
   RoomInitializers,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -16,7 +16,7 @@ export { createClient } from "./client";
 export type { BaseAuthResult, Delegates } from "./connection";
 export type {
   LegacyConnectionStatus as ConnectionStatus,
-  NewConnectionStatus as Status,
+  Status,
 } from "./connection";
 export { LiveList } from "./crdts/LiveList";
 export { LiveMap } from "./crdts/LiveMap";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -868,7 +868,6 @@ export function createRoom<
   }
 
   function onDidConnect() {
-    // XXX We're in onDidConnect already, so status will always be connected! Can we just remove this throw? We don't seem to need this really, do we?
     const sessionInfo = context.sessionInfo.current;
     if (sessionInfo === null) {
       // Totally unexpected by now
@@ -913,7 +912,6 @@ export function createRoom<
   // We never have to unsubscribe, because the Room and the Connection Manager
   // will have the same life-time.
   managedSocket.events.onMessage.subscribe(handleServerMessage);
-  // managedSocket.events.tokenDidChange.subscribe(onTokenDidChange);   // XXX Perhaps this would be nice?
   managedSocket.events.statusDidChange.subscribe(onStatusDidChange);
   managedSocket.events.didConnect.subscribe(onDidConnect);
   managedSocket.events.didDisconnect.subscribe(onDidDisconnect);
@@ -2028,7 +2026,7 @@ export function createRoom<
 
     // Core
     getStatus: () => managedSocket.getStatus(),
-    getConnectionState: () => managedSocket.getLegacyStatus(), // XXX This was newToLegacyStatus(context.connection.current.status) -- is that not the same?
+    getConnectionState: () => managedSocket.getLegacyStatus(),
     isSelfAware: () => context.sessionInfo.current !== null,
     getSelf: () => self.current,
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -73,14 +73,12 @@ export type Connection =
       sessionInfo?: never;
       lastSessionInfo: SessionInfo | null;
     }
-  /* Authentication has started, but not finished yet */
-  | {
-      status: "authenticating";
-      sessionInfo?: never;
-      lastSessionInfo: SessionInfo | null;
-    }
   /* Authentication succeeded, now attempting to connect to a room */
-  | { status: "connecting"; sessionInfo: SessionInfo; lastSessionInfo?: never }
+  | {
+      status: "connecting";
+      sessionInfo: SessionInfo | null;
+      lastSessionInfo?: never;
+    }
   /* Successful room connection, on the happy path */
   | { status: "open"; sessionInfo: SessionInfo; lastSessionInfo?: never }
   /* Connection lost unexpectedly, considered a temporary hiccup, will retry */
@@ -894,14 +892,13 @@ export function createRoom<
         }
       : null;
 
-    if (newStatus === "open" || newStatus === "connecting") {
+    if (newStatus === "open") {
       if (sessionInfo === null) {
         throw new Error("Unexpected missing session info");
       }
-      context.connection.set({
-        status: newStatus,
-        sessionInfo,
-      });
+      context.connection.set({ status: newStatus, sessionInfo });
+    } else if (newStatus === "connecting") {
+      context.connection.set({ status: newStatus, sessionInfo });
     } else {
       context.connection.set({
         status: newStatus,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -916,6 +916,8 @@ export function createRoom<
   }
 
   function onDidConnect() {
+    // XXX We're in onDidConnect already, so status will always be connected! Can we just remove this throw? We don't seem to need this really, do we?
+
     const conn = context.connection.current;
     if (conn.status !== "connected") {
       // Totally unexpected by now
@@ -955,6 +957,7 @@ export function createRoom<
     clearTimeout(context.buffer.flushTimerID);
 
     batchUpdates(() => {
+      // XXX Move this clearing-of-others to the "connection-unstable" event
       context.others.clearOthers();
       notify({ others: [{ type: "reset" }] }, doNotBatchUpdates);
     });

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -66,7 +66,7 @@ type CustomEvent<TRoomEvent extends Json> = {
   event: TRoomEvent;
 };
 
-export type Connection =
+type Connection =
   /* The initial state, before connecting */
   | {
       status: "closed";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1,4 +1,4 @@
-import type { Delegates, PublicConnectionStatus } from "./connection";
+import type { Delegates, LegacyConnectionStatus } from "./connection";
 import { ManagedSocket, StopRetrying } from "./connection";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { OpSource } from "./crdts/AbstractCrdt";
@@ -94,8 +94,6 @@ type Connection =
       lastSessionInfo: SessionInfo | null;
     };
 
-export type ConnectionStatus = Connection["status"];
-
 export type StorageStatus =
   /* The storage is not loaded and has not been requested. */
   | "not-loaded"
@@ -122,7 +120,7 @@ type RoomEventCallbackMap<
     event: OthersEvent<TPresence, TUserMeta>
   ) => void;
   error: Callback<Error>;
-  connection: Callback<ConnectionStatus>;
+  connection: Callback<LegacyConnectionStatus>;
   history: Callback<HistoryEvent>;
   "storage-status": Callback<StorageStatus>;
 };
@@ -316,7 +314,7 @@ type SubscribeFn<
    * @returns Unsubscribe function.
    *
    */
-  (type: "connection", listener: Callback<ConnectionStatus>): () => void;
+  (type: "connection", listener: Callback<LegacyConnectionStatus>): () => void;
 
   /**
    * Subscribes to changes made on a Live structure. Returns an unsubscribe function.
@@ -417,7 +415,7 @@ export type Room<
    * metadata and connection ID (from the auth server).
    */
   isSelfAware(): boolean;
-  getConnectionState(): ConnectionStatus;
+  getConnectionState(): LegacyConnectionStatus;
   readonly subscribe: SubscribeFn<TPresence, TStorage, TUserMeta, TRoomEvent>;
 
   /**
@@ -514,7 +512,7 @@ export type Room<
     readonly me: Observable<TPresence>;
     readonly others: Observable<{ others: Others<TPresence, TUserMeta>; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
-    readonly connection: Observable<ConnectionStatus>;
+    readonly connection: Observable<LegacyConnectionStatus>;
     readonly storage: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
 
@@ -881,7 +879,7 @@ export function createRoom<
   const doNotBatchUpdates = (cb: () => void): void => cb();
   const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;
 
-  function onStatusDidChange(newStatus: PublicConnectionStatus) {
+  function onStatusDidChange(newStatus: LegacyConnectionStatus) {
     const token = managedSocket.token?.parsed;
     const sessionInfo = token
       ? {
@@ -2167,7 +2165,7 @@ function makeClassicSubscribeFn<
 
         case "connection":
           return events.connection.subscribe(
-            callback as Callback<ConnectionStatus>
+            callback as Callback<LegacyConnectionStatus>
           );
 
         case "history":

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -874,20 +874,20 @@ export function createRoom<
       throw new Error("Unexpected missing session info");
     }
 
-    // Re-broadcast the full user presence as soon as we reconnect
-    // NOTE: This condition tries to guard "is this a reconnect". There may be
-    // a more robust way to check that.
-    if (sessionInfo?.id !== null) {
-      context.buffer.me = {
-        type: "full",
-        data:
-          // Because state.me.current is a readonly object, we'll have to
-          // make a copy here. Otherwise, type errors happen later when
-          // "patching" my presence.
-          { ...context.me.current },
-      };
-      tryFlushing();
-    }
+    // Re-broadcast the full user presence as soon as we (re)connect
+    context.buffer.me = {
+      type: "full",
+      data:
+        // Because context.me.current is a readonly object, we'll have to
+        // make a copy here. Otherwise, type errors happen later when
+        // "patching" my presence.
+        { ...context.me.current },
+    };
+
+    // NOTE: There was a flush here before, but I don't think it's really
+    // needed anymore. We're now combining this flush with the one below, to
+    // combine them in a single batch.
+    // tryFlushing();
 
     context.idFactory = makeIdFactory(sessionInfo.id);
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1,4 +1,8 @@
-import type { Delegates, LegacyConnectionStatus } from "./connection";
+import type {
+  Delegates,
+  LegacyConnectionStatus,
+  NewConnectionStatus as Status,
+} from "./connection";
 import { ManagedSocket, StopRetrying } from "./connection";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { OpSource } from "./crdts/AbstractCrdt";
@@ -109,6 +113,8 @@ type RoomEventCallbackMap<
   TUserMeta extends BaseUserMeta,
   TRoomEvent extends Json
 > = {
+  connection: Callback<LegacyConnectionStatus>; // Old/deprecated API
+  status: Callback<Status>; // New/recommended API
   event: Callback<CustomEvent<TRoomEvent>>;
   "my-presence": Callback<TPresence>;
   //
@@ -120,7 +126,6 @@ type RoomEventCallbackMap<
     event: OthersEvent<TPresence, TUserMeta>
   ) => void;
   error: Callback<Error>;
-  connection: Callback<LegacyConnectionStatus>;
   history: Callback<HistoryEvent>;
   "storage-status": Callback<StorageStatus>;
 };
@@ -509,7 +514,9 @@ export type Room<
   getStorageSnapshot(): LiveObject<TStorage> | null;
 
   readonly events: {
-    readonly connection: Observable<LegacyConnectionStatus>;
+    readonly connection: Observable<LegacyConnectionStatus>; // Old/legacy API
+    readonly status: Observable<Status>; // New/recommended API
+
     readonly customEvent: Observable<{ connectionId: number; event: TRoomEvent; }>; // prettier-ignore
     readonly me: Observable<TPresence>;
     readonly others: Observable<{ others: Others<TPresence, TUserMeta>; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
@@ -1034,7 +1041,9 @@ export function createRoom<
   };
 
   const eventHub = {
-    connection: makeEventSource<LegacyConnectionStatus>(),
+    connection: makeEventSource<LegacyConnectionStatus>(), // Old/deprecated API
+    status: makeEventSource<Status>(), // New/recommended API
+
     customEvent: makeEventSource<CustomEvent<TRoomEvent>>(),
     me: makeEventSource<TPresence>(),
     others: makeEventSource<{
@@ -2010,7 +2019,9 @@ export function createRoom<
   );
 
   const events = {
-    connection: eventHub.connection.observable,
+    connection: eventHub.connection.observable, // Old/deprecated API
+    status: eventHub.status.observable, // New/recommended API
+
     customEvent: eventHub.customEvent.observable,
     others: eventHub.others.observable,
     me: eventHub.me.observable,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1,8 +1,4 @@
-import type {
-  Delegates,
-  LegacyConnectionStatus,
-  NewConnectionStatus as Status,
-} from "./connection";
+import type { Delegates, LegacyConnectionStatus, Status } from "./connection";
 import { ManagedSocket, StopRetrying } from "./connection";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { OpSource } from "./crdts/AbstractCrdt";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2177,6 +2177,9 @@ function makeClassicSubscribeFn<
             callback as Callback<LegacyConnectionStatus>
           );
 
+        case "status":
+          return events.status.subscribe(callback as Callback<Status>);
+
         case "history":
           return events.history.subscribe(callback as Callback<HistoryEvent>);
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1714,7 +1714,7 @@ export function createRoom<
       notifyStorageStatus();
     }
 
-    if (managedSocket.status !== "open") {
+    if (managedSocket.getLegacyStatus() !== "open") {
       context.buffer.storageOperations = [];
       return;
     }
@@ -1789,7 +1789,7 @@ export function createRoom<
     }
   ) {
     if (
-      managedSocket.status !== "open" &&
+      managedSocket.getLegacyStatus() !== "open" &&
       !options.shouldQueueEventIfNotReady
     ) {
       return;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -415,7 +415,7 @@ export type Room<
    * metadata and connection ID (from the auth server).
    */
   isSelfAware(): boolean;
-  getConnectionState(): LegacyConnectionStatus;
+  getConnectionState(): LegacyConnectionStatus; // XXX Deprecate this in favor of getStatus()
   getStatus(): Status;
   readonly subscribe: SubscribeFn<TPresence, TStorage, TUserMeta, TRoomEvent>;
 
@@ -677,7 +677,7 @@ type RoomState<
     storageOperations: Op[];
   };
 
-  readonly connection: ValueRef<Connection>; // TODO Make this a derived property?
+  readonly connection: ValueRef<Connection>; // XXX Make this a derived property?
   readonly me: MeRef<TPresence>;
   readonly others: OthersRef<TPresence, TUserMeta>;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -889,6 +889,8 @@ export function createRoom<
     // combine them in a single batch.
     // tryFlushing();
 
+    // NOTE: Soon, once the actor ID assignment gets delayed until after the
+    // room connection happens, we won't know the connection ID here just yet.
     context.idFactory = makeIdFactory(sessionInfo.id);
 
     if (context.root) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -493,8 +493,9 @@ export type Room<
     readonly history: Observable<HistoryEvent>;
 
     /**
-     * Subscribe to the storage loaded event. Will fire at most once during the
-     * lifetime of a Room.
+     * Subscribe to the storage loaded event. Will fire any time a full Storage
+     * copy is downloaded. (This happens after the initial connect, and on
+     * every reconnect.)
      */
     readonly storageDidLoad: Observable<void>;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -282,12 +282,38 @@ type SubscribeFn<
   (type: "error", listener: ErrorCallback): () => void;
 
   /**
-   * Subscribe to connection state updates.
+   * @deprecated This API will be removed in a future version of Liveblocks.
+   * Prefer using the newer `.subscribe('status')` API.
+   *
+   * We recommend making the following changes if you use these APIs:
+   *
+   *     OLD APIs                       NEW APIs
+   *     .getConnectionState()     -->  .getStatus()
+   *     .subscribe('connection')  -->  .subscribe('status')
+   *
+   *     OLD STATUSES         NEW STATUSES
+   *     closed          -->  initial
+   *     authenticating  -->  connecting
+   *     connecting      -->  connecting
+   *     open            -->  connected
+   *     unavailable     -->  reconnecting
+   *     failed          -->  disconnected
+   *
+   * Subscribe to legacy connection status updates.
    *
    * @returns Unsubscribe function.
    *
    */
   (type: "connection", listener: Callback<LegacyConnectionStatus>): () => void;
+
+  /**
+   * Subscribe to connection status updates. The callback will be called any
+   * time the status changes.
+   *
+   * @returns Unsubscribe function.
+   *
+   */
+  (type: "status", listener: Callback<Status>): () => void;
 
   /**
    * Subscribes to changes made on a Live structure. Returns an unsubscribe function.
@@ -388,7 +414,29 @@ export type Room<
    * metadata and connection ID (from the auth server).
    */
   isSelfAware(): boolean;
-  getConnectionState(): LegacyConnectionStatus; // XXX Deprecate this in favor of getStatus()
+  /**
+   * @deprecated This API will be removed in a future version of Liveblocks.
+   * Prefer using `.getStatus()` instead.
+   *
+   * We recommend making the following changes if you use these APIs:
+   *
+   *     OLD APIs                       NEW APIs
+   *     .getConnectionState()     -->  .getStatus()
+   *     .subscribe('connection')  -->  .subscribe('status')
+   *
+   *     OLD STATUSES         NEW STATUSES
+   *     closed          -->  initial
+   *     authenticating  -->  connecting
+   *     connecting      -->  connecting
+   *     open            -->  connected
+   *     unavailable     -->  reconnecting
+   *     failed          -->  disconnected
+   */
+  getConnectionState(): LegacyConnectionStatus;
+  /**
+   * Return the current connection status for this room. Can be used to display
+   * a status badge for your Liveblocks connection.
+   */
   getStatus(): Status;
   readonly subscribe: SubscribeFn<TPresence, TStorage, TUserMeta, TRoomEvent>;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -73,7 +73,7 @@ export type Connection =
       sessionInfo?: never;
       lastSessionInfo: SessionInfo | null;
     }
-  /* Authentication succeeded, now attempting to connect to a room */
+  /* In the process of authenticating and establishing a WebSocket connection */
   | {
       status: "connecting";
       sessionInfo: SessionInfo | null;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -509,11 +509,11 @@ export type Room<
   getStorageSnapshot(): LiveObject<TStorage> | null;
 
   readonly events: {
+    readonly connection: Observable<LegacyConnectionStatus>;
     readonly customEvent: Observable<{ connectionId: number; event: TRoomEvent; }>; // prettier-ignore
     readonly me: Observable<TPresence>;
     readonly others: Observable<{ others: Others<TPresence, TUserMeta>; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
-    readonly connection: Observable<LegacyConnectionStatus>;
     readonly storage: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
 
@@ -1034,6 +1034,7 @@ export function createRoom<
   };
 
   const eventHub = {
+    connection: makeEventSource<LegacyConnectionStatus>(),
     customEvent: makeEventSource<CustomEvent<TRoomEvent>>(),
     me: makeEventSource<TPresence>(),
     others: makeEventSource<{
@@ -1041,7 +1042,6 @@ export function createRoom<
       event: OthersEvent<TPresence, TUserMeta>;
     }>(),
     error: makeEventSource<Error>(),
-    connection: makeEventSource<ConnectionStatus>(),
     storage: makeEventSource<StorageUpdate[]>(),
     history: makeEventSource<HistoryEvent>(),
     storageDidLoad: makeEventSource<void>(),
@@ -2010,11 +2010,11 @@ export function createRoom<
   );
 
   const events = {
+    connection: eventHub.connection.observable,
     customEvent: eventHub.customEvent.observable,
     others: eventHub.others.observable,
     me: eventHub.me.observable,
     error: eventHub.error.observable,
-    connection: eventHub.connection.observable,
     storage: eventHub.storage.observable,
     history: eventHub.history.observable,
     storageDidLoad: eventHub.storageDidLoad.observable,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -416,6 +416,7 @@ export type Room<
    */
   isSelfAware(): boolean;
   getConnectionState(): LegacyConnectionStatus;
+  getStatus(): Status;
   readonly subscribe: SubscribeFn<TPresence, TStorage, TUserMeta, TRoomEvent>;
 
   /**
@@ -2070,6 +2071,7 @@ export function createRoom<
     events,
 
     // Core
+    getStatus: () => managedSocket.getStatus(),
     getConnectionState: () => context.connection.current.status,
     isSelfAware: () => hasSessionInfo(context.connection.current),
     getSelf: () => self.current,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -630,18 +630,12 @@ function makeIdFactory(connectionId: number): IdFactory {
   return () => `${connectionId}:${count++}`;
 }
 
-function hasSessionInfo(connection: Connection): boolean {
-  return (
-    connection.status === "open" ||
-    connection.status === "connecting" ||
-    connection.lastSessionInfo !== null
-  );
+function getSessionInfo(connection: Connection): SessionInfo | null {
+  return connection.sessionInfo ?? connection.lastSessionInfo ?? null;
 }
 
-function getSessionInfo(connection: Connection): SessionInfo | null {
-  return connection.status === "open" || connection.status === "connecting"
-    ? connection.sessionInfo
-    : connection.lastSessionInfo;
+function hasSessionInfo(connection: Connection): boolean {
+  return getSessionInfo(connection) !== null;
 }
 
 type HistoryOp<TPresence extends JsonObject> =

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1598,8 +1598,8 @@ export function createRoom<
             const unacknowledgedOps = new Map(context.unacknowledgedOps);
             createOrUpdateRootFromMessage(message, doNotBatchUpdates);
             applyAndSendOps(unacknowledgedOps, doNotBatchUpdates);
-            if (_getInitialStateResolver !== null) {
-              _getInitialStateResolver();
+            if (_resolveInitialStatePromise !== null) {
+              _resolveInitialStatePromise();
             }
             notifyStorageStatus();
             eventHub.storageDidLoad.notify();
@@ -1761,14 +1761,14 @@ export function createRoom<
   }
 
   let _getInitialStatePromise: Promise<void> | null = null;
-  let _getInitialStateResolver: (() => void) | null = null;
+  let _resolveInitialStatePromise: (() => void) | null = null;
 
   function startLoadingStorage(): Promise<void> {
     if (_getInitialStatePromise === null) {
       context.buffer.messages.push({ type: ClientMsgCode.FETCH_STORAGE });
       tryFlushing();
       _getInitialStatePromise = new Promise(
-        (resolve) => (_getInitialStateResolver = resolve)
+        (resolve) => (_resolveInitialStatePromise = resolve)
       );
       notifyStorageStatus();
     }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -9,6 +9,7 @@ import type {
   LsonObject,
   Others,
   Room,
+  Status,
   User,
 } from "@liveblocks/client";
 import { shallow } from "@liveblocks/client";
@@ -212,6 +213,13 @@ export function createRoomContext<
       throw new Error("RoomProvider is missing from the react tree");
     }
     return room;
+  }
+
+  function useStatus(): Status {
+    const room = useRoom();
+    const subscribe = room.events.status.subscribe;
+    const getSnapshot = room.getStatus;
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   }
 
   function useMyPresence(): [
@@ -711,6 +719,7 @@ export function createRoomContext<
     RoomProvider,
 
     useRoom,
+    useStatus,
 
     useBatch,
     useBroadcastEvent,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -8,6 +8,7 @@ import type {
   LsonObject,
   Others,
   Room,
+  Status,
   User,
 } from "@liveblocks/client";
 import type { Resolve, RoomInitializers, ToImmutable } from "@liveblocks/core";
@@ -106,6 +107,12 @@ export type RoomContextBundle<
    * tree.
    */
   useRoom(): Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
+
+  /**
+   * Returns the current connection status for the Room, and triggers
+   * a re-render whenever it changes. Can be used to render a status badge.
+   */
+  useStatus(): Status;
 
   /**
    * Returns a function that batches modifications made during the given function.


### PR DESCRIPTION
This introduces a new API to get the room's status using much more user-friendly status names than what we currently offer. **This work is intended to land in the 1.1 release.**

```ts
// ❌ Current/deprecated statuses
room.getConnectionState();  // "closed" | "authenticating" | "connecting" | "open" | "unavailable" | "failed"

// ✅ New/simpler statuses
room.getStatus();  // "initial" | "connecting" | "connected" | "reconnecting" | "disconnected"
```

These should be more user friendly and suitable to display in an application, in the form of a status badge, much like we do in DevTools, too.

After switching to the new statuses, I was able to do some more internal cleanups as a result, which you can see in the diff.

This PR partially implements https://github.com/liveblocks/liveblocks/issues/878:
- [x] A new `room.getStatus()` accessor (to replace `room.getConnectionState()`, which is now deprecated)
- [x] A new `room.subscribe('status')` event (to replace `room.subscribe('connection')`, which is now deprecated)
- [x] For React, a new `useStatus()` hook, which can be used to easily display a connectivity badge
- [ ] **(won't be part of this PR)** The proposed `room.subscribe("reconnect")` subscription API
- [ ] **(won't be part of this PR)** The proposed `useReconnectListener()` hook

I may implement those last two in a separate PR, as I think this change is nice to merge in as-is already.
