### PR TITLE
Fix potential `Error: "undefined" is not a valid event name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### `@liveblocks/react`
 
 - Fix confusing `Error: "undefined" is not a valid event name` error when using
-  the (deprecated) `useMap()`, `useObject`, or `useList()` hooks on
+  the (deprecated) `useMap()`, `useObject()`, or `useList()` hooks on
   uninitialized storage values.
 
 # v1.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### `@liveblocks/react`
 
 - Fix confusing `Error: "undefined" is not a valid event name` error when using
-  `useMap()`, `useObject`, or `useList()` on uninitialized storage values.
+  the (deprecated) `useMap()`, `useObject`, or `useList()` hooks on
+  uninitialized storage values.
 
 # v1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.3.4
+
+### `@liveblocks/react`
+
+- Fix confusing `Error: "undefined" is not a valid event name` error when using
+  `useMap()`, `useObject`, or `useList()` on uninitialized storage values.
+
 # v1.3.3
 
 ### `@liveblocks/*`

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -24,6 +24,7 @@ export type {
   LostConnectionEvent,
   Status,
 } from "./connection";
+export { isLiveNode } from "./crdts/liveblocks-helpers";
 export { LiveList } from "./crdts/LiveList";
 export { LiveMap } from "./crdts/LiveMap";
 export { LiveObject } from "./crdts/LiveObject";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2394,7 +2394,10 @@ function makeClassicSubscribeFn<
 
         // istanbul ignore next
         default:
-          return assertNever(first, "Unknown event");
+          return assertNever(
+            first,
+            `"${String(first)}" is not a valid event name`
+          );
       }
     }
 
@@ -2419,7 +2422,9 @@ function makeClassicSubscribeFn<
       }
     }
 
-    throw new Error(`"${String(first)}" is not a valid event name`);
+    throw new Error(
+      `${String(first)} is not a value that can be subscribed to.`
+    );
   }
 
   return subscribe;

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -245,10 +245,24 @@ describe("useObject", () => {
     const sim = await websocketSimulator();
     act(() => sim.simulateStorageLoaded());
 
-    expect(result.current?.toImmutable()).toEqual({
+    expect(result.current!.toImmutable()).toEqual({
       a: 0,
       nested: ["foo", "bar"],
     });
+  });
+
+  test("initialization of non-existing fields does not crash (regression)", async () => {
+    const { result } = renderHook(() => useObject("non-existing-field" as any));
+
+    // On the initial render, this hook will return `null` (indicating storage hasn't loaded)
+    expect(result.current).toBeNull();
+
+    const sim = await websocketSimulator();
+    act(() => sim.simulateStorageLoaded());
+
+    // After loading storage, this value will be `undefined` (because missing)
+    // Previously this used to throw a confusing Error: `"undefined" is not a valid event name`
+    expect(result.current).toBeUndefined();
   });
 
   test("unmounting useObject while storage is loading should not cause a memory leak", async () => {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -631,9 +631,9 @@ export function createRoomContext<
       function onRootChange() {
         const newValue = root.get(key);
         if (newValue !== curr) {
-          unsubscribeCrdt();
+          unsub();
           curr = newValue;
-          unsubscribeCrdt = room.subscribe(
+          unsub = room.subscribe(
             curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
             rerender
           );
@@ -641,7 +641,7 @@ export function createRoomContext<
         }
       }
 
-      let unsubscribeCrdt = room.subscribe(
+      let unsub = room.subscribe(
         curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         rerender
       );
@@ -654,7 +654,7 @@ export function createRoomContext<
 
       return () => {
         unsubscribeRoot();
-        unsubscribeCrdt();
+        unsub();
       };
     }, [rootOrNull, room, key, rerender]);
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -624,11 +624,12 @@ export function createRoomContext<
       if (rootOrNull === null) {
         return;
       }
+      const root = rootOrNull;
 
-      let liveValue = rootOrNull.get(key);
+      let liveValue = root.get(key);
 
       function onRootChange() {
-        const newCrdt = rootOrNull!.get(key);
+        const newCrdt = root.get(key);
         if (newCrdt !== liveValue) {
           unsubscribeCrdt();
           liveValue = newCrdt;
@@ -645,7 +646,7 @@ export function createRoomContext<
         rerender
       );
       const unsubscribeRoot = room.subscribe(
-        rootOrNull as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
+        root as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         onRootChange
       );
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -631,9 +631,9 @@ export function createRoomContext<
       function onRootChange() {
         const newValue = root.get(key);
         if (newValue !== curr) {
-          unsub();
+          unsubCurr();
           curr = newValue;
-          unsub = room.subscribe(
+          unsubCurr = room.subscribe(
             curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
             rerender
           );
@@ -641,7 +641,7 @@ export function createRoomContext<
         }
       }
 
-      let unsub = room.subscribe(
+      let unsubCurr = room.subscribe(
         curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         rerender
       );
@@ -653,7 +653,7 @@ export function createRoomContext<
       );
       return () => {
         unsubscribeRoot();
-        unsub();
+        unsubCurr();
       };
     }, [rootOrNull, room, key, rerender]);
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -629,10 +629,10 @@ export function createRoomContext<
       let curr = root.get(key);
 
       function onRootChange() {
-        const newCrdt = root.get(key);
-        if (newCrdt !== curr) {
+        const newValue = root.get(key);
+        if (newValue !== curr) {
           unsubscribeCrdt();
-          curr = newCrdt;
+          curr = newValue;
           unsubscribeCrdt = room.subscribe(
             curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
             rerender

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -645,13 +645,12 @@ export function createRoomContext<
         curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         rerender
       );
+      rerender();
+
       const unsubscribeRoot = room.subscribe(
         root as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         onRootChange
       );
-
-      rerender();
-
       return () => {
         unsubscribeRoot();
         unsub();

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -626,12 +626,13 @@ export function createRoomContext<
       }
       const root = rootOrNull;
 
+      let unsubCurr: (() => void) | undefined;
       let curr = root.get(key);
 
       function onRootChange() {
         const newValue = root.get(key);
         if (newValue !== curr) {
-          unsubCurr();
+          unsubCurr?.();
           curr = newValue;
           unsubCurr = room.subscribe(
             curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
@@ -641,7 +642,7 @@ export function createRoomContext<
         }
       }
 
-      let unsubCurr = room.subscribe(
+      unsubCurr = room.subscribe(
         curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         rerender
       );
@@ -653,7 +654,7 @@ export function createRoomContext<
       );
       return () => {
         unsubscribeRoot();
-        unsubCurr();
+        unsubCurr?.();
       };
     }, [rootOrNull, room, key, rerender]);
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -617,18 +617,18 @@ export function createRoomContext<
     key: TKey
   ): TStorage[TKey] | null {
     const room = useRoom();
-    const root = useMutableStorageRoot();
+    const rootOrNull = useMutableStorageRoot();
     const rerender = useRerender();
 
     React.useEffect(() => {
-      if (root === null) {
+      if (rootOrNull === null) {
         return;
       }
 
-      let liveValue = root.get(key);
+      let liveValue = rootOrNull.get(key);
 
       function onRootChange() {
-        const newCrdt = root!.get(key);
+        const newCrdt = rootOrNull!.get(key);
         if (newCrdt !== liveValue) {
           unsubscribeCrdt();
           liveValue = newCrdt;
@@ -645,7 +645,7 @@ export function createRoomContext<
         rerender
       );
       const unsubscribeRoot = room.subscribe(
-        root as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
+        rootOrNull as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         onRootChange
       );
 
@@ -655,12 +655,12 @@ export function createRoomContext<
         unsubscribeRoot();
         unsubscribeCrdt();
       };
-    }, [root, room, key, rerender]);
+    }, [rootOrNull, room, key, rerender]);
 
-    if (root === null) {
+    if (rootOrNull === null) {
       return null;
     } else {
-      return root.get(key);
+      return rootOrNull.get(key);
     }
   }
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -626,15 +626,15 @@ export function createRoomContext<
       }
       const root = rootOrNull;
 
-      let liveValue = root.get(key);
+      let curr = root.get(key);
 
       function onRootChange() {
         const newCrdt = root.get(key);
-        if (newCrdt !== liveValue) {
+        if (newCrdt !== curr) {
           unsubscribeCrdt();
-          liveValue = newCrdt;
+          curr = newCrdt;
           unsubscribeCrdt = room.subscribe(
-            liveValue as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
+            curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
             rerender
           );
           rerender();
@@ -642,7 +642,7 @@ export function createRoomContext<
       }
 
       let unsubscribeCrdt = room.subscribe(
-        liveValue as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
+        curr as any /* AbstractCrdt */, // TODO: This is hiding a bug! If `liveValue` happens to be the string `"event"` this actually subscribes an event handler!
         rerender
       );
       const unsubscribeRoot = room.subscribe(


### PR DESCRIPTION
A user [reported a bug on Discord](https://discord.com/channels/913109211746009108/913158542565994606/1151980952046809180) where if you'd just do:

```tsx
function MyComponent() {
  const foo = useMap("foo");
}
```

On an empty room where `"foo"` is _not_ initialized, then this runtime error would get thrown:

```
Error: "undefined" is not a valid event name
```

This is caused by the hook trying to create a subscription on the live node it finds at `root.foo`, but in this case, no such root node exists, and as a result it tried to subscribe to `undefined`.

This is only a bug in our legacy `use{Map,Object,List}` hooks. The newer/preferred `useStorage` hook is **not affected**.
