### PR TITLE
Fix authentication steps in the docs

### DIFF
--- a/docs/pages/rooms/authentication/express.mdx
+++ b/docs/pages/rooms/authentication/express.mdx
@@ -11,99 +11,96 @@ start building your own security logic.
 
 ## Quickstart
 
-<Steps
-  steps={[
-    {
-      title: (
-        <>
-          Install the <code>@liveblocks/node</code> package
-        </>
-      ),
-      code: {
-        language: "bash",
-        code: `npm install @liveblocks/node`,
-      },
-    },
-    {
-      title: "Setup authentication endpoint",
-      description: (
-        <>
-          Users can only interact with rooms they have access to. You can
-          configure permission access in an <code>api/auth</code> endpoint by
-          creating the <code>auth.ts</code>
-          file with the following code. This is where you will implement your security
-          and define if the current user has access to a specific room.
-        </>
-      ),
-      code: {
-        file: "auth.ts",
-        language: "ts",
-        code: `const express = require("express");
-const { authorize } = require("@liveblocks/node");
-\r
-const secret = "{{SECRET_KEY}}";
-\r
-const app = express();
-\r
-app.use(express.json());
-\r
-app.post("/api/auth", (req, res) => {
-  /**
-   * Implement your own security here.
-   *
-   * It's your responsibility to ensure that the caller of this endpoint
-   * is a valid user by validating the cookies or authentication headers
-   * and that it has access to the requested room.
-   */
-  authorize({
-    room: req.body.room,
-    secret,
-    userId: "123",
-    groupIds: ["456"], // Optional
-    userInfo: {
-      // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
-      name: "Ada Lovelace",
-      color: "red",
-    },
-  })
-    .then((authResponse) => {
-      res.send(authResponse.body);
-    })
-    .catch((er) => {
-      res.status(403).end();
-    });
-});`,
-      },
-    },
-    {
-      title: "Setup the client",
-      description: (
-        <>
-          On the front-end, you can now replace the <code>publicApiKey</code>{" "}
-          option with <code>authEndpoint</code> pointing to the endpoint you
-          just created.
-        </>
-      ),
-      code: {
-        language: "ts",
-        code: `import { createClient } from "@liveblocks/client";
-\r
-const client = createClient({
-  authEndpoint: "/api/auth",
-});`,
-      },
-    },
-  ]}
-/>
+<Steps>
+  <Step>
+    <StepTitle>Install the `liveblocks/node` package</StepTitle>
+    <StepContent>
+
+      ```bash
+      npm install @liveblocks/node
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step>
+    <StepTitle>Set up authentication endpoint</StepTitle>
+    <StepContent>
+
+      Users can only interact with rooms they have access to. You can
+      configure permission access in an `api/auth` endpoint by
+      creating the `auth.ts` file with the
+      following code. This is where you will implement your security and
+      define if the current user has access to a specific room.
+
+      ```ts file="auth.ts"
+      const express = require("express");
+      const { authorize } = require("@liveblocks/node");
+
+      const secret = "{{SECRET_KEY}}";
+
+      const app = express();
+
+      app.use(express.json());
+
+      app.post("/api/auth", (req, res) => {
+        /**
+         * Implement your own security here.
+         *
+         * It's your responsibility to ensure that the caller of this endpoint
+         * is a valid user by validating the cookies or authentication headers
+         * and that it has access to the requested room.
+         */
+        authorize({
+          room: req.body.room,
+          secret,
+          userId: "123",
+          groupIds: ["456"], // Optional
+          userInfo: {
+            // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
+            name: "Ada Lovelace",
+            color: "red",
+          },
+        })
+          .then((authResponse) => {
+            res.send(authResponse.body);
+          })
+          .catch((er) => {
+            res.status(403).end();
+          });
+      });
+      ```
+    </StepContent>
+
+  </Step>
+  <Step lastStep>
+    <StepTitle>Set up the client</StepTitle>
+    <StepContent>
+      On the front-end, you can now replace the `publicApiKey`
+      option with `authEndpoint` pointing to the endpoint you
+      just created.
+
+      ```ts file="liveblocks.config.ts"
+      import { createClient } from "@liveblocks/client";
+
+      const client = createClient({
+        authEndpoint: "/api/auth",
+      });
+      ```
+
+    </StepContent>
+
+  </Step>
+</Steps>
 
 ## More information
 
-The `userId` used in the `authorize` function corresponds to userId used in our
-APIs when setting permissions (e.g. in create room). You can use the following
-example to use data from `userId` and `userInfo` on the front-end.
+The `userId` used in the `authorize` function corresponds to `userId` used in
+our APIs when setting permissions when creating a room. Both `userId` and
+`userInfo` can then be used in your JavaScript application as such:
 
 ```ts
