### PR TITLE
Fix format & lint scripts for all `package.json`

### DIFF
--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always --passWithNoTests",
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always --passWithNoTests",
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:types": "tsd",

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:types": "tsd",

--- a/packages/liveblocks-devtools/package.json
+++ b/packages/liveblocks-devtools/package.json
@@ -11,7 +11,7 @@
     "build": "tsc && plasmo build --build-path=dist --zip",
     "build:firefox": "tsc && plasmo build --build-path=dist --zip --target=firefox-mv2",
     "lint": "eslint src/",
-    "format": "eslint --fix src/ && prettier --write src/"
+    "format": "(eslint --fix src/ || true) && prettier --write src/"
   },
   "dependencies": {
     "@liveblocks/core": "*",

--- a/packages/liveblocks-devtools/package.json
+++ b/packages/liveblocks-devtools/package.json
@@ -11,7 +11,7 @@
     "build": "tsc && plasmo build --build-path=dist --zip",
     "build:firefox": "tsc && plasmo build --build-path=dist --zip --target=firefox-mv2",
     "lint": "eslint src/",
-    "format": "eslint --fix src/; prettier --write src/"
+    "format": "eslint --fix src/ && prettier --write src/"
   },
   "dependencies": {
     "@liveblocks/core": "*",

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -13,7 +13,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "start": "tsup --watch",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/; npm run check:exports",
     "check:exports": "tsc scripts/check-factory-exports.ts && node scripts/check-factory-exports.js",
     "test": "jest --silent --verbose --color=always",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -13,8 +13,8 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "start": "tsup --watch",
-    "format": "eslint --fix src/ && prettier --write src/",
-    "lint": "eslint src/; npm run check:exports",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
+    "lint": "(eslint src/ || true) && npm run check:exports",
     "check:exports": "tsc scripts/check-factory-exports.ts && node scripts/check-factory-exports.js",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:types": "tsd",

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "lint": "eslint src/",
     "test": "jest --silent --verbose --color=always",
     "test:types": "tsd",

--- a/schema-lang/codemirror-language/package.json
+++ b/schema-lang/codemirror-language/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint src/",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "test": "jest --colors --verbose --no-coverage"
   },
   "repository": {

--- a/schema-lang/codemirror-language/package.json
+++ b/schema-lang/codemirror-language/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint src/",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "test": "jest --colors --verbose --no-coverage"
   },
   "repository": {

--- a/schema-lang/infer-schema/package.json
+++ b/schema-lang/infer-schema/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint src/",
-    "format": "eslint --fix src/ ; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "test": "jest --colors --verbose --no-coverage"
   },
   "repository": {

--- a/schema-lang/infer-schema/package.json
+++ b/schema-lang/infer-schema/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint src/",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "test": "jest --colors --verbose --no-coverage"
   },
   "repository": {

--- a/schema-lang/liveblocks-schema/package.json
+++ b/schema-lang/liveblocks-schema/package.json
@@ -13,7 +13,7 @@
     "build:ast": "generate-ast src/ast/ast.grammar src/ast/index.ts && tsc --noEmit src/ast/index.ts && node bin/update-returntypes.js",
     "build:parser": "bin/build-parser && tsc --noEmit src/parser/generated-parser.ts",
     "lint": "eslint src/",
-    "format": "eslint --fix src/; prettier --write src/",
+    "format": "eslint --fix src/ && prettier --write src/",
     "test": "jest --colors --verbose --no-coverage"
   },
   "repository": {

--- a/schema-lang/liveblocks-schema/package.json
+++ b/schema-lang/liveblocks-schema/package.json
@@ -13,7 +13,7 @@
     "build:ast": "generate-ast src/ast/ast.grammar src/ast/index.ts && tsc --noEmit src/ast/index.ts && node bin/update-returntypes.js",
     "build:parser": "bin/build-parser && tsc --noEmit src/parser/generated-parser.ts",
     "lint": "eslint src/",
-    "format": "eslint --fix src/ && prettier --write src/",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
     "test": "jest --colors --verbose --no-coverage"
   },
   "repository": {

--- a/schema-lang/vscode-extension/package.json
+++ b/schema-lang/vscode-extension/package.json
@@ -17,7 +17,7 @@
     "build": "npm run esbuild -- --sourcemap",
     "dev": "npm run esbuild -- --sourcemap --watch",
     "lint": "eslint src/",
-    "format": "eslint --fix src/; prettier --write src/"
+    "format": "eslint --fix src/ && prettier --write src/"
   },
   "contributes": {
     "languages": [

--- a/schema-lang/vscode-extension/package.json
+++ b/schema-lang/vscode-extension/package.json
@@ -17,7 +17,7 @@
     "build": "npm run esbuild -- --sourcemap",
     "dev": "npm run esbuild -- --sourcemap --watch",
     "lint": "eslint src/",
-    "format": "eslint --fix src/ && prettier --write src/"
+    "format": "(eslint --fix src/ || true) && prettier --write src/"
   },
   "contributes": {
     "languages": [


### PR DESCRIPTION
## Description

Semicolon is apparently not a valid command separator in Windows, so `npm run format` will fail when running locally. To preserve the original behavior of running prettier even if eslint fails, the command is wrapped like so:
```json
"format": "(eslint --fix src/ || true) && prettier --write src/"
```