### PR TITLE
Support native `Headers` in `verifyRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### `@liveblocks/node`
 
 - Add Yjs document change event (`YDocUpdatedEvent`) to `WebhookHandler`.
+- Allow `Header` object to be passed to `headers` in
+  `WebhookHandler.verifyRequest()`
 
 # v1.2.1
 
@@ -421,17 +423,17 @@ To migrate, make the following code changes:
   create<WithLiveblocks<MyState, ...>>()(liveblocks(...))
   ```
   To be clear:
-  1. First, move the type annotation away from the `liveblocks` middleware call,
-     and onto the `create` call.
-  2. Next, wrap your `MyState` type in a `WithLiveblocks<...>` wrapper. This
-     will make sure the injected `liveblocks` property on your Zustand state
-     will be correctly typed.
-  3. Finally, make sure to add the extra call `()` wrapper, needed by Zustand v4
-     now:
-     ```ts
-     create<WithLiveblocks<MyState, ...>>()(liveblocks(...))
-     //                                  ^^ Not a typo
-     ```
+  1.  First, move the type annotation away from the `liveblocks` middleware
+      call, and onto the `create` call.
+  2.  Next, wrap your `MyState` type in a `WithLiveblocks<...>` wrapper. This
+      will make sure the injected `liveblocks` property on your Zustand state
+      will be correctly typed.
+  3.  Finally, make sure to add the extra call `()` wrapper, needed by Zustand
+      v4 now:
+      ```ts
+      create<WithLiveblocks<MyState, ...>>()(liveblocks(...))
+      //                                  ^^ Not a typo
+      ```
 - Remove the second argument to `state.liveblocks.enterRoom()`: it no longer
   takes an explicit initial state. Instead, it's automatically be populated from
   your Zustand state.

--- a/packages/liveblocks-node/src/__tests__/webhooks.test.ts
+++ b/packages/liveblocks-node/src/__tests__/webhooks.test.ts
@@ -261,6 +261,30 @@ describe("WebhookHandler", () => {
       expect(event).toEqual(userEnteredBody);
     });
 