-const self = useSelf();
+const self = room.getSelf(); // or useSelf() in React
 
 // "123"
 console.log(self.id);

--- a/docs/pages/rooms/authentication/firebase.mdx
+++ b/docs/pages/rooms/authentication/firebase.mdx
@@ -11,107 +11,98 @@ start building your own security logic.
 
 ## Quickstart
 
-<Steps
-  steps={[
-    {
-      title: (
-        <>
-          Install the <code>@liveblocks/node</code> package
-        </>
-      ),
-      description: (
-        <>
-          Let’s first install the <code>@liveblocks/node</code> package in your
-          Firebase functions project.
-        </>
-      ),
-      code: {
-        language: "bash",
-        code: `npm install @liveblocks/node`,
-      },
-    },
-    {
-      title: "Setup authentication endpoint",
-      description: (
-        <>
-          Create a new Firebase{" "}
-          <a href="https://firebase.google.com/docs/functions/callable">
-            callable function
-          </a>{" "}
-          as shown below. This is where you will implement your security and
-          define if the current user has access to a specific room.
-        </>
-      ),
-      code: {
-        language: "js",
-        code: `const functions = require("firebase-functions");
-const { authorize } = require("@liveblocks/node");
-\r
-exports.auth = functions.https.onCall((data, context) => {
-  /**
-   * Implement your own security here.
-   *
-   * It's your responsibility to ensure that the caller of this endpoint
-   * is a valid user by validating the cookies or authentication headers
-   * and that it has access to the requested room.
-   */
-  return authorize({
-    room: data.room,
-    secret: "sk_prod_xxxxxxxxxxxxxxxxxxxxxxxx",
-    userId: "123",
-    groupIds: ["456"], // Optional
-    userInfo: {
-      // Optional, corresponds to the UserMeta[info] info defined in liveblocks.config.ts
-      name: "Ada Lovelace",
-      color: "red",
-    },
-  }).then((authResult) => {
-    if (authResult.status !== 200) {
-      throw new functions.https.HttpsError(authResult.status, authResult.body);
-    }
-    return JSON.parse(authResult.body);
-  });
-});`,
-      },
-    },
-    {
-      title: "Setup the client",
-      description: (
-        <>
-          On the front-end, you can now replace the <code>publicApiKey</code>{" "}
-          option with <code>authEndpoint</code> pointing to the endpoint you
-          just created.
-        </>
-      ),
-      code: {
-        language: "js",
-        code: `import { createClient } from "@liveblocks/client";
-import firebase from "firebase";
-import "firebase/functions";
-\r
-firebase.initializeApp({
-  /* Firebase config */
-});
-\r
-const auth = firebase.functions().httpsCallable("auth");
-\r
-// Create a Liveblocks client
-const client = createClient({
-  authEndpoint: async (room) => (await auth({ room })).data,
-});`,
-      },
-    },
-  ]}
-/>
+<Steps>
+  <Step>
+    <StepTitle>Install the `liveblocks/node` package</StepTitle>
+    <StepContent>
+      Let’s first install the `@liveblocks/node` package in your
+      Firebase functions project.
+      
+      ```bash
+      npm install @liveblocks/node
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step>
+    <StepTitle>Set up authentication endpoint</StepTitle>
+    <StepContent>
+
+      Create a new Firebase [callable function](https://firebase.google.com/docs/functions/callable)
+      as shown below. This is where you will implement your security and
+      define if the current user has access to a specific room.
+
+      ```js
+      const functions = require("firebase-functions");
+      const { authorize } = require("@liveblocks/node");
+
+      exports.auth = functions.https.onCall((data, context) => {
+        /**
+         * Implement your own security here.
+         *
+         * It's your responsibility to ensure that the caller of this endpoint
+         * is a valid user by validating the cookies or authentication headers
+         * and that it has access to the requested room.
+         */
+        return authorize({
+          room: data.room,
+          secret: "sk_prod_xxxxxxxxxxxxxxxxxxxxxxxx",
+          userId: "123",
+          groupIds: ["456"], // Optional
+          userInfo: {
+            // Optional, corresponds to the UserMeta[info] info defined in liveblocks.config.ts
+            name: "Ada Lovelace",
+            color: "red",
+          },
+        }).then((authResult) => {
+          if (authResult.status !== 200) {
+            throw new functions.https.HttpsError(authResult.status, authResult.body);
+          }
+          return JSON.parse(authResult.body);
+        });
+      });
+      ```
+    </StepContent>
+
+  </Step>
+  <Step lastStep>
+    <StepTitle>Set up the client</StepTitle>
+    <StepContent>
+      On the front-end, you can now replace the `publicApiKey`
+      option with `authEndpoint` pointing to the endpoint you
+      just created.
+
+      ```js
+      import { createClient } from "@liveblocks/client";
+      import firebase from "firebase";
+      import "firebase/functions";
+
+      firebase.initializeApp({
+        /* Firebase config */
+      });
+
+      const auth = firebase.functions().httpsCallable("auth");
+
+      // Create a Liveblocks client
+      const client = createClient({
+        authEndpoint: async (room) => (await auth({ room })).data,
+      });
+      ```
+
+    </StepContent>
+
+  </Step>
+</Steps>
 
 ## More information
 
-The `userId` used in the `authorize` function corresponds to userId used in our
-APIs when setting permissions (e.g. in create room). You can use the following
-example to use data from `userId` and `userInfo` on the front-end.
+The `userId` used in the `authorize` function corresponds to `userId` used in
+our APIs when setting permissions when creating a room. Both `userId` and
+`userInfo` can then be used in your JavaScript application as such:
 
 ```ts
