### PR TITLE
Loosen dupe detection alert a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.1.6
+
+### `@liveblocks/*`
+
+Loosen duplicate import detection so it won't throw when used in test runners
+that deliberately run multiple instances of a module (like Jest or Playwright
+can do).
+
 # v1.1.5
 
 ### `@liveblocks/*`

--- a/packages/liveblocks-core/src/dupe-detection.ts
+++ b/packages/liveblocks-core/src/dupe-detection.ts
@@ -39,6 +39,8 @@ export function detectDupes(
 
   if (!g[pkgId]) {
     g[pkgId] = pkgBuildInfo;
+  } else if (g[pkgId] === pkgBuildInfo) {
+    // Allow it, see XXX
   } else {
     const msg = [
       `Multiple copies of Liveblocks are being loaded in your project. This will cause issues! See ${


### PR DESCRIPTION
Some test runners will deliberately run multiple copies of a module instance to ensure proper test isolation. They will do this by clearing their module cache between test runs, so the next test run will re-execute a module's code again. From a test runner's perspective, this is fine behavior. This behavior as-such will not break any assumptions Liveblocks internally has to make, so it should be fine to do this in a test runner context.

The issue now, however, is that these test runners don't also reset the `globalThis` instance when they clear their module cache, and since this is where we keep track of the module instances being loaded, we'll be reporting false positives.

Ideally, there would be a central/global place we could query that _also_ gets reset by test runners (so something different than `globalThis`), but I don't know of such global.

So this PR loosens the check in a different way: if the already-loaded and currently-being-loaded version are the exact same version + format, then we'll allow it, and assume it's a test runner deliberately loading multiple instances of the code, and allow it.
