### PR TITLE
Throw when encountering a cached token from the backend

### DIFF
--- a/packages/liveblocks-core/src/auth-manager.ts
+++ b/packages/liveblocks-core/src/auth-manager.ts
@@ -84,9 +84,6 @@ export function createAuthManager(
       if (token.parsed.k === TokenKind.ID_TOKEN) {
         // When ID token method is used, only one token per user should be used and cached at the same time.
         return token;
-      } else if (token.parsed.k === TokenKind.SECRET_LEGACY) {
-        // Legacy tokens are not cached.
-        return undefined;
       } else if (token.parsed.k === TokenKind.ACCESS_TOKEN) {
         for (const [resource, scopes] of Object.entries(token.parsed.perms)) {
           if (
@@ -180,8 +177,11 @@ export function createAuthManager(
         (token.parsed.exp - token.parsed.iat) -
         BUFFER;
 
-      tokens.push(token);
-      expiryTimes.push(expiresAt);
+      // Legacy tokens should not get cached
+      if (token.parsed.k !== TokenKind.SECRET_LEGACY) {
+        tokens.push(token);
+        expiryTimes.push(expiresAt);
+      }
 
       return { type: "secret", token };
     } finally {


### PR DESCRIPTION
Fixes an issue that could put the client into an unhealthy reconnecting loop if caching is implemented by customers in the `/api/liveblocks-auth` endpoint. The Liveblocks client already implements its own caching, so it will not hit the backend unnecessarily with requests. If it does, it expects a fresh new token (with an `iat` date that's equal to the current date).

Starting with this PR, we expicitly forbid caching in the `/api/liveblocks-auth` endpoint (we should document this). This was previously implied, but not made explicit enough. If the backend returns a cached token (issued before in the past), the client will now throw this error:

> _"The same Liveblocks auth token was issued from the backend before. Caching Liveblocks tokens is not supported."_

It's expected that developers/users will never see this error, unless they have explicitly implemented caching in their `/api/liveblocks-auth` endpoint. If so, the solution is to remove this caching layer from `/api/liveblocks-auth` and always making a fresh request to the Liveblocks servers for every token request.

[Context](https://liveblocks.slack.com/archives/C02PZL7QAAW/p1694512460266229?thread_ts=1694455495.336149&cid=C02PZL7QAAW)
