### PR TITLE
Fixes a regression in our Suspense hooks

### DIFF
--- a/e2e/next-sandbox/package.json
+++ b/e2e/next-sandbox/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev --port 3007",
     "start": "next start",
-    "test": "playwright test"
+    "test": "playwright test --max-failures=1"
   },
   "dependencies": {
     "@liveblocks/client": "*",

--- a/e2e/next-sandbox/pages/index.tsx
+++ b/e2e/next-sandbox/pages/index.tsx
@@ -8,9 +8,19 @@ export default function Home() {
 
       <ul>
         <li>
-          <Link href="/presence">
-            <a>/presence</a>
-          </Link>
+          <div>/storage</div>
+          <ul>
+            <li>
+              <Link href="/presence">
+                <a>/presence</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/presence/with-suspense">
+                <a>/presence/with-suspense</a>
+              </Link>
+            </li>
+          </ul>
         </li>
         <li>
           <div>/storage</div>
@@ -28,6 +38,11 @@ export default function Home() {
             <li>
               <Link href="/storage/object">
                 <a>/storage/object</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/storage/with-suspense">
+                <a>/storage/with-suspense</a>
               </Link>
             </li>
           </ul>

--- a/e2e/next-sandbox/pages/presence/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/presence/with-suspense.tsx
@@ -1,0 +1,134 @@
+import { Json, createRoomContext, ClientSideSuspense } from "@liveblocks/react";
+import React from "react";
+import createLiveblocksClient from "../../utils/createClient";
+
+const client = createLiveblocksClient();
+
+type Presence = {
+  count?: number;
+  secondProp?: number;
+  thirdProp?: number;
+};
+
+const {
+  suspense: {
+    RoomProvider,
+    useBroadcastEvent,
+    useEventListener,
+    useMyPresence,
+    useOthers,
+  },
+} = createRoomContext<
+  Presence,
+  never,
+  never,
+  { emoji: string; type: "EMOJI" } | number
+>(client);
+
+export default function Home() {
+  const [isVisible, setIsVisible] = React.useState(true);
+
+  let roomId = "e2e-presence-with-suspense";
+  if (typeof window !== "undefined") {
+    const queryParam = window.location.search;
+    if (queryParam.split("room=").length > 1) {
+      roomId = queryParam.split("room=")[1];
+    }
+  }
+  return (
+    <>
+      <button id="leave-room" onClick={() => setIsVisible(false)}>
+        Leave
+      </button>
+      <button id="enter-room" onClick={() => setIsVisible(true)}>
+        Enter
+      </button>
+      {isVisible && (
+        <RoomProvider id={roomId} initialPresence={{}}>
+          <div>
+            <h1>Presence sandbox (with suspense hooks)</h1>
+          </div>
+          <ClientSideSuspense fallback="Loading...">
+            {() => (
+              <>
+                <PresenceSandbox />
+                <EventSandbox />
+              </>
+            )}
+          </ClientSideSuspense>
+        </RoomProvider>
+      )}
+    </>
+  );
+}
+
+function PresenceSandbox() {
+  const others = useOthers();
+  const [me, updateMyPresence] = useMyPresence();
+
+  return (
+    <>
+      <button
+        id="increment-button"
+        onClick={() => updateMyPresence({ count: me.count ? me.count + 1 : 1 })}
+      >
+        Increment
+      </button>
+
+      <button
+        id="set-second-prop"
+        onClick={() => updateMyPresence({ secondProp: 1 })}
+      >
+        Set second prop
+      </button>
+
+      <button
+        id="set-third-prop"
+        onClick={() => updateMyPresence({ thirdProp: 1 })}
+      >
+        Set third prop
+      </button>
+
+      <h2>Current user</h2>
+      <div>
+        Count: <span id="me-count">{me.count}</span>
+        Second prop: <span id="me-count">{me.secondProp}</span>
+        Third prop: <span id="me-count">{me.thirdProp}</span>
+      </div>
+
+      <h2>Others</h2>
+      <p id="othersCount">
+        {others.toArray().filter((o) => o.presence !== undefined).length}
+      </p>
+      <div id="others" style={{ whiteSpace: "pre" }}>
+        {JSON.stringify(others.toArray(), null, 2)}
+      </div>
+    </>
+  );
+}
+
+function EventSandbox() {
+  const broadcast = useBroadcastEvent();
+  const [received, setReceived] = React.useState<Json[]>([]);
+
+  useEventListener(({ event }) => {
+    setReceived((x) => [...x, event]);
+  });
+
+  return (
+    <div>
+      <h1>Event sandbox</h1>
+      <button
+        id="broadcast-emoji"
+        onClick={() => broadcast({ type: "EMOJI", emoji: "🔥" })}
+      >
+        Broadcast 🔥
+      </button>
+      <button id="broadcast-number" onClick={() => broadcast(42)}>
+        Broadcast 42
+      </button>
+
+      <pre id="events">{JSON.stringify(received, null, 2)}</pre>
+    </div>
+  );
+}

--- a/e2e/next-sandbox/pages/storage/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/storage/with-suspense.tsx
@@ -1,0 +1,137 @@
+import { createRoomContext, ClientSideSuspense } from "@liveblocks/react";
+import { LiveList } from "@liveblocks/client";
+import React from "react";
+import createLiveblocksClient from "../../utils/createClient";
+
+const client = createLiveblocksClient();
+
+const {
+  suspense: { RoomProvider, useList, useRedo, useSelf, useUndo },
+} = createRoomContext<never, { items: LiveList<string> }>(client);
+
+export default function Home() {
+  let roomId = "e2e-storage-with-suspense";
+  if (typeof window !== "undefined") {
+    const queryParam = window.location.search;
+    if (queryParam.split("room=").length > 1) {
+      roomId = queryParam.split("room=")[1];
+    }
+  }
+  return (
+    <RoomProvider
+      id={roomId}
+      initialPresence={{} as never}
+      initialStorage={{ items: new LiveList() }}
+    >
+      <ClientSideSuspense fallback={<div>Loading...</div>}>
+        {() => <Sandbox />}
+      </ClientSideSuspense>
+    </RoomProvider>
+  );
+}
+
+let item = "A";
+
+function generateRandomNumber(max: number, ignore?: number) {
+  let result = 0;
+  while (true) {
+    result = Math.floor(Math.random() * max);
+    if (result !== ignore) {
+      return result;
+    }
+  }
+}
+
+function Sandbox() {
+  const undo = useUndo();
+  const redo = useRedo();
+  const list = useList("items");
+  const me = useSelf();
+
+  return (
+    <div>
+      <h1>Storage sandbox (with suspense hooks)</h1>
+      <button
+        id="push"
+        onClick={() => {
+          list.push(me.connectionId + ":" + item);
+          item = String.fromCharCode(item.charCodeAt(0) + 1);
+        }}
+      >
+        Push
+      </button>
+
+      <button
+        id="insert"
+        onClick={() => {
+          list.insert(me.connectionId + ":" + item, 0);
+          item = String.fromCharCode(item.charCodeAt(0) + 1);
+        }}
+      >
+        Insert
+      </button>
+
+      <button
+        id="move"
+        onClick={() => {
+          if (list.length < 2) {
+            return;
+          }
+
+          const index = generateRandomNumber(list.length);
+          const target = generateRandomNumber(list.length, index);
+          list.move(index, target);
+        }}
+      >
+        Move
+      </button>
+
+      <button
+        id="set"
+        onClick={() => {
+          if (list.length === 0) {
+            return;
+          }
+
+          const index = generateRandomNumber(list.length - 1);
+          list.set(index, me.connectionId + ":" + item);
+          item = String.fromCharCode(item.charCodeAt(0) + 1);
+        }}
+      >
+        Set
+      </button>
+
+      <button
+        id="delete"
+        onClick={() => {
+          if (list.length > 0) {
+            const index = generateRandomNumber(list.length);
+            list.delete(index);
+          }
+        }}
+      >
+        Delete
+      </button>
+
+      <button id="clear" onClick={() => list.clear()}>
+        Clear
+      </button>
+
+      <button id="undo" onClick={undo}>
+        Undo
+      </button>
+
+      <button id="redo" onClick={redo}>
+        Redo
+      </button>
+
+      <h2>Items</h2>
+      <p id="itemsCount" style={{ visibility: "hidden" }}>
+        {list.length}
+      </p>
+      <div id="items" style={{ whiteSpace: "pre" }}>
+        {JSON.stringify(list.toArray(), null, 2)}
+      </div>
+    </div>
+  );
+}

--- a/e2e/next-sandbox/test/presence/with-suspense.test.ts
+++ b/e2e/next-sandbox/test/presence/with-suspense.test.ts
@@ -1,0 +1,197 @@
+import type { Json, JsonObject } from "@liveblocks/client";
+import { Page, test, expect } from "@playwright/test";
+import {
+  preparePage,
+  delay,
+  getJsonContent,
+  waitForTextContent,
+  // getTextContent,
+  // preparePages,
+  assertContainText,
+} from "../utils";
+
+function getOthers(page: Page): Promise<JsonObject[]> {
+  return getJsonContent(page, "others") as Promise<JsonObject[]>;
+}
+
+function getEvents(page: Page): Promise<Json[]> {
+  return getJsonContent(page, "events") as Promise<Json[]>;
+}
+
+const TEST_URL = "http://localhost:3007/presence/with-suspense";
+
+test.describe("Presence w/ Suspense", () => {
+  test("connect A => connect B => verify others on A and B", async () => {
+    const testUrl = TEST_URL + "?room=e2e-presence-with-suspense-scenario1";
+    const firstPage = await preparePage(testUrl);
+    const secondPage = await preparePage(testUrl);
+
+    await Promise.all([
+      firstPage.waitForSelector("#others"),
+      secondPage.waitForSelector("#others"),
+    ]);
+
+    await assertContainText([firstPage, secondPage], "1", "othersCount");
+
+    const othersFirstPage = await getOthers(firstPage);
+    const othersSecondPage = await getOthers(secondPage);
+
+    expect(othersFirstPage.length).toEqual(1);
+    expect(othersFirstPage[0].presence).toEqual({});
+    expect(othersSecondPage.length).toEqual(1);
+    expect(othersSecondPage[0].presence).toEqual({});
+
+    await firstPage.close();
+    await secondPage.close();
+  });
+
+  test("connect A => update presence A => connect B => verify presence A on B", async () => {
+    const testUrl = TEST_URL + "?room=e2e-presence-with-suspense-scenario2";
+    const firstPage = await preparePage(testUrl);
+
+    await firstPage.click("#increment-button");
+
+    const secondPage = await preparePage(testUrl);
+
+    await assertContainText([firstPage, secondPage], "1", "othersCount");
+
+    const othersSecondPage = await getOthers(secondPage);
+
+    expect(othersSecondPage.length).toEqual(1);
+    expect(othersSecondPage[0].presence).toEqual({ count: 1 });
+
+    await firstPage.close();
+    await secondPage.close();
+  });
+
+  test("connect A => connect B => update presence A => verify presence A on B", async () => {
+    const testUrl = TEST_URL + "?room=e2e-presence-with-suspense-scenario3";
+    const firstPage = await preparePage(testUrl);
+
+    const secondPage = await preparePage(testUrl);
+
+    await Promise.all([
+      firstPage.waitForSelector("#others"),
+      secondPage.waitForSelector("#others"),
+    ]);
+
+    await assertContainText([firstPage, secondPage], "1", "othersCount");
+
+    await firstPage.click("#increment-button");
+
+    await delay(100);
+
+    const othersSecondPage = await getOthers(secondPage);
+
+    expect(othersSecondPage.length).toEqual(1);
+    expect(othersSecondPage[0].presence).toEqual({ count: 1 });
+
+    await firstPage.close();
+    await secondPage.close();
+  });
+
+  test("connect A => connect B => verify other on B => disconnect A => verify others is empty on B", async () => {
+    const testUrl = TEST_URL + "?room=e2e-presence-with-suspense-scenario4";
+    const firstPage = await preparePage(testUrl);
+
+    const secondPage = await preparePage(testUrl);
+
+    await Promise.all([
+      firstPage.waitForSelector("#others"),
+      secondPage.waitForSelector("#others"),
+    ]);
+
+    await assertContainText([firstPage, secondPage], "1", "othersCount");
+
+    let othersSecondPage = await getOthers(secondPage);
+    expect(othersSecondPage.length).toEqual(1);
+    expect(othersSecondPage[0].presence).toEqual({});
+
+    await firstPage.close();
+
+    await delay(300);
+
+    othersSecondPage = await getOthers(secondPage);
+    expect(othersSecondPage.length).toEqual(0);
+
+    await secondPage.close();
+  });
+
+  test("client B receives other update presence before initial presence", async () => {
+    const testUrl = TEST_URL + "?room=e2e-presence-with-suspense-scenario5";
+    const firstPage = await preparePage(testUrl);
+    const secondPage = await preparePage(testUrl);
+
+    await Promise.all([
+      firstPage.waitForSelector("#others"),
+      secondPage.waitForSelector("#others"),
+    ]);
+
+    await assertContainText([firstPage, secondPage], "1", "othersCount");
+
+    await firstPage.click("#set-second-prop");
+    await firstPage.click("#set-third-prop");
+
+    await delay(1000);
+
+    for (let i = 0; i < 5; i++) {
+      await secondPage.click("#leave-room");
+
+      await secondPage.click("#enter-room");
+      await delay(500);
+      await firstPage.click("#set-second-prop");
+
+      await assertContainText([secondPage], "1", "othersCount");
+
+      let othersSecondPage = await getOthers(secondPage);
+      expect(othersSecondPage[0].presence).toEqual({
+        secondProp: 1,
+        thirdProp: 1,
+      });
+
+      await delay(1000);
+    }
+
+    await firstPage.close();
+    await secondPage.close();
+  });
+});
+
+test.describe("Broadcast w/ Suspense", () => {
+  test("connect A => connect B => broadcast from A => verify B got event", async () => {
+    const testUrl = TEST_URL + "?room=e2e-broadcast-with-suspense-scenario1";
+    const firstPage = await preparePage(testUrl);
+    const secondPage = await preparePage(testUrl);
+
+    await Promise.all([
+      firstPage.waitForSelector("#events"),
+      secondPage.waitForSelector("#events"),
+    ]);
+
+    // Wait until the other client is connected
+    await waitForTextContent(firstPage, "#othersCount", "1");
+
+    await firstPage.click("#broadcast-emoji");
+    await delay(500);
+
+    // Now check contents of page
+    let eventsFirstPage = await getEvents(firstPage);
+    let eventsSecondPage = await getEvents(secondPage);
+    expect(eventsFirstPage).toEqual([]);
+    expect(eventsSecondPage).toEqual([{ type: "EMOJI", emoji: "🔥" }]);
+
+    await secondPage.click("#broadcast-number");
+    await secondPage.click("#broadcast-emoji");
+    await secondPage.click("#broadcast-number");
+    await delay(500);
+
+    // Check again
+    eventsFirstPage = await getEvents(firstPage);
+    eventsSecondPage = await getEvents(secondPage);
+    expect(eventsFirstPage).toEqual([42, { type: "EMOJI", emoji: "🔥" }, 42]);
+    expect(eventsSecondPage).toEqual([{ type: "EMOJI", emoji: "🔥" }]);
+
+    await firstPage.close();
+    await secondPage.close();
+  });
+});

--- a/e2e/next-sandbox/test/storage/with-suspense.test.ts
+++ b/e2e/next-sandbox/test/storage/with-suspense.test.ts
@@ -1,0 +1,148 @@
+import { Page, test, expect } from "@playwright/test";
+
+import {
+  delay,
+  assertContainText,
+  pickRandomItem,
+  pickNumberOfUnderRedo,
+  waitForContentToBeEquals,
+  preparePages,
+} from "../utils";
+
+function pickRandomAction() {
+  return pickRandomItem(["#push", "#delete", "#move", "#set"]);
+}
+
+const TEST_URL = "http://localhost:3007/storage/with-suspense";
+
+test.describe("Storage w/ Suspense", () => {
+  let pages: Page[];
+
+  test.beforeEach(async ({}, testInfo) => {
+    const roomName = `e2e-storage-with-suspense-${testInfo.title.replaceAll(
+      " ",
+      "-"
+    )}`;
+    pages = await preparePages(`${TEST_URL}?room=${roomName}`);
+  });
+
+  test.afterEach(async () => {
+    pages.forEach(async (page) => {
+      await page.close();
+    });
+  });
+
+  test("list push basic", async () => {
+    await pages[0].click("#clear");
+    await assertContainText(pages, "0");
+
+    await pages[0].click("#push");
+    await assertContainText(pages, "1");
+
+    await waitForContentToBeEquals(pages);
+
+    await pages[0].click("#push");
+    await assertContainText(pages, "2");
+    await waitForContentToBeEquals(pages);
+
+    await pages[0].click("#push");
+    await assertContainText(pages, "3");
+    await waitForContentToBeEquals(pages);
+  });
+
+  test("list move", async () => {
+    await pages[0].click("#clear");
+    await assertContainText(pages, "0");
+
+    for (let i = 0; i < 5; i++) {
+      await pages[0].click("#push");
+      await delay(50);
+    }
+
+    await waitForContentToBeEquals(pages);
+
+    for (let i = 0; i < 10; i++) {
+      await pages[0].click("#move");
+      await delay(50);
+    }
+
+    await waitForContentToBeEquals(pages);
+  });
+
+  test("push conflicts", async () => {
+    await pages[0].click("#clear");
+    await assertContainText(pages, "0");
+
+    for (let i = 0; i < 10; i++) {
+      // no await to create randomness
+      pages[0].click("#push");
+      pages[1].click("#push");
+      await delay(50);
+    }
+
+    await assertContainText(pages, "20");
+    await waitForContentToBeEquals(pages);
+  });
+
+  test("set conflicts", async () => {
+    await pages[0].click("#clear");
+    await assertContainText(pages, "0");
+
+    for (let i = 0; i < 1; i++) {
+      await pages[0].click("#push");
+      await delay(50);
+    }
+
+    for (let i = 0; i < 10; i++) {
+      // no await to create randomness
+      pages[0].click("#set");
+      pages[1].click("#set");
+      await delay(50);
+    }
+
+    await assertContainText(pages, "1");
+    await waitForContentToBeEquals(pages);
+  });
+
+  // TODO: This test is flaky and occasionally fails in CI--make it more robust
+  // See https://github.com/liveblocks/liveblocks/runs/8032018966?check_suite_focus=true#step:6:45
+  test.skip("fuzzy with undo/redo push delete and move", async () => {
+    await pages[0].click("#clear");
+    await assertContainText(pages, "0");
+
+    const numberOfItemsAtStart = 5;
+    for (let i = 0; i < numberOfItemsAtStart; i++) {
+      // no await to create randomness
+      pages[0].click("#push");
+      await delay(50);
+    }
+
+    await expect(pages[0].locator("#itemsCount")).toContainText(
+      numberOfItemsAtStart.toString()
+    );
+
+    await waitForContentToBeEquals(pages);
+
+    for (let i = 0; i < 50; i++) {
+      // no await to create randomness
+      pages.forEach((page) => {
+        const nbofUndoRedo = pickNumberOfUnderRedo();
+
+        if (nbofUndoRedo > 0) {
+          for (let y = 0; y < nbofUndoRedo; y++) {
+            page.click("#undo");
+          }
+          for (let y = 0; y < nbofUndoRedo; y++) {
+            page.click("#redo");
+          }
+        } else {
+          page.click(pickRandomAction());
+        }
+      });
+
+      await delay(50);
+    }
+
+    await waitForContentToBeEquals(pages);
+  });
+});

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -555,6 +555,7 @@ export type Room<
   getStorageSnapshot(): LiveObject<TStorage> | null;
 
   readonly events: {
+    /** @deprecated Prefer `status` instead. */
     readonly connection: Observable<LegacyConnectionStatus>; // Old/legacy API
     readonly status: Observable<Status>; // New/recommended API
     readonly lostConnection: Observable<LostConnectionEvent>;

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -612,7 +612,7 @@ export function createRoomContext<
 
   function useSuspendUntilPresenceLoaded(): void {
     const room = useRoom();
-    if (room.getSelf() === null) {
+    if (room.getSelf() !== null) {
       return;
     }
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -622,7 +622,7 @@ export function createRoomContext<
     // promise resolves (aka until storage has loaded). After that, it will
     // render this component tree again.
     throw new Promise<void>((res) => {
-      room.events.connection.subscribeOnce(() => res());
+      room.events.status.subscribeOnce(() => res());
     });
   }
 


### PR DESCRIPTION
This fixes a bug where I accidentally introduced a regression to our Suspense hooks on the 1.2 release branch, unsuspending on the wrong condition 🙈

What's worse is that I could introduce this issue without _any_ test noticing.

So this PR:
1. First adds E2E tests for our Suspense hooks, basically copies of the existing e2e tests/pages, but adjusted to use Suspense (e2e tests fail)
2. Then fixes the stupid bug in 4f4c63ba2fcd88e0883c2b562f53bdfc48e7b492 (e2e pass again)
