### PR TITLE
Small doc fix - install command for y-codemirror.next 

### DIFF
--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-react-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-react-and-liveblocks.mdx
@@ -30,7 +30,7 @@ Run the following command to install the CodeMirror, Yjs, and Liveblocks
 packages:
 
 ```bash
-npm install codemirror @codemirror/lang-javascript @y-codemirror.next @liveblocks/client @liveblocks/react @liveblocks/yjs yjs
+npm install codemirror @codemirror/lang-javascript y-codemirror.next @liveblocks/client @liveblocks/react @liveblocks/yjs yjs
 ```
 
 ## Initialize the `liveblocks.config.ts` file


### PR DESCRIPTION
Visit the docs: https://liveblocks.io/docs/guides/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-react-and-liveblocks#Install-CodeMirror-Yjs-and-Liveblocks-into-your-React-application

The npm install command is using the wrong npm package name for y-codemirror.next  - to fix removed the @