### PR TITLE
Cursor overflow problem fixed in Monaco editor

### DIFF
--- a/examples/nextjs-yjs-monaco/src/components/CollaborativeEditor.module.css
+++ b/examples/nextjs-yjs-monaco/src/components/CollaborativeEditor.module.css
@@ -19,5 +19,4 @@
 .editorContainer {
   position: relative;
   flex-grow: 1;
-  padding-top: 1rem;
 }

--- a/examples/nextjs-yjs-monaco/src/globals.css
+++ b/examples/nextjs-yjs-monaco/src/globals.css
@@ -66,3 +66,9 @@ main {
   user-select: none;
   z-index: 1000;
 }
+
+/* Move the editor down so cursors aren't hidden by overflow */
+.monaco-editor .overflow-guard > .margin,
+.monaco-editor .lines-content > * {
+  top: 20px !important;
+}

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
@@ -292,7 +292,6 @@ editor looks nice and tidy.
 .editorContainer {
   position: relative;
   flex-grow: 1;
-  padding-top: 1rem;
 }
 ```
 
@@ -423,6 +422,12 @@ a global CSS file:
   pointer-events: none;
   user-select: none;
   z-index: 1000;
+}
+
+/* Move the editor down so cursors aren't hidden by overflow */
+.monaco-editor .overflow-guard > .margin,
+.monaco-editor .lines-content > * {
+  top: 20px !important;
 }
 ```
 


### PR DESCRIPTION
Multiplayer cursors on the first line were hidden by `overflow: hidden`. This is now fixed.