+    it("should allow a native Headers object", () => {
+      jest.useFakeTimers({
+        now: 1674850126000,
+      });
+      const webhookHandler = new WebhookHandler(secret);
+
+      const headers = new Headers({
+        ...userEnteredHeaders,
+        "webhook-signature": generateSignatureWithSvix(
+          secret,
+          userEnteredHeaders["webhook-id"],
+          userEnteredHeaders["webhook-timestamp"],
+          rawUserEnteredBody
+        ),
+      });
+
+      const event = webhookHandler.verifyRequest({
+        headers,
+        rawBody: rawUserEnteredBody,
+      });
+
+      expect(event).toEqual(userEnteredBody);
+    });
+
     it("should throw if the signature is invalid", () => {
       jest.useFakeTimers({
         now: 1674850126000,

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -62,15 +62,13 @@ export class WebhookHandler {
   private verifyHeaders(headers: IncomingHttpHeaders | Headers) {
     const sanitizedHeaders: IncomingHttpHeaders = {};
 
-    if (headers.constructor === Headers) {
+    if (headers instanceof Headers) {
       for (const [key, value] of headers) {
         sanitizedHeaders[key.toLowerCase()] = value;
       }
     } else {
       Object.keys(headers).forEach((key) => {
-        sanitizedHeaders[key.toLowerCase()] = (headers as IncomingHttpHeaders)[
-          key
-        ];
+        sanitizedHeaders[key.toLowerCase()] = headers[key];
       });
     }
 

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -154,13 +154,19 @@ const isNotUndefined = <T>(value: T | undefined): value is T =>
 
 type WebhookRequest = {
   /**
-   * Headers of the request
+   * Headers of the request, can be a regular object or a Headers object
    * @example
    * {
    *  "webhook-id": "123",
    *  "webhook-timestamp": "1614588800000",
    *  "webhook-signature": "v1,bm9ldHUjKzFob2VudXRob2VodWUzMjRvdWVvdW9ldQo= v2,MzJsNDk4MzI0K2VvdSMjMTEjQEBAQDEyMzMzMzEyMwo="
    * }
+   *
+   * new Headers({
+   *  "webhook-id": "123",
+   *  "webhook-timestamp": "1614588800000",
+   *  "webhook-signature": "v1,bm9ldHUjKzFob2VudXRob2VodWUzMjRvdWVvdW9ldQo= v2,MzJsNDk4MzI0K2VvdSMjMTEjQEBAQDEyMzMzMzEyMwo="
+   * }}
    */
   headers: IncomingHttpHeaders | Headers;
   /**

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -4,6 +4,7 @@ import type { IncomingHttpHeaders } from "http";
 export class WebhookHandler {
   private secretBuffer: Buffer;
   private static secretPrefix = "whsec_";
+
   constructor(
     /**
      * The signing secret provided on the dashboard's webhooks page
@@ -58,11 +59,20 @@ export class WebhookHandler {
   /**
    * Verifies the headers and returns the webhookId, timestamp and rawSignatures
    */
-  private verifyHeaders(headers: IncomingHttpHeaders) {
+  private verifyHeaders(headers: IncomingHttpHeaders | Headers) {
     const sanitizedHeaders: IncomingHttpHeaders = {};
-    Object.keys(headers).forEach((key) => {
-      sanitizedHeaders[key.toLowerCase()] = headers[key];
-    });
+
+    if (headers.constructor === Headers) {
+      for (const [key, value] of headers) {
+        sanitizedHeaders[key.toLowerCase()] = value;
+      }
+    } else {
+      Object.keys(headers).forEach((key) => {
+        sanitizedHeaders[key.toLowerCase()] = (headers as IncomingHttpHeaders)[
+          key
+        ];
+      });
+    }
 
     const webhookId = sanitizedHeaders["webhook-id"];
     if (typeof webhookId !== "string")
@@ -154,7 +164,7 @@ type WebhookRequest = {
    *  "webhook-signature": "v1,bm9ldHUjKzFob2VudXRob2VodWUzMjRvdWVvdW9ldQo= v2,MzJsNDk4MzI0K2VvdSMjMTEjQEBAQDEyMzMzMzEyMwo="
    * }
    */
-  headers: IncomingHttpHeaders;
+  headers: IncomingHttpHeaders | Headers;
   /**
    * Raw body of the request, do not parse it
    * @example '{"type":"storageUpdated","data":{"roomId":"my-room-id","appId":"my-app-id","updatedAt":"2021-03-01T12:00:00.000Z"}}'

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -60,8 +60,11 @@ export class WebhookHandler {
    * Verifies the headers and returns the webhookId, timestamp and rawSignatures
    */
   private verifyHeaders(headers: IncomingHttpHeaders | Headers) {
-    const normalizedHeaders =
-      headers instanceof Headers ? Object.fromEntries(headers) : headers;
+    const usingNativeHeaders =
+      typeof Headers !== "undefined" && headers instanceof Headers;
+    const normalizedHeaders = usingNativeHeaders
+      ? Object.fromEntries(headers)
+      : (headers as IncomingHttpHeaders);
 
     const sanitizedHeaders: IncomingHttpHeaders = {};
     Object.keys(normalizedHeaders).forEach((key) => {

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -60,17 +60,13 @@ export class WebhookHandler {
    * Verifies the headers and returns the webhookId, timestamp and rawSignatures
    */
   private verifyHeaders(headers: IncomingHttpHeaders | Headers) {
-    const sanitizedHeaders: IncomingHttpHeaders = {};
+    const normalizedHeaders =
+      headers instanceof Headers ? Object.fromEntries(headers) : headers;
 
-    if (headers instanceof Headers) {
-      for (const [key, value] of headers) {
-        sanitizedHeaders[key.toLowerCase()] = value;
-      }
-    } else {
-      Object.keys(headers).forEach((key) => {
-        sanitizedHeaders[key.toLowerCase()] = headers[key];
-      });
-    }
+    const sanitizedHeaders: IncomingHttpHeaders = {};
+    Object.keys(normalizedHeaders).forEach((key) => {
+      sanitizedHeaders[key.toLowerCase()] = normalizedHeaders[key];
+    });
 
     const webhookId = sanitizedHeaders["webhook-id"];
     if (typeof webhookId !== "string")


### PR DESCRIPTION
It'd be nice if the native `Headers` object was supported in [`WebhookHandler.verifyRequest`](https://liveblocks.io/docs/api-reference/liveblocks-node#verifyRequest), then it'd work with [Next.js](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#headers) `/app` and other modern frameworks.

This would enable both of these:
```ts
export function POST(request: Request) {
  const event = webhookHandler.verifyRequest({
    headers: request.headers,
    rawBody: "",
  });

  // ...
}
```

```ts
import { headers } from "next/headers";

export function ServerComponent() {
  const event = webhookHandler.verifyRequest({
    headers: headers(),
    rawBody: "",
  });

  // ...
}
``