### PR TITLE
Mention `/pages` endpoints in important places, improve permissions guide

### DIFF
--- a/docs/pages/rooms/authentication/access-token-permissions/nextjs.mdx
+++ b/docs/pages/rooms/authentication/access-token-permissions/nextjs.mdx
@@ -39,7 +39,7 @@ start building your own security logic in Next.js’ `/app` directory.
       });
 
       export async function POST(request: Request) {
-      // Get the current user from your database
+        // Get the current user from your database
         const user = __getUserFromDB__(request);
 
         // Start an auth session inside your endpoint
@@ -57,6 +57,40 @@ start building your own security logic in Next.js’ `/app` directory.
         // Authorize the user and return the result
         const { status, body } = await session.authorize();
         return new Response(body, { status });
+      }
+      ```
+
+      Here’s an example using the older API routes format in `/pages`.
+
+      ```ts file="pages/api/liveblocks-auth.ts" isCollapsed isCollapsable
+      import { Liveblocks } from "@liveblocks/node";
+      import type { NextApiRequest, NextApiResponse } from "next";
+
+      const API_KEY = "{{SECRET_KEY}}";
+
+      const liveblocks = new Liveblocks({
+        secret: API_KEY!,
+      });
+
+      export default async function handler(request: NextApiRequest, response: NextApiResponse) {
+        // Get the current user from your database
+        const user = __getUserFromDB__(request);
+
+        // Start an auth session inside your endpoint
+        const session = liveblocks.prepareSession(
+          user.id,
+          { userInfo: user.metadata } // Optional
+        );
+
+        // Implement your own security, and give the user access to the room
+        const { room } = request.body;
+        if (room && __shouldUserHaveAccess__(user, room)) {
+          session.allow(room, session.FULL_ACCESS);
+        }
+
+        // Authorize the user and return the result
+        const { status, body } = await session.authorize();
+        response.status(status).send(body);
       }
       ```
 

--- a/docs/pages/rooms/authentication/id-token-permissions/nextjs.mdx
+++ b/docs/pages/rooms/authentication/id-token-permissions/nextjs.mdx
@@ -52,6 +52,34 @@ start building your own security logic in Next.js’ `/app` directory.
       }
       ```
 
+      Here’s an example using the older API routes format in `/pages`.
+
+      ```ts file="pages/api/liveblocks-auth.ts" isCollapsed isCollapsable
+      import { Liveblocks } from "@liveblocks/node";
+      import type { NextApiRequest, NextApiResponse } from "next";
+
+      const API_KEY = "{{SECRET_KEY}}";
+
+      const liveblocks = new Liveblocks({
+        secret: API_KEY!,
+      });
+
+      export default async function handler(request: NextApiRequest, response: NextApiResponse) {
+        // Get the current user from your database
+        const user = __getUserFromDB__(request);
+
+        // Identify the user and return the result
+        const { status, body } = await liveblocks.identifyUser({
+          userId: user.id,
+          groupIds, // Optional
+        });
+
+        // Authorize the user and return the result
+        const { status, body } = await session.authorize();
+        response.status(status).send(body);
+      }
+      ```
+
     </StepContent>
 
   </Step>

--- a/docs/pages/rooms/permissions/id-token.mdx
+++ b/docs/pages/rooms/permissions/id-token.mdx
@@ -61,6 +61,7 @@ To check if a user only has read-only access to storage in your app, the
 ```ts
 // Vanilla
 const { isReadOnly } = room.getSelf();
+
 // React
 const selfIsReadOnly = useSelf((me) => me.isReadOnly);
 ```
