### PR TITLE
Minor cleanups

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -3,6 +3,7 @@ import type { LsonObject } from "../crdts/Lson";
 import type { ToImmutable } from "../crdts/utils";
 import type { Json, JsonObject } from "../lib/Json";
 import { makePosition } from "../lib/position";
+import { deepClone } from "../lib/utils";
 import type { Authentication } from "../protocol/Authentication";
 import type { MinimalTokenPayload } from "../protocol/AuthToken";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
@@ -51,19 +52,6 @@ export function makeMinimalTokenPayload(
     actor,
     scopes,
   };
-}
-
-/**
- * Deep-clones a JSON-serializable value.
- *
- * NOTE: We should be able to replace `deepClone` by `structuredClone` once
- * we've upgraded to Node 18.
- */
-function deepClone<T extends Json>(items: T): T {
-  // NOTE: In this case, the combination of JSON.parse() and JSON.stringify
-  // won't lead to type unsafety, so this use case is okay.
-  // eslint-disable-next-line no-restricted-syntax
-  return JSON.parse(JSON.stringify(items)) as T;
 }
 
 // NOTE: we have some instability with opIds in the undo/redo stack and this should be investigated

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -557,7 +557,7 @@ describe("room", () => {
 
       await jest.advanceTimersByTimeAsync(0);
       expect(wss.receivedMessages.length).toBe(1); // Still no new data received
-      expect(room.__internal.buffer.me?.data).toEqual({ x: 2 });
+      expect(room.__internal.presenceBuffer).toEqual({ x: 2 });
 
       // Forwarding time by the flush threshold will trigger the future flush
       await jest.advanceTimersByTimeAsync(THROTTLE_DELAY);
@@ -577,7 +577,7 @@ describe("room", () => {
     room.updatePresence({ x: 0 });
 
     expect(room.getPresence()).toStrictEqual({ x: 0 });
-    expect(room.__internal.buffer.me?.data).toStrictEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toStrictEqual({ x: 0 });
   });
 
   test("should merge current presence and set flushData presence when connection is closed", () => {
@@ -586,11 +586,11 @@ describe("room", () => {
     room.updatePresence({ x: 0 });
 
     expect(room.getPresence()).toStrictEqual({ x: 0 });
-    expect(room.__internal.buffer.me?.data).toStrictEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toStrictEqual({ x: 0 });
 
     room.updatePresence({ y: 0 });
     expect(room.getPresence()).toStrictEqual({ x: 0, y: 0 });
-    expect(room.__internal.buffer.me?.data).toStrictEqual({ x: 0, y: 0 });
+    expect(room.__internal.presenceBuffer).toStrictEqual({ x: 0, y: 0 });
   });
 
   test("others should be iterable", async () => {
@@ -880,20 +880,20 @@ describe("room", () => {
     room.connect();
 
     await waitUntilStatus(room, "connected");
-    expect(room.__internal.buffer.me).toEqual(null); // Buffer was flushed
+    expect(room.__internal.presenceBuffer).toEqual(null); // Buffer was flushed
     room.updatePresence({ x: 0 }, { addToHistory: true });
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
     room.updatePresence({ x: 1 }, { addToHistory: true });
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 1 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 1 });
 
     room.history.undo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
     expect(room.getPresence()).toEqual({ x: 0 });
 
     room.history.redo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 1 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 1 });
     expect(room.getPresence()).toEqual({ x: 1 });
   });
 
@@ -963,14 +963,14 @@ describe("room", () => {
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
     room.updatePresence({ x: 1 }, { addToHistory: true });
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 1 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 1 });
 
     room.history.pause();
     room.history.resume();
 
     room.history.undo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
     expect(room.getPresence()).toEqual({ x: 0 });
   });
 
@@ -991,28 +991,28 @@ describe("room", () => {
     // room.connect();  // Seems not even needed?
 
     room.updatePresence({ x: 0 }, { addToHistory: true });
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
 
     room.history.pause();
 
     for (let i = 1; i <= 10; i++) {
       room.updatePresence({ x: i }, { addToHistory: true });
-      expect(room.__internal.buffer.me?.data).toEqual({ x: i });
+      expect(room.__internal.presenceBuffer).toEqual({ x: i });
     }
 
     expect(room.getPresence()).toEqual({ x: 10 });
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 10 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 10 });
 
     room.history.resume();
 
     room.history.undo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
     expect(room.getPresence()).toEqual({ x: 0 });
 
     room.history.redo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 10 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 10 });
     expect(room.getPresence()).toEqual({ x: 10 });
   });
 
@@ -1032,7 +1032,7 @@ describe("room", () => {
     room.history.undo();
 
     expect(room.getPresence()).toEqual({ x: 0 });
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
   });
 
   test("undo redo with presence + storage", async () => {
@@ -1058,17 +1058,17 @@ describe("room", () => {
       storage.root.set("x", 1);
     });
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 1 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 1 });
 
     room.history.undo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 0 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 0 });
     expect(room.getPresence()).toEqual({ x: 0 });
     expect(storage.root.toObject()).toEqual({ x: 0 });
 
     room.history.redo();
 
