### PR TITLE
Fix DevTools to work with upcoming 1.1 beta, too

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -118,7 +118,8 @@ If you are using CommonJS, downgrade `node-fetch` to v2.
 
 ### WebSocket throttle [#createClientThrottle]
 
-By default, the client throttle the WebSocket messages sent to 100 milliseconds.
+By default, the client throttles the WebSocket messages sent to 100
+milliseconds.
 
 It is possible to override that configuration with the `throttle` option.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6590,9 +6590,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001429",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-      "integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==",
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6601,6 +6601,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -24463,9 +24467,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001429",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
-      "integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg=="
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg=="
     },
     "capital-case": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17996,7 +17996,7 @@
     },
     "packages/liveblocks-devtools": {
       "name": "@liveblocks/devtools",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@liveblocks/core": "*",
         "@plasmohq/storage": "^0.14.0",

--- a/packages/liveblocks-core/src/devtools/bridge.ts
+++ b/packages/liveblocks-core/src/devtools/bridge.ts
@@ -67,7 +67,7 @@ if (process.env.NODE_ENV !== "production" && typeof window !== "undefined") {
       //   "%c[client ← panel] %c%s",
       //   "color: purple",
       //   "color: purple; font-weight: bold",
-      //   event.data.msg,
+      //   (event.data as Record<string, unknown>).msg,
       //   event.data
       // );
       eventSource.notify(event.data as DevTools.FullPanelToClientMessage);

--- a/packages/liveblocks-devtools/README.md
+++ b/packages/liveblocks-devtools/README.md
@@ -40,8 +40,7 @@ Download the extension for your browser:
 
 ### Chrome
 
-1. Run `turbo build --filter @liveblocks/devtools` from the project root to
-   build the browser extension
+1. Run `turbo build` from this directory to build the browser extension
 1. Navigate to [chrome://extensions](chrome://extensions)
 1. Disable the production Liveblocks extension, if you already have it installed
    (it will conflict with the development version)
@@ -51,8 +50,7 @@ Download the extension for your browser:
 
 ### Firefox
 
-1. Run `turbo build:firefox --filter @liveblocks/devtools` from the project root
-   to build the browser extension
+1. Run `turbo build:firefox` from this directory to build the browser extension
 1. Navigate to
    [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox)
 1. Disable the production Liveblocks extension, if you already have it installed

--- a/packages/liveblocks-devtools/package.json
+++ b/packages/liveblocks-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/devtools",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "displayName": "Liveblocks DevTools",
   "description": "A browser extension that lets you inspect Liveblocks real-time collaborative experiences. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",

--- a/packages/liveblocks-devtools/src/devtools/tabs/presence.tsx
+++ b/packages/liveblocks-devtools/src/devtools/tabs/presence.tsx
@@ -13,7 +13,11 @@ export function Presence({ className, ...props }: ComponentProps<"div">) {
   const others = useOthers();
   const presence = useMemo(() => (me ? [me, ...others] : others), [me, others]);
 
-  if (currentStatus === "open") {
+  if (
+    currentStatus === "connected" ||
+    currentStatus === "open" || // Same as "connected", but only sent by old clients (prior to 1.1)
+    currentStatus === "reconnecting"
+  ) {
     if (presence.length > 0) {
       return (
         <div

--- a/packages/liveblocks-devtools/src/devtools/tabs/storage.tsx
+++ b/packages/liveblocks-devtools/src/devtools/tabs/storage.tsx
@@ -52,7 +52,11 @@ export function Storage({
     []
   );
 
-  if (currentStatus === "open") {
+  if (
+    currentStatus === "connected" ||
+    currentStatus === "open" || // Same as "connected", but only sent by old clients (prior to 1.1)
+    currentStatus === "reconnecting"
+  ) {
     if (filteredStorage.length > 0) {
       return (
         <div className={cx(className, "absolute inset-0")} {...props}>

--- a/packages/liveblocks-devtools/turbo.json
+++ b/packages/liveblocks-devtools/turbo.json
@@ -2,12 +2,16 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "pipeline": {
+    "build": {
+      "outputs": ["dist/chrome-**"]
+    },
     "dev:firefox": {
       "dependsOn": ["^build"],
       "cache": false
     },
     "build:firefox": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/firefox-**"]
     }
   }
 }


### PR DESCRIPTION
Follow-up on #927. Storage/Presence views would only be rendered when status is `"open"`. This needed to be update for the new status values.