### PR TITLE
Clean up exported auth types

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_behaviors.ts
+++ b/packages/liveblocks-core/src/__tests__/_behaviors.ts
@@ -9,17 +9,17 @@
  */
 
 import { StopRetrying } from "../connection";
-import type { RichToken } from "../protocol/AuthToken";
+import type { ParsedAuthToken } from "../protocol/AuthToken";
 import type { RoomDelegates } from "../room";
 import type { WebsocketCloseCodes } from "../types/IWebSocket";
 import type { MockWebSocket } from "./_MockWebSocketServer";
 import { MockWebSocketServer } from "./_MockWebSocketServer";
 import { makeMinimalTokenPayload } from "./_utils";
 
-type AuthBehavior = () => RichToken;
+type AuthBehavior = () => ParsedAuthToken;
 type SocketBehavior = (wss: MockWebSocketServer) => MockWebSocket;
 
-function makeRichToken(actor: number, scopes: string[]): RichToken {
+function makeToken(actor: number, scopes: string[]): ParsedAuthToken {
   return {
     raw: "<some fake JWT token>",
     parsed: makeMinimalTokenPayload(actor, scopes),
@@ -73,7 +73,7 @@ export function defineBehavior(
 export const AUTH_SUCCESS = ALWAYS_AUTH_AS(1);
 
 export function ALWAYS_AUTH_AS(actor: number, scopes: string[] = []) {
-  return () => makeRichToken(actor, scopes);
+  return () => makeToken(actor, scopes);
 }
 
 export function ALWAYS_FAIL_AUTH(): never {

--- a/packages/liveblocks-core/src/__tests__/_behaviors.ts
+++ b/packages/liveblocks-core/src/__tests__/_behaviors.ts
@@ -14,19 +14,16 @@ import type { RoomDelegates } from "../room";
 import type { WebsocketCloseCodes } from "../types/IWebSocket";
 import type { MockWebSocket } from "./_MockWebSocketServer";
 import { MockWebSocketServer } from "./_MockWebSocketServer";
-import { makeRoomToken } from "./_utils";
+import { makeMinimalTokenPayload } from "./_utils";
 
 type AuthBehavior = () => RichToken;
 type SocketBehavior = (wss: MockWebSocketServer) => MockWebSocket;
 
 function makeRichToken(actor: number, scopes: string[]): RichToken {
-  const raw = "<some fake JWT token>";
-  const parsed = {
-    ...makeRoomToken(actor, scopes),
-    iat: Date.now() / 1000,
-    exp: Date.now() / 1000 + 60, // Valid for 1 minute
+  return {
+    raw: "<some fake JWT token>",
+    parsed: makeMinimalTokenPayload(actor, scopes),
   };
-  return { raw, parsed };
 }
 
 /**

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -34,7 +34,7 @@ import { MockWebSocket } from "./_MockWebSocketServer";
 import type { JsonStorageUpdate } from "./_updatesUtils";
 import { serializeUpdateToJson } from "./_updatesUtils";
 
-export function makeRoomToken(
+export function makeMinimalTokenPayload(
   actor: number,
   scopes: string[]
 ): MinimalTokenPayload {
@@ -43,6 +43,8 @@ export function makeRoomToken(
   // defined in the (private) backend in case you're interested, see
   // https://github.com/liveblocks/liveblocks-cloudflare/blob/main/src/security.ts
   return {
+    iat: Date.now() / 1000,
+    exp: Date.now() / 1000 + 60, // Valid for 1 minute
     appId: "my-app",
     roomId: "my-room",
     id: "user1",

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -4,7 +4,7 @@ import type { ToImmutable } from "../crdts/utils";
 import type { Json, JsonObject } from "../lib/Json";
 import { makePosition } from "../lib/position";
 import type { Authentication } from "../protocol/Authentication";
-import type { RoomAuthToken } from "../protocol/AuthToken";
+import type { MinimalTokenPayload } from "../protocol/AuthToken";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import type { ClientMsg } from "../protocol/ClientMsg";
 import { ClientMsgCode } from "../protocol/ClientMsg";
@@ -34,7 +34,14 @@ import { MockWebSocket } from "./_MockWebSocketServer";
 import type { JsonStorageUpdate } from "./_updatesUtils";
 import { serializeUpdateToJson } from "./_updatesUtils";
 
-export function makeRoomToken(actor: number, scopes: string[]): RoomAuthToken {
+export function makeRoomToken(
+  actor: number,
+  scopes: string[]
+): MinimalTokenPayload {
+  // NOTE: This is not the complete JWT token, but one that has enough fields
+  // to we can run the unit tests. The actual full shape of these JWT tokens is
+  // defined in the (private) backend in case you're interested, see
+  // https://github.com/liveblocks/liveblocks-cloudflare/blob/main/src/security.ts
   return {
     appId: "my-app",
     roomId: "my-room",

--- a/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/AuthToken.test.ts
@@ -1,7 +1,7 @@
 import type { JwtMetadata } from "../../protocol/AuthToken";
 import {
   isTokenExpired,
-  parseRoomAuthToken,
+  parseAuthToken,
   RoomScope,
 } from "../../protocol/AuthToken";
 
@@ -55,7 +55,7 @@ describe("parseRoomAuthToken", () => {
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MTY3MjM2NjcsImV4cCI6MTYxNjcyNzI2NywiYXBwSWQiOiI2MDVhNGZkMzFhMzZkNWVhN2EyZTA5MTQiLCJzY29wZXMiOlsicm9vbTpyZWFkIiwicm9vbTp3cml0ZSJdfQ.7Wplt6YV_YbpPAcAFyC8pX8tk5BGNy53GdoH1_u8sjo";
 
   test("should parse a valid token", () => {
-    const { parsed } = parseRoomAuthToken(roomToken);
+    const { parsed } = parseAuthToken(roomToken);
     expect(parsed).toEqual({
       actor: 87,
       appId: "605a4fd31a36d5ea7a2e08f1",
@@ -68,7 +68,7 @@ describe("parseRoomAuthToken", () => {
 
   test("should throw if token is not a room token", () => {
     try {
-      parseRoomAuthToken(apiToken);
+      parseAuthToken(apiToken);
     } catch (error) {
       expect(error).toEqual(
         new Error(

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -61,8 +61,6 @@ export {
   tryParseJson,
   withTimeout,
 } from "./lib/utils";
-export type { AuthToken, RoomAuthToken } from "./protocol/AuthToken";
-export { isAuthToken, isRoomAuthToken } from "./protocol/AuthToken";
 export type { BaseUserMeta } from "./protocol/BaseUserMeta";
 export type {
   BroadcastEventClientMsg,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -61,16 +61,8 @@ export {
   tryParseJson,
   withTimeout,
 } from "./lib/utils";
-export type {
-  AppOnlyAuthToken,
-  AuthToken,
-  RoomAuthToken,
-} from "./protocol/AuthToken";
-export {
-  isAppOnlyAuthToken,
-  isAuthToken,
-  isRoomAuthToken,
-} from "./protocol/AuthToken";
+export type { AuthToken, RoomAuthToken } from "./protocol/AuthToken";
+export { isAuthToken, isRoomAuthToken } from "./protocol/AuthToken";
 export type { BaseUserMeta } from "./protocol/BaseUserMeta";
 export type {
   BroadcastEventClientMsg,

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -23,6 +23,10 @@ export type MinimalTokenPayload = {
   // opaque, and not relied on by the client.
   [other: string]: Json | undefined;
 
+  // Issued at and expiry fields (from JWT spec)
+  iat: number;
+  exp: number;
+
   // XXX Try to remove as many fields below from this type as possible
   appId: string;
   roomId: string; // Discriminating field for AuthToken type
@@ -42,7 +46,7 @@ export type MinimalTokenPayload = {
 // XXX Rename to ParsedAuthToken?
 export type RichToken = {
   readonly raw: string; // The raw JWT value, unchanged
-  readonly parsed: MinimalTokenPayload & JwtMetadata; // Rich data on the JWT value
+  readonly parsed: MinimalTokenPayload; // Rich data on the JWT value
 };
 
 export interface JwtMetadata extends JsonObject {
@@ -60,9 +64,7 @@ function isStringList(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((i) => typeof i === "string");
 }
 
-function isMinimalTokenPayload(
-  data: Json
-): data is JwtMetadata & MinimalTokenPayload {
+function isMinimalTokenPayload(data: Json): data is MinimalTokenPayload {
   //
   // NOTE: This is the hard-coded definition of the following decoder:
   //

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -115,7 +115,7 @@ export function parseAuthToken(rawTokenString: string): RichToken {
     throw new Error("Authentication error: missing JWT metadata");
   }
 
-  if (!(payload && isMinimalTokenPayload(payload))) {
+  if (!isMinimalTokenPayload(payload)) {
     throw new Error(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"
     );

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -23,7 +23,6 @@ export type MinimalTokenPayload = {
   iat: number;
   exp: number;
 
-  // XXX Try to remove as many fields below from this type as possible
   scopes: string[]; // Think Scope[], but it could also hold scopes from the future, hence string[]
   actor: number;
 

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -111,11 +111,7 @@ export function parseAuthToken(rawTokenString: string): RichToken {
   }
 
   const payload = tryParseJson(b64decode(tokenParts[1]));
-  if (!(payload && hasJwtMeta(payload))) {
-    throw new Error("Authentication error: missing JWT metadata");
-  }
-
-  if (!isMinimalTokenPayload(payload)) {
+  if (!(payload && hasJwtMeta(payload) && isMinimalTokenPayload(payload))) {
     throw new Error(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"
     );

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -110,7 +110,7 @@ function parseJwtToken(token: string): JwtMetadata {
   }
 }
 
-export function parseRoomAuthToken(tokenString: string): RichToken {
+export function parseAuthToken(tokenString: string): RichToken {
   const data = parseJwtToken(tokenString);
   if (!(data && isMinimalTokenPayload(data))) {
     throw new Error(

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -24,20 +24,17 @@ export type MinimalTokenPayload = {
   exp: number;
 
   // XXX Try to remove as many fields below from this type as possible
-  appId: string;
-  roomId: string; // Discriminating field for AuthToken type
   scopes: string[]; // Think Scope[], but it could also hold scopes from the future, hence string[]
   actor: number;
-  maxConnectionsPerRoom?: number;
 
   // Extra payload as defined by the customer's own authorization
+  id?: string;
   info?: Json;
-  groupIds?: string[];
 
   // IMPORTANT: All other fields on the JWT token are deliberately treated as
   // opaque, and not relied on by the client.
   [other: string]: Json | undefined;
-} & ({ id: string; anonymousId?: never } | { id?: never; anonymousId: string });
+};
 
 // The "rich" token is data we obtain by parsing the JWT token and making all
 // metadata on it accessible. It's done right after hitting the backend, but
@@ -66,14 +63,11 @@ function isMinimalTokenPayload(data: Json): data is MinimalTokenPayload {
   //
   // NOTE: This is the hard-coded definition of the following decoder:
   //
-  //   object({
+  //   inexact({
   //     iat: number,
   //     exp: number,
-  //     appId: string,
-  //     roomId: string,
   //     actor: number,
   //     scopes: array(scope),
-  //     maxConnectionsPerRoom: optional(number),
   //     id: optional(string),
   //     info: optional(json),
   //   })
@@ -82,16 +76,10 @@ function isMinimalTokenPayload(data: Json): data is MinimalTokenPayload {
     isPlainObject(data) &&
     typeof data.iat === "number" &&
     typeof data.exp === "number" &&
-    typeof data.appId === "string" &&
-    typeof data.roomId === "string" &&
     typeof data.actor === "number" &&
     (data.id === undefined || typeof data.id === "string") &&
-    isStringList(data.scopes) &&
-    (data.maxConnectionsPerRoom === undefined ||
-      typeof data.maxConnectionsPerRoom === "number")
-    // NOTE: Nothing to validate for `info` field. It's already Json | undefined,
-    // because data is a JsonObject
-    // info?: Json;
+    isStringList(data.scopes)
+    // && data.info will already be `Json | undefined`, given the nature of the data here
   );
 }
 

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -1,4 +1,4 @@
-import type { Json, JsonObject } from "../lib/Json";
+import type { Json } from "../lib/Json";
 import { b64decode, isPlainObject, tryParseJson } from "../lib/utils";
 
 export enum RoomScope {
@@ -49,10 +49,8 @@ export type RichToken = {
   readonly parsed: MinimalTokenPayload; // Rich data on the JWT value
 };
 
-export interface JwtMetadata extends JsonObject {
-  iat: number;
-  exp: number;
-}
+/** @internal - For unit tests only */
+export type JwtMetadata = Pick<MinimalTokenPayload, "iat" | "exp">;
 
 export function isTokenExpired(token: JwtMetadata): boolean {
   const now = Date.now() / 1000;

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -111,11 +111,11 @@ function parseJwtToken(rawTokenString: string): JwtMetadata {
   }
 
   const data = tryParseJson(b64decode(tokenParts[1]));
-  if (data && hasJwtMeta(data)) {
-    return data;
-  } else {
+  if (!(data && hasJwtMeta(data))) {
     throw new Error("Authentication error: missing JWT metadata");
   }
+
+  return data;
 }
 
 export function parseAuthToken(rawTokenString: string): RichToken {

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -97,8 +97,8 @@ function isMinimalTokenPayload(data: JsonObject): data is MinimalTokenPayload {
   );
 }
 
-function parseJwtToken(token: string): JwtMetadata {
-  const tokenParts = token.split(".");
+function parseJwtToken(rawTokenString: string): JwtMetadata {
+  const tokenParts = rawTokenString.split(".");
   if (tokenParts.length !== 3) {
     throw new Error("Authentication error: invalid JWT token");
   }
@@ -111,16 +111,16 @@ function parseJwtToken(token: string): JwtMetadata {
   }
 }
 
-export function parseAuthToken(tokenString: string): RichToken {
-  const data = parseJwtToken(tokenString);
-  if (!(data && isMinimalTokenPayload(data))) {
+export function parseAuthToken(rawTokenString: string): RichToken {
+  const payload = parseJwtToken(rawTokenString);
+  if (!(payload && isMinimalTokenPayload(payload))) {
     throw new Error(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"
     );
   }
 
   return {
-    raw: tokenString,
-    parsed: data,
+    raw: rawTokenString,
+    parsed: payload,
   };
 }

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -97,6 +97,13 @@ function isMinimalTokenPayload(data: JsonObject): data is MinimalTokenPayload {
   );
 }
 
+/**
+ * Parses a raw JWT token string, which allows reading the metadata/payload of
+ * the token.
+ *
+ * NOTE: Doesn't do any validation, so always treat the metadata as other user
+ * input: never trust these values for anything important.
+ */
 function parseJwtToken(rawTokenString: string): JwtMetadata {
   const tokenParts = rawTokenString.split(".");
   if (tokenParts.length !== 3) {

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -19,10 +19,6 @@ export enum RoomScope {
  * @internal For unit tests only.
  */
 export type MinimalTokenPayload = {
-  // IMPORTANT: All other fields on the JWT token are deliberately treated as
-  // opaque, and not relied on by the client.
-  [other: string]: Json | undefined;
-
   // Issued at and expiry fields (from JWT spec)
   iat: number;
   exp: number;
@@ -37,6 +33,10 @@ export type MinimalTokenPayload = {
   // Extra payload as defined by the customer's own authorization
   info?: Json;
   groupIds?: string[];
+
+  // IMPORTANT: All other fields on the JWT token are deliberately treated as
+  // opaque, and not relied on by the client.
+  [other: string]: Json | undefined;
 } & ({ id: string; anonymousId?: never } | { id?: never; anonymousId: string });
 
 // The "rich" token is data we obtain by parsing the JWT token and making all

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -39,8 +39,7 @@ export type MinimalTokenPayload = {
 // metadata on it accessible. It's done right after hitting the backend, but
 // before the promise will get returned, so it's an inherent part of the
 // authentication step.
-// XXX Rename to ParsedAuthToken?
-export type RichToken = {
+export type ParsedAuthToken = {
   readonly raw: string; // The raw JWT value, unchanged
   readonly parsed: MinimalTokenPayload; // Rich data on the JWT value
 };
@@ -89,7 +88,7 @@ function isMinimalTokenPayload(data: Json): data is MinimalTokenPayload {
  * NOTE: Doesn't do any validation, so always treat the metadata as other user
  * input: never trust these values for anything important.
  */
-export function parseAuthToken(rawTokenString: string): RichToken {
+export function parseAuthToken(rawTokenString: string): ParsedAuthToken {
   const tokenParts = rawTokenString.split(".");
   if (tokenParts.length !== 3) {
     throw new Error("Authentication error: invalid JWT token");

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -70,7 +70,7 @@ function isStringList(value: unknown): value is string[] {
 }
 
 function isMinimalTokenPayload(
-  data: JsonObject
+  data: Json
 ): data is JwtMetadata & MinimalTokenPayload {
   //
   // NOTE: This is the hard-coded definition of the following decoder:

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -119,15 +119,8 @@ export function parseAuthToken(tokenString: string): RichToken {
     );
   }
 
-  const {
-    // If this legacy field is found on the token, pretend it wasn't there,
-    // to make all internally used token payloads uniform
-    maxConnections: _legacyField,
-    ...parsedToken
-  } = data;
-
   return {
     raw: tokenString,
-    parsed: parsedToken,
+    parsed: data,
   };
 }

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -39,6 +39,7 @@ export type MinimalTokenPayload = {
 // metadata on it accessible. It's done right after hitting the backend, but
 // before the promise will get returned, so it's an inherent part of the
 // authentication step.
+// XXX Rename to ParsedAuthToken?
 export type RichToken = {
   readonly raw: string; // The raw JWT value, unchanged
   readonly parsed: MinimalTokenPayload & JwtMetadata; // Rich data on the JWT value

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -50,15 +50,6 @@ export interface JwtMetadata extends JsonObject {
   exp: number;
 }
 
-function hasJwtMeta(data: unknown): data is JwtMetadata {
-  if (!isPlainObject(data)) {
-    return false;
-  }
-
-  const { iat, exp } = data;
-  return typeof iat === "number" && typeof exp === "number";
-}
-
 export function isTokenExpired(token: JwtMetadata): boolean {
   const now = Date.now() / 1000;
   const valid = now <= token.exp - 300 && now >= token.iat - 300;
@@ -76,6 +67,8 @@ function isMinimalTokenPayload(
   // NOTE: This is the hard-coded definition of the following decoder:
   //
   //   object({
+  //     iat: number,
+  //     exp: number,
   //     appId: string,
   //     roomId: string,
   //     actor: number,
@@ -86,7 +79,9 @@ function isMinimalTokenPayload(
   //   })
   //
   return (
-    hasJwtMeta(data) &&
+    isPlainObject(data) &&
+    typeof data.iat === "number" &&
+    typeof data.exp === "number" &&
     typeof data.appId === "string" &&
     typeof data.roomId === "string" &&
     typeof data.actor === "number" &&

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -7,6 +7,15 @@ export enum RoomScope {
   PresenceWrite = "room:presence:write",
 }
 
+/**
+ * Fields of the JWT payload that the client relies on and interprets. There
+ * exist more fields in the JWT payload, but those aren't needed by the client
+ * directly, and simply passed back to the backend.
+ *
+ * This type should only list the properties that client uses, so we're still
+ * free to change the other fields on the token without breaking backward
+ * compatibility.
+ */
 // XXX Rename to MinimalTokenMetadata
 // XXX Try to remove as many fields from this type as possible
 export type RoomAuthToken = {

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -104,22 +104,17 @@ function isMinimalTokenPayload(data: JsonObject): data is MinimalTokenPayload {
  * NOTE: Doesn't do any validation, so always treat the metadata as other user
  * input: never trust these values for anything important.
  */
-function parseJwtToken(rawTokenString: string): JwtMetadata {
+export function parseAuthToken(rawTokenString: string): RichToken {
   const tokenParts = rawTokenString.split(".");
   if (tokenParts.length !== 3) {
     throw new Error("Authentication error: invalid JWT token");
   }
 
-  const data = tryParseJson(b64decode(tokenParts[1]));
-  if (!(data && hasJwtMeta(data))) {
+  const payload = tryParseJson(b64decode(tokenParts[1]));
+  if (!(payload && hasJwtMeta(payload))) {
     throw new Error("Authentication error: missing JWT metadata");
   }
 
-  return data;
-}
-
-export function parseAuthToken(rawTokenString: string): RichToken {
-  const payload = parseJwtToken(rawTokenString);
   if (!(payload && isMinimalTokenPayload(payload))) {
     throw new Error(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -69,7 +69,9 @@ function isStringList(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((i) => typeof i === "string");
 }
 
-function isMinimalTokenPayload(data: JsonObject): data is MinimalTokenPayload {
+function isMinimalTokenPayload(
+  data: JsonObject
+): data is JwtMetadata & MinimalTokenPayload {
   //
   // NOTE: This is the hard-coded definition of the following decoder:
   //
@@ -84,6 +86,7 @@ function isMinimalTokenPayload(data: JsonObject): data is MinimalTokenPayload {
   //   })
   //
   return (
+    hasJwtMeta(data) &&
     typeof data.appId === "string" &&
     typeof data.roomId === "string" &&
     typeof data.actor === "number" &&
@@ -111,7 +114,7 @@ export function parseAuthToken(rawTokenString: string): RichToken {
   }
 
   const payload = tryParseJson(b64decode(tokenParts[1]));
-  if (!(payload && hasJwtMeta(payload) && isMinimalTokenPayload(payload))) {
+  if (!(payload && isMinimalTokenPayload(payload))) {
     throw new Error(
       "Authentication error: we expected a room token but did not get one. Hint: if you are using a callback, ensure the room is passed when creating the token. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback"
     );

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -28,7 +28,7 @@ import { asPos } from "./lib/position";
 import type { Resolve } from "./lib/Resolve";
 import { compact, isPlainObject, tryParseJson } from "./lib/utils";
 import type { Authentication } from "./protocol/Authentication";
-import type { RichToken } from "./protocol/AuthToken";
+import type { ParsedAuthToken } from "./protocol/AuthToken";
 import {
   isTokenExpired,
   parseAuthToken,
@@ -788,7 +788,7 @@ export type RoomInitializers<
   shouldInitiallyConnect?: boolean;
 }>;
 
-export type RoomDelegates = Delegates<RichToken>;
+export type RoomDelegates = Delegates<ParsedAuthToken>;
 
 /** @internal */
 export type RoomConfig = {
@@ -868,7 +868,7 @@ export function createRoom<
     ),
   };
 
-  const managedSocket: ManagedSocket<RichToken> = new ManagedSocket(
+  const managedSocket: ManagedSocket<ParsedAuthToken> = new ManagedSocket(
     delegates,
     config.enableDebugLogging
   );
@@ -918,7 +918,7 @@ export function createRoom<
   const doNotBatchUpdates = (cb: () => void): void => cb();
   const batchUpdates = config.unstable_batchedUpdates ?? doNotBatchUpdates;
 
-  let lastToken: RichToken["parsed"] | undefined;
+  let lastToken: ParsedAuthToken["parsed"] | undefined;
   function onStatusDidChange(newStatus: Status) {
     const token = managedSocket.token?.parsed;
     if (token !== undefined && token !== lastToken) {
@@ -2304,7 +2304,7 @@ function makeCreateSocketDelegateForRoom(
   liveblocksServer: string,
   WebSocketPolyfill?: IWebSocket
 ) {
-  return (richToken: RichToken): IWebSocketInstance => {
+  return (richToken: ParsedAuthToken): IWebSocketInstance => {
     const ws: IWebSocket | undefined =
       WebSocketPolyfill ??
       (typeof WebSocket === "undefined" ? undefined : WebSocket);
@@ -2348,7 +2348,7 @@ function makeAuthDelegateForRoom(
   roomId: string,
   authentication: Authentication,
   fetchPolyfill?: typeof window.fetch
-): () => Promise<RichToken> {
+): () => Promise<ParsedAuthToken> {
   const fetcher =
     fetchPolyfill ?? (typeof window === "undefined" ? undefined : window.fetch);
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -31,7 +31,7 @@ import type { Authentication } from "./protocol/Authentication";
 import type { RichToken } from "./protocol/AuthToken";
 import {
   isTokenExpired,
-  parseRoomAuthToken,
+  parseAuthToken,
   RoomScope,
 } from "./protocol/AuthToken";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
@@ -2363,7 +2363,7 @@ function makeAuthDelegateForRoom(
       return fetchAuthEndpoint(fetcher, authentication.url, {
         room: roomId,
         publicApiKey: authentication.publicApiKey,
-      }).then(({ token }) => parseRoomAuthToken(token));
+      }).then(({ token }) => parseAuthToken(token));
     };
   } else if (authentication.type === "private") {
     return async () => {
@@ -2375,7 +2375,7 @@ function makeAuthDelegateForRoom(
 
       return fetchAuthEndpoint(fetcher, authentication.url, {
         room: roomId,
-      }).then(({ token }) => parseRoomAuthToken(token));
+      }).then(({ token }) => parseAuthToken(token));
     };
   } else if (authentication.type === "custom") {
     return async () => {
@@ -2385,7 +2385,7 @@ function makeAuthDelegateForRoom(
           'We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
         );
       }
-      return parseRoomAuthToken(response.token);
+      return parseAuthToken(response.token);
     };
   } else {
     throw new Error("Internal error. Unexpected authentication type");


### PR DESCRIPTION
Cleans up the AuthToken types exported by `@liveblocks/core`. Some backend systems have been relying on these type definitions, but since these are versioned (older client versions could have different type definitions), this setup wasn't ideal for backend systems to consume, because they would always have to account for other in-the-wild versions of these shapes.

In addition, this PR now stops the runtime validation of the following fields:

- `appId`
- `roomId`
- `maxConnectionsPerRoom`

Those fields are intended for the backend only, and the client has no business validating them. After this PR, those fields are treated as opaque, and simply passed through to the backend.

Because we introduced this runtime check a long time ago, we cannot touch or change any of these fields without breaking old clients, unfortunately — see this [overview sheet](https://docs.google.com/spreadsheets/d/1mP6WAdvlkX6GpFjGZ0gvImFbcK-NaUvFxTeflKyYGEE/edit?usp=sharing) I put together.