### PR TITLE
fix(tutorial): Import missing in `tutorial/react/getting-started/nesting-data-types/initial/Room.tsx`

### DIFF
--- a/tutorial/react/getting-started/nesting-data-types/initial/Room.tsx
+++ b/tutorial/react/getting-started/nesting-data-types/initial/Room.tsx
@@ -1,5 +1,5 @@
-import { useStorage, useMutation } from "./liveblocks.config";
 import { LiveObject } from "@liveblocks/client";
+import { useStorage, useMutation } from "./liveblocks.config";
 
 export function Room() {
   const person = useStorage((root) => root.person);

--- a/tutorial/react/getting-started/nesting-data-types/initial/Room.tsx
+++ b/tutorial/react/getting-started/nesting-data-types/initial/Room.tsx
@@ -1,4 +1,5 @@
 import { useStorage, useMutation } from "./liveblocks.config";
+import { LiveObject } from "@liveblocks/client";
 
 export function Room() {
   const person = useStorage((root) => root.person);


### PR DESCRIPTION
All the tutorial steps do not require any import. Still, it is in `Nesting data types`, so I added it in `tutorial/react/getting-started/nesting-data-types/initial/Room.tsx` to keep consistency.
