### PR TITLE
Show yjs in integrations side bar

### DIFF
--- a/docs/pages/concepts/how-liveblocks-works.mdx
+++ b/docs/pages/concepts/how-liveblocks-works.mdx
@@ -52,11 +52,10 @@ collaborative experiences to your product:
 [JavaScript](/docs/api-reference/liveblocks-client),
 [React](/docs/api-reference/liveblocks-react),
 [Redux](/docs/api-reference/liveblocks-redux),
-[Zustand](/docs/api-reference/liveblocks-zustand),
-[Yjs](/docs/api-reference/liveblocks-yjs), and
-[Node.js](/docs/api-reference/liveblocks-node). Integrations are designed to
-serve various collaboration use cases such as text editors, comments, creative
-tools, forms, and more.
+[Zustand](/docs/api-reference/liveblocks-zustand), and
+[Yjs](/docs/api-reference/liveblocks-yjs). Integrations are designed to serve
+various collaboration use cases such as text editors, comments, creative tools,
+forms, and more.
 
 <Figure highlight>
   <Image

--- a/docs/pages/concepts/how-liveblocks-works.mdx
+++ b/docs/pages/concepts/how-liveblocks-works.mdx
@@ -49,14 +49,14 @@ and each room can have specific [permissions](/docs/rooms/permissions) and
 
 Integrations for specific libraries and frameworks to add Liveblocks-powered
 collaborative experiences to your product:
-[JavaScript](/api-reference/liveblocks-client),
-[React](/api-reference/liveblocks-react),
-[Redux](/api-reference/liveblocks-redux),
-[Zustand](/api-reference/liveblocks-zustand),
-[Yjs](/api-reference/liveblocks-yjs), and
-[Node.js](/api-reference/liveblocks-node). Integrations are designed to serve
-various collaboration use cases such as text editors, comments, creative tools,
-forms, and more.
+[JavaScript](/docs/api-reference/liveblocks-client),
+[React](/docs/api-reference/liveblocks-react),
+[Redux](/docs/api-reference/liveblocks-redux),
+[Zustand](/docs/api-reference/liveblocks-zustand),
+[Yjs](/docs/api-reference/liveblocks-yjs), and
+[Node.js](/docs/api-reference/liveblocks-node). Integrations are designed to
+serve various collaboration use cases such as text editors, comments, creative
+tools, forms, and more.
 
 <Figure highlight>
   <Image

--- a/docs/pages/concepts/how-liveblocks-works.mdx
+++ b/docs/pages/concepts/how-liveblocks-works.mdx
@@ -48,7 +48,13 @@ and each room can have specific [permissions](/docs/rooms/permissions) and
 ## Integrations
 
 Integrations for specific libraries and frameworks to add Liveblocks-powered
-collaborative experiences to your product. Integrations are designed to serve
+collaborative experiences to your product:
+[JavaScript](/api-reference/liveblocks-client),
+[React](/api-reference/liveblocks-react),
+[Redux](/api-reference/liveblocks-redux),
+[Zustand](/api-reference/liveblocks-zustand),
+[Yjs](/api-reference/liveblocks-yjs), and
+[Node.js](/api-reference/liveblocks-node). Integrations are designed to serve
 various collaboration use cases such as text editors, comments, creative tools,
 forms, and more.
 

--- a/docs/pages/get-started/yjs-slate-react.mdx
+++ b/docs/pages/get-started/yjs-slate-react.mdx
@@ -28,7 +28,7 @@ We’d love to hear from you.
     <StepContent>
 
       ```bash
-      npm install @liveblocks/client @liveblocks/react @liveblocks/yjs yjs slate slate-react @slate-yjs/core @slate-yjs/react
+      npm install @liveblocks/client @liveblocks/react @liveblocks/yjs yjs slate slate-react @slate-yjs/core
       ```
 
     </StepContent>

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -354,7 +354,6 @@
       },
       {
         "title": "@liveblocks/yjs",
-        "hidden": true,
         "path": "/api-reference/liveblocks-yjs"
       },
       {


### PR DESCRIPTION
- Show @liveblocks/yjs in side bar
- Link integrations in concepts page
- Removed unused package from slate guide

![image](https://github.com/liveblocks/liveblocks/assets/33033422/f4857f60-6eea-409c-9185-35716b92756f)

