### PR TITLE
Upgrade dev dependencies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,12 +1,4 @@
 {
-  "semi": true,
-  "tabWidth": 2,
-  "useTabs": false,
-  "singleQuote": false,
-  "jsxSingleQuote": false,
-  "arrowParens": "always",
-  "bracketSpacing": true,
-  "bracketSameLine": false,
   "trailingComma": "es5",
   "proseWrap": "always"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.4.2",
         "dependency-cruiser": "^13.0.5",
-        "prettier": "^2.8.8",
+        "prettier": "^3.0.0",
         "publint": "^0.1.16",
         "tsd": "^0.24.1",
         "tsup": "^7.1.0",
@@ -6323,6 +6323,21 @@
       "dev": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/ast-generator/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/ast-generator/node_modules/typescript": {
@@ -14800,15 +14815,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -25232,6 +25247,12 @@
           "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
           "dev": true
         },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
+        },
         "typescript": {
           "version": "4.9.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -31307,9 +31328,9 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true
     },
     "prettier-plugin-tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "e2e/next-sandbox"
       ],
       "devDependencies": {
-        "@arethetypeswrong/cli": "^0.4.2",
-        "dependency-cruiser": "^13.0.5",
+        "@arethetypeswrong/cli": "^0.6.0",
+        "dependency-cruiser": "^13.1.0",
         "prettier": "^3.0.0",
         "publint": "^0.1.16",
-        "tsd": "^0.24.1",
+        "tsd": "^0.28.1",
         "tsup": "^7.1.0",
         "turbo": "^1.10.7",
         "typescript": "<4.8"
@@ -81,12 +81,12 @@
       "dev": true
     },
     "node_modules/@arethetypeswrong/cli": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.4.2.tgz",
-      "integrity": "sha512-RlAiNUUgvsM8GX9kzNTgB8xuANf2j9klpHxU3xPhfqO03MU9ybD7Qq82ULWECe/pAX9CfT93EzEzFmoFivv5VA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.6.0.tgz",
+      "integrity": "sha512-9UEf0fRU32ZIJ1/NSl7xZTkYBJw8zc/1rlAYZ0uEpCL+W8jBXbxOm1V7fhkkALeMbjhfqM6Y0hKLs+jtESd2vg==",
       "dev": true,
       "dependencies": {
-        "@arethetypeswrong/core": "0.4.1",
+        "@arethetypeswrong/core": "0.6.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -123,22 +123,38 @@
       }
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.4.1.tgz",
-      "integrity": "sha512-DNRPu3ndvMqr6hewDP+Od8K9jZTj6cP8f/5eqRvEyZQPl11FmqOWaEuDFTEKym4nLGHM2cV5OOCnQBJ1IQbXQA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-561h7MMTJlm/etFiO9RkQJLMxLOUUasT3GqY2muc4v/WAQRRko0Z7Bfd7wMZdRAeN/QTH8VdV3dEGPilpQXiDA==",
       "dev": true,
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.0",
         "fetch-ponyfill": "^7.1.0",
         "fflate": "^0.7.4",
+        "semver": "^7.5.4",
         "typescript": "^5.1.3",
         "validate-npm-package-name": "^5.0.0"
       }
     },
+    "node_modules/@arethetypeswrong/core/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@arethetypeswrong/core/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5278,9 +5294,9 @@
       "dev": true
     },
     "node_modules/@tsd/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-WMFNVstwWGyDuZP2LGPRZ+kPHxZLmhO+2ormstDvnXiyoBPtW1qq9XhhrkI4NVtxgs+2ZiUTl9AG7nNIRq/uCg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -5877,9 +5893,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "node_modules/acorn": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7626,12 +7642,12 @@
       "dev": true
     },
     "node_modules/dependency-cruiser": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-13.0.5.tgz",
