### PR TITLE
Add examples to getting started pages

### DIFF
--- a/docs/pages/get-started/javascript.mdx
+++ b/docs/pages/get-started/javascript.mdx
@@ -119,11 +119,11 @@ collaborative experiences for your JavaScript application.
   />
   <ExampleCard
     example={{
-      title: "Live Avatar Stack",
-      slug: "live-avatar-stack",
+      title: "Live Cursors",
+      slug: "live-cursors/javascript-live-cursors",
       image: "/images/examples/thumbnails/live-avatar-stack.jpg",
     }}
-    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
     openInNewWindow
   />
 </ListGrid>

--- a/docs/pages/get-started/javascript.mdx
+++ b/docs/pages/get-started/javascript.mdx
@@ -105,6 +105,8 @@ collaborative experiences for your JavaScript application.
 - [JavaScript guides](/docs/guides?technologies=javascript)
 - [Authentication](/docs/rooms/authentication)
 
+---
+
 ## Examples using JavaScript
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/javascript.mdx
+++ b/docs/pages/get-started/javascript.mdx
@@ -111,7 +111,7 @@ collaborative experiences for your JavaScript application.
   <ExampleCard
     example={{
       title: "Collaborative To-do List",
-      slug: "collaborative-todo-list",
+      slug: "collaborative-todo-list/javascript-todo-list",
       image: "/images/examples/thumbnails/collaborative-todo-list.jpg",
     }}
     technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}

--- a/docs/pages/get-started/javascript.mdx
+++ b/docs/pages/get-started/javascript.mdx
@@ -104,3 +104,26 @@ collaborative experiences for your JavaScript application.
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
 - [JavaScript guides](/docs/guides?technologies=javascript)
 - [Authentication](/docs/rooms/authentication)
+
+## Examples using JavaScript
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative To-do List",
+      slug: "collaborative-todo-list",
+      image: "/images/examples/thumbnails/collaborative-todo-list.jpg",
+    }}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Live Avatar Stack",
+      slug: "live-avatar-stack",
+      image: "/images/examples/thumbnails/live-avatar-stack.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/nextjs.mdx
+++ b/docs/pages/get-started/nextjs.mdx
@@ -159,3 +159,48 @@ collaborative experiences for your React application.
 - [Next.js and React guides](/docs/guides?technologies=nextjs%2Creact)
 - [How to use Liveblocks Presence with React](/docs/guides/how-to-use-liveblocks-presence-with-react)
 - [How to use Liveblocks Storage with React](/docs/guides/how-to-use-liveblocks-storage-with-react)
+
+## Examples using Next.js
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative To-do List",
+      slug: "collaborative-todo-list/nextjs-todo-list",
+      image: "/images/examples/thumbnails/collaborative-todo-list.jpg",
+    }}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Live Avatar Stack",
+      slug: "live-avatar-stack/nextjs-live-avatars",
+      image: "/images/examples/thumbnails/live-avatar-stack.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Spreadsheet",
+      slug: "collaborative-spreadsheet-advanced/nextjs-spreadsheet-advanced",
+      image:
+        "/images/examples/thumbnails/collaborative-spreadsheet-advanced.jpg",
+      advanced: true,
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Whiteboard",
+      slug: "collaborative-whiteboard-advanced/nextjs-whiteboard-advanced",
+      image:
+        "/images/examples/thumbnails/collaborative-whiteboard-advanced.jpg",
+      advanced: true,
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/nextjs.mdx
+++ b/docs/pages/get-started/nextjs.mdx
@@ -160,6 +160,8 @@ collaborative experiences for your React application.
 - [How to use Liveblocks Presence with React](/docs/guides/how-to-use-liveblocks-presence-with-react)
 - [How to use Liveblocks Storage with React](/docs/guides/how-to-use-liveblocks-storage-with-react)
 
+---
+
 ## Examples using Next.js
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/react.mdx
+++ b/docs/pages/get-started/react.mdx
@@ -129,6 +129,8 @@ collaborative experiences for your React application.
 - [How to use Liveblocks Presence with React](/docs/guides/how-to-use-liveblocks-presence-with-react)
 - [How to use Liveblocks Storage with React](/docs/guides/how-to-use-liveblocks-storage-with-react)
 
+---
+
 ## Examples using React
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/react.mdx
+++ b/docs/pages/get-started/react.mdx
@@ -128,3 +128,48 @@ collaborative experiences for your React application.
 - [React guides](/docs/guides?technologies=react)
 - [How to use Liveblocks Presence with React](/docs/guides/how-to-use-liveblocks-presence-with-react)
 - [How to use Liveblocks Storage with React](/docs/guides/how-to-use-liveblocks-storage-with-react)
