### PR TITLE
Make room internals non-enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.1.5
+
+### `@liveblocks/client`
+
+Fix a bug where the room internals could become non-functional when used in
+combination with Immer due to Immer’s excessive auto-freezing, which would break
+the room’s internals. (This became an issue since Liveblocks 1.1 was released.)
+
 # v1.1.4
 
 Undo the changes made in 1.1.3. We’ve got some bug reports where Liveblocks


### PR DESCRIPTION
This solves the Immer incompatibility issue in a more robust way, since Immer will not freeze non-enumerable properties.