-      "integrity": "sha512-SWP7zQ6K7hKkHAAbhWnsnv+vqpJviYBlNbiqyN1WpRIcBha3kduLn6utOdJjkSoZU+Wme6SyQ5rrDVaeHAylWw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-13.1.0.tgz",
+      "integrity": "sha512-ps8o8+3FW0kV7JWUq+h5VjaaH/Y4ztp0oArye9PcdPIZc2+a6otFwCA4GZRND/Ho/EiftkuVNEWYAsIvxqJF2w==",
       "dev": true,
       "dependencies": {
-        "acorn": "8.9.0",
+        "acorn": "8.10.0",
         "acorn-jsx": "5.3.2",
         "acorn-jsx-walk": "2.0.0",
         "acorn-loose": "8.3.0",
@@ -7641,7 +7657,7 @@
         "commander": "11.0.0",
         "enhanced-resolve": "5.15.0",
         "figures": "5.0.0",
-        "glob": "10.3.1",
+        "glob": "10.3.3",
         "handlebars": "4.7.7",
         "ignore": "5.2.4",
         "indent-string": "5.0.0",
@@ -7652,7 +7668,7 @@
         "prompts": "2.4.2",
         "rechoir": "^0.8.0",
         "safe-regex": "2.1.1",
-        "semver": "^7.5.3",
+        "semver": "^7.5.4",
         "semver-try-require": "6.2.3",
         "teamcity-service-messages": "0.1.14",
         "tsconfig-paths-webpack-plugin": "4.0.1",
@@ -7776,16 +7792,16 @@
       }
     },
     "node_modules/dependency-cruiser/node_modules/glob": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.1.tgz",
-      "integrity": "sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.10.0"
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
       },
       "bin": {
         "glob": "dist/cjs/src/bin.js"
@@ -7828,9 +7844,9 @@
       "dev": true
     },
     "node_modules/dependency-cruiser/node_modules/minimatch": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
-      "integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7843,9 +7859,9 @@
       }
     },
     "node_modules/dependency-cruiser/node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12790,9 +12806,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.1.tgz",
+      "integrity": "sha512-NQ8MCKimInjVlaIqx51RKJJB7mINVkLTJbsZKmto4UAAOC/CWXES8PGaOgoBZyqoUsUA/U3DToGK7GJkkHbjJw==",
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -13752,13 +13768,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
-      "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^9.1.1 || ^10.0.0",
-        "minipass": "^5.0.0 || ^6.0.2"
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -17123,14 +17139,15 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.24.1.tgz",
-      "integrity": "sha512-sD+s81/2aM4RRhimCDttd4xpBNbUFWnoMSHk/o8kC8Ek23jljeRNWjsxFJmOmYLuLTN9swRt1b6iXfUXTcTiIA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.28.1.tgz",
+      "integrity": "sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==",
       "dev": true,
       "dependencies": {
-        "@tsd/typescript": "~4.8.3",
+        "@tsd/typescript": "~5.0.2",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
+        "jest-diff": "^29.0.3",
         "meow": "^9.0.0",
         "path-exists": "^4.0.0",
         "read-pkg-up": "^7.0.0"
@@ -20166,12 +20183,12 @@
       "dev": true
     },
     "@arethetypeswrong/cli": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.4.2.tgz",
-      "integrity": "sha512-RlAiNUUgvsM8GX9kzNTgB8xuANf2j9klpHxU3xPhfqO03MU9ybD7Qq82ULWECe/pAX9CfT93EzEzFmoFivv5VA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.6.0.tgz",
+      "integrity": "sha512-9UEf0fRU32ZIJ1/NSl7xZTkYBJw8zc/1rlAYZ0uEpCL+W8jBXbxOm1V7fhkkALeMbjhfqM6Y0hKLs+jtESd2vg==",
       "dev": true,
       "requires": {
-        "@arethetypeswrong/core": "0.4.1",
+        "@arethetypeswrong/core": "0.6.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -20198,22 +20215,32 @@
       }
     },
     "@arethetypeswrong/core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.4.1.tgz",
