### PR TITLE
Improved the error message on createClient package, when both publicApiKey & authEndpoint are not defined

### DIFF
--- a/packages/liveblocks-core/src/__tests__/client.node.test.ts
+++ b/packages/liveblocks-core/src/__tests__/client.node.test.ts
@@ -43,12 +43,12 @@ describe("createClient", () => {
     [
       undefined,
       undefined,
-      "Invalid Liveblocks client options. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClient",
+      "Invalid Liveblocks client options. Please provide either publicApiKey or authEndpoint. Both options cannot be empty. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClient",
     ],
     [
       null,
       undefined,
-      "Invalid Liveblocks client options. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClient",
+      "Invalid Liveblocks client options. Please provide either publicApiKey or authEndpoint. Both options cannot be empty. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClient",
     ],
     [
       undefined,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -324,7 +324,7 @@ function prepareAuthentication(
   }
 
   throw new Error(
-    "Invalid Liveblocks client options. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClient"
+    "Invalid Liveblocks client options. Please provide either publicApiKey or authEndpoint. Both options cannot be empty. For more information: https://liveblocks.io/docs/api-reference/liveblocks-client#createClient"
   );
 }
 


### PR DESCRIPTION
I would like to inform you that I have made a modification to the error message that appears during the "createClient" process when both the publicKeyApi and authEndpoint parameters are missing. The reason behind this modification is that I recently encountered a situation where a user in the Liveblock's Discord community encountered this error and was unable to identify the root cause.

In order to assist users in troubleshooting such issues more effectively, I have made the error message more informative. This enhancement will provide clearer guidance to users when they encounter this specific error scenario.

I believe that improving the error message in this manner will contribute to a smoother user experience and help to minimize confusion and frustration.

Thankx, have a nice day.