### PR TITLE
Fix `@liveblocks/yjs` package so it avoids the dual package hazard problem in bundlers

### DIFF
--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -27,6 +27,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
         "default": "./dist/index.js"
       }
     }


### PR DESCRIPTION
This doesn't address:

- A potential dual package hazard problem that still exists in `yjs` itself
- It doesn't make our client package ESM/CJS dual published yet

But to make it work completely, all shackles in the chain need to be configured to play well. This just fixes the `@liveblocks/yjs` shackle.