-      "integrity": "sha512-DNRPu3ndvMqr6hewDP+Od8K9jZTj6cP8f/5eqRvEyZQPl11FmqOWaEuDFTEKym4nLGHM2cV5OOCnQBJ1IQbXQA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-561h7MMTJlm/etFiO9RkQJLMxLOUUasT3GqY2muc4v/WAQRRko0Z7Bfd7wMZdRAeN/QTH8VdV3dEGPilpQXiDA==",
       "dev": true,
       "requires": {
         "@andrewbranch/untar.js": "^1.0.0",
         "fetch-ponyfill": "^7.1.0",
         "fflate": "^0.7.4",
+        "semver": "^7.5.4",
         "typescript": "^5.1.3",
         "validate-npm-package-name": "^5.0.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true
         }
       }
@@ -24398,9 +24425,9 @@
       "dev": true
     },
     "@tsd/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-WMFNVstwWGyDuZP2LGPRZ+kPHxZLmhO+2ormstDvnXiyoBPtW1qq9XhhrkI4NVtxgs+2ZiUTl9AG7nNIRq/uCg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==",
       "dev": true
     },
     "@types/babel__core": {
@@ -24905,9 +24932,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "acorn": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ=="
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -26295,12 +26322,12 @@
       "dev": true
     },
     "dependency-cruiser": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-13.0.5.tgz",
-      "integrity": "sha512-SWP7zQ6K7hKkHAAbhWnsnv+vqpJviYBlNbiqyN1WpRIcBha3kduLn6utOdJjkSoZU+Wme6SyQ5rrDVaeHAylWw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-13.1.0.tgz",
+      "integrity": "sha512-ps8o8+3FW0kV7JWUq+h5VjaaH/Y4ztp0oArye9PcdPIZc2+a6otFwCA4GZRND/Ho/EiftkuVNEWYAsIvxqJF2w==",
       "dev": true,
       "requires": {
-        "acorn": "8.9.0",
+        "acorn": "8.10.0",
         "acorn-jsx": "5.3.2",
         "acorn-jsx-walk": "2.0.0",
         "acorn-loose": "8.3.0",
@@ -26310,7 +26337,7 @@
         "commander": "11.0.0",
         "enhanced-resolve": "5.15.0",
         "figures": "5.0.0",
-        "glob": "10.3.1",
+        "glob": "10.3.3",
         "handlebars": "4.7.7",
         "ignore": "5.2.4",
         "indent-string": "5.0.0",
@@ -26321,7 +26348,7 @@
         "prompts": "2.4.2",
         "rechoir": "^0.8.0",
         "safe-regex": "2.1.1",
-        "semver": "^7.5.3",
+        "semver": "^7.5.4",
         "semver-try-require": "6.2.3",
         "teamcity-service-messages": "0.1.14",
         "tsconfig-paths-webpack-plugin": "4.0.1",
@@ -26397,16 +26424,16 @@
           }
         },
         "glob": {
-          "version": "10.3.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.1.tgz",
-          "integrity": "sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==",
+          "version": "10.3.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+          "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^2.0.3",
             "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2",
-            "path-scurry": "^1.10.0"
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
           }
         },
         "indent-string": {
@@ -26428,18 +26455,18 @@
           "dev": true
         },
         "minimatch": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
-          "integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "semver": {
-          "version": "7.5.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -29891,9 +29918,9 @@
       }
     },
     "minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.1.tgz",
+      "integrity": "sha512-NQ8MCKimInjVlaIqx51RKJJB7mINVkLTJbsZKmto4UAAOC/CWXES8PGaOgoBZyqoUsUA/U3DToGK7GJkkHbjJw==",
       "dev": true
     },
     "mkdirp": {
@@ -30606,13 +30633,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-scurry": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
-      "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^9.1.1 || ^10.0.0",
-        "minipass": "^5.0.0 || ^6.0.2"
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -32994,14 +33021,15 @@
       }
     },
     "tsd": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.24.1.tgz",
