### PR TITLE
Detect problem with token fetching and throw an stopTrying error

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2424,9 +2424,13 @@ function makeAuthDelegateForRoom(
     return async () => {
       const response = await authentication.callback(roomId);
       if (!response || !response.token) {
-        throw new Error(
-          'We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
-        );
+        if(response.error && response.error === 'forbidden') {
+          throw new StopRetrying(response.reason ?? "The callback didn't return a token.");
+        } else {
+          throw new Error(
+            'We expect the authentication callback to return a token, but it does not. Hint: the return value should look like: { token: "..." }'
+          );
+        }
       }
       return parseAuthToken(response.token);
     };


### PR DESCRIPTION
### Adding a feature

- Honor new error convention on authEndpoint callback to stop retrying in the event of 401/403

#### Related issue(s)

- Add the related issue(s) here:
  - https://github.com/liveblocks/liveblocks/issues/1017