### PR TITLE
Fix bug where `useSelf` would not always update correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v1.1.7
+
+### `@liveblocks/react`
+
+Fix a bug with `useSelf()` where it would not correctly re-render after entering
+an empty room. It’s now consistent again with `useMyPresence()`.
+
+### DevTools
+
+Fix a bug in the Liveblocks [DevTools](https://liveblocks.io/devtools) panel
+where the "me" view would incorrectly stay empty after entering an empty room.
+
 # v1.1.6
 
 ### `@liveblocks/*`

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1121,7 +1121,7 @@ describe("room", () => {
 
       const callback = jest.fn();
 
-      room.events.me.subscribe(callback);
+      room.events.myPresence.subscribe(callback);
 
       room.batch(() => {
         room.updatePresence({ x: 0 });
@@ -1349,7 +1349,7 @@ describe("room", () => {
       const { room } = createTestableRoom({});
 
       const callback = jest.fn();
-      const unsubscribe = room.events.me.subscribe(callback);
+      const unsubscribe = room.events.myPresence.subscribe(callback);
 
       room.updatePresence({ x: 0 });
 

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -106,7 +106,7 @@ function startSyncStream(
     room.events.storage.subscribe(() => partialSyncStorage(room)),
 
     // Any time "me" or "others" updates, send the new values accordingly
-    room.events.myPresence.subscribe(() => partialSyncMe(room)),
+    room.events.self.subscribe(() => partialSyncMe(room)),
     room.events.others.subscribe(() => partialSyncOthers(room)),
   ]);
 }

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -106,7 +106,7 @@ function startSyncStream(
     room.events.storage.subscribe(() => partialSyncStorage(room)),
 
     // Any time "me" or "others" updates, send the new values accordingly
-    room.events.me.subscribe(() => partialSyncMe(room)),
+    room.events.myPresence.subscribe(() => partialSyncMe(room)),
     room.events.others.subscribe(() => partialSyncOthers(room)),
   ]);
 }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1285,6 +1285,7 @@ export function createRoom<
         const updates = Array.from(storageUpdates.values());
         eventHub.storage.notify(updates);
       }
+      notifyStorageStatus();
     });
   }
 
@@ -1396,10 +1397,6 @@ export function createRoom<
         }
       }
     }
