### PR TITLE
Dual-package ESM and CJS for all of our packages again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v1.1.3
+
+Ship all of our packages as both ESM and CJS modules. By upgrading, your
+project’s bundler can now perform (better) tree-shaking on the Liveblocks code.
+
+You can expect (at least) the following bundle size reductions:
+
+- `@liveblocks/client` from 80kB → 70kB
+- `@liveblocks/react` from 129kB → 80kB
+- `@liveblocks/redux` from 84kB → 38kB
+- `@liveblocks/zustand` from 83kB → 37kB
+- `@liveblocks/yjs` from 129kB → 74kB
+
 # v1.1.2
 
 ### `@liveblocks/yjs`

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -5,6 +5,19 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"

--- a/packages/liveblocks-client/tsconfig.json
+++ b/packages/liveblocks-client/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["dom", "es2015"],
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["dom"],
 
     // TODO: Try to get rid of these overrides
     "noUncheckedIndexedAccess": false // OVERWRITTEN to relax a bit

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   splitting: true,
   clean: true,
   target: "es2015",
-  format: ["cjs"],
+  format: ["esm", "cjs"],
+  minify: true,
+  sourcemap: true,
 
   esbuildOptions(options, _context) {
     // Replace __PACKAGE_VERSION__ global constant with a concrete version
@@ -14,8 +16,4 @@ export default defineConfig({
       require("./package.json").version
     );
   },
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
 });

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-  minify: true,
   sourcemap: true,
 
   esbuildOptions(options, _context) {

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liveblocks/core",
   "version": "1.1.2",
-  "description": "Shared code and foundational internals for Liveblocks",
+  "description": "Private internals for Liveblocks. DO NOT import directly from this package!",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -4,6 +4,19 @@
   "description": "Shared code and foundational internals for Liveblocks",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -2,7 +2,6 @@ import type { LiveNode, Lson, LsonObject } from "../crdts/Lson";
 import { nn } from "../lib/assert";
 import type { JsonObject } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
-import { fromEntries } from "../lib/utils";
 import type {
   CreateChildOp,
   CreateObjectOp,
@@ -488,7 +487,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
    * Transform the LiveObject into a javascript object
    */
   toObject(): O {
-    return fromEntries(this._map) as O;
+    return Object.fromEntries(this._map) as O;
   }
 
   /**

--- a/packages/liveblocks-core/src/lib/__tests__/utils.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/utils.test.ts
@@ -5,7 +5,6 @@ import {
   compact,
   compactObject,
   entries,
-  fromEntries,
   isPlainObject,
   keys,
   mapValues,
@@ -45,17 +44,6 @@ describe("TypeScript wrapper utils", () => {
       ["1", 1],
       ["2", 2],
     ]);
-  });
-
-  it("fromEntries (alias of Object.fromEntries)", () => {
-    expect(fromEntries([])).toEqual({});
-    expect(fromEntries([["a", 1]])).toEqual({ a: 1 });
-    expect(
-      fromEntries([
-        ["1", 1],
-        ["2", 2],
-      ])
-    ).toEqual({ [1]: 1, [2]: 2 });
   });
 });
 

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -16,20 +16,6 @@ export function isPlainObject(
 }
 
 /**
- * Polyfill for Object.fromEntries() to be able to target ES2015 output without
- * including external polyfill dependencies.
- */
-export function fromEntries<K, V>(
-  iterable: Iterable<[K, V]>
-): { [key: string]: V } {
-  const obj: { [key: string]: V } = {};
-  for (const [key, val] of iterable) {
-    obj[key as unknown as string] = val;
-  }
-  return obj;
-}
-
-/**
  * Drop-in replacement for Object.entries() that retains better types.
  */
 export function entries<

--- a/packages/liveblocks-core/tsconfig.json
+++ b/packages/liveblocks-core/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["dom", "es2015"],
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["dom"],
 
     // TODO: Try to get rid of these overrides
     "noUncheckedIndexedAccess": false // OVERWRITTEN to relax a bit

--- a/packages/liveblocks-core/tsup.config.ts
+++ b/packages/liveblocks-core/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 

--- a/packages/liveblocks-core/tsup.config.ts
+++ b/packages/liveblocks-core/tsup.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   splitting: true,
   clean: true,
   target: "es2015",
-  format: ["cjs"],
+  format: ["esm", "cjs"],
+  minify: true,
+  sourcemap: true,
 
   esbuildOptions(options, _context) {
     // Replace __PACKAGE_VERSION__ global constant with a concrete version
@@ -14,8 +16,4 @@ export default defineConfig({
       require("./package.json").version
     );
   },
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
 });

--- a/packages/liveblocks-core/tsup.config.ts
+++ b/packages/liveblocks-core/tsup.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-  minify: true,
   sourcemap: true,
 
   esbuildOptions(options, _context) {

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -5,6 +5,19 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"

--- a/packages/liveblocks-node/tsconfig.json
+++ b/packages/liveblocks-node/tsconfig.json
@@ -3,7 +3,7 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2020",
     "module": "es2020"
   },
   "include": ["src/**/*"]

--- a/packages/liveblocks-node/tsup.config.ts
+++ b/packages/liveblocks-node/tsup.config.ts
@@ -7,8 +7,5 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
+  sourcemap: true,
 });

--- a/packages/liveblocks-node/tsup.config.ts
+++ b/packages/liveblocks-node/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 });

--- a/packages/liveblocks-node/tsup.config.ts
+++ b/packages/liveblocks-node/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   splitting: true,
   clean: true,
   target: "es2015",