@@ -133,8 +134,9 @@ The default permission types can later be modified with the
 [update room API](/docs/api-reference/rest-api-endpoints#post-rooms-roomId), in
 this example turning the room private:
 
-```ts highlight="5"
+```ts highlight="6"
 const roomId = "my-room-name";
+
 fetch(`https://api.liveblocks.io/v2/rooms/${roomId}`, {
   method: "POST",
   body: JSON.stringify({
@@ -160,14 +162,23 @@ group within room.
 Groups are represented by a `groupId`—a custom string that represents a
 selection of users in your app. Groups can be attached to a user by passing an
 array of `groupId` values in `groupIds`, during
-[authentication](/docs/rooms/authentication).
+[authentication](/docs/rooms/authentication/id-token-permissions).
 
-```js highlight="3"
-import { authorize } from "@liveblocks/node";
-const response = await authorize({
-  groupIds: ["engineering"],
-  // ...
+```js highlight="10"
+import { Liveblocks } from "@liveblocks/node";
+
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
 });
+
+export async function POST(request: Request) {
+  const { status, body } = await liveblocks.identifyUser({
+    userId: "marie@example.com",
+    groupIds: ["engineering"]
+  });
+
+  return new Response(body, { status });
+}
 ```
 
 In our APIs you can then set group accesses by using the `groupId` as the key,
@@ -187,8 +198,9 @@ presence, we can use the
 [update room API](/docs/api-reference/rest-api-endpoints#post-rooms-roomId) with
 `engineering` as a `groupId`:
 
-```ts highlight="6"
+```ts highlight="7"
 const roomId = "my-room-name";
+
 fetch(`https://api.liveblocks.io/v2/rooms/${roomId}`, {
   method: "POST",
   body: JSON.stringify({
@@ -203,8 +215,9 @@ To remove a group’s permissions, we can use the
 [update room API](/docs/api-reference/rest-api-endpoints#post-rooms-roomId)
 again, and set the permission type to `null`:
 
-```ts highlight="6"
+```ts highlight="7"
 const roomId = "my-room-name";
+
 fetch(`https://api.liveblocks.io/v2/rooms/${roomId}`, {
   method: "POST",
   body: JSON.stringify({
@@ -235,12 +248,20 @@ room.
 To use this, first a user is given a `userId` during
 [authentication](/docs/rooms/authentication).
 
-```js highlight="3"
-import { authorize } from "@liveblocks/node";
-const response = await authorize({
-  userId: "ellen@acme.inc",
-  // ...
+```js highlight="9"
+import { Liveblocks } from "@liveblocks/node";
+
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
 });
+
+export async function POST(request: Request) {
+  const { status, body } = await liveblocks.identifyUser({
+    userId: "ellen@acme.inc"
+  });
+
+  return new Response(body, { status });
+}
 ```
 
 Then, if you want the user with the `userId` id to make edits, set `userId` to
@@ -259,8 +280,9 @@ To create an invitation system, we can use the
 [update room API](/docs/api-reference/rest-api-endpoints#post-rooms-roomId) and
 use an email address as a `userId`:
 
-```ts highlight="6"
+```ts highlight="7"
 const roomId = "my-room-name";
+
 fetch(`https://api.liveblocks.io/v2/rooms/${roomId}`, {
   method: "POST",
   body: JSON.stringify({

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
@@ -83,6 +83,48 @@ export async function POST(request: NextRequest) {
 }
 ```
 
+Here’s an example using the older API routes format in `/pages`.
+
+```ts file="pages/api/liveblocks-auth.ts" isCollapsed isCollapsable
+import { Liveblocks } from "@liveblocks/node";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const API_KEY = "{{SECRET_KEY}}";
+
+const liveblocks = new Liveblocks({
+  secret: API_KEY!,
+});
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  // Get the current user's info from your database
+  const user = {
+    id: "charlielayne@example.com",
+    info: {
+      name: "Charlie Layne",
+      color: "#D583F0",
+      picture: "https://liveblocks.io/avatars/avatar-1.png",
+    },
+  };
+
+  // Create a session for the current user
+  // userInfo is made available in Liveblocks presence hooks, e.g. useOthers
+  const session = liveblocks.prepareSession(user.id, {
+    userInfo: user.info,
+  });
+
+  // Give the user access to the room
+  const { room } = request.body;
+  session.allow(room, session.FULL_ACCESS);
+
+  // Authorize the user and return the result
+  const { status, body } = await session.authorize();
+  response.status(status).send(body);
+}
+```
+
 ## Initialize your Liveblocks config file
 
 Let’s initialize the `liveblocks.config.ts` file in which you’ll set up the

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
@@ -69,6 +69,7 @@ You may need to upgrade to a newer version of Next.js for this to work.
 ```bash
 npm i next@latest
 ```
+
 ## Set up access token authentication
 
 The first step in connecting to Liveblocks is to set up an authentication
@@ -111,11 +112,11 @@ export async function POST(request: NextRequest) {
 }
 ```
 
-Here’s an example using the Next.js API routes format in `/pages`.
+Here’s an example using the older API routes format in `/pages`.
 
 ```ts file="/pages/api/liveblocks-auth.ts" isCollapsed isCollapsable
-import { Liveblocks } from '@liveblocks/node';
-import type { NextApiRequest, NextApiResponse } from 'next';
+import { Liveblocks } from "@liveblocks/node";
+import type { NextApiRequest, NextApiResponse } from "next";
 
 const API_KEY = "{{SECRET_KEY}}";
 
@@ -123,14 +124,17 @@ const liveblocks = new Liveblocks({
   secret: API_KEY!,
 });
 
-export default async function POST(request: NextApiRequest, response: NextApiResponse) {
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
   // Get the current user's info from your database
   const user = {
-    id: 'charlielayne@example.com',
+    id: "charlielayne@example.com",
     info: {
-      name: 'Charlie Layne',
-      color: '#D583F0',
-      picture: 'https://liveblocks.io/avatars/avatar-1.png',
+      name: "Charlie Layne",
+      color: "#D583F0",
+      picture: "https://liveblocks.io/avatars/avatar-1.png",
     },
   };
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
@@ -82,6 +82,48 @@ export async function POST(request: NextRequest) {
 }
 ```
 
+Here’s an example using the older API routes format in `/pages`.
+
+```ts file="pages/api/liveblocks-auth.ts" isCollapsed isCollapsable
+import { Liveblocks } from "@liveblocks/node";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const API_KEY = "{{SECRET_KEY}}";
+
+const liveblocks = new Liveblocks({
+  secret: API_KEY!,
+});
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  // Get the current user's info from your database
+  const user = {
+    id: "charlielayne@example.com",
+    info: {
+      name: "Charlie Layne",
+      color: "#D583F0",
+      picture: "https://liveblocks.io/avatars/avatar-1.png",
+    },
+  };
+
+  // Create a session for the current user
+  // userInfo is made available in Liveblocks presence hooks, e.g. useOthers
+  const session = liveblocks.prepareSession(user.id, {
+    userInfo: user.info,
+  });
+
+  // Give the user access to the room
+  const { room } = request.body;
+  session.allow(room, session.FULL_ACCESS);
+
+  // Authorize the user and return the result
+  const { status, body } = await session.authorize();
+  response.status(status).send(body);
+}
+```
+
 ## Initialize your Liveblocks config file
 
 Let’s initialize the `liveblocks.config.ts` file in which you’ll set up the


### PR DESCRIPTION
It's okay to use `/app` endpoints up front, and in blog posts, but on reflection we should also have collapsible `/pages` endpoint examples in important places.

Also improvements to the permissions guide, as it didn't use our new auth in a couple of places.