### PR TITLE
Add support for Starter Kit in deploy-checking script

### DIFF
--- a/scripts/should-rebuild-on-vercel.sh
+++ b/scripts/should-rebuild-on-vercel.sh
@@ -117,8 +117,7 @@ get_all_changed_files () {
 #
 get_interesting_changed_files () {
     get_all_changed_files \
-      | grep -Ee '^examples/' \
-      | grep -Ee '^starter-kits/' \
+      | grep -Ee '^(examples|starter-kits)/' \
       | grep -vEe "/[.]" \
       | grep -vEe "(\.md)\$" \
       | grep -vEe "\b(test|jest)\b"


### PR DESCRIPTION
This PR attempts to make our deploy-checking script more generic to support other things than examples (by supporting any path), it would only add support for the Starter Kit for now.

When/if we merge this, right before, we'll update the "ignore" commands for all projects in Vercel. Because of that, all existing branches will have to rebase on `main` to get the new script and pass their builds.