-  format: ["cjs"],
+  format: ["esm", "cjs"],
 
   // Perhaps enable later?
   // "minify": true,

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -5,6 +5,19 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -21,7 +21,7 @@ import {
   errorIf,
 } from "@liveblocks/core";
 import * as React from "react";
-import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 
 import { useInitial, useRerender } from "./hooks";
 import type {

--- a/packages/liveblocks-react/tsconfig.json
+++ b/packages/liveblocks-react/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["dom", "es2015"],
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["dom"],
 
     // Transform JSX syntax from input *.tsx files into React.createElement()
     // calls in the *.js build output.

--- a/packages/liveblocks-react/tsup.config.ts
+++ b/packages/liveblocks-react/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 });

--- a/packages/liveblocks-react/tsup.config.ts
+++ b/packages/liveblocks-react/tsup.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-  minify: true,
   sourcemap: true,
 });

--- a/packages/liveblocks-react/tsup.config.ts
+++ b/packages/liveblocks-react/tsup.config.ts
@@ -6,9 +6,7 @@ export default defineConfig({
   splitting: true,
   clean: true,
   target: "es2015",
-  format: ["cjs"],
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
+  format: ["esm", "cjs"],
+  minify: true,
+  sourcemap: true,
 });

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -5,6 +5,19 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"

--- a/packages/liveblocks-redux/tsconfig.json
+++ b/packages/liveblocks-redux/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["dom", "es2015"]
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["dom"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/liveblocks-redux/tsup.config.ts
+++ b/packages/liveblocks-redux/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 });

--- a/packages/liveblocks-redux/tsup.config.ts
+++ b/packages/liveblocks-redux/tsup.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-  minify: true,
   sourcemap: true,
 });

--- a/packages/liveblocks-redux/tsup.config.ts
+++ b/packages/liveblocks-redux/tsup.config.ts
@@ -6,9 +6,7 @@ export default defineConfig({
   splitting: true,
   clean: true,
   target: "es2015",
-  format: ["cjs"],
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
+  format: ["esm", "cjs"],
+  minify: true,
+  sourcemap: true,
 });

--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -5,6 +5,19 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"
@@ -18,19 +31,6 @@
     "test": "jest --silent --verbose --color=always",
     "test:types": "tsd",
     "test:watch": "jest --silent --verbose --color=always --watch"
-  },
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "module": "./dist/index.mjs",
-        "default": "./dist/index.js"
-      }
-    }
   },
   "dependencies": {
     "@liveblocks/client": "1.1.2",

--- a/packages/liveblocks-yjs/tsconfig.json
+++ b/packages/liveblocks-yjs/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["dom", "es2015"]
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["dom"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/liveblocks-yjs/tsup.config.ts
+++ b/packages/liveblocks-yjs/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 });

--- a/packages/liveblocks-yjs/tsup.config.ts
+++ b/packages/liveblocks-yjs/tsup.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-  minify: true,
   sourcemap: true,
 });

--- a/packages/liveblocks-yjs/tsup.config.ts
+++ b/packages/liveblocks-yjs/tsup.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
+  minify: true,
+  sourcemap: true,
 });

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -5,6 +5,19 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist/**",
     "README.md"

--- a/packages/liveblocks-zustand/tsconfig.json
+++ b/packages/liveblocks-zustand/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "../../shared/tsconfig.common.json",
 
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["dom", "es2015"]
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["dom"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/liveblocks-zustand/tsup.config.ts
+++ b/packages/liveblocks-zustand/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2015",
+  target: "es2020",
   format: ["esm", "cjs"],
   sourcemap: true,
 });

--- a/packages/liveblocks-zustand/tsup.config.ts
+++ b/packages/liveblocks-zustand/tsup.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   clean: true,
   target: "es2015",
   format: ["esm", "cjs"],
-  minify: true,
   sourcemap: true,
 });

--- a/packages/liveblocks-zustand/tsup.config.ts
+++ b/packages/liveblocks-zustand/tsup.config.ts
@@ -6,9 +6,7 @@ export default defineConfig({
   splitting: true,
   clean: true,
   target: "es2015",
-  format: ["cjs"],
-
-  // Perhaps enable later?
-  // "minify": true,
-  // "sourcemap": true,
+  format: ["esm", "cjs"],
+  minify: true,
+  sourcemap: true,
 });


### PR DESCRIPTION
This is another attempt at dual-packaging our packages, shipping both ESM and CJS source code.

- [x] Passes all lints on publint.dev
  - [x] https://publint.dev/@liveblocks/core@1.1.1-dual6
  - [x] https://publint.dev/@liveblocks/client@1.1.1-dual6
  - [x] https://publint.dev/@liveblocks/react@1.1.1-dual6
  - [x] https://publint.dev/@liveblocks/redux@1.1.1-dual6
  - [x] https://publint.dev/@liveblocks/zustand@1.1.1-dual6
  - [x] https://publint.dev/@liveblocks/yjs@1.1.1-dual6
  - [x] https://publint.dev/@liveblocks/node@1.1.1-dual6
- [x] Passes all lints on arethetypeswrong.github.io
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Fcore%401.1.1-dual6
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Fclient%401.1.1-dual6
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Freact%401.1.1-dual6
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Fredux%401.1.1-dual6
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Fzustand%401.1.1-dual6
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Fyjs%401.1.1-dual6
  - [x] https://arethetypeswrong.github.io/?p=%40liveblocks%2Fnode%401.1.1-dual6
- [x] Works in [Vite projects](https://codesandbox.io/p/sandbox/patient-silence-jym33x?file=%2Fsrc%2Fliveblocks.config.ts%3A4%2C19) (these used to fail with build and/or runtime errors specifically in the past)
- [x] Works with all of our examples