-const self = useSelf();
+const self = room.getSelf(); // or useSelf() in React
 
 // "123"
 console.log(self.id);

--- a/docs/pages/rooms/authentication/nextjs.mdx
+++ b/docs/pages/rooms/authentication/nextjs.mdx
@@ -11,90 +11,87 @@ start building your own security logic in Next.js’ `/app` directory.
 
 ## Quickstart
 
-<Steps
-  steps={[
-    {
-      title: (
-        <>
-          Install the <code>@liveblocks/node</code> package
-        </>
-      ),
-      code: {
-        language: "bash",
-        code: `npm install @liveblocks/node`,
-      },
-    },
-    {
-      title: "Setup authentication endpoint",
-      description: (
-        <>
-          Users can only interact with rooms they have access to. You can
-          configure permission access in an <code>api/auth</code> endpoint by
-          creating the <code>app/api/auth/route.ts</code> file with the
-          following code. This is where you will implement your security and
-          define if the current user has access to a specific room.
-        </>
-      ),
-      code: {
-        file: "app/api/auth/route.ts",
-        language: "ts",
-        code: `import { NextResponse } from "next/server";
-import { authorize } from "@liveblocks/node";
-\r
-const secret = "{{SECRET_KEY}}";
-\r
-export async function POST(request: Request) {
-  /**
-   * Implement your own security here.
-   *
-   * It's your responsibility to ensure that the caller of this endpoint
-   * is a valid user by validating the cookies or authentication headers
-   * and that it has access to the requested room.
-   */
-  const { room } = await request.json();
-\r
-  const result = await authorize({
-    room,
-    secret,
-    userId: "123",
-    groupIds: ["456"], // Optional
-    userInfo: {
-      // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
-      name: "Ada Lovelace",
-      color: "red",
-    },
-  });
-\r
-  return NextResponse.json(JSON.parse(result.body));
-}`,
-      },
-    },
-    {
-      title: "Setup the client",
-      description: (
-        <>
-          On the front-end, you can now replace the <code>publicApiKey</code>{" "}
-          option with <code>authEndpoint</code> pointing to the endpoint you
-          just created.
-        </>
-      ),
-      code: {
-        language: "ts",
-        code: `import { createClient } from "@liveblocks/client";
-\r
-const client = createClient({
-  authEndpoint: "/api/auth",
-});`,
-      },
-    },
-  ]}
-/>
+<Steps>
+  <Step>
+    <StepTitle>Install the `liveblocks/node` package</StepTitle>
+    <StepContent>
+
+      ```bash
+      npm install @liveblocks/node
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step>
+    <StepTitle>Set up authentication endpoint</StepTitle>
+    <StepContent>
+      Users can only interact with rooms they have access to. You can
+      configure permission access in an `api/auth` endpoint by
+      creating the `app/api/auth/route.ts` file with the
+      following code. This is where you will implement your security and
+      define if the current user has access to a specific room.
+
+      ```ts file="app/api/auth/route.ts"
+      import { NextResponse } from "next/server";
+      import { authorize } from "@liveblocks/node";
+
+      const secret = "{{SECRET_KEY}}";
+
+      export async function POST(request: Request) {
+        /**
+         * Implement your own security here.
+         *
+         * It's your responsibility to ensure that the caller of this endpoint
+         * is a valid user by validating the cookies or authentication headers
+         * and that it has access to the requested room.
+         */
+        const { room } = await request.json();
+
+        const result = await authorize({
+          room,
+          secret,
+          userId: "123",
+          groupIds: ["456"], // Optional
+          userInfo: {
+            // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
+            name: "Ada Lovelace",
+            color: "red",
+          },
+        });
+
+        return NextResponse.json(JSON.parse(result.body));
+      }
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step lastStep>
+    <StepTitle>Set up the client</StepTitle>
+    <StepContent>
+      On the front-end, you can now replace the `publicApiKey`
+      option with `authEndpoint` pointing to the endpoint you
+      just created.
+
+      ```ts file="liveblocks.config.ts"
+      import { createClient } from "@liveblocks/client";
+
+      const client = createClient({
+        authEndpoint: "/api/auth",
+      });
+      ```
+
+    </StepContent>
+
+  </Step>
+</Steps>
 
 ## More information
 
