### PR TITLE
Implement Auto-Linking Feature in Rich Text Editor for Comments

### DIFF
--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -111,6 +111,7 @@ import {
   getPlacementFromPosition,
   getSideAndAlignFromPlacement,
 } from "./utils";
+import { withAutoLinks } from "../../slate/plugins/auto-links";
 
 const MENTION_SUGGESTIONS_POSITION: SuggestionsPosition = "top";
 
@@ -129,8 +130,10 @@ const emptyCommentBody: CommentBody = {
 
 function createComposerEditor() {
   return withMentions(
-    withEmptyClearFormatting(
-      withAutoFormatting(withHistory(withReact(createEditor())))
+    withAutoLinks(
+      withEmptyClearFormatting(
+        withAutoFormatting(withHistory(withReact(createEditor())))
+      )
     )
   );
 }

--- a/packages/liveblocks-react-comments/src/slate.d.ts
+++ b/packages/liveblocks-react-comments/src/slate.d.ts
@@ -3,6 +3,7 @@ import type { HistoryEditor } from "slate-history";
 import type { ReactEditor, RenderElementProps } from "slate-react";
 
 import type {
+  ComposerBodyAutoLink,
   ComposerBodyMention,
   ComposerBodyParagraph,
   ComposerBodyText,
@@ -11,7 +12,7 @@ import type {
 declare module "slate" {
   interface CustomTypes {
     Editor: BaseEditor & ReactEditor & HistoryEditor;
-    Element: ComposerBodyParagraph | ComposerBodyMention;
+    Element: ComposerBodyParagraph | ComposerBodyMention | ComposerBodyAutoLink;
     Text: ComposerBodyText;
   }
 }

--- a/packages/liveblocks-react-comments/src/slate/plugins/auto-links.ts
+++ b/packages/liveblocks-react-comments/src/slate/plugins/auto-links.ts
@@ -1,0 +1,316 @@
+import {
+  Editor,
+  Node,
+  NodeEntry,
+  Text,
+  Transforms,
+  Element,
+  Path,
+  Range,
+} from "slate";
+import type { ComposerBodyAutoLink } from "../../types";
+
+/**
+ * This implementation is inspired by Lexical's AutoLink plugin.
+ * Additional modifications and features were added to adapt it to our specific needs.
+ *
+ * Original Lexical AutoLink plugin can be found at [Lexical's Github Repository](https://github.com/facebook/lexical/blob/main/packages/lexical-react/src/LexicalAutoLinkPlugin.ts)
+ */
+export function withAutoLinks(editor: Editor): Editor {
+  const { isInline, normalizeNode, deleteBackward } = editor;
+
+  editor.isInline = (element) => {
+    return element.type === "auto-link" ? true : isInline(element);
+  };
+
+  editor.normalizeNode = (entry) => {
+    const [node, path] = entry;
+
+    if (Text.isText(node)) {
+      const parentNode = Node.parent(editor, path);
+
+      if (isComposerBodyAutoLink(parentNode)) {
+        const parentPath = Path.parent(path);
+        handleLinkEdit(editor, [parentNode, parentPath]);
+      } else {
+        handleLinkCreate(editor, [node, path]);
+        handleNeighbours(editor, [node, path]);
+      }
+    }
+
+    normalizeNode(entry);
+  };
+
+  editor.deleteBackward = (unit) => {
+    deleteBackward(unit);
+    const { selection } = editor;
+    if (!selection) return;
+
+    if (!Range.isCollapsed(selection)) return;
+
+    const [match] = Editor.nodes(editor, {
+      at: selection,
+      match: isComposerBodyAutoLink,
+      mode: "lowest",
+    });
+
+    if (!match) return;
+
+    Transforms.unwrapNodes(editor, {
+      match: isComposerBodyAutoLink,
+    });
+  };
+
+  return editor;
+}
+
+export function isComposerBodyAutoLink(
+  node: Node
+): node is ComposerBodyAutoLink {
+  return Element.isElement(node) && node.type === "auto-link";
+}
+
+/**
+ * 1. ((https?:\/\/(www\.)?)|(www\.))
+ * - Matches 'http://' or 'https://' optionally followed by 'www.', or just 'www.'
+ *
+ * 2. [-a-zA-Z0-9@:%._+~#=]{1,256}
+ * - Matches any character in the set [-a-zA-Z0-9@:%._+~#=] between 1 and 256 times, often found in the domain and subdomain part of the URL
+ *
+ * 3. \.[a-zA-Z0-9()]{1,6}
+ * - Matches a period followed by any character in the set [a-zA-Z0-9()] between 1 and 6 times, usually indicating the domain extension like .com, .org, etc.
+ *
+ * 4. \b
+ * - Represents a word boundary, ensuring that the characters following cannot be part of a different word
+ *
+ * 5. ([-a-zA-Z0-9().@:%_+~#?&//=]*)
+ * - Matches any character in the set [-a-zA-Z0-9().@:%_+~#?&//=] between 0 and unlimited times, often found in the path, query parameters, or anchor part of the URL
+ *
+ * Matching URLs:
+ * - http://www.example.com
+ * - https://www.example.com
+ * - www.example.com
+ * - https://example.com/path?query=param#anchor
+ *
+ * Non-Matching URLs:
+ * - http:/example.com (malformed scheme)
+ * - example (missing scheme and domain extension)
+ * - ftp://example.com (ftp scheme is not supported)
+ * - example.com (missing scheme)
+ */
+const URL_REGEX =
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9().@:%_+~#?&//=]*)/;
+
+const PUNCTUATION_OR_SPACE = /[.,;\s]/;
+
+/**
+ * Helper function to check if a character is a separator (punctuation or space)
+ * @param char The character to check
+ * @returns Whether the character is a separator or not
+ */
+function isSeparator(char: string): boolean {
+  return PUNCTUATION_OR_SPACE.test(char);
+}
+
+/**
+ * Helper function to check if a text content ends with a separator (punctuation or space)
+ * @param textContent The text content to check
+ * @returns Whether the text content ends with a separator or not
+ */
+function endsWithSeparator(textContent: string): boolean {
+  return isSeparator(textContent[textContent.length - 1]);
+}
+
+/**
+ * Helper function to check if a text content starts with a separator (punctuation or space)
+ * @param textContent The text content to check
+ * @returns Whether the text content starts with a separator or not
+ */
+function startsWithSeparator(textContent: string): boolean {
+  return isSeparator(textContent[0]);
+}
+
+/**
+ * Helper function to check if a text content ends with a period
+ * @param textContent The text content to check
+ * @returns Whether the text content ends with a period or not
+ */
+function endsWithPeriod(textContent: string): boolean {
+  return textContent[textContent.length - 1] === ".";
+}
+
+/**
+ * Helper function to check if the previous node is valid (text node that ends with a separator or is empty)
+ */
+function isPreviousNodeValid(editor: Editor, path: Path): boolean {
+  const entry = Editor.previous(editor, { at: path });
+  if (!entry) return true;
+
+  return (
+    Text.isText(entry[0]) &&
+    (endsWithSeparator(entry[0].text) || entry[0].text === "")
+  );
+}
+
+/**
+ * Helper function to check if the next node is valid (text node that starts with a separator or is empty)
+ */
+function isNextNodeValid(editor: Editor, path: Path): boolean {
+  const entry = Editor.next(editor, { at: path });
+  if (!entry) return true;
+
+  return (
+    Text.isText(entry[0]) &&
+    (startsWithSeparator(entry[0].text) || entry[0].text === "")
+  );
+}
+
+/**
+ * Helper function to check if the content around a text node is valid.
+ * @param editor
+ * @param entry
+ * @param start
+ * @param end
+ * @returns
+ */
+function isContentAroundValid(
+  editor: Editor,
+  entry: NodeEntry<Text>,
+  start: number,
+  end: number
+): boolean {
+  const [node, path] = entry;
+  const text = node.text;
+
+  const contentBeforeIsValid =
+    start > 0
+      ? isSeparator(text[start - 1])
+      : isPreviousNodeValid(editor, path);
+
+  const contentAfterIsValid =
+    end < text.length ? isSeparator(text[end]) : isNextNodeValid(editor, path);
+
+  return contentBeforeIsValid && contentAfterIsValid;
+}
+
+const handleLinkEdit = (
+  editor: Editor,
+  entry: NodeEntry<ComposerBodyAutoLink>
+) => {
+  const [node, path] = entry;
+
+  // Step 1: Ensure that the Link node only contains text nodes as children
+  const children = Node.children(editor, path);
+  for (const [child] of children) {
+    if (Text.isText(child)) continue;
+    Transforms.unwrapNodes(editor, { at: path });
+    return;
+  }
+  // Attempt to match the text content (of the Link node) against the URL regex
+  const text = Node.string(node);
+  const match = URL_REGEX.exec(text);
+
+  // Step 2: Ensure that the text content of the Link node matches the URL regex and is identical to the match
+  if (!match || match[0] !== text) {
+    Transforms.unwrapNodes(editor, { at: path });
+    return;
+  }
+
+  // Step 3: Ensure that if the text content of the Link node ends with a period, we unwrap the Link node and wrap the text before the period in a new Link node
+  if (endsWithPeriod(text)) {
+    Transforms.unwrapNodes(editor, { at: path });
+
+    const textBeforePeriod = text.slice(0, text.length - 1);
+
+    // Remove the last character from the link text and wrap the remaining text in a new link node
+    Transforms.wrapNodes(
+      editor,
+      {
+        type: "auto-link",
+        href: textBeforePeriod,
+        children: [],
+      },
+      {
+        at: {
+          anchor: { path, offset: 0 },
+          focus: { path, offset: textBeforePeriod.length },
+        },
+        split: true,
+      }
+    );
+    return;
+  }
+
+  // Step 4: Ensure that the text content of the Link node is surrounded by separators or the start/end of the text content
+  if (!isPreviousNodeValid(editor, path) || !isNextNodeValid(editor, path)) {
+    Transforms.unwrapNodes(editor, { at: path });
+    return;
+  }
+
+  // Step 5: Ensure that the href attribute of the Link node is identical to its text content
+  if (node.href !== text) {
+    Transforms.setNodes(editor, { href: match[0] }, { at: path });
+    return;
+  }
+};
+
+const handleLinkCreate = (editor: Editor, entry: NodeEntry<Text>) => {
+  const [node, path] = entry;
+
+  // Step 1: Ensure that the text content of the node matches the URL regex
+  const match = URL_REGEX.exec(node.text);
+  if (!match) return;
+
+  const start = match.index;
+  const end = start + match[0].length;
+
+  // Step 2: Ensure that the content around the node is valid
+  if (!isContentAroundValid(editor, entry, start, end)) return;
+
+  Transforms.wrapNodes<ComposerBodyAutoLink>(
+    editor,
+    {
+      type: "auto-link",
+      href: match[0],
+      children: [],
+    },
+    {
+      at: {
+        anchor: { path, offset: start },
+        focus: { path, offset: end },
+      },
+      split: true,
+    }
+  );
+  return;
+};
+
+const handleNeighbours = (editor: Editor, entry: NodeEntry<Text>) => {
+  const [node, path] = entry;
+  const text = node.text;
+
+  const previousSibling = Editor.previous(editor, { at: path });
+
+  if (previousSibling && isComposerBodyAutoLink(previousSibling[0])) {
+    if (/^\.[a-zA-Z0-9]+/.test(text)) {
+      Transforms.unwrapNodes(editor, { at: previousSibling[1] });
+      Transforms.mergeNodes(editor, { at: path });
+      return;
+    }
+
+    if (!startsWithSeparator(text)) {
+      Transforms.unwrapNodes(editor, { at: previousSibling[1] });
+      return;
+    }
+  }
+
+  const nextSibling = Editor.next(editor, { at: path });
+  if (
+    nextSibling &&
+    isComposerBodyAutoLink(nextSibling[0]) &&
+    !endsWithSeparator(text)
+  ) {
+    Transforms.unwrapNodes(editor, { at: nextSibling[1] });
+    return;
+  }
+};

--- a/packages/liveblocks-react-comments/src/types.ts
+++ b/packages/liveblocks-react-comments/src/types.ts
@@ -11,11 +11,20 @@ export type ComponentPropsWithSlot<TElement extends ElementType<any>> =
 
 export type ComposerBodyBlockElement = ComposerBodyParagraph;
 
-export type ComposerBodyInlineElement = ComposerBodyText | ComposerBodyMention;
+export type ComposerBodyInlineElement =
+  | ComposerBodyText
+  | ComposerBodyMention
+  | ComposerBodyAutoLink;
 
 export type ComposerBodyParagraph = {
   type: "paragraph";
   children: ComposerBodyInlineElement[];
+};
+
+export type ComposerBodyAutoLink = {
+  type: "auto-link";
+  href: string;
+  children: ComposerBodyText[];
 };
 
 export type ComposerBodyMention = {


### PR DESCRIPTION
### Summary 
This Pull Request introduces auto-linking feature to the rich text editor used in our Comments component, implemented using [Slate.js](https://www.slatejs.org/examples/richtext). 

### Details
The PR modifies the editor by adding a custom Slate.js plugin (called `withAutoLinks`). This plugin modifies the `normalizeNode` and `deleteBackward` function of the editor in order to ensure any url entered in the editor is recognized correctly and automatically create an auto-link node around the url. The key functionalities added by the plugin are:

- **Auto-Link Creation:** When a user enters or pastes a URL that matches the prescribed regex, it will automatically wrap the URL in a "link" node, providing immediate hyperlinking without the user needing to perform additional actions.
- **Link Correction:** If any modifications invalidate an existing "link" node, the plugin will automatically unwrap the node, reverting it back to a standard text node. This ensures that the links remain valid even after surrounding text changes.

> Note: There isn't any UI change in the rich text editor despite the addition of a new plugin. The plugin operates in the background, automatically creating auto-link nodes for applicable texts. However, there is a noticeable UI change in the comment component that displays the published comments. This component now renders clickable hyperlinks whenever a URL is detected.