+
+## Examples using React
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative To-do List",
+      slug: "collaborative-todo-list/nextjs-todo-list",
+      image: "/images/examples/thumbnails/collaborative-todo-list.jpg",
+    }}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Live Avatar Stack",
+      slug: "live-avatar-stack/nextjs-live-avatars",
+      image: "/images/examples/thumbnails/live-avatar-stack.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Spreadsheet",
+      slug: "collaborative-spreadsheet-advanced/nextjs-spreadsheet-advanced",
+      image:
+        "/images/examples/thumbnails/collaborative-spreadsheet-advanced.jpg",
+      advanced: true,
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Whiteboard",
+      slug: "collaborative-whiteboard-advanced/nextjs-whiteboard-advanced",
+      image:
+        "/images/examples/thumbnails/collaborative-whiteboard-advanced.jpg",
+      advanced: true,
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/redux.mdx
+++ b/docs/pages/get-started/redux.mdx
@@ -149,6 +149,8 @@ collaborative experiences for your Redux store.
 - [How to create a collaborative online whiteboard with Redux](/docs/guides/how-to-create-a-collaborative-online-whiteboard-with-react-redux-and-liveblocks)
 - [How to create a collaborative to-do list with Redux](/docs/guides/how-to-create-a-collaborative-to-do-list-with-react-redux-and-liveblocks)
 
+---
+
 ## Examples using Redux
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/redux.mdx
+++ b/docs/pages/get-started/redux.mdx
@@ -148,3 +148,27 @@ collaborative experiences for your Redux store.
 - [Redux guides](/docs/guides?technologies=redux)
 - [How to create a collaborative online whiteboard with Redux](/docs/guides/how-to-create-a-collaborative-online-whiteboard-with-react-redux-and-liveblocks)
 - [How to create a collaborative to-do list with Redux](/docs/guides/how-to-create-a-collaborative-to-do-list-with-react-redux-and-liveblocks)
+
+## Examples using Redux
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative To-do List",
+      slug: "collaborative-todo-list/redux-todo-list",
+      image: "/images/examples/thumbnails/collaborative-todo-list.jpg",
+    }}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Whiteboard",
+      slug: "collaborative-whiteboard/redux-whiteboard",
+      image: "/images/examples/thumbnails/collaborative-whiteboard.jpg",
+      advanced: true,
+    }}
+    technologies={["nextjs", "redux", "zustand"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/solidjs.mdx
+++ b/docs/pages/get-started/solidjs.mdx
@@ -124,3 +124,26 @@ Congratulations! You now have set up the foundation to start building
 collaborative experiences for your SolidJS application.
 
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
+
+## Examples using SolidJS
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Live Avatar Stack",
+      slug: "live-avatar-stack/solidjs-live-avatars",
+      image: "/images/examples/thumbnails/live-avatar-stack.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Live Cursors",
+      slug: "live-cursors/solidjs-live-cursors",
+      image: "/images/examples/thumbnails/live-cursors.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/solidjs.mdx
+++ b/docs/pages/get-started/solidjs.mdx
@@ -125,6 +125,8 @@ collaborative experiences for your SolidJS application.
 
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
 
+---
+
 ## Examples using SolidJS
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/svelte.mdx
+++ b/docs/pages/get-started/svelte.mdx
@@ -127,7 +127,7 @@ collaborative experiences for your Svelte application.
   <ExampleCard
     example={{
       title: "Live Cursors",
-      slug: "live-cursors",
+      slug: "live-cursors/sveltekit-live-cursors",
       image: "/images/examples/thumbnails/live-cursors.jpg",
     }}
     technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
@@ -136,7 +136,7 @@ collaborative experiences for your Svelte application.
   <ExampleCard
     example={{
       title: "Live Avatar Stack",
-      slug: "live-avatar-stack",
+      slug: "live-avatar-stack/sveltekit-live-avatars",
       image: "/images/examples/thumbnails/live-avatar-stack.jpg",
     }}
     technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}

--- a/docs/pages/get-started/svelte.mdx
+++ b/docs/pages/get-started/svelte.mdx
@@ -120,3 +120,26 @@ Congratulations! You now have set up the foundation to start building
 collaborative experiences for your Svelte application.
 
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
+
+## Examples using Svelte
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Live Cursors",
+      slug: "live-cursors",
+      image: "/images/examples/thumbnails/live-cursors.jpg",
+    }}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Live Avatar Stack",
+      slug: "live-avatar-stack",
+      image: "/images/examples/thumbnails/live-avatar-stack.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/svelte.mdx
+++ b/docs/pages/get-started/svelte.mdx
@@ -121,6 +121,8 @@ collaborative experiences for your Svelte application.
 
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
 
