### PR TITLE
Fix @liveblocks/react lint script

### DIFF
--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -14,7 +14,7 @@
     "build": "tsup",
     "start": "tsup --watch",
     "format": "eslint --fix src/; prettier --write src/",
-    "lint": "eslint src/; npm run check:exports",
+    "lint": "eslint src/ && npm run check:exports",
     "check:exports": "tsc scripts/check-factory-exports.ts && node scripts/check-factory-exports.js",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"


### PR DESCRIPTION
## Description

Linting fails in package `@liveblocks/react` when running `npm run lint` due to the lint path being `src/;`. 

### Before
```
@liveblocks/react:lint: 
@liveblocks/react:lint: > @liveblocks/react@1.0.12 lint
@liveblocks/react:lint: > eslint src/; npm run check:exports
@liveblocks/react:lint:
@liveblocks/react:lint: Oops! Something went wrong! :(
@liveblocks/react:lint:
@liveblocks/react:lint: ESLint: 8.38.0
@liveblocks/react:lint:
@liveblocks/react:lint: No files matching the pattern "src/;" were found.
@liveblocks/react:lint: Please check for typing mistakes in the pattern.
@liveblocks/react:lint:
@liveblocks/react:lint: npm ERR! Lifecycle script `lint` failed with error:
@liveblocks/react:lint: npm ERR! Error: command failed
@liveblocks/react:lint: npm ERR!   in workspace: @liveblocks/react@1.0.12
```

### After
```
@liveblocks/react:lint: 
@liveblocks/react:lint: > @liveblocks/react@1.0.12 lint
@liveblocks/react:lint: > eslint src/ && npm run check:exports
@liveblocks/react:lint:
@liveblocks/react:lint: > @liveblocks/react@1.0.12 check:exports
@liveblocks/react:lint: > tsc scripts/check-factory-exports.ts && node scripts/check-factory-exports.js
@liveblocks/react:lint:
```