### PR TITLE
Fix a small export bug in `@liveblocks/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@arethetypeswrong/cli": "^0.4.2",
         "dependency-cruiser": "^13.0.5",
         "prettier": "^2.8.8",
-        "publint": "^0.1.15",
+        "publint": "^0.1.16",
         "tsd": "^0.24.1",
         "tsup": "^7.1.0",
         "turbo": "^1.10.7",
@@ -14909,9 +14909,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/publint": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/publint/-/publint-0.1.15.tgz",
-      "integrity": "sha512-LyoUm/J1oSOik9EYftHSyUEwJATToqFyO1wad8i2m2KvaNcBmV5rbD3ZvPqQAHzVs47MLa2Rsd8nw9NmV/Ep0w==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.1.16.tgz",
+      "integrity": "sha512-wJgk7HnXDT5Ap0DjFYbGz78kPkN44iQvDiaq8P63IEEyNU9mYXvaMd2cAyIM6OgqXM/IA3CK6XWIsRq+wjNpgw==",
       "dev": true,
       "dependencies": {
         "npm-packlist": "^5.1.3",
@@ -31396,9 +31396,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "publint": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/publint/-/publint-0.1.15.tgz",
-      "integrity": "sha512-LyoUm/J1oSOik9EYftHSyUEwJATToqFyO1wad8i2m2KvaNcBmV5rbD3ZvPqQAHzVs47MLa2Rsd8nw9NmV/Ep0w==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.1.16.tgz",
+      "integrity": "sha512-wJgk7HnXDT5Ap0DjFYbGz78kPkN44iQvDiaq8P63IEEyNU9mYXvaMd2cAyIM6OgqXM/IA3CK6XWIsRq+wjNpgw==",
       "dev": true,
       "requires": {
         "npm-packlist": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@arethetypeswrong/cli": "^0.4.2",
     "dependency-cruiser": "^13.0.5",
     "prettier": "^2.8.8",
-    "publint": "^0.1.15",
+    "publint": "^0.1.16",
     "tsd": "^0.24.1",
     "tsup": "^7.1.0",
     "turbo": "^1.10.7",

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -35,7 +35,8 @@ export type {
   LiveObjectUpdate,
   StorageUpdate,
 } from "./crdts/StorageUpdates";
-export type { ToImmutable, toPlainLson } from "./crdts/utils";
+export type { ToImmutable } from "./crdts/utils";
+export { toPlainLson } from "./crdts/utils";
 export {
   legacy_patchImmutableObject,
   lsonToJson,


### PR DESCRIPTION
Fixes a bug where `toPlainLson` was not exported correctly at the top-level.
Also upgrade publint to the latest version.