+---
+
 ## Examples using Svelte
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/vuejs.mdx
+++ b/docs/pages/get-started/vuejs.mdx
@@ -122,3 +122,26 @@ Congratulations! You now have set up the foundation to start building
 collaborative experiences for your Vue.js application.
 
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
+
+## Examples using Vue.js
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Live Avatar Stack",
+      slug: "live-avatar-stack/vuejs-live-avatars",
+      image: "/images/examples/thumbnails/live-avatar-stack.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Live Cursors",
+      slug: "live-cursors/vuejs-live-cursors",
+      image: "/images/examples/thumbnails/live-cursors.jpg",
+    }}
+    technologies={["nextjs", "nuxtjs", "vuejs", "sveltekit", "solidjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/vuejs.mdx
+++ b/docs/pages/get-started/vuejs.mdx
@@ -123,6 +123,8 @@ collaborative experiences for your Vue.js application.
 
 - [@liveblocks/client API Reference](/docs/api-reference/liveblocks-client)
 
+---
+
 ## Examples using Vue.js
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/yjs-codemirror-react.mdx
+++ b/docs/pages/get-started/yjs-codemirror-react.mdx
@@ -191,6 +191,8 @@ CodeMirror editor inside your React application.
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [CodeMirror website](https://codemirror.net)
 
+---
+
 ## Examples using CodeMirror
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/yjs-codemirror-react.mdx
+++ b/docs/pages/get-started/yjs-codemirror-react.mdx
@@ -190,3 +190,17 @@ CodeMirror editor inside your React application.
 - [How to create a collaborative code editor with CodeMirror, Yjs, Next.js, and Liveblocks](/docs/guides/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks)
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [CodeMirror website](https://codemirror.net)
+
+## Examples using CodeMirror
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative Code Editor",
+      slug: "collaborative-code-editor/nextjs-yjs-codemirror",
+      image: "/images/examples/thumbnails/code-editor.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/yjs-lexical-react.mdx
+++ b/docs/pages/get-started/yjs-lexical-react.mdx
@@ -190,3 +190,17 @@ Lexical text editor inside your React application.
 - [How to create a collaborative text editor with Lexical, Yjs, Next.js, and Liveblocks ](/docs/guides/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks#Create-live-avatars-with-Liveblocks-hooks)
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Lexical website](https://lexical.dev/)
+
+## Examples using Lexical
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative Text Editor",
+      slug: "collaborative-text-editor/nextjs-yjs-lexical",
+      image: "/images/examples/thumbnails/text-editor.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/yjs-lexical-react.mdx
+++ b/docs/pages/get-started/yjs-lexical-react.mdx
@@ -191,6 +191,8 @@ Lexical text editor inside your React application.
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Lexical website](https://lexical.dev/)
 
+---
+
 ## Examples using Lexical
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -194,6 +194,8 @@ Monaco code editor inside your React application.
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Monaco website](https://microsoft.github.io/monaco-editor/)
 
+---
+
 ## Examples using Monaco
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -193,3 +193,17 @@ Monaco code editor inside your React application.
 - [How to create a collaborative code editor with Monaco, Yjs, Next.js, and Liveblocks](/docs/guides/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks)
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Monaco website](https://microsoft.github.io/monaco-editor/)
+
+## Examples using Monaco
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative Code Editor",
+      slug: "collaborative-code-editor/nextjs-yjs-monaco",
+      image: "/images/examples/thumbnails/code-editor.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/yjs-quill-react.mdx
+++ b/docs/pages/get-started/yjs-quill-react.mdx
@@ -210,3 +210,17 @@ text editor inside your React application.
 - [How to create a collaborative text editor with Quill, Yjs, Next.js, and Liveblocks](/docs/guides/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks)
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Quill website](https://quilljs.com)
+
+## Examples using Quill
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative Text Editor",
+      slug: "collaborative-text-editor/nextjs-yjs-quill",
+      image: "/images/examples/thumbnails/text-editor.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/yjs-quill-react.mdx
+++ b/docs/pages/get-started/yjs-quill-react.mdx
@@ -211,6 +211,8 @@ text editor inside your React application.
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Quill website](https://quilljs.com)
 
+---
+
 ## Examples using Quill
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/yjs-slate-react.mdx
+++ b/docs/pages/get-started/yjs-slate-react.mdx
@@ -246,6 +246,8 @@ text editor inside your React application.
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Slate website](https://docs.slatejs.org/)
 
+---
+
 ## Examples using Slate
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/yjs-slate-react.mdx
+++ b/docs/pages/get-started/yjs-slate-react.mdx
@@ -245,3 +245,17 @@ text editor inside your React application.
 - [How to create a collaborative text editor with Slate, Yjs, Next.js, and Liveblocks](/docs/guides/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks)
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Slate website](https://docs.slatejs.org/)
+
+## Examples using Slate
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative Text Editor",
+      slug: "collaborative-text-editor/nextjs-yjs-slate",
+      image: "/images/examples/thumbnails/text-editor.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/yjs-tiptap-react.mdx
+++ b/docs/pages/get-started/yjs-tiptap-react.mdx
@@ -190,3 +190,26 @@ Tiptap text editor inside your React application.
 - [How to create a collaborative text editor with Tiptap, Yjs, Next.js, and Liveblocks](/docs/guides/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks)
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Tiptap website](https://tiptap.dev)
+
+## Examples using Tiptap
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative Text Editor",
+      slug: "collaborative-text-editor/nextjs-yjs-tiptap",
+      image: "/images/examples/thumbnails/text-editor.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Advanced Collaborative Text Editor",
+      slug: "collaborative-text-editor-advanced/nextjs-yjs-tiptap-advanced",
+      image: "/images/examples/thumbnails/text-editor-advanced.jpg",
+    }}
+    technologies={["nextjs"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/yjs-tiptap-react.mdx
+++ b/docs/pages/get-started/yjs-tiptap-react.mdx
@@ -191,6 +191,8 @@ Tiptap text editor inside your React application.
 - [@liveblocks/yjs API Reference](/docs/api-reference/liveblocks-yjs)
 - [Tiptap website](https://tiptap.dev)
 
+---
+
 ## Examples using Tiptap
 
 <ListGrid columns={2}>

--- a/docs/pages/get-started/zustand.mdx
+++ b/docs/pages/get-started/zustand.mdx
@@ -140,3 +140,37 @@ collaborative experiences for your Zustand store.
 - [Zustand guides](/docs/guides?technologies=zustand)
 - [How to use Liveblocks Presence with Zustand](/docs/guides/how-to-create-a-collaborative-to-do-list-with-react-zustand-and-liveblocks)
 - [How to use Liveblocks Storage with Zustand](/docs/guides/how-to-use-liveblocks-storage-with-zustand)
+
+## Examples using Zustand
+
+<ListGrid columns={2}>
+  <ExampleCard
+    example={{
+      title: "Collaborative To-do List",
+      slug: "collaborative-todo-list/zustand-todo-list",
+      image: "/images/examples/thumbnails/collaborative-todo-list.jpg",
+    }}
+    technologies={["nextjs", "vuejs", "sveltekit", "solidjs", "javascript"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Whiteboard",
+      slug: "collaborative-whiteboard/zustand-whiteboard",
+      image: "/images/examples/thumbnails/collaborative-whiteboard.jpg",
+      advanced: true,
+    }}
+    technologies={["nextjs", "redux", "zustand"]}
+    openInNewWindow
+  />
+  <ExampleCard
+    example={{
+      title: "Collaborative Flowchart",
+      slug: "collaborative-flowchart/zustand-flowchart",
+      image: "/images/examples/thumbnails/collaborative-flowchart.jpg",
+      advanced: true,
+    }}
+    technologies={["zustand"]}
+    openInNewWindow
+  />
+</ListGrid>

--- a/docs/pages/get-started/zustand.mdx
+++ b/docs/pages/get-started/zustand.mdx
@@ -141,6 +141,8 @@ collaborative experiences for your Zustand store.
 - [How to use Liveblocks Presence with Zustand](/docs/guides/how-to-create-a-collaborative-to-do-list-with-react-zustand-and-liveblocks)
 - [How to use Liveblocks Storage with Zustand](/docs/guides/how-to-use-liveblocks-storage-with-zustand)
 
+---
+
 ## Examples using Zustand
 
 <ListGrid columns={2}>


### PR DESCRIPTION
Add "Examples using X" section to getting started guides.

**TODO**
- [x] Added relevant examples to all frameworks with examples 

![image](https://github.com/liveblocks/liveblocks/assets/33033422/a276cf44-1f52-430b-b928-93b3505feb18)