-    expect(room.__internal.buffer.me?.data).toEqual({ x: 1 });
+    expect(room.__internal.presenceBuffer).toEqual({ x: 1 });
     expect(storage.root.toObject()).toEqual({ x: 1 });
     expect(room.getPresence()).toEqual({ x: 1 });
   });

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -78,6 +78,19 @@ export function tryParseJson(rawMessage: string): Json | undefined {
 }
 
 /**
+ * Deep-clones a JSON-serializable value.
+ *
+ * NOTE: We should be able to replace `deepClone` by `structuredClone` once
+ * we've upgraded to Node 18.
+ */
+export function deepClone<T extends Json>(items: T): T {
+  // NOTE: In this case, the combination of JSON.parse() and JSON.stringify
+  // won't lead to type unsafety, so this use case is okay.
+  // eslint-disable-next-line no-restricted-syntax
+  return JSON.parse(JSON.stringify(items)) as T;
+}
+
+/**
  * Decode base64 string.
  */
 export function b64decode(b64value: string): string {

--- a/packages/liveblocks-core/src/refs/PatchableRef.ts
+++ b/packages/liveblocks-core/src/refs/PatchableRef.ts
@@ -25,10 +25,10 @@ export class PatchableRef<T extends JsonObject> extends ImmutableRef<T> {
    * Patches the current object.
    */
   patch(patch: Partial<T>): void {
-    const oldMe = this._data;
-    const newMe = merge(oldMe, patch);
-    if (oldMe !== newMe) {
-      this._data = freeze(newMe);
+    const oldData = this._data;
+    const newData = merge(oldData, patch);
+    if (oldData !== newData) {
+      this._data = freeze(newData);
       this.invalidate();
     }
   }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -423,7 +423,7 @@ export type Room<
    * Liveblocks, NEVER USE ANY OF THESE METHODS DIRECTLY, because bad things
    * will probably happen if you do.
    */
-  readonly __internal: PrivateRoomAPI<TPresence, TStorage, TUserMeta, TRoomEvent>; // prettier-ignore
+  readonly __internal: PrivateRoomAPI; // prettier-ignore
 
   /**
    * The id of the room.
@@ -656,15 +656,10 @@ export type Room<
  * Liveblocks, NEVER USE ANY OF THESE METHODS DIRECTLY, because bad things
  * will probably happen if you do.
  */
-type PrivateRoomAPI<
-  TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json,
-> = {
+type PrivateRoomAPI = {
   // For introspection in unit tests only
-  buffer: RoomState<TPresence, TStorage, TUserMeta, TRoomEvent>["buffer"]; // prettier-ignore
-  undoStack: readonly (readonly Readonly<HistoryOp<TPresence>>[])[];
+  presenceBuffer: JsonObject | undefined;
+  undoStack: readonly (readonly Readonly<HistoryOp<JsonObject>>[])[];
   nodeCount: number;
 
   // For DevTools support (Liveblocks browser extension)
@@ -2132,8 +2127,8 @@ export function createRoom<
   return {
     /* NOTE: Exposing __internal here only to allow testing implementation details in unit tests */
     __internal: {
-      get buffer() { return context.buffer }, // prettier-ignore
-      get undoStack() { return context.undoStack }, // prettier-ignore
+      get presenceBuffer() { return JSON.parse(JSON.stringify(context.buffer.me?.data ?? null)) }, // prettier-ignore
+      get undoStack() { return JSON.parse(JSON.stringify(context.undoStack)) }, // prettier-ignore
       get nodeCount() { return context.nodes.size }, // prettier-ignore
 
       // Support for the Liveblocks browser extension

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1455,10 +1455,15 @@ export function createRoom<
     const oldValues = {} as TPresence;
 
     if (context.buffer.presenceUpdates === null) {
+      // try {
       context.buffer.presenceUpdates = {
         type: "partial",
         data: {},
       };
+      // } catch (err) {
+      //   window.console.log({ context, patch, err });
+      //   throw err;
+      // }
     }
 
     for (const key in patch) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -26,7 +26,7 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import { asPos } from "./lib/position";
 import type { Resolve } from "./lib/Resolve";
-import { compact, isPlainObject, tryParseJson } from "./lib/utils";
+import { compact, deepClone, isPlainObject, tryParseJson } from "./lib/utils";
 import type { Authentication } from "./protocol/Authentication";
 import type { ParsedAuthToken } from "./protocol/AuthToken";
 import {
@@ -658,7 +658,7 @@ export type Room<
  */
 type PrivateRoomAPI = {
   // For introspection in unit tests only
-  presenceBuffer: JsonObject | undefined;
+  presenceBuffer: Json | undefined;
   undoStack: readonly (readonly Readonly<HistoryOp<JsonObject>>[])[];
   nodeCount: number;
 
@@ -2127,8 +2127,8 @@ export function createRoom<
   return {
     /* NOTE: Exposing __internal here only to allow testing implementation details in unit tests */
     __internal: {
-      get presenceBuffer() { return JSON.parse(JSON.stringify(context.buffer.presenceUpdates?.data ?? null)) }, // prettier-ignore
-      get undoStack() { return JSON.parse(JSON.stringify(context.undoStack)) }, // prettier-ignore
+      get presenceBuffer() { return deepClone(context.buffer.presenceUpdates?.data ?? null) }, // prettier-ignore
+      get undoStack() { return deepClone(context.undoStack) }, // prettier-ignore
       get nodeCount() { return context.nodes.size }, // prettier-ignore
 
       // Support for the Liveblocks browser extension


### PR DESCRIPTION
Just some minor cleanups that I did after looking into [this bug report](https://liveblocks.slack.com/archives/C0540DQAT9P/p1688757565996999), renaming internal variables to make it easier to distinguish `context.me` from `context.buffer.me` (now called `context.buffer.presenceUpdates`), which have very different purposes. Also reduces the surface area of some internal APIs we're exposing.

This PR does _not_ solve the bug, but should make the area where that bug could be lurking smaller.
