### PR TITLE
Ignore events sent to the state machine after it has been stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.1.1
+
+Fixes a bug where under certain circumstances the Liveblocks client could
+incorrectly throw a `Not started yet` error message.
+
 # v1.1.0
 
 This release improves the client’s internals to ensure a more reliable

--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -79,7 +79,7 @@ describe("finite state machine", () => {
     );
   });
 
-  test("sending events after the FSM has stopped will get ignored", () => {
+  test("sending *known* events after the FSM has stopped will get ignored", () => {
     const fsm = new FSM({})
       .addState("one")
       .addState("two")
@@ -90,12 +90,12 @@ describe("finite state machine", () => {
     expect(() => fsm.send({ type: "GO" })).not.toThrow();
   });
 
-  test("sending events after the FSM has stopped will get ignored", () => {
+  test("sending *unknown* events after the FSM has stopped will still throw", () => {
     const fsm = new FSM({}).addState("initial");
     fsm.start();
     fsm.stop();
-    expect(() => fsm.send({ type: "SOME_EVENT" })).toThrow(
-      'Invalid event "SOME_EVENT"'
+    expect(() => fsm.send({ type: "UNKNOWN" })).toThrow(
+      'Invalid event "UNKNOWN"'
     );
   });
 

--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -68,9 +68,15 @@ describe("finite state machine", () => {
       .addState("two")
       .addTransitions("one", { GO: "two" });
 
-    // NOT calling fsm.start() heree
     // Events sent before starting the machine will throw
     expect(() => fsm.send({ type: "GO" })).toThrow("Not started yet");
+  });
+
+  test("stopping a machine that hasn't started yet will throw", () => {
+    const fsm = new FSM({}).addState("one");
+    expect(() => fsm.stop()).toThrow(
+      "Cannot stop a state machine that hasn't started yet"
+    );
   });
 
   test("sending events after the FSM has stopped will get ignored", () => {

--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -63,8 +63,34 @@ describe("finite state machine", () => {
   });
 
   test("cannot use FSM when it hasn't started yet", () => {
-    const fsm = new FSM({});
-    expect(() => fsm.send({ type: "SOME_EVENT" })).toThrow("Not started yet");
+    const fsm = new FSM({})
+      .addState("one")
+      .addState("two")
+      .addTransitions("one", { GO: "two" });
+
+    // NOT calling fsm.start() heree
+    // Events sent before starting the machine will throw
+    expect(() => fsm.send({ type: "GO" })).toThrow("Not started yet");
+  });
+
+  test("sending events after the FSM has stopped will get ignored", () => {
+    const fsm = new FSM({})
+      .addState("one")
+      .addState("two")
+      .addTransitions("one", { GO: "two" });
+    fsm.start();
+    fsm.stop();
+    // Events sent after stopping the machine will get ignored (but will NOT throw)
+    expect(() => fsm.send({ type: "GO" })).not.toThrow();
+  });
+
+  test("sending events after the FSM has stopped will get ignored", () => {
+    const fsm = new FSM({}).addState("initial");
+    fsm.start();
+    fsm.stop();
+    expect(() => fsm.send({ type: "SOME_EVENT" })).toThrow(
+      'Invalid event "SOME_EVENT"'
+    );
   });
 
   test("cannot get current state when machine hasn't started yet", () => {

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -291,8 +291,8 @@ export class FSM<
     if (this.runningState !== RunningState.STARTED) {
       throw new Error("Cannot stop a state machine that isn't started yet");
     }
-    this.runningState = RunningState.STOPPED;
     this.exit(null);
+    this.runningState = RunningState.STOPPED;
     this.currentStateOrNull = null;
   }
 

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -293,7 +293,7 @@ export class FSM<
    */
   public stop(): void {
     if (this.runningState !== RunningState.STARTED) {
-      throw new Error("Cannot stop a state machine that isn't started yet");
+      throw new Error("Cannot stop a state machine that hasn't started yet");
     }
     this.exit(null);
     this.runningState = RunningState.STOPPED;

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -264,7 +264,11 @@ export class FSM<
 
   public get currentState(): TState {
     if (this.currentStateOrNull === null) {
-      throw new Error("Not started yet");
+      if (this.runningState === RunningState.NOT_STARTED_YET) {
+        throw new Error("Not started yet");
+      } else {
+        throw new Error("Already stopped");
+      }
     }
     return this.currentStateOrNull;
   }
@@ -511,10 +515,11 @@ export class FSM<
    * Exits the current state, and executes any necessary cleanup functions.
    * Call this before changing the current state to the next state.
    *
-   * @param levels Defines how many "levels" of nesting will be exited. For
-   * example, if you transition from `foo.bar.qux` to `foo.bar.baz`, then
-   * the level is 1. But if you transition from `foo.bar.qux` to `bla.bla`,
-   * then the level is 3.
+   * @param levels Defines how many "levels" of nesting will be
+   * exited. For example, if you transition from `foo.bar.qux` to
+   * `foo.bar.baz`, then the level is 1. But if you transition from
+   * `foo.bar.qux` to `bla.bla`, then the level is 3.
+   * If `null`, it will exit all levels.
    */
   private exit(levels: number | null) {
     this.eventHub.willExitState.notify(this.currentState);
@@ -557,15 +562,25 @@ export class FSM<
    * transition to happen. When that happens, will trigger side effects.
    */
   public send(event: TEvent): void {
-    const targetFn = this.getTargetFn(event.type);
-    if (targetFn !== undefined) {
-      return this.transition(event, targetFn);
-    }
-
     // Ignore the event otherwise, but throw if the event is entirely unknown,
     // which may likely be a configuration error
     if (!this.knownEventTypes.has(event.type)) {
       throw new Error(`Invalid event ${JSON.stringify(event.type)}`);
+    }
+
+    if (this.runningState === RunningState.STOPPED) {
+      // Ignore all events sent to the machine after it has stopped. This is
+      // similar to how we ignore events sent to the machine after it
+      // transitioned to a phase in which the event won't be handled: it would
+      // also get ignored.
+      // However, if the machine _hasn't started yet_, we still let it throw an
+      // error, because then it's most likely a usage error.
+      return;
+    }
+
+    const targetFn = this.getTargetFn(event.type);
+    if (targetFn !== undefined) {
+      return this.transition(event, targetFn);
     } else {
       this.eventHub.didIgnoreEvent.notify(event);
     }

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -562,8 +562,7 @@ export class FSM<
    * transition to happen. When that happens, will trigger side effects.
    */
   public send(event: TEvent): void {
-    // Ignore the event otherwise, but throw if the event is entirely unknown,
-    // which may likely be a configuration error
+    // Throw if the event is unknown, which may likely be a configuration error
     if (!this.knownEventTypes.has(event.type)) {
       throw new Error(`Invalid event ${JSON.stringify(event.type)}`);
     }
@@ -582,6 +581,7 @@ export class FSM<
     if (targetFn !== undefined) {
       return this.transition(event, targetFn);
     } else {
+      // Ignore the event otherwise
       this.eventHub.didIgnoreEvent.notify(event);
     }
   }


### PR DESCRIPTION
This PR fixes a bug that was reported in our Discord channel yesterday.

![🐛](https://github.com/liveblocks/liveblocks/assets/83844/3d4b2f52-cd95-417c-a8fd-cbbf8b539b92)