-
-    notifyStorageStatus();
-    notifySelfChanged(doNotBatchUpdates);
-    //                ^^^^^^^^^^^^^^^^^ Incorrect! This entire applyOps function should be called in a batched updates wrapper
 
     return {
       ops,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -566,6 +566,7 @@ export type Room<
     readonly lostConnection: Observable<LostConnectionEvent>;
 
     readonly customEvent: Observable<{ connectionId: number; event: TRoomEvent; }>; // prettier-ignore
+    readonly self: Observable<User<TPresence, TUserMeta>>;
     readonly myPresence: Observable<TPresence>;
     readonly others: Observable<{ others: Others<TPresence, TUserMeta>; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
@@ -1107,6 +1108,7 @@ export function createRoom<
     lostConnection: makeEventSource<LostConnectionEvent>(),
 
     customEvent: makeEventSource<CustomEvent<TRoomEvent>>(),
+    self: makeEventSource<User<TPresence, TUserMeta>>(),
     myPresence: makeEventSource<TPresence>(),
     others: makeEventSource<{
       others: Others<TPresence, TUserMeta>;
@@ -2118,6 +2120,7 @@ export function createRoom<
 
     customEvent: eventHub.customEvent.observable,
     others: eventHub.others.observable,
+    self: eventHub.self.observable,
     myPresence: eventHub.myPresence.observable,
     error: eventHub.error.observable,
     storage: eventHub.storage.observable,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -566,7 +566,7 @@ export type Room<
     readonly lostConnection: Observable<LostConnectionEvent>;
 
     readonly customEvent: Observable<{ connectionId: number; event: TRoomEvent; }>; // prettier-ignore
-    readonly me: Observable<TPresence>;
+    readonly myPresence: Observable<TPresence>;
     readonly others: Observable<{ others: Others<TPresence, TUserMeta>; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
     readonly storage: Observable<StorageUpdate[]>;
@@ -1107,7 +1107,7 @@ export function createRoom<
     lostConnection: makeEventSource<LostConnectionEvent>(),
 
     customEvent: makeEventSource<CustomEvent<TRoomEvent>>(),
-    me: makeEventSource<TPresence>(),
+    myPresence: makeEventSource<TPresence>(),
     others: makeEventSource<{
       others: Others<TPresence, TUserMeta>;
       event: OthersEvent<TPresence, TUserMeta>;
@@ -1263,7 +1263,7 @@ export function createRoom<
       }
 
       if (presence) {
-        eventHub.me.notify(context.me.current);
+        eventHub.myPresence.notify(context.me.current);
       }
 
       if (storageUpdates.size > 0) {
@@ -2118,7 +2118,7 @@ export function createRoom<
 
     customEvent: eventHub.customEvent.observable,
     others: eventHub.others.observable,
-    me: eventHub.me.observable,
+    myPresence: eventHub.myPresence.observable,
     error: eventHub.error.observable,
     storage: eventHub.storage.observable,
     history: eventHub.history.observable,
@@ -2263,7 +2263,7 @@ function makeClassicSubscribeFn<
           );
 
         case "my-presence":
-          return events.me.subscribe(callback as Callback<TPresence>);
+          return events.myPresence.subscribe(callback as Callback<TPresence>);
 
         case "others": {
           // NOTE: Others have a different callback structure, where the API

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -228,7 +228,7 @@ export function createRoomContext<
     (patch: Partial<TPresence>, options?: { addToHistory: boolean }) => void,
   ] {
     const room = useRoom();
-    const subscribe = room.events.me.subscribe;
+    const subscribe = room.events.myPresence.subscribe;
     const getSnapshot = room.getPresence;
     const presence = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
     const setPresence = room.updatePresence;
@@ -430,8 +430,8 @@ export function createRoomContext<
 
     const subscribe = React.useCallback(
       (onChange: () => void) => {
-        const unsub1 = room.events.me.subscribe(onChange);
-        const unsub2 = room.events.connection.subscribe(onChange);
+        const unsub1 = room.events.myPresence.subscribe(onChange);
+        const unsub2 = room.events.status.subscribe(onChange);
         return () => {
           unsub1();
           unsub2();

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -427,24 +427,11 @@ export function createRoomContext<
     type Selection = T | null;
 
     const room = useRoom();
-
-    const subscribe = React.useCallback(
-      (onChange: () => void) => {
-        const unsub1 = room.events.myPresence.subscribe(onChange);
-        const unsub2 = room.events.status.subscribe(onChange);
-        return () => {
-          unsub1();
-          unsub2();
-        };
-      },
-      [room]
-    );
-
+    const subscribe = room.events.self.subscribe;
     const getSnapshot: () => Snapshot = room.getSelf;
 
     const selector =
       maybeSelector ?? (identity as (me: User<TPresence, TUserMeta>) => T);
-
     const wrappedSelector = React.useCallback(
       (me: Snapshot): Selection => (me !== null ? selector(me) : null),
       [selector]

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -239,7 +239,7 @@ const internalEnhancer = <TState>(options: {
         );
 
         unsubscribeCallbacks.push(
-          room.events.me.subscribe(() => {
+          room.events.myPresence.subscribe(() => {
             if (isPatching === false) {
               store.dispatch({
                 type: ACTION_TYPES.PATCH_REDUX_STATE,

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -208,7 +208,7 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
       );
 
       unsubscribeCallbacks.push(
-        room.events.me.subscribe(() => {
+        room.events.myPresence.subscribe(() => {
           if (isPatching === false) {
             set(
               selectFields(


### PR DESCRIPTION
I found a bug in the `useSelf()` hook, where it would not get re-rendered correctly when joining an empty room. In contrast, `useMyPresence()` _would_ update correctly. DevTools used the same event, so it also suffered from this problem.

## Before the fix

Before the fix, "me" would not get updated/rerendered correctly until it got updated. The data was there internally, but it didn't get rendered correctly.

https://github.com/liveblocks/liveblocks/assets/83844/c90383eb-d113-410c-9d69-4c088de79a36

## After the fix

After the fix, "me" will get updated correctly after loading:

https://github.com/liveblocks/liveblocks/assets/83844/b56e200c-ea1a-4233-90d0-db8fea080a44