-The `userId` used in the `authorize` function corresponds to userId used in our
-APIs when setting permissions (e.g. in create room). You can use the following
-example to use data from `userId` and `userInfo` on the front-end.
+The `userId` used in the `authorize` function corresponds to `userId` used in
+our APIs when setting permissions when creating a room. Both `userId` and
+`userInfo` can then be used in your React application as such:
 
 ```ts
 const self = useSelf();

--- a/docs/pages/rooms/authentication/nuxtjs.mdx
+++ b/docs/pages/rooms/authentication/nuxtjs.mdx
@@ -11,93 +11,89 @@ start building your own security logic.
 
 ## Quickstart
 
-<Steps
-  steps={[
-    {
-      title: (
-        <>
-          Install the <code>@liveblocks/node</code> package
-        </>
-      ),
-      code: {
-        language: "bash",
-        code: `npm install @liveblocks/node`,
-      },
-    },
-    {
-      title: "Setup authentication endpoint",
-      description: (
-        <>
-          Users can only interact with rooms they have access to. You can
-          configure permission access in an <code>api/auth</code> endpoint by
-          creating the <code>server/api/auth.ts</code> file with the following
-          code. This is where you will implement your security and define if the
-          current user has access to a specific room.
-        </>
-      ),
-      code: {
-        file: "server/api/auth.ts",
-        language: "ts",
-        code: `import { authorize } from "@liveblocks/node";
-\r
-const secret = "{{SECRET_KEY}}";
-\r
-export default defineEventHandler(async (event) => {
-  /**
-   * Implement your own security here.
-   *
-   * It's your responsibility to ensure that the caller of this endpoint
-   * is a valid user by validating the cookies or authentication headers
-   * and that it has access to the requested room.
-   */
-  const { room } = await readBody(event)
-\r
-  const result = await authorize({
-    room,
-    secret,
-    userId: "123",
-    groupIds: ["456"], // Optional
-    userInfo: {
-      // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
-      name: "Ada Lovelace",
-      color: "red",
-    },
-  });
-\r
-  return result.body
-})
-`,
-      },
-    },
-    {
-      title: "Setup the client",
-      description: (
-        <>
-          On the front-end, you can now replace the <code>publicApiKey</code>{" "}
-          option with <code>authEndpoint</code> pointing to the endpoint you
-          just created.
-        </>
-      ),
-      code: {
-        language: "ts",
-        code: `import { createClient } from "@liveblocks/client";
-\r
-const client = createClient({
-  authEndpoint: "/api/auth",
-});`,
-      },
-    },
-  ]}
-/>
+<Steps>
+  <Step>
+    <StepTitle>Install the `liveblocks/node` package</StepTitle>
+    <StepContent>
+
+      ```bash
+      npm install @liveblocks/node
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step>
+    <StepTitle>Set up authentication endpoint</StepTitle>
+    <StepContent>
+      Users can only interact with rooms they have access to. You can
+      configure permission access in an `api/auth` endpoint by
+      creating the `server/api/auth.ts` file with the
+      following code. This is where you will implement your security and
+      define if the current user has access to a specific room.
+
+      ```ts file="server/api/auth.ts"
+      import { authorize } from "@liveblocks/node";
+
+      const secret = "{{SECRET_KEY}}";
+
+      export default defineEventHandler(async (event) => {
+        /**
+         * Implement your own security here.
+         *
+         * It's your responsibility to ensure that the caller of this endpoint
+         * is a valid user by validating the cookies or authentication headers
+         * and that it has access to the requested room.
+         */
+        const { room } = await readBody(event)
+
+        const result = await authorize({
+          room,
+          secret,
+          userId: "123",
+          groupIds: ["456"], // Optional
+          userInfo: {
+            // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
+            name: "Ada Lovelace",
+            color: "red",
+          },
+        });
+
+        return result.body
+      })
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step lastStep>
+    <StepTitle>Set up the client</StepTitle>
+    <StepContent>
+      On the front-end, you can now replace the `publicApiKey`
+      option with `authEndpoint` pointing to the endpoint you
+      just created.
+
+      ```ts
+      import { createClient } from "@liveblocks/client";
+
+      const client = createClient({
+        authEndpoint: "/api/auth",
+      });
+      ```
+
+    </StepContent>
+
+  </Step>
+</Steps>
 
 ## More information
 
-The `userId` used in the `authorize` function corresponds to userId used in our
-APIs when setting permissions (e.g. in create room). You can use the following
-example to use data from `userId` and `userInfo` on the front-end.
+The `userId` used in the `authorize` function corresponds to `userId` used in
+our APIs when setting permissions when creating a room. Both `userId` and
+`userInfo` can then be used in your Vue.js application as such:
 
 ```ts
