### PR TITLE
Add unit test for patching `LiveList` state using `set` update type

### DIFF
--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -914,6 +914,41 @@ describe("legacy_patchImmutableObject", () => {
     });
   });
 
+  test("replace an element in Array/LiveList", () => {
+    const state = {
+      list: [{ a: 1 }, { a: 2 }, { a: 3 }],
+    };
+
+    const root = new LiveObject<{
+      list: typeof liveList;
+    }>();
+    const liveList = new LiveList<LiveObject<{ a: number }>>();
+    liveList.push(new LiveObject({ a: 1 }));
+    liveList.push(new LiveObject({ a: 2 }));
+    liveList.push(new LiveObject({ a: 3 }));
+    const obj1 = new LiveObject({ a: 4 });
+    liveList.set(1, obj1);
+    root.set("list", liveList);
+
+    const updates: StorageUpdate[] = [
+      {
+        type: "LiveList",
+        node: root.get("list"),
+        updates: [{ index: 1, item: obj1, type: "set" }],
+      },
+    ];
+
+    const newState = legacy_patchImmutableObject(state, updates);
+
+    expect(newState.list[0] === state.list[0]).toBeTruthy();
+    expect(newState.list[1] === state.list[1]).toBeFalsy();
+    expect(newState.list[2] === state.list[2]).toBeTruthy();
+
+    expect(newState).toEqual({
+      list: [{ a: 1 }, { a: 4 }, { a: 3 }],
+    });
+  });
+
   test("insert element at the end of Array/LiveList", () => {
     const state = {
       list: [{ a: 1 }, { a: 2 }],


### PR DESCRIPTION
<!--
## For Contributors

### Fixing a bug

- Provide helpful info for reviewer:
  - Steps to reproduce
  - A clear and concise description of the problem that the bug is causing.
  - Steps to reproduce the issue, if applicable.
  - An explanation of the changes made to fix the bug, including any relevant code snippets.
  - Any new or updated tests that were added to ensure that the bug is fully resolved.
  - A summary of any potential side effects that could result from the bug fix, if any.
  - A list of any other related issues or PRs that may be impacted by the bug fix.
 -->
## Description

Fixes #293. This test ensures expected behavior of `legacy_patchImmutableObject` when patching `LiveList` state via `set` update. Redux and Zustand packages are expected to continue using the legacy patch functions until a reimplementation using `.toImmutable()` is done.

Local testing shows successful coverage.

![image](https://github.com/liveblocks/liveblocks/assets/24194862/27464d41-3ca2-430d-a98e-85b6317f6727)
