### PR TITLE
Make `TOKEN_EXPIRED` code 4109, change client logic based on error ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### `@liveblocks/*`
 
-Support the new and improved Liveblocks authorization.
+- Support the new and improved Liveblocks authorization.
+- Change client logic to stop retrying if room is full. Instead, the client will
+  now disconnect. To retry, call `room.reconnect()` explicitly.
 
 ### `@liveblocks/node`
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -529,17 +529,35 @@ const unsubscribe = room.subscribe("connection", (status) => {
 
 ### Room.subscribe("error") [#Room.subscribe.error]
 
-Subscribe to potential room connection errors.
+Subscribe to unrecoverable room connection errors. This event will be emitted
+right before the client disconnects and won’t try reconnecting again.
 
 Returns an unsubscribe function.
 
 ```ts
 const unsubscribe = room.subscribe("error", (error) => {
-  if (error.code === 4005) {
-    // Maximum concurrent connections per room exceeded.
+  switch (error.code) {
+    case -1:
+      // Authentication error
+      break;
+
+    case 4001:
+      // Could not connect because you don't have access to this room
+      break;
+
+    case 4005:
+      // Could not connect because room was full
+      break;
+
+    default:
+      // Unexpected error
+      break;
   }
 });
 ```
+
+You can use this event to trigger a “Not allowed” screen/dialog. If you want to
+offer retrying connecting, call `room.reconnect()`.
 
 ### Room.subscribe("history") [#Room.subscribe.history]
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -556,8 +556,8 @@ const unsubscribe = room.subscribe("error", (error) => {
 });
 ```
 
-You can use this event to trigger a “Not allowed” screen/dialog. If you want to
-offer retrying connecting, call `room.reconnect()`.
+You can use this event to trigger a “Not allowed” screen/dialog. If you’d like to
+retry connecting, call `room.reconnect()`.
 
 ### Room.subscribe("history") [#Room.subscribe.history]
 

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -711,7 +711,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
         // If the server actively refuses the connection attempt, stop trying.
         if (isCloseEvent(err)) {
           // If the token was expired we can reauthorize immediately (no back-off)
-          if (err.code === 4009 /* Token Expired */) {
+          if (err.code === 4109 /* Token Expired */) {
             return "@auth.busy";
           }
 
@@ -836,7 +836,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
         }
 
         // Server instructs us to reauthenticate
-        if (e.event.code === 4009 /* Token Expired */) {
+        if (e.event.code === 4109 /* Token Expired */) {
           return {
             target: "@auth.backoff",
             effect: [increaseBackoffDelay, logCloseEvent(e.event)],

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -14,7 +14,12 @@ import type {
   IWebSocketInstance,
   IWebSocketMessageEvent,
 } from "./types/IWebSocket";
-import { WebsocketCloseCodes } from "./types/IWebSocket";
+import {
+  shouldDisconnect,
+  shouldReauth,
+  shouldRetryWithoutReauth,
+  WebsocketCloseCodes,
+} from "./types/IWebSocket";
 
 /**
  * Old connection statuses, here for backward-compatibility reasons only.
@@ -304,20 +309,6 @@ function isCloseEvent(
 ): error is IWebSocketCloseEvent {
   return !(error instanceof Error) && error.type === "close";
 }
-
-/**
- * The set of server side error codes for which reauthorizing won't have an
- * effect. When these codes happen, we'll back off but don't need to get a new
- * auth token.
- */
-const NO_REAUTH_CLOSE_CODES = [
-  WebsocketCloseCodes.TRY_AGAIN_LATER,
-  WebsocketCloseCodes.INVALID_MESSAGE_FORMAT,
-  WebsocketCloseCodes.MAX_NUMBER_OF_MESSAGES_PER_SECONDS,
-  WebsocketCloseCodes.MAX_NUMBER_OF_CONCURRENT_CONNECTIONS,
-  WebsocketCloseCodes.MAX_NUMBER_OF_MESSAGES_PER_DAY_PER_APP,
-  WebsocketCloseCodes.MAX_NUMBER_OF_CONCURRENT_CONNECTIONS_PER_ROOM,
-];
 
 export type Delegates<T extends BaseAuthResult> = {
   authenticate: () => Promise<T>;
@@ -710,33 +701,30 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
 
         // If the server actively refuses the connection attempt, stop trying.
         if (isCloseEvent(err)) {
-          // If the token was expired we can reauthorize immediately (no back-off)
-          if (err.code === 4109 /* Token Expired */) {
+          // The default fall-through behavior is going to be reauthorizing
+          // with a back-off strategy. If we know the token was expired however
+          // we can reauthorize immediately (without back-off).
+          if (err.code === WebsocketCloseCodes.TOKEN_EXPIRED) {
             return "@auth.busy";
           }
 
-          // If the token was not allowed we can stop trying because getting
-          // another token for the same user won't help
-          if (
-            err.code === 4001 /* Not Allowed */ ||
-            err.code === 4999 /* Close Without Retry */
-          ) {
-            return {
-              target: "@idle.failed",
-              effect: log(LogLevel.ERROR, err.reason),
-            };
-          }
-
-          // The set of server side error codes for which reauthorizing won't
-          // have an effect. When these codes happen, we'll back off
-          // (aggressively) but don't need to get a new auth token.
-          if (NO_REAUTH_CLOSE_CODES.includes(err.code)) {
+          if (shouldRetryWithoutReauth(err.code)) {
+            // Retry after backoff, but don't get a new token
             return {
               target: "@connecting.backoff",
               effect: [
                 increaseBackoffDelayAggressively,
                 logPrematureErrorOrCloseEvent(err),
               ],
+            };
+          }
+
+          // If the token was not allowed we can stop trying because getting
+          // another token for the same user won't help
+          if (shouldDisconnect(err.code)) {
+            return {
+              target: "@idle.failed",
+              effect: log(LogLevel.ERROR, err.reason),
             };
           }
         }
@@ -825,27 +813,29 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
 
       EXPLICIT_SOCKET_CLOSE: (e) => {
         // Server instructed us to stop retrying, so move to failed state
-        if (
-          e.event.code === 4001 /* Not Allowed */ ||
-          e.event.code === 4999 /* Close Without Retry */
-        ) {
+        if (shouldDisconnect(e.event.code)) {
           return {
             target: "@idle.failed",
             effect: logPermanentClose,
-          }; // Should not retry, give up
-        }
-
-        // Server instructs us to reauthenticate
-        if (e.event.code === 4109 /* Token Expired */) {
-          return {
-            target: "@auth.backoff",
-            effect: [increaseBackoffDelay, logCloseEvent(e.event)],
           };
         }
 
-        // If this is a custom Liveblocks server close reason, back off more
-        // aggressively, and emit a Liveblocks error event...
-        if (e.event.code >= 4000 && e.event.code < 5000) {
+        if (shouldReauth(e.event.code)) {
+          if (e.event.code === WebsocketCloseCodes.TOKEN_EXPIRED) {
+            // Token expiry is a special case, we can reauthorize immediately
+            // (without back-off)
+            return "@auth.busy";
+          } else {
+            return {
+              target: "@auth.backoff",
+              effect: [increaseBackoffDelay, logCloseEvent(e.event)],
+            };
+          }
+        }
+
+        if (shouldRetryWithoutReauth(e.event.code)) {
+          // If this is a custom Liveblocks server close reason, back off more
+          // aggressively, and emit a Liveblocks error event...
           return {
             target: "@connecting.backoff",
             effect: [
@@ -853,14 +843,15 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
               logCloseEvent(e.event),
               () => {
                 const err = new LiveblocksError(e.event.reason, e.event.code);
+                // XXX Only "throw errors" when disconnecting!
                 onLiveblocksError.notify(err);
               },
             ],
           };
         }
 
-        // Consider this close event a temporary hiccup, and try re-opening
-        // a new socket
+        // Consider any other close event a temporary network hiccup, and retry
+        // after a normal backoff delay
         return {
           target: "@connecting.backoff",
           effect: [increaseBackoffDelay, logCloseEvent(e.event)],

--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -45,25 +45,35 @@ export interface IWebSocket {
   new (address: string): IWebSocketInstance;
 }
 
+/**
+ * The following ranges will be respected by the client:
+ *
+ *   40xx: client will disconnect
+ *   41xx: client will reauthorize
+ *   42xx: client will retry without reauthorizing (currently not used)
+ *
+ */
 export enum WebsocketCloseCodes {
+  /** Unexpected error happened with the network/infra level. In spirit akin to HTTP 503 */
   CLOSE_ABNORMAL = 1006,
-
-  /** Like an "HTTP 500" */
+  /** Unexpected error happened. In spirit akin to HTTP 500 */
   UNEXPECTED_CONDITION = 1011,
   /** Please back off for now, but try again in a few moments */
   TRY_AGAIN_LATER = 1013,
-
-  /** Like an "HTTP 403". Server understood the request, but refused to allow it. Re-authorizing won't help. */
-  NOT_ALLOWED = 4001,
-  /** The auth token used is expired, getting a fresh one and retrying might work. In spirit, it's a bit more akin to an "HTTP 401". */
-  TOKEN_EXPIRED = 4109,
-
+  /** Message wasn't understood, disconnect */
   INVALID_MESSAGE_FORMAT = 4000,
+  /** Server refused to allow connection. Re-authorizing won't help. Disconnect. In spirit akin to HTTP 403 */
+  NOT_ALLOWED = 4001,
+  /** Unused */
   MAX_NUMBER_OF_MESSAGES_PER_SECONDS = 4002,
+  /** Unused */
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS = 4003,
+  /** Unused */
   MAX_NUMBER_OF_MESSAGES_PER_DAY_PER_APP = 4004,
+  /** Room is full, disconnect */
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS_PER_ROOM = 4005,
-
-  // Puts the client in "disconnected" state immediately, don't try to connect again
+  /** The auth token is expired, reauthorize to get a fresh one. In spirit akin to HTTP 401 */
+  TOKEN_EXPIRED = 4109,
+  /** Disconnect immediately */
   CLOSE_WITHOUT_RETRY = 4999,
 }

--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -77,3 +77,21 @@ export enum WebsocketCloseCodes {
   /** Disconnect immediately */
   CLOSE_WITHOUT_RETRY = 4999,
 }
+
+export function shouldDisconnect(code: WebsocketCloseCodes): boolean {
+  return (
+    code === WebsocketCloseCodes.CLOSE_WITHOUT_RETRY ||
+    (code >= 4000 && code < 4100)
+  );
+}
+
+export function shouldReauth(code: WebsocketCloseCodes): boolean {
+  return code >= 4100 && code < 4200;
+}
+
+export function shouldRetryWithoutReauth(code: WebsocketCloseCodes): boolean {
+  return (
+    code === WebsocketCloseCodes.TRY_AGAIN_LATER ||
+    (code >= 4200 && code < 4300)
+  );
+}

--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -56,7 +56,7 @@ export enum WebsocketCloseCodes {
   /** Like an "HTTP 403". Server understood the request, but refused to allow it. Re-authorizing won't help. */
   NOT_ALLOWED = 4001,
   /** The auth token used is expired, getting a fresh one and retrying might work. In spirit, it's a bit more akin to an "HTTP 401". */
-  TOKEN_EXPIRED = 4009,
+  TOKEN_EXPIRED = 4109,
 
   INVALID_MESSAGE_FORMAT = 4000,
   MAX_NUMBER_OF_MESSAGES_PER_SECONDS = 4002,


### PR DESCRIPTION
Part of [Release 1.2](https://github.com/liveblocks/liveblocks/pull/975).
Client-side counterpart to https://github.com/liveblocks/liveblocks-cloudflare/pull/469.

---

This changes a couple things:
- `TOKEN_EXPIRED` is now 4109
- Close code range `40xx` will now _disconnect_ the client (and emit an `"error"` event, i.e. what can be observed with `room.subscribe("error")`)
- Close code range `41xx` will now _reauthorize_ after a (normal) backoff delay. One exception is `TOKEN_EXPIRED` (4019), which will be the only error code that will reauthorize _without_ a backoff delay.
- Close code range `42xx` will now _retry without reauthorizing_ after an (aggressive) backoff delay.

This updates all the unit tests to reflect this new behavior.
