### PR TITLE
Replaced Twitter with X

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -8,7 +8,7 @@
 </p>
 <p align="center">
   <a href="https://twitter.com/liveblocks">
-    <img src="https://img.shields.io/badge/liveblocks-message?style=flat&logo=twitter&color=555&logoColor=fff" alt="Twitter" />
+    <img src="https://img.shields.io/badge/liveblocks-message?style=flat&logo=x&color=555&logoColor=fff" alt="X" />
   </a>
   <a href="https://liveblocks.io/discord">
     <img src="https://img.shields.io/discord/913109211746009108?style=flat&label=discord&logo=discord&color=85f&logoColor=fff" alt="Discord" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 <p align="center">
   <a href="https://twitter.com/liveblocks">
-    <img src="https://img.shields.io/badge/liveblocks-message?style=flat&logo=twitter&color=555&logoColor=fff" alt="Twitter" />
+    <img src="https://img.shields.io/badge/liveblocks-message?style=flat&logo=x&color=555&logoColor=fff" alt="X" />
   </a>
   <a href="https://liveblocks.io/discord">
     <img src="https://img.shields.io/discord/913109211746009108?style=flat&label=discord&logo=discord&color=85f&logoColor=fff" alt="Discord" />
@@ -93,8 +93,8 @@ You can read our release notes
   community, ask questions and share tips.
 - [Email](https://liveblocks.io/contact) to contact us directly for support and
   sales enquiries.
-- [Twitter](https://twitter.com/liveblocks) to receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) to receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ forms, and more.
 
 - [`@liveblocks/client`](https://liveblocks.io/docs/api-reference/liveblocks-client)
 - [`@liveblocks/react`](https://liveblocks.io/docs/api-reference/liveblocks-react)
-- [`@liveblocks/yjs`](https://liveblocks.io/docs/api-reference/liveblocks-yjs)
 - [`@liveblocks/zustand`](https://liveblocks.io/docs/api-reference/liveblocks-zustand)
 - [`@liveblocks/redux`](https://liveblocks.io/docs/api-reference/liveblocks-redux)
 

--- a/README.md
+++ b/README.md
@@ -51,17 +51,16 @@ interact with rooms, and each room can have specific
 
 ### Integrations
 
-Liveblocks and its community provide integrations that developers can use to
-integrate with the Liveblocks products within the rooms. You can use existing
-integrations for specific libraries and frameworks, or create a custom one for
-your needs.
+Integrations for specific libraries and frameworks to add Liveblocks-powered
+collaborative experiences to your product. Integrations are designed to serve
+various collaboration use cases such as text editors, comments, creative tools,
+forms, and more.
 
-|                                                                                      | Presence | Broadcast | Storage | Comments |
-| ------------------------------------------------------------------------------------ | -------- | --------- | ------- | -------- |
-| [`@liveblocks/client`](https://liveblocks.io/docs/api-reference/liveblocks-client)   | ✅       | ✅        | ✅      | ✅       |
-| [`@liveblocks/react`](https://liveblocks.io/docs/api-reference/liveblocks-react)     | ✅       | ✅        | ✅      | ✅       |
-| [`@liveblocks/redux`](https://liveblocks.io/docs/api-reference/liveblocks-redux)     | ✅       | ❌        | ✅      | ❌       |
-| [`@liveblocks/zustand`](https://liveblocks.io/docs/api-reference/liveblocks-zustand) | ✅       | ❌        | ✅      | ❌       |
+- [`@liveblocks/client`](https://liveblocks.io/docs/api-reference/liveblocks-client)
+- [`@liveblocks/react`](https://liveblocks.io/docs/api-reference/liveblocks-react)
+- [`@liveblocks/yjs`](https://liveblocks.io/docs/api-reference/liveblocks-yjs)
+- [`@liveblocks/zustand`](https://liveblocks.io/docs/api-reference/liveblocks-zustand)
+- [`@liveblocks/redux`](https://liveblocks.io/docs/api-reference/liveblocks-redux)
 
 ### Platform
 

--- a/docs/pages/concepts/how-liveblocks-works.mdx
+++ b/docs/pages/concepts/how-liveblocks-works.mdx
@@ -47,10 +47,10 @@ and each room can have specific [permissions](/docs/rooms/permissions) and
 
 ## Integrations
 
-Liveblocks and its community provide integrations that developers can use to
-integrate with the Liveblocks products within the rooms. You can use existing
-integrations for specific libraries and frameworks, or create a custom one for
-your needs.
+Integrations for specific libraries and frameworks to add Liveblocks-powered
+collaborative experiences to your product. Integrations are designed to serve
+various collaboration use cases such as text editors, comments, creative tools,
+forms, and more.
 
 <Figure highlight>
   <Image

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -109,10 +109,10 @@ showTitle: false
 
 <ListGrid columns={3}>
   <DocsCard
-    title="Twitter"
-    href="https://twitter.com/liveblocks"
-    description="Follow us on Twitter for the latest news and updates."
-    visual={<DocsTwitterIcon />}
+    title="X"
+    href="https://x.com/liveblocks"
+    description="Follow us on X for the latest news and updates."
+    visual={<DocsXIcon />}
     openInNewWindow
   />
   <DocsCard

--- a/docs/pages/tools/nextjs-starter-kit.mdx
+++ b/docs/pages/tools/nextjs-starter-kit.mdx
@@ -590,9 +590,8 @@ export const authOptions = {
 
 It’s not only possible with GitHub and Auth0, any
 [NextAuth provider](https://next-auth.js.org/providers/) will work, such as
-Google, Twitter, Reddit, or more. You can find more information about getting
-the necessary secrets on the NextAuth documentation, or on the provider’s
-website.
+Google, X, Reddit, or more. You can find more information about getting the
+necessary secrets on the NextAuth documentation, or on the provider’s website.
 
 Note that if you’re using `CredentialsProvider` (for example, as used in the
 demo authentication), `CredentialsProvider` must be removed before any other

--- a/packages/liveblocks-client/README.md
+++ b/packages/liveblocks-client/README.md
@@ -21,8 +21,9 @@
   </a>
 </p>
 
-A client that lets you interact with [Liveblocks](https://liveblocks.io)
-servers.
+`@liveblocks/client` provides the APIs to integrate with Liveblocks—a platform
+to build, host, and scale collaborative applications with zero configuration, no
+maintenance required.
 
 ## Installation
 

--- a/packages/liveblocks-client/README.md
+++ b/packages/liveblocks-client/README.md
@@ -54,8 +54,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-devtools/README.md
+++ b/packages/liveblocks-devtools/README.md
@@ -93,8 +93,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-node/README.md
+++ b/packages/liveblocks-node/README.md
@@ -21,8 +21,8 @@
   </a>
 </p>
 
-A server-side utility that lets you set up a [Liveblocks](https://liveblocks.io)
-authentication endpoint.
+`@liveblocks/node` provides server-side utilities to set up
+[Liveblocks](https://liveblocks.io) authentication endpoints.
 
 ## Installation
 

--- a/packages/liveblocks-node/README.md
+++ b/packages/liveblocks-node/README.md
@@ -54,8 +54,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-react/README.md
+++ b/packages/liveblocks-react/README.md
@@ -54,8 +54,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-react/README.md
+++ b/packages/liveblocks-react/README.md
@@ -21,8 +21,9 @@
   </a>
 </p>
 
-A set of [React](https://reactjs.org/) hooks and providers to use
-[Liveblocks](https://liveblocks.io) declaratively.
+`@liveblocks/react` provides [React](https://reactjs.org/) hooks and providers
+to integrate with Liveblocks—a platform to build, host, and scale collaborative
+applications with zero configuration, no maintenance required.
 
 ## Installation
 

--- a/packages/liveblocks-redux/README.md
+++ b/packages/liveblocks-redux/README.md
@@ -21,10 +21,11 @@
   </a>
 </p>
 
-A
+`@liveblocks/redux` provides a
 [store enhancer](https://redux.js.org/understanding/thinking-in-redux/glossary#store-enhancer)
-to integrate [Liveblocks](https://liveblocks.io) into
-[Redux](https://redux-toolkit.js.org/) stores.
+to make [Redux](https://redux-toolkit.js.org/) stores collaborative with
+Liveblocks—a platform to build, host, and scale collaborative applications with
+zero configuration, no maintenance required.
 
 ## Installation
 

--- a/packages/liveblocks-redux/README.md
+++ b/packages/liveblocks-redux/README.md
@@ -56,8 +56,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-yjs/README.md
+++ b/packages/liveblocks-yjs/README.md
@@ -9,7 +9,10 @@
 
 # `@liveblocks/yjs`
 
-Provides Yjs integration to effortlessly back your Yjs apps with Liveblocks
+`@liveblocks/yjs` provides a provider to integrate
+[Yjs](https://github.com/yjs/yjs) applications with Liveblocks—a platform to
+build, host, and scale collaborative applications with zero configuration, no
+maintenance required.
 
 ## Installation
 
@@ -24,6 +27,12 @@ Read the
 guides and API references.
 
 ## Examples
+
+Explore our [collaborative examples](https://liveblocks.io/examples) to help you
+get started.
+
+> All examples are open-source and live in this repository, within
+> [`/examples`](../../examples).
 
 ## Releases
 

--- a/packages/liveblocks-yjs/README.md
+++ b/packages/liveblocks-yjs/README.md
@@ -35,8 +35,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-zustand/README.md
+++ b/packages/liveblocks-zustand/README.md
@@ -55,8 +55,8 @@ learn more about
 
 - [Discord](https://liveblocks.io/discord) - To get involved with the Liveblocks
   community, ask questions and share tips.
-- [Twitter](https://twitter.com/liveblocks) - To receive updates, announcements,
-  blog posts, and general Liveblocks tips.
+- [X](https://x.com/liveblocks) - To receive updates, announcements, blog posts,
+  and general Liveblocks tips.
 
 ## License
 

--- a/packages/liveblocks-zustand/README.md
+++ b/packages/liveblocks-zustand/README.md
@@ -21,9 +21,11 @@
   </a>
 </p>
 
-A [middleware](https://github.com/pmndrs/zustand#middleware) to integrate
-[Liveblocks](https://liveblocks.io) into
-[Zustand](https://github.com/pmndrs/zustand) stores.
+`@liveblocks/redux` provides a
+[middleware](https://github.com/pmndrs/zustand#middleware) to make
+[Zustand](https://github.com/pmndrs/zustand) stores collaborative with
+Liveblocks—a platform to build, host, and scale collaborative applications with
+zero configuration, no maintenance required.
 
 ## Installation
 


### PR DESCRIPTION
We need to merge a change on the marketing site as soon as this is merged: `DocsTwitterIcon` needs to be `DocsXIcon`.