### PR TITLE
Fix Suspense option in create-liveblocks-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+### `create-liveblocks-app`
+
+- Fix Suspense option when specifying a framework
+- Add comments by default
+
 # v1.2.2
 
 ### `@liveblocks/node`

--- a/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
+++ b/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
@@ -54,6 +54,8 @@ export async function createLiveblocksApp() {
     process.exit(0);
   }
 
+  flags.comments = true;
+
   // If any --no-[FLAGNAME] is set, set --[FLAGNAME] to false
   // e.g. `--no-install === true` -> `--install === false`
   Object.entries(flags).forEach(([key, val]) => {

--- a/packages/create-liveblocks-app/bin/templates/init/init-prompts.ts
+++ b/packages/create-liveblocks-app/bin/templates/init/init-prompts.ts
@@ -25,6 +25,10 @@ export async function initPrompts(flags: Record<string, any>) {
     },
     {
       type: (prev) => {
+        if (flags.framework === "react" && !flags.suspense) {
+          return "confirm";
+        }
+
         if (flags.suspense || prev !== "react") {
           return null;
         }
@@ -39,12 +43,6 @@ export async function initPrompts(flags: Record<string, any>) {
       type: flags.typescript !== undefined ? null : "confirm",
       name: "typescript",
       message: "Are you using TypeScript?",
-      initial: true,
-    },
-    {
-      type: flags.comments !== undefined ? null : "confirm",
-      name: "comments",
-      message: "Add helpful comments?",
       initial: true,
     },
   ];


### PR DESCRIPTION
This PR fixes the Suspense option when specifying a framework and adds comments by default.