### PR TITLE
New reconnection issue APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # v1.1.0-beta1
 
-This release improves the client's internals to ensure a more reliable
+This release improves the client’s internals to ensure a more reliable
 connection with Liveblocks servers.
 
 ### `@liveblocks/core`
 
 - New APIs:
-  - `room.getStatus()`  (`"initial"`, `"connecting"`, `"connected"`,
+  - `room.getStatus()` (`"initial"`, `"connecting"`, `"connected"`,
     `"reconnecting"`, `"disconnected"`)
-  - `room.subscribe('status')`
+  - `room.subscribe("status")`
+  - `room.subscribe("reconnection-issue")` - High-level API to get informed when
+    Liveblocks’ automatic reconnection process is taking longer than usual, so
+    you can show a toast message on screen.
 - Client will stop retrying to establish a connection in cases where retrying
   would not help (explicit unauthorized/forbidden response, or a configuration
   error)
@@ -17,8 +20,10 @@ connection with Liveblocks servers.
 
 - New APIs:
   - `useStatus()`
+  - `useReconnectionIssueListener()`
 
 ### Deprecated APIs
+
 These APIs still work, but are replaced by newer APIs. The old APIs will be
 removed in a future release of Liveblocks.
 

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -15,6 +15,7 @@ export type {
   Lson,
   LsonObject,
   Others,
+  ReconnectionIssueEvent,
   Room,
   Status,
   StorageStatus,

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -35,6 +35,20 @@ export type Status =
   | "reconnecting"
   | "disconnected";
 
+/**
+ * Used to report about app-level reconnection issues.
+ *
+ * Normal (quick) reconnects won't be reported about. Instead, the application
+ * will only get an event if the reconnection attempts by the client are taking
+ * (much) longer than usual. Definitely a situation you want to inform your
+ * users about, for example, by throwing a toast message on screen, or show
+ * a "trying to reconnect" banner.
+ */
+export type ReconnectionIssueEvent =
+  | "issue" // the client is trying to reconnect to Liveblocks, but it's taking (much) longer than usual
+  | "recovered" // the client did reconnect after all
+  | "error"; // the client was told to stop trying
+
 export function newToLegacyStatus(status: Status): LegacyConnectionStatus {
   switch (status) {
     case "connecting":

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -14,7 +14,11 @@
 export type { Client } from "./client";
 export { createClient } from "./client";
 export type { BaseAuthResult, Delegates } from "./connection";
-export type { LegacyConnectionStatus, Status } from "./connection";
+export type {
+  LegacyConnectionStatus,
+  ReconnectionIssueEvent,
+  Status,
+} from "./connection";
 export { LiveList } from "./crdts/LiveList";
 export { LiveMap } from "./crdts/LiveMap";
 export { LiveObject } from "./crdts/LiveObject";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -932,7 +932,7 @@ export function createRoom<
   }
 
   // Number of seconds of continuously being in "reconnecting" state
-  const RECONNECTION_ISSUE_THRESHOLD = 5000;
+  const RECONNECTION_ISSUE_THRESHOLD = 5000; // XXX Make this configurable as a client option
 
   let _reconnectionIssueTimerId: TimeoutID | undefined;
   let _hasReportedIssue = false;

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -8,6 +8,7 @@ import type {
   LiveObject,
   LsonObject,
   Others,
+  ReconnectionIssueEvent,
   Room,
   Status,
   User,
@@ -354,6 +355,25 @@ export function createRoomContext<
       ) => {
         room.broadcastEvent(event, options);
       },
+      [room]
+    );
+  }
+
+  function useReconnectionIssueListener(
+    callback: (event: ReconnectionIssueEvent) => void
+  ): void {
+    const room = useRoom();
+    const savedCallback = React.useRef(callback);
+
+    React.useEffect(() => {
+      savedCallback.current = callback;
+    });
+
+    React.useEffect(
+      () =>
+        room.events.reconnectionIssue.subscribe(
+          (event: ReconnectionIssueEvent) => savedCallback.current(event)
+        ),
       [room]
     );
   }
@@ -723,6 +743,7 @@ export function createRoomContext<
 
     useBatch,
     useBroadcastEvent,
+    useReconnectionIssueListener,
     useErrorListener,
     useEventListener,
 
@@ -759,6 +780,7 @@ export function createRoomContext<
 
       useBatch,
       useBroadcastEvent,
+      useReconnectionIssueListener,
       useErrorListener,
       useEventListener,
 

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -7,6 +7,7 @@ import type {
   LiveObject,
   LsonObject,
   Others,
+  ReconnectionIssueEvent,
   Room,
   Status,
   User,
@@ -131,6 +132,30 @@ export type RoomContextBundle<
    * broadcast({ type: "CUSTOM_EVENT", data: { x: 0, y: 0 } });
    */
   useBroadcastEvent(): (event: TRoomEvent, options?: BroadcastOptions) => void;
+
+  /**
+   * Get informed when reconnecting to the Liveblocks servers is taking
+   * longer than usual. This typically is a sign of a client that has lost
+   * internet connectivity.
+   *
+   * This isn't problematic (because the Liveblocks client is still trying to
+   * reconnect), but it's typically a good idea to inform users about it if
+   * the connection takes too long to recover.
+   *
+   * @example
+   * useReconnectionIssueListener(event => {
+   *   if (event === 'issue') {
+   *     toast.warn('Reconnecting to the Liveblocks servers is taking longer than usual...')
+   *   } else if (event === 'error') {
+   *     toast.warn('Reconnecting to the Liveblocks servers failed.')
+   *   } else if (event === 'recovered') {
+   *     toast.clear();
+   *   }
+   * })
+   */
+  useReconnectionIssueListener(
+    callback: (event: ReconnectionIssueEvent) => void
+  ): void;
 
   /**
    * useErrorListener is a react hook that lets you react to potential room connection errors.
@@ -540,6 +565,30 @@ export type RoomContextBundle<
       event: TRoomEvent,
       options?: BroadcastOptions
     ) => void;
+
+    /**
+     * Get informed when reconnecting to the Liveblocks servers is taking
+     * longer than usual. This typically is a sign of a client that has lost
+     * internet connectivity.
+     *
+     * This isn't problematic (because the Liveblocks client is still trying to
+     * reconnect), but it's typically a good idea to inform users about it if
+     * the connection takes too long to recover.
+     *
+     * @example
+     * useReconnectionIssueListener(event => {
+     *   if (event === 'issue') {
+     *     toast.warn('Reconnecting to the Liveblocks servers is taking longer than usual...')
+     *   } else if (event === 'error') {
+     *     toast.warn('Reconnecting to the Liveblocks servers failed.')
+     *   } else if (event === 'recovered') {
+     *     toast.clear();
+     *   }
+     * })
+     */
+    useReconnectionIssueListener(
+      callback: (event: ReconnectionIssueEvent) => void
+    ): void;
 
     /**
      * useErrorListener is a react hook that lets you react to potential room connection errors.


### PR DESCRIPTION
This implements the second part of the [high-level status API proposal](https://github.com/liveblocks/liveblocks/issues/878): the API to get informed about the exceptional condition when the client is having trouble to reconnect you to a room that you have previously succesfully connected to.

This is an important event from an application developer's perspective, because it will be important to let the user of the application know that there hasn't been a connection to the server for a longer-than-usual amount of time. Technically: the room is and has been in a `"reconnecting"` state for longer than 5 seconds (or whatever configured).

When this happens, you'll want to throw a toast message on screen, or turn the application canvas grayscale, or make it read-only, or however you want to indicate this to your users. Every professional Liveblocks application will have to handle this state, but doing so (and doing it right) was a pain before this API exists.

## Naming
Naming this API is _hard_. We'll want to pick a name that is simple, clear, and that will not be confused with the existing APIs we have.

**This API is only there to help the app developer to notify their end users about exceptional connectivity circumstances.** These events will **never** fire under normal/expected conditions. For example, if an application reconnects quickly (`connected` → `reconnecting` → `connected` within 5 seconds), none of these events will ever be fired.

Here is the meaning of each of the possible events:
1. `"issue"`: fired when the client has been in `"reconnecting"` state for 5 seconds. It should not take this long normally, so we're informing the end user about this.
2. `"recovered"`: fired if the client succesfully got back to `"connected"` state after all. Is only emitted if (1) was fired prior.
3. `"failed"`: fired if the client transitioned from `"reconnecting"` → `"disconnected"` directly. This means the client wasn't able to reconnect, and it has stopped trying. This only happens when explicitly forbidden to reconnect, so a rare condition.

| Subscribe API `room.subscribe(...)` | React hook | Event names | Why rejected |
|--------|--------|--------|--------|
| ⭐ `"reconnection-issue"` | `useReconnectionIssueListener` | `"issue"`, `"recovered"`, `"failed"` | – |
| `reconnect` | `useReconnectListener` | `"reconnecting"`, `"reconnected"`, `"disconnected"` | Too similar to our status names. |
| `offline` | `useOfflineListener` | `"offline"`, `"online"`, `"failed"` | We're not technically offline. We're just trying to reestablish the connection (which is fine), it's just taking us longer than normal. It _could_ be the case that this is because your browser is offline, but not only because of that. Also, it may make people think of "navigator offline" events the browser gets. |
| `network-issue` | `useNetworkIssueListener` | … | It's not technically correct. Network issues _could_ be the cause, but it can also be different reasons why reconnecting is slower than normally. |
| `connectivity` | `useConnectivityListener` | … | We currently have `room.subscribe("connection")`. Even though that API is being deprecated in this release, introducing `"connectivity"` as a new (and different) event source would be confusing. |
| `quality` | `useConnectionQualityListener` | `"degraded"`, `"restored"`, `"lost"` | These are bad names, because the connection to the server is already nonexistent for at least 5 seconds when this "degraded" would be sent, so "degraded" is an understatement. |
| ??? | ??? | ??? | ??? |

🙏  Please, if you have better name suggestions… let me know!
