### PR TITLE
Allow custom `authEndpoint` callback function to signal that client should stop retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v1.1.7
+
+### `@liveblocks/client`
+
+When initializing the client with a
+[custom auth callback](https://liveblocks.io/docs/api-reference/liveblocks-client#createClientCallback),
+you can now return `{ error: "forbidden", reason: ... }` as the response, which
+the client will treat as a sign to stop retrying. The client will then
+disconnect from the room, instead of remaining in `"connecting"` status
+indefinitely.
+
 # v1.1.6
 
 ### `@liveblocks/*`

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -37,7 +37,15 @@ const client = createClient({ authEndpoint: "/api/auth" });
 ### createClient with callback [#createClientCallback]
 
 If you need to add additional headers or use your own function to call the
-endpoint, `authEndpoint` also supports a callback.
+endpoint, `authEndpoint` can be provided as a custom callback.
+
+Allowed responses:
+
+1. A valid token. Return a `{ "token": "..." }` shaped response.
+1. Explicitly forbid access. Return an
+   `{ "error": "forbidden", "reason": "..." }` shaped response.
+
+Example implementation:
 
 ```ts
 import { createClient } from "@liveblocks/client";
@@ -47,7 +55,7 @@ const client = createClient({
     const response = await fetch("/api/auth", {
       method: "POST",
       headers: {
-        Authentication: "token",
+        Authentication: "<your own headers>",
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ room }),

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -39,14 +39,18 @@ const client = createClient({ authEndpoint: "/api/auth" });
 If you need to add additional headers or use your own function to call the
 endpoint, `authEndpoint` can be provided as a custom callback.
 
-Allowed responses:
+Your async function should return either of the following values:
 
-1. A valid token. Return a `{ "token": "..." }` shaped response.
-1. Explicitly forbid access. Return an
+1. **A valid token.** Return a `{ "token": "..." }` shaped response.
+1. **Explicitly forbid access.** Return an
    `{ "error": "forbidden", "reason": "..." }` shaped response. If you return
    this response, the client will disconnect and won't keep trying to authorize.
 
-Example implementation:
+Any other error will be treated as an unexpected error, after which the client
+will retry making the request until it gets either (1) or (2).
+
+You’re responsible for making the fetch to your own backend. Example
+implementation:
 
 ```ts
 import { createClient } from "@liveblocks/client";
@@ -56,10 +60,10 @@ const client = createClient({
     const response = await fetch("/api/auth", {
       method: "POST",
       headers: {
-        Authentication: "<your own headers>",
+        Authentication: "<your own headers here>",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ room }),
+      body: JSON.stringify({ room }), // Don't forget to pass `room` down
     });
     return await response.json();
   },

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -43,7 +43,8 @@ Allowed responses:
 
 1. A valid token. Return a `{ "token": "..." }` shaped response.
 1. Explicitly forbid access. Return an
-   `{ "error": "forbidden", "reason": "..." }` shaped response.
+   `{ "error": "forbidden", "reason": "..." }` shaped response. If you return
+   this response, the client will disconnect and won't keep trying to authorize.
 
 Example implementation:
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -174,6 +174,9 @@ describe("room / auth", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Authentication failed: We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
       );
+
+      // Keeps trying to reconnect
+      await waitUntilStatus(room, "connecting");
       room.destroy();
     }
   );

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -181,6 +181,53 @@ describe("room / auth", () => {
     }
   );
 
+  test("custom authentication that throws should fail", async () => {
+    const room = createRoom(
+      { initialPresence: {} as never },
+      {
+        ...makeRoomConfig(),
+        authentication: {
+          type: "custom",
+          callback: () => {
+            throw new Error("Oops");
+          },
+        },
+      }
+    );
+
+    room.connect();
+    await waitUntilStatus(room, "connecting");
+    await waitFor(() => consoleErrorSpy.mock.calls.length > 0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Authentication failed: Oops");
+
+    // Keeps trying to reconnect
+    await waitUntilStatus(room, "connecting");
+    room.destroy();
+  });
+
+  test('custom authentication that returns explicit "forbidden" error should disconnect', async () => {
+    const room = createRoom(
+      { initialPresence: {} as never },
+      {
+        ...makeRoomConfig(),
+        authentication: {
+          type: "custom",
+          callback: () =>
+            Promise.resolve({ error: "forbidden", reason: "Nope" }),
+        },
+      }
+    );
+
+    room.connect();
+    await waitUntilStatus(room, "connecting");
+    await waitFor(() => consoleErrorSpy.mock.calls.length > 0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Authentication failed: Nope");
+
+    // Should stop retrying
+    await waitUntilStatus(room, "disconnected");
+    room.destroy();
+  });
+
   test("private authentication with 403 status should fail", async () => {
     const room = createRoom(
       { initialPresence: {} as never },

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -67,6 +67,7 @@ export {
   tryParseJson,
   withTimeout,
 } from "./lib/utils";
+export type { CustomAuthenticationResult } from "./protocol/Authentication";
 export type { BaseUserMeta } from "./protocol/BaseUserMeta";
 export type {
   BroadcastEventClientMsg,

--- a/packages/liveblocks-core/src/protocol/Authentication.ts
+++ b/packages/liveblocks-core/src/protocol/Authentication.ts
@@ -1,3 +1,8 @@
+export type CustomAuthenticationResult =
+  | { token: string; error?: never }
+  | { token?: never; error: "forbidden"; reason: string } // Will stop retrying and disconnect
+  | { token?: never; error: string; reason: string }; // Will log the error and keep retrying
+
 export type Authentication =
   | {
       type: "public";
@@ -10,5 +15,5 @@ export type Authentication =
     }
   | {
       type: "custom";
-      callback: (room: string) => Promise<{ token: string }>;
+      callback: (room: string) => Promise<CustomAuthenticationResult>;
     };

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2423,12 +2423,31 @@ function makeAuthDelegateForRoom(
   } else if (authentication.type === "custom") {
     return async () => {
       const response = await authentication.callback(roomId);
-      if (!response || !response.token) {
+      if (response == null || typeof response !== "object") {
         throw new Error(
           'We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
         );
       }
-      return parseAuthToken(response.token);
+
+      if (typeof response.token === "string") {
+        return parseAuthToken(response.token);
+      } else if (typeof response.error === "string") {
+        const reason = `Authentication failed: ${
+          "reason" in response && typeof response.reason === "string"
+            ? response.reason
+            : "Forbidden"
+        }`;
+
+        if (response.error === "forbidden") {
+          throw new StopRetrying(reason);
+        } else {
+          throw new Error(reason);
+        }
+      } else {
+        throw new Error(
+          'We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
+        );
+      }
     };
   } else {
     throw new Error("Internal error. Unexpected authentication type");

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2423,7 +2423,7 @@ function makeAuthDelegateForRoom(
   } else if (authentication.type === "custom") {
     return async () => {
       const response = await authentication.callback(roomId);
-      if (response == null || typeof response !== "object") {
+      if (!response || typeof response !== "object") {
         throw new Error(
           'We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
         );


### PR DESCRIPTION
Fixes #1017.