-      "integrity": "sha512-sD+s81/2aM4RRhimCDttd4xpBNbUFWnoMSHk/o8kC8Ek23jljeRNWjsxFJmOmYLuLTN9swRt1b6iXfUXTcTiIA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.28.1.tgz",
+      "integrity": "sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==",
       "dev": true,
       "requires": {
-        "@tsd/typescript": "~4.8.3",
+        "@tsd/typescript": "~5.0.2",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
+        "jest-diff": "^29.0.3",
         "meow": "^9.0.0",
         "path-exists": "^4.0.0",
         "read-pkg-up": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "format": "turbo run format"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.4.2",
-    "dependency-cruiser": "^13.0.5",
+    "@arethetypeswrong/cli": "^0.6.0",
+    "dependency-cruiser": "^13.1.0",
     "prettier": "^3.0.0",
     "publint": "^0.1.16",
-    "tsd": "^0.24.1",
+    "tsd": "^0.28.1",
     "tsup": "^7.1.0",
     "turbo": "^1.10.7",
     "typescript": "<4.8"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.4.2",
     "dependency-cruiser": "^13.0.5",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "publint": "^0.1.16",
     "tsd": "^0.24.1",
     "tsup": "^7.1.0",

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -108,7 +108,7 @@ export async function prepareRoomWithStorage<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   items: IdTuple<SerializedCrdt>[],
   actor: number = 0,
@@ -206,7 +206,7 @@ export async function prepareStorageTest<
   TStorage extends LsonObject,
   TPresence extends JsonObject = never,
   TUserMeta extends BaseUserMeta = never,
-  TRoomEvent extends Json = never
+  TRoomEvent extends Json = never,
 >(items: IdTuple<SerializedCrdt>[], actor: number = 0, scopes: string[] = []) {
   let currentActor = actor;
   const operations: Op[] = [];
@@ -402,7 +402,7 @@ export async function prepareStorageUpdateTest<
   TStorage extends LsonObject,
   TPresence extends JsonObject = never,
   TUserMeta extends BaseUserMeta = never,
-  TRoomEvent extends Json = never
+  TRoomEvent extends Json = never,
 >(
   items: IdTuple<SerializedCrdt>[]
 ): Promise<{
@@ -467,7 +467,7 @@ export async function prepareDisconnectedStorageUpdateTest<
   TStorage extends LsonObject,
   TPresence extends JsonObject = never,
   TUserMeta extends BaseUserMeta = never,
-  TRoomEvent extends Json = never
+  TRoomEvent extends Json = never,
 >(items: IdTuple<SerializedCrdt>[]) {
   const { storage, room } = await prepareRoomWithStorage<
     TPresence,

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -32,7 +32,7 @@ export async function prepareStorageImmutableTest<
   TStorage extends LsonObject,
   TPresence extends JsonObject = never,
   TUserMeta extends BaseUserMeta = never,
-  TRoomEvent extends Json = never
+  TRoomEvent extends Json = never,
 >(items: IdTuple<SerializedCrdt>[], actor: number = 0) {
   let state = {} as ToJson<TStorage>;
   let refState = {} as ToJson<TStorage>;

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -84,7 +84,7 @@ function createTestableRoom<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   initialPresence: TPresence,
   authBehavior = AUTH_SUCCESS,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -19,7 +19,7 @@ const DEFAULT_LOST_CONNECTION_TIMEOUT = 5000;
 
 type EnterOptions<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
 > = Resolve<
   // Enter options are just room initializers, plus an internal option
   RoomInitializers<TPresence, TStorage> & {
@@ -45,7 +45,7 @@ export type Client = {
     TPresence extends JsonObject,
     TStorage extends LsonObject = LsonObject,
     TUserMeta extends BaseUserMeta = BaseUserMeta,
-    TRoomEvent extends Json = never
+    TRoomEvent extends Json = never,
   >(
     roomId: string
   ): Room<TPresence, TStorage, TUserMeta, TRoomEvent> | null;
@@ -59,7 +59,7 @@ export type Client = {
     TPresence extends JsonObject,
     TStorage extends LsonObject = LsonObject,
     TUserMeta extends BaseUserMeta = BaseUserMeta,
-    TRoomEvent extends Json = never
+    TRoomEvent extends Json = never,
   >(
     roomId: string,
     options: EnterOptions<TPresence, TStorage>
@@ -155,7 +155,7 @@ export function createClient(options: ClientOptions): Client {
     TPresence extends JsonObject,
     TStorage extends LsonObject = LsonObject,
     TUserMeta extends BaseUserMeta = BaseUserMeta,
-    TRoomEvent extends Json = never
+    TRoomEvent extends Json = never,
   >(roomId: string): Room<TPresence, TStorage, TUserMeta, TRoomEvent> | null {
     const room = rooms.get(roomId);
     return room
@@ -167,7 +167,7 @@ export function createClient(options: ClientOptions): Client {
     TPresence extends JsonObject,
     TStorage extends LsonObject = LsonObject,
     TUserMeta extends BaseUserMeta = BaseUserMeta,
-    TRoomEvent extends Json = never
+    TRoomEvent extends Json = never,
   >(
     roomId: string,
     options: EnterOptions<TPresence, TStorage>

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -215,7 +215,10 @@ export class StopRetrying extends Error {
 }
 
 class LiveblocksError extends Error {
-  constructor(message: string, public code: number) {
+  constructor(
+    message: string,
+    public code: number
+  ) {
     super(message);
   }
 }

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -40,7 +40,7 @@ export type LiveMapUpdates<TKey extends string, TValue extends Lson> = {
  */
 export class LiveMap<
   TKey extends string,
-  TValue extends Lson
+  TValue extends Lson,
 > extends AbstractCrdt {
   /** @internal */
   private _map: Map<TKey, LiveNode>;

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -198,7 +198,7 @@ export function patchLiveList<T extends Lson>(
 export function patchLiveObjectKey<
   O extends LsonObject,
   K extends keyof O,
-  V extends Json
+  V extends Json,
 >(liveObject: LiveObject<O>, key: K, prev?: V, next?: V): void {
   if (process.env.NODE_ENV !== "production") {
     const nonSerializableValue = findNonSerializableValue(next);

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -40,7 +40,7 @@ export type EnterFn<TContext> = (
 export type TargetFn<
   TContext extends object,
   TEvent extends BaseEvent,
-  TState extends string
+  TState extends string,
 > = (
   event: TEvent,
   context: Readonly<TContext>
@@ -57,7 +57,7 @@ export type Effect<TContext, TEvent extends BaseEvent> = (
 export type TargetObject<
   TContext extends object,
   TEvent extends BaseEvent,
-  TState extends string
+  TState extends string,
 > = {
   target: TState;
 
@@ -71,7 +71,7 @@ export type TargetObject<
 export type Target<
   TContext extends object,
   TEvent extends BaseEvent,
-  TState extends string
+  TState extends string,
 > =
   | TState // Static, e.g. 'complete'
   | TargetObject<TContext, TEvent, TState>
@@ -160,7 +160,7 @@ class SafeContext<TContext extends object> {
           for (const pair of Object.entries(patch)) {
             const [key, value] = pair as [
               keyof TContext,
-              TContext[keyof TContext]
+              TContext[keyof TContext],
             ];
             if (key !== "patch") {
               (this as TContext)[key] = value;
@@ -191,7 +191,7 @@ let nextId = 1;
 export class FSM<
   TContext extends object,
   TEvent extends BaseEvent,
-  TState extends string
+  TState extends string,
 > {
   public id: number;
 

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -20,7 +20,7 @@ export function isPlainObject(
  */
 export function entries<
   O extends { [key: string]: unknown },
-  K extends keyof O
+  K extends keyof O,
 >(obj: O): [K, O[K]][] {
   return Object.entries(obj) as [K, O[K]][];
 }

--- a/packages/liveblocks-core/src/protocol/ServerMsg.ts
+++ b/packages/liveblocks-core/src/protocol/ServerMsg.ts
@@ -26,7 +26,7 @@ export enum ServerMsgCode {
 export type ServerMsg<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > =
   // For Presence
   | UpdatePresenceServerMsg<TPresence> // Broadcasted

--- a/packages/liveblocks-core/src/refs/OthersRef.ts
+++ b/packages/liveblocks-core/src/refs/OthersRef.ts
@@ -23,7 +23,7 @@ function makeUser<TPresence extends JsonObject, TUserMeta extends BaseUserMeta>(
 
 export class OthersRef<
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > extends ImmutableRef<Others<TPresence, TUserMeta>> {
   // To track "others"
   /** @internal */

--- a/packages/liveblocks-core/src/refs/ValueRef.ts
+++ b/packages/liveblocks-core/src/refs/ValueRef.ts
@@ -28,7 +28,7 @@ export class DerivedRef<
     [K in keyof Is]: Is[K] extends ImmutableRef<unknown>
       ? Is[K]["current"]
       : never;
-  }
+  },
 > extends ImmutableRef<T> {
   /** @internal */
   private _refs: Is;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -84,7 +84,7 @@ export type StorageStatus =
 type RoomEventCallbackMap<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   connection: Callback<LegacyConnectionStatus>; // Old/deprecated API
   status: Callback<Status>; // New/recommended API
@@ -197,7 +197,7 @@ export type RoomEventCallbackFor<
   E extends RoomEventName,
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = RoomEventCallbackMap<TPresence, TUserMeta, TRoomEvent>[E];
 
 export type RoomEventCallback = RoomEventCallbackFor<
@@ -220,7 +220,7 @@ type SubscribeFn<
   TPresence extends JsonObject,
   _TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   /**
    * Subscribes to changes made on any Live structure. Returns an unsubscribe function.
@@ -414,7 +414,7 @@ export type Room<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   /**
    * @internal
@@ -660,7 +660,7 @@ type PrivateRoomAPI<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   // For introspection in unit tests only
   buffer: RoomState<TPresence, TStorage, TUserMeta, TRoomEvent>["buffer"]; // prettier-ignore
@@ -708,7 +708,7 @@ type RoomState<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   /**
    * All pending changes that yet need to be synced.
@@ -784,7 +784,7 @@ export type Polyfills = {
 
 export type RoomInitializers<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
 > = Resolve<{
   /**
    * The initial Presence to use and announce when you enter the Room. The
@@ -853,7 +853,7 @@ export function createRoom<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   options: Omit<
     RoomInitializers<TPresence, TStorage>,
@@ -2201,7 +2201,7 @@ function makeClassicSubscribeFn<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   events: Room<TPresence, TStorage, TUserMeta, TRoomEvent>["events"]
 ): SubscribeFn<TPresence, TStorage, TUserMeta, TRoomEvent> {

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -8,12 +8,12 @@ import type { User } from "./User";
  */
 export type Others<
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > = ReadonlyArrayWithLegacyMethods<User<TPresence, TUserMeta>>;
 
 export type OthersEvent<
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > =
   | {
       type: "leave";

--- a/packages/liveblocks-core/src/types/User.ts
+++ b/packages/liveblocks-core/src/types/User.ts
@@ -6,7 +6,7 @@ import type { BaseUserMeta } from "../protocol/BaseUserMeta";
  */
 export type User<
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > = {
   /**
    * The connection ID of the User. It is unique and increment at every new connection.

--- a/packages/liveblocks-devtools/src/devtools/panel.html
+++ b/packages/liveblocks-devtools/src/devtools/panel.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/packages/liveblocks-devtools/src/devtools/styles.css
+++ b/packages/liveblocks-devtools/src/devtools/styles.css
@@ -111,7 +111,8 @@ input[type="search"]::-webkit-search-cancel-button {
 
 #loading-top,
 #loading-bottom {
-  animation: loading-offset-distance var(--loading-duration) infinite
+  animation:
+    loading-offset-distance var(--loading-duration) infinite
       var(--ease-in-out-quart),
     loading-offset-rotate var(--loading-duration) infinite
       var(--ease-in-out-expo);

--- a/packages/liveblocks-devtools/src/popup/styles.css
+++ b/packages/liveblocks-devtools/src/popup/styles.css
@@ -62,7 +62,8 @@ body {
 #loading-top {
   offset-path: path("M73.5 67C73.5 67 51 96 41 86C31 76 54.5 61 54.5 61");
   transform-origin: 73.5px 67px;
-  animation: loading-offset-distance var(--loading-duration) infinite
+  animation:
+    loading-offset-distance var(--loading-duration) infinite
       var(--ease-in-out-quart),
     loading-offset-rotate var(--loading-duration) infinite
       var(--ease-in-out-expo);
@@ -71,7 +72,8 @@ body {
 #loading-bottom {
   offset-path: path("M54.5 61C54.5 61 77 32 87 42C97 52 73.5 67 73.5 67");
   transform-origin: 54.5px 61px;
-  animation: loading-offset-distance var(--loading-duration) infinite
+  animation:
+    loading-offset-distance var(--loading-duration) infinite
       var(--ease-in-out-quart),
     loading-offset-rotate var(--loading-duration) infinite
       var(--ease-in-out-expo);

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -73,7 +73,7 @@ function makeMutationContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   room: Room<TPresence, TStorage, TUserMeta, TRoomEvent>
 ): MutationContext<TPresence, TStorage, TUserMeta> {
@@ -116,7 +116,7 @@ export function createRoomContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject = LsonObject,
   TUserMeta extends BaseUserMeta = BaseUserMeta,
-  TRoomEvent extends Json = never
+  TRoomEvent extends Json = never,
 >(
   client: Client
 ): RoomContextBundle<TPresence, TStorage, TUserMeta, TRoomEvent> {
@@ -225,7 +225,7 @@ export function createRoomContext<
 
   function useMyPresence(): [
     TPresence,
-    (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void
+    (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void,
   ] {
     const room = useRoom();
     const subscribe = room.events.me.subscribe;
@@ -646,7 +646,7 @@ export function createRoomContext<
     F extends (
       context: MutationContext<TPresence, TStorage, TUserMeta>,
       ...args: any[]
-    ) => any
+    ) => any,
   >(callback: F, deps: readonly unknown[]): OmitFirstArg<F> {
     const room = useRoom();
     return React.useMemo(

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -16,7 +16,7 @@ import type { Resolve, RoomInitializers, ToImmutable } from "@liveblocks/core";
 
 export type RoomProviderProps<
   TPresence extends JsonObject,
-  TStorage extends LsonObject
+  TStorage extends LsonObject,
 > = Resolve<
   {
     /**
@@ -67,7 +67,7 @@ export type OmitFirstArg<F> = F extends (
 export type MutationContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > = {
   storage: LiveObject<TStorage>;
   self: User<TPresence, TUserMeta>;
@@ -82,7 +82,7 @@ export type RoomContextBundle<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   /**
    * You normally don't need to directly interact with the RoomContext, but
@@ -334,7 +334,7 @@ export type RoomContextBundle<
    */
   useMyPresence(): [
     TPresence,
-    (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void
+    (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void,
   ];
 
   /**
@@ -507,7 +507,7 @@ export type RoomContextBundle<
     F extends (
       context: MutationContext<TPresence, TStorage, TUserMeta>,
       ...args: any[]
-    ) => any
+    ) => any,
   >(
     callback: F,
     deps: readonly unknown[]
@@ -725,7 +725,7 @@ export type RoomContextBundle<
      */
     useMyPresence(): [
       TPresence,
-      (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void
+      (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void,
     ];
 
     /**
@@ -900,7 +900,7 @@ export type RoomContextBundle<
       F extends (
         context: MutationContext<TPresence, TStorage, TUserMeta>,
         ...args: any[]
-      ) => any
+      ) => any,
     >(
       callback: F,
       deps: readonly unknown[]

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -41,7 +41,7 @@ const ACTION_TYPES = {
 
 type LiveblocksContext<
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > = {
   /**
    * Other users in the room. Empty no room is currently synced
@@ -80,7 +80,7 @@ type LiveblocksContext<
 export type LiveblocksState<
   TState,
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > = WithLiveblocks<TState, TPresence, TUserMeta>;
 
 /**
@@ -89,7 +89,7 @@ export type LiveblocksState<
 export type WithLiveblocks<
   TState,
   TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta
+  TUserMeta extends BaseUserMeta,
 > = TState & { readonly liveblocks: LiveblocksContext<TPresence, TUserMeta> };
 
 const internalEnhancer = <TState>(options: {

--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -29,7 +29,6 @@
     "lint": "eslint src/",
     "lint:package": "publint --strict && attw --pack",
     "test": "jest --silent --verbose --color=always",
-    "test:types": "tsd",
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {

--- a/packages/liveblocks-yjs/src/index.ts
+++ b/packages/liveblocks-yjs/src/index.ts
@@ -129,7 +129,7 @@ export default class LiveblocksProvider<
   P extends JsonObject,
   S extends LsonObject,
   U extends BaseUserMeta,
-  E extends Json
+  E extends Json,
 > extends Observable<unknown> {
   private room: Room<P, S, U, E>;
   private doc: Y.Doc;

--- a/packages/liveblocks-zustand/src/__tests__/index.test.ts
+++ b/packages/liveblocks-zustand/src/__tests__/index.test.ts
@@ -98,7 +98,7 @@ function prepareClientAndStore<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   stateCreator: StateCreator<TState>,
   options: {

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -30,7 +30,7 @@ export type LiveblocksContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 > = {
   /**
    * Enters a room and starts sync it with zustand state
@@ -85,7 +85,7 @@ export type LiveblocksState<
   TPresence extends JsonObject = JsonObject,
   TStorage extends LsonObject = LsonObject,
   TUserMeta extends BaseUserMeta = BaseUserMeta,
-  TRoomEvent extends Json = Json
+  TRoomEvent extends Json = Json,
 > = WithLiveblocks<TState, TPresence, TStorage, TUserMeta, TRoomEvent>;
 
 /**
@@ -96,7 +96,7 @@ export type WithLiveblocks<
   TPresence extends JsonObject = JsonObject,
   TStorage extends LsonObject = LsonObject,
   TUserMeta extends BaseUserMeta = BaseUserMeta,
-  TRoomEvent extends Json = Json
+  TRoomEvent extends Json = Json,
 > = TState & {
   readonly liveblocks: LiveblocksContext<
     TPresence,
@@ -128,7 +128,7 @@ type Options<T> = {
 type OuterLiveblocksMiddleware = <
   TState,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = []
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
 >(
   config: StateCreator<TState, Mps, Mcs, Omit<TState, "liveblocks">>,
   options: Options<Omit<TState, "liveblocks">>
@@ -142,18 +142,18 @@ type InnerLiveblocksMiddleware = <
       BaseUserMeta,
       Json
     >;
-  }
+  },
 >(
   config: StateCreator<TState, [], []>,
   options: Options<TState>
 ) => StateCreator<TState, [], []>;
 
 type ExtractPresence<
-  TRoom extends Room<JsonObject, LsonObject, BaseUserMeta, Json>
+  TRoom extends Room<JsonObject, LsonObject, BaseUserMeta, Json>,
 > = TRoom extends Room<infer P, any, any, any> ? P : never;
 
 type ExtractStorage<
-  TRoom extends Room<JsonObject, LsonObject, BaseUserMeta, Json>
+  TRoom extends Room<JsonObject, LsonObject, BaseUserMeta, Json>,
 > = TRoom extends Room<any, infer S, any, any> ? S : never;
 
 const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
@@ -361,7 +361,7 @@ function updateLiveblocksContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   set: (
     callbackOrPartial: (
@@ -387,7 +387,7 @@ function updatePresence<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json
+  TRoomEvent extends Json,
 >(
   room: Room<TPresence, TStorage, TUserMeta, TRoomEvent>,
   oldState: TPresence,


### PR DESCRIPTION
Just some digital gardening.

This upgrades:
- `prettier` (to 3.0)
- `dependency-cruiser`
- `@arethetypeswrong/cli`
- `tsd`
