### PR TITLE
Comments: Hide @ button when not using mentions

### DIFF
--- a/packages/liveblocks-react-comments/src/components/Composer.tsx
+++ b/packages/liveblocks-react-comments/src/components/Composer.tsx
@@ -225,6 +225,7 @@ const ComposerWithContext = forwardRef<
     },
     forwardedRef
   ) => {
+    const { hasResolveMentionSuggestions } = useRoomContextBundle();
     const { isEmpty } = useComposer();
     const $ = useOverrides(overrides);
     const [collapsed, onCollapsedChange] = useControllableState(
@@ -314,9 +315,11 @@ const ComposerWithContext = forwardRef<
         {!collapsed && (
           <div className="lb-composer-footer">
             <div className="lb-composer-editor-actions">
-              <ComposerInsertMentionEditorAction
-                label={$.COMPOSER_INSERT_MENTION}
-              />
+              {hasResolveMentionSuggestions && (
+                <ComposerInsertMentionEditorAction
+                  label={$.COMPOSER_INSERT_MENTION}
+                />
+              )}
             </div>
             {showLogo && <Logo className="lb-composer-logo" />}
             <div className="lb-composer-actions">

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -294,7 +294,17 @@ export function createRoomContext<
 
     return (
       <RoomContext.Provider value={room}>
-        <ContextBundle.Provider value={internalBundle}>
+        <ContextBundle.Provider
+          value={
+            internalBundle as unknown as InternalRoomContextBundle<
+              JsonObject,
+              LsonObject,
+              BaseUserMeta,
+              never,
+              BaseMetadata
+            >
+          }
+        >
           {props.children}
         </ContextBundle.Provider>
       </RoomContext.Provider>
@@ -1080,16 +1090,17 @@ export function createRoomContext<
     },
   };
 
-  const internalBundle = {
+  const internalBundle: InternalRoomContextBundle<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TRoomEvent,
+    TThreadMetadata
+  > = {
     ...bundle,
+    hasResolveMentionSuggestions: resolveMentionSuggestions !== undefined,
     useMentionSuggestions,
-  } as unknown as InternalRoomContextBundle<
-    JsonObject,
-    LsonObject,
-    BaseUserMeta,
-    never,
-    BaseMetadata
-  >;
+  };
 
   return bundle;
 }

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -801,6 +801,7 @@ export type InternalRoomContextBundle<
     TRoomEvent,
     TThreadMetadata
   > & {
+    hasResolveMentionSuggestions: boolean;
     useMentionSuggestions(search?: string): string[] | undefined;
   }
 >;

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -600,11 +600,6 @@ export type RoomContextBundle<
      */
     useUser(userId: string): UserState<TUserMeta["info"]>;
 
-    /**
-     * @private
-     */
-    useMentionSuggestions(search?: string): string[] | undefined;
-
     //
     // Legacy hooks
     //
@@ -789,5 +784,23 @@ export type RoomContextBundle<
         ): TStorage[TKey];
       }
     >;
+  }
+>;
+
+export type InternalRoomContextBundle<
+  TPresence extends JsonObject,
+  TStorage extends LsonObject,
+  TUserMeta extends BaseUserMeta,
+  TRoomEvent extends Json,
+  TThreadMetadata extends BaseMetadata,
+> = Resolve<
+  RoomContextBundle<
+    TPresence,
+    TStorage,
+    TUserMeta,
+    TRoomEvent,
+    TThreadMetadata
+  > & {
+    useMentionSuggestions(search?: string): string[] | undefined;
   }
 >;


### PR DESCRIPTION
This PR hides the @ button in `<Composer />` when not using mentions. It also shuffles a few internal things to make exposing private methods/properties from `@liveblocks/react` to `@liveblocks/react-comments` easier through `useRoomContextBundle`.