### PR TITLE
Detect network lost events sooner by listening to browser hints

### DIFF
--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -710,7 +710,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
       WINDOW_GOT_FOCUS: { target: "@ok.awaiting-pong", effect: sendHeartbeat },
     });
 
-  const noPongAction: Target<Context, Event | BuiltinEvent, State> = {
+  const implicitNetworkLoss: Target<Context, Event | BuiltinEvent, State> = {
     target: "@connecting.busy",
     // Log implicit connection loss and drop the current open socket
     effect: log(
@@ -741,8 +741,8 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
       };
     })
 
-    .addTimedTransition("@ok.awaiting-pong", PONG_TIMEOUT, noPongAction)
-    .addTransitions("@ok.awaiting-pong", { PONG_TIMEOUT: noPongAction }) // Only needed for E2E testing application
+    .addTimedTransition("@ok.awaiting-pong", PONG_TIMEOUT, implicitNetworkLoss)
+    .addTransitions("@ok.awaiting-pong", { PONG_TIMEOUT: implicitNetworkLoss }) // Only needed for E2E testing application
 
     .addTransitions("@ok.awaiting-pong", { PONG: "@ok.connected" })
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2104,7 +2104,7 @@ export function createRoom<
       send: {
         // These exist only for our E2E testing app
         explicitClose: (event) => managedSocket._privateSendMachineEvent({ type: "EXPLICIT_SOCKET_CLOSE", event }),
-        implicitClose: () => managedSocket._privateSendMachineEvent({ type: "PONG_TIMEOUT" }),
+        implicitClose: () => managedSocket._privateSendMachineEvent({ type: "NAVIGATOR_OFFLINE" }), // XXX ...or just keep it?
       },
     },
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2104,7 +2104,7 @@ export function createRoom<
       send: {
         // These exist only for our E2E testing app
         explicitClose: (event) => managedSocket._privateSendMachineEvent({ type: "EXPLICIT_SOCKET_CLOSE", event }),
-        implicitClose: () => managedSocket._privateSendMachineEvent({ type: "NAVIGATOR_OFFLINE" }), // XXX ...or just keep it?
+        implicitClose: () => managedSocket._privateSendMachineEvent({ type: "NAVIGATOR_OFFLINE" }),
       },
     },
 


### PR DESCRIPTION
This PR makes the managed socket listen to browser's `"offline"` events to trigger a heartbeat as soon as possible — basically running a quick network test to ensure the network is actually offline when a browser reports it is. We do this double-check because the `"offline"` event is known to sometimes report false negatives (where it says the network is offline even though it's not). If so, no problem: we are still connected. If not, great: we can now start reconnecting as soon as possible.