-const self = useSelf();
+const self = ref(room.getSelf());
 
 // "123"
 console.log(self.id);

--- a/docs/pages/rooms/authentication/remix.mdx
+++ b/docs/pages/rooms/authentication/remix.mdx
@@ -11,90 +11,87 @@ start building your own security logic.
 
 ## Quickstart
 
-<Steps
-  steps={[
-    {
-      title: (
-        <>
-          Install the <code>@liveblocks/node</code> package
-        </>
-      ),
-      code: {
-        language: "bash",
-        code: `npm install @liveblocks/node`,
-      },
-    },
-    {
-      title: "Setup authentication endpoint",
-      description: (
-        <>
-          Users can only interact with rooms they have access to. You can
-          configure permission access in an <code>api/auth</code> endpoint by
-          creating the <code>app/routes/api/auth.ts</code> file with the
-          following code. This is where you will implement your security and
-          define if the current user has access to a specific room.
-        </>
-      ),
-      code: {
-        file: "app/routes/api/auth.ts",
-        language: "ts",
-        code: `import type { ActionFunction } from "@remix-run/node";
-import { authorize } from "@liveblocks/node";
-\r
-const secret = "{{SECRET_KEY}}";
-\r
-export const action: ActionFunction = async ({ request }) => {
-  /**
-   * Implement your own security here.
-   *
-   * It's your responsibility to ensure that the caller of this endpoint
-   * is a valid user by validating the cookies or authentication headers
-   * and that it has access to the requested room.
-   */
-  const { room } = await request.json();
-\r
-  const result = await authorize({
-    room,
-    secret,
-    userId: "123",
-    groupIds: ["456"], // Optional
-    userInfo: {
-      // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
-      name: "Ada Lovelace",
-      color: "red",
-    },
-  });
-\r
-  return new Response(result.body, { status: result.status });
-}`,
-      },
-    },
-    {
-      title: "Setup the client",
-      description: (
-        <>
-          On the front-end, you can now replace the <code>publicApiKey</code>{" "}
-          option with <code>authEndpoint</code> pointing to the endpoint you
-          just created.
-        </>
-      ),
-      code: {
-        language: "ts",
-        code: `import { createClient } from "@liveblocks/client";
-\r
-const client = createClient({
-  authEndpoint: "/api/auth",
-});`,
-      },
-    },
-  ]}
-/>
+<Steps>
+  <Step>
+    <StepTitle>Install the `liveblocks/node` package</StepTitle>
+    <StepContent>
+
+      ```bash
+      npm install @liveblocks/node
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step>
+    <StepTitle>Set up authentication endpoint</StepTitle>
+    <StepContent>
+      Users can only interact with rooms they have access to. You can
+      configure permission access in an `api/auth` endpoint by
+      creating the `app/routes/api/auth.ts` file with the
+      following code. This is where you will implement your security and
+      define if the current user has access to a specific room.
+
+      ```ts file="app/routes/api/auth.ts"
+      import type { ActionFunction } from "@remix-run/node";
+      import { authorize } from "@liveblocks/node";
+
+      const secret = "{{SECRET_KEY}}";
+
+      export const action: ActionFunction = async ({ request }) => {
+        /**
+         * Implement your own security here.
+         *
+         * It's your responsibility to ensure that the caller of this endpoint
+         * is a valid user by validating the cookies or authentication headers
+         * and that it has access to the requested room.
+         */
+        const { room } = await request.json();
+
+        const result = await authorize({
+          room,
+          secret,
+          userId: "123",
+          groupIds: ["456"], // Optional
+          userInfo: {
+            // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
+            name: "Ada Lovelace",
+            color: "red",
+          },
+        });
+
+        return new Response(result.body, { status: result.status });
+      }
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step lastStep>
+    <StepTitle>Set up the client</StepTitle>
+    <StepContent>
+      On the front-end, you can now replace the `publicApiKey`
+      option with `authEndpoint` pointing to the endpoint you
+      just created.
+
+      ```ts
+      import { createClient } from "@liveblocks/client";
+
+      const client = createClient({
+        authEndpoint: "/api/auth",
+      });
+      ```
+
+    </StepContent>
+
+  </Step>
+</Steps>
 
 ## More information
 
