### PR TITLE
Fix future reconnection bug

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_behaviors.ts
+++ b/packages/liveblocks-core/src/__tests__/_behaviors.ts
@@ -11,6 +11,7 @@
 import { StopRetrying } from "../connection";
 import type { RichToken } from "../protocol/AuthToken";
 import type { RoomDelegates } from "../room";
+import type { WebsocketCloseCodes } from "../types/IWebSocket";
 import type { MockWebSocket } from "./_MockWebSocketServer";
 import { MockWebSocketServer } from "./_MockWebSocketServer";
 import { makeRoomToken } from "./_utils";
@@ -116,6 +117,29 @@ export function SOCKET_THROWS(errmsg: string = "You shall not pass") {
   return (_wss: MockWebSocketServer) => {
     throw new Error(errmsg);
   };
+}
+
+/**
+ * Configures the MockWebSocketServer to accept-and-immediately-close the
+ * connection.
+ */
+export function SOCKET_REFUSES(
+  code: WebsocketCloseCodes,
+  reason: string = "No good reason"
+): SocketBehavior {
+  return (wss: MockWebSocketServer) =>
+    wss.newSocket((socket) => {
+      // Accept-then-immediately-close the connection. This is how the
+      // websocket server will refuse a connection that isn't allowed.
+      socket.server.accept();
+      socket.server.close(
+        new CloseEvent("close", {
+          reason,
+          code,
+          wasClean: true,
+        })
+      );
+    });
 }
 
 /**

--- a/packages/liveblocks-core/src/__tests__/_waitUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_waitUtils.ts
@@ -34,7 +34,8 @@ export async function waitFor(predicate: () => boolean): Promise<void> {
  */
 export async function waitUntilStatus(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>,
-  targetStatus: Status
+  targetStatus: Status,
+  timeout = 1000
 ): Promise<void> {
   if (room.getStatus() === targetStatus) {
     return;
@@ -42,8 +43,10 @@ export async function waitUntilStatus(
 
   await withTimeout(
     room.events.status.waitUntil((status) => status === targetStatus),
-    1000,
-    `Room did not reach connection status "${targetStatus}" within 1s`
+    timeout,
+    `Room did not reach connection status "${targetStatus}" within ${
+      timeout / 1000
+    }s`
   );
 }
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -364,8 +364,7 @@ describe("room", () => {
           "Room full"
         ),
         SOCKET_AUTOCONNECT // Repeated to infinity
-      ),
-      { enableDebugLogging: true } // XXX Remove!
+      )
     );
     room.connect();
 

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -272,9 +272,7 @@ function logPrematureErrorOrCloseEvent(e: IWebSocketEvent | Error) {
     } else {
       console.warn(
         isCloseEvent(e)
-          ? `${conn} closed prematurely (code: ${
-              (e as IWebSocketCloseEvent).code
-            }). Retrying in ${ctx.backoffDelay}ms.`
+          ? `${conn} closed prematurely (code: ${e.code}). Retrying in ${ctx.backoffDelay}ms.`
           : `${conn} could not be established.`
       );
     }

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -67,6 +67,7 @@ export function newToLegacyStatus(status: Status): LegacyConnectionStatus {
     case "initial":
       return "closed";
 
+    // istanbul ignore next
     default:
       return "closed";
   }
@@ -94,6 +95,7 @@ function toNewConnectionStatus(machine: FSM<Context, Event, State>): Status {
     case "@idle.failed":
       return "disconnected";
 
+    // istanbul ignore next
     default:
       return assertNever(state, "Unknown state");
   }
@@ -546,6 +548,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
 
         const connect$ = new Promise<[IWebSocketInstance, () => void]>(
           (resolve, rej) => {
+            // istanbul ignore next
             if (ctx.token === null) {
               throw new Error("No auth token"); // This should never happen
             }

--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -49,10 +49,10 @@ export enum WebsocketCloseCodes {
   CLOSE_ABNORMAL = 1006,
 
   INVALID_MESSAGE_FORMAT = 4000,
-  NOT_ALLOWED = 4001,
+  NOT_ALLOWED = 4001, // Not allowed with the current token, force the client to get a new auth token before retrying
   MAX_NUMBER_OF_MESSAGES_PER_SECONDS = 4002,
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS = 4003,
   MAX_NUMBER_OF_MESSAGES_PER_DAY_PER_APP = 4004,
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS_PER_ROOM = 4005,
-  CLOSE_WITHOUT_RETRY = 4999,
+  CLOSE_WITHOUT_RETRY = 4999, // Puts the client in "disconnected" state, don't try to connect again
 }


### PR DESCRIPTION
I found a small suboptimalness in our reconnecting logic that would be a (small) bug in the near future (when our new authentication method would land).

When connecting a socket, we should not fall back to re-authenticate in cases where for example the room is full. We just have to back off and try again with the same token. This is differently for cases where there is an explicit "Not Allowed" (4001) code sent by the server (which explicitly asks to re-auth), or an _unexpected_ error (which _could_ be a re-auth case which we cannot detect, so we have to err on the safe end and re-auth anyway).

Similarly, the machine wasn't responding to 4999 codes yet (which should put the client in "disconnected" state explicitly) when coming back from the WebSocket server.

Please note that these test cases address _future_ issues. Our WebSocket server currently does not refuse connections with 4001 Not Allowed or 4999 Close Without Retry just yet, but it will in the (very) near future. The client is adjusted in this PR to respond appropriately in these cases.
