### PR TITLE
Add `YDocUpdatedEvent` to `WebhookHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.2.2
+
+### `@liveblocks/node`
+
+- Add Yjs document change event (`YDocUpdatedEvent`) to `WebhookHandler`.
+
 # v1.2.1
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-node/src/__tests__/webhooks.test.ts
+++ b/packages/liveblocks-node/src/__tests__/webhooks.test.ts
@@ -224,6 +224,42 @@ describe("WebhookHandler", () => {
       expect(event).toEqual(roomDeleted);
     });
 
+    it('should verify a "ydocUpdated" event', () => {
+      const ydocUpdated = {
+        data: {
+          appId: "605a50b01a36d5ea7a2e9104",
+          roomId: "hero-grid-12-01-2022",
+          updatedAt: "2023-01-27T20:27:48.744Z",
+        },
+        type: "ydocUpdated",
+      };
+      const rawYdocUpdated = JSON.stringify(ydocUpdated);
+
+      const headersYdocUpdated = {
+        "webhook-id": "msg_2KvOK6yK9FO0U0nIyJYkM3jPwBs",
+        "webhook-timestamp": "1674851522",
+        "webhook-signature": generateSignatureWithSvix(
+          secret,
+          "msg_2KvOK6yK9FO0U0nIyJYkM3jPwBs",
+          "1674851522",
+          rawYdocUpdated
+        ),
+      };
+
+      jest.useFakeTimers({
+        now: 1674851522000,
+      });
+
+      const webhookHandler = new WebhookHandler(secret);
+
+      const event = webhookHandler.verifyRequest({
+        headers: headersYdocUpdated,
+        rawBody: rawYdocUpdated,
+      });
+
+      expect(event).toEqual(ydocUpdated);
+    });
+
     it("should verify an event with multiple signatures", () => {
       jest.useFakeTimers({
         now: 1674850126000,

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -4,6 +4,7 @@ import type { IncomingHttpHeaders } from "http";
 export class WebhookHandler {
   private secretBuffer: Buffer;
   private static secretPrefix = "whsec_";
+
   constructor(
     /**
      * The signing secret provided on the dashboard's webhooks page
@@ -129,6 +130,7 @@ export class WebhookHandler {
         "userLeft",
         "roomCreated",
         "roomDeleted",
+        "ydocUpdated",
       ].includes(event.type)
     )
       return;
@@ -167,7 +169,8 @@ type WebhookEvent =
   | UserEnteredEvent
   | UserLeftEvent
   | RoomCreatedEvent
-  | RoomDeletedEvent;
+  | RoomDeletedEvent
+  | YDocUpdatedEvent;
 
 type StorageUpdatedEvent = {
   type: "storageUpdated";
@@ -244,6 +247,19 @@ type RoomDeletedEvent = {
   };
 };
 
+type YDocUpdatedEvent = {
+  type: "ydocUpdated";
+  data: {
+    appId: string;
+    roomId: string;
+    /**
+     * ISO 8601 datestring
+     * @example "2021-03-01T12:00:00.000Z"
+     */
+    deletedAt: string;
+  };
+};
+
 export type {
   RoomCreatedEvent,
   RoomDeletedEvent,
@@ -252,4 +268,5 @@ export type {
   UserLeftEvent,
   WebhookEvent,
   WebhookRequest,
+  YDocUpdatedEvent,
 };


### PR DESCRIPTION
This adds [`YDocUpdatedEvent`](https://liveblocks.io/docs/platform/webhooks#YDocUpdatedEvent) to `WebhookHandler`. Please check this is correct, and that no other changes are needed elsewhere. I think the back end is already working and set up? I see the events on our webhooks dashboard.