-The `userId` used in the `authorize` function corresponds to userId used in our
-APIs when setting permissions (e.g. in create room). You can use the following
-example to use data from `userId` and `userInfo` on the front-end.
+The `userId` used in the `authorize` function corresponds to `userId` used in
+our APIs when setting permissions when creating a room. Both `userId` and
+`userInfo` can then be used in your React application as such:
 
 ```ts
 const self = useSelf();

--- a/docs/pages/rooms/authentication/sveltekit.mdx
+++ b/docs/pages/rooms/authentication/sveltekit.mdx
@@ -11,93 +11,90 @@ start building your own security logic.
 
 ## Quickstart
 
-<Steps
-  steps={[
-    {
-      title: (
-        <>
-          Install the <code>@liveblocks/node</code> package
-        </>
-      ),
-      code: {
-        language: "bash",
-        code: `npm install @liveblocks/node`,
-      },
-    },
-    {
-      title: "Setup authentication endpoint",
-      description: (
-        <>
-          Users can only interact with rooms they have access to. You can
-          configure permission access in an <code>api/auth</code> endpoint by
-          creating the <code>src/routes/api/auth/+server.ts</code> file with the
-          following code. This is where you will implement your security and
-          define if the current user has access to a specific room.
-        </>
-      ),
-      code: {
-        file: "src/routes/api/auth/+server.ts",
-        language: "ts",
-        code: `import { type RequestEvent } from "@sveltejs/kit";
-import { authorize } from "@liveblocks/node";
-\r
-const secret = "{{SECRET_KEY}}";
-\r
-export async function POST({ request }: RequestEvent) {
-  /**
-   * Implement your own security here.
-   *
-   * It's your responsibility to ensure that the caller of this endpoint
-   * is a valid user by validating the cookies or authentication headers
-   * and that it has access to the requested room.
-   */
-  const { room } = await request.json();
-\r
-  const result = await authorize({
-    room,
-    secret,
-    userId: "123",
-    groupIds: ["456"], // Optional
-    userInfo: {
-      // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
-      name: "Ada Lovelace",
-      color: "red",
-    },
-  });
-\r
-  return new Response(result.body, { status: response.status });
-}`,
-      },
-    },
-    {
-      title: "Setup the client",
-      description: (
-        <>
-          On the front-end, you can now replace the <code>publicApiKey</code>{" "}
-          option with <code>authEndpoint</code> pointing to the endpoint you
-          just created.
-        </>
-      ),
-      code: {
-        language: "ts",
-        code: `import { createClient } from "@liveblocks/client";
-\r
-const client = createClient({
-  authEndpoint: "/api/auth",
-});`,
-      },
-    },
-  ]}
-/>
+<Steps>
+  <Step>
+    <StepTitle>Install the `liveblocks/node` package</StepTitle>
+    <StepContent>
+
+      ```bash
+      npm install @liveblocks/node
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step>
+    <StepTitle>Set up authentication endpoint</StepTitle>
+    <StepContent>
+      Users can only interact with rooms they have access to. You can
+      configure permission access in an `api/auth` endpoint by
+      creating the `src/routes/api/auth/+server.ts` file with the
+      following code. This is where you will implement your security and
+      define if the current user has access to a specific room.
+
+      ```ts file="src/routes/api/auth/+server.ts"
+      import { type RequestEvent } from "@sveltejs/kit";
+      import { authorize } from "@liveblocks/node";
+
+      const secret = "{{SECRET_KEY}}";
+
+      export async function POST({ request }: RequestEvent) {
+        /**
+         * Implement your own security here.
+         *
+         * It's your responsibility to ensure that the caller of this endpoint
+         * is a valid user by validating the cookies or authentication headers
+         * and that it has access to the requested room.
+         */
+        const { room } = await request.json();
+
+        const result = await authorize({
+          room,
+          secret,
+          userId: "123",
+          groupIds: ["456"], // Optional
+          userInfo: {
+            // Optional, corresponds to the UserMeta[info] type defined in liveblocks.config.ts
+            name: "Ada Lovelace",
+            color: "red",
+          },
+        });
+
+        return new Response(result.body, { status: response.status });
+      }
+      ```
+
+    </StepContent>
+
+  </Step>
+  <Step lastStep>
+    <StepTitle>Set up the client</StepTitle>
+    <StepContent>
+      On the front-end, you can now replace the `publicApiKey`
+      option with `authEndpoint` pointing to the endpoint you
+      just created.
+
+      ```ts
+      import { createClient } from "@liveblocks/client";
+
+      const client = createClient({
+        authEndpoint: "/api/auth",
+      });
+      ```
+
+    </StepContent>
+
+  </Step>
+</Steps>
 
 ## More information
 
-The `userId` used in the `authorize` function corresponds to userId used in our
-APIs when setting permissions (e.g. in create room). You can use the following
-example to use data from `userId` and `userInfo` on the front-end.
+The `userId` used in the `authorize` function corresponds to `userId` used in
+our APIs when setting permissions when creating a room. Both `userId` and
+`userInfo` can then be used in your Svelte application as such:
 
 ```ts
-const self = useSelf();
+const self = room.getSelf();
 
 // "123"
 console.log(self.id);


### PR DESCRIPTION
A previous commit broken authentication guides: the step-by-step instructions didn't show up due to a change in our Steps component.

This PR fixes this issue.