### PR TITLE
[doc] update room id limit section

### DIFF
--- a/docs/pages/guides/limits.mdx
+++ b/docs/pages/guides/limits.mdx
@@ -24,7 +24,7 @@ take a look at the [pricing guide](/docs/guides/pricing).
 
 ### Room `id`
 
-A room `id` cannot exceed 128 characters.
+A room `id` cannot exceed 128 characters and cannot contain `*`.
 
 ### User `id`
 


### PR DESCRIPTION
Update the documentation section about room ID limit, to inform that an id cannot contain `*`.