### PR TITLE
Officially mark `useList`, `useMap`, `useObject` as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.3.5
+
+### `@liveblocks/react`
+
+- Officially mark `useList()`, `useMap()`, and `useObject()` as deprecated in
+  JSDoc comments (we stopped recommending them since the release of 0.18)
+
 # v1.3.4
 
 ### `@liveblocks/react`

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -623,8 +623,8 @@ export type RoomContextBundle<
      * a re-render if the LiveList is updated, however it does not triggers
      * a re-render if a nested CRDT is updated.
      *
-     * @param key The storage key associated with the LiveList
-     * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
+     * @param key The top-level storage key associated with the LiveList
+     * @returns null while storage is still loading, otherwise, returns the LiveList instance at the storage key
      *
      * @example
      * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
@@ -643,8 +643,8 @@ export type RoomContextBundle<
      * a re-render if the LiveMap is updated, however it does not triggers
      * a re-render if a nested CRDT is updated.
      *
-     * @param key The storage key associated with the LiveMap
-     * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
+     * @param key The top-level storage key associated with the LiveMap
+     * @returns null while storage is still loading, otherwise, returns the LiveMap instance at the storage key
      *
      * @example
      * const shapesById = useMap("shapes");                   // ❌ No longer recommended
@@ -661,8 +661,8 @@ export type RoomContextBundle<
      * Returns the LiveObject associated with the provided key.
      * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
      *
-     * @param key The storage key associated with the LiveObject
-     * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
+     * @param key The top-level storage key associated with the LiveObject
+     * @returns null while storage is still loading, otherwise, returns the LiveObject instance at the storage key
      *
      * @example
      * const object = useObject("obj");                // ❌ No longer recommended
@@ -773,8 +773,8 @@ export type RoomContextBundle<
          * a re-render if the LiveList is updated, however it does not triggers
          * a re-render if a nested CRDT is updated.
          *
-         * @param key The storage key associated with the LiveList
-         * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
+         * @param key The top-level storage key associated with the LiveList
+         * @returns Returns the LiveList instance at the storage key
          *
          * @example
          * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
@@ -793,8 +793,8 @@ export type RoomContextBundle<
          * a re-render if the LiveMap is updated, however it does not triggers
          * a re-render if a nested CRDT is updated.
          *
-         * @param key The storage key associated with the LiveMap
-         * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
+         * @param key The top-level storage key associated with the LiveMap
+         * @returns Returns the LiveMap instance at the storage key
          *
          * @example
          * const shapesById = useMap("shapes");                   // ❌ No longer recommended
@@ -811,8 +811,8 @@ export type RoomContextBundle<
          * Returns the LiveObject associated with the provided key.
          * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
          *
-         * @param key The storage key associated with the LiveObject
-         * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
+         * @param key The top-level storage key associated with the LiveObject
+         * @returns Returns the LiveObject instance at the storage key
          *
          * @example
          * const object = useObject("obj");                // ❌ No longer recommended

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -627,7 +627,11 @@ export type RoomContextBundle<
      * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
      *
      * @example
-     * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
+     * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
+     * const animals = useStorage((root) => root.animals);                    // ✅ Do this instead
+     *
+     * @deprecated We no longer recommend using `useList`. Prefer `useStorage`
+     * for reading and `useMutation` for writing.
      */
     useList<TKey extends Extract<keyof TStorage, string>>(
       key: TKey
@@ -643,7 +647,11 @@ export type RoomContextBundle<
      * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
      *
      * @example
-     * const shapesById = useMap("shapes");
+     * const shapesById = useMap("shapes");                   // ❌ No longer recommended
+     * const shapesById = useStorage((root) => root.shapes);  // ✅ Do this instead
+     *
+     * @deprecated We no longer recommend using `useMap`. Prefer `useStorage`
+     * for reading and `useMutation` for writing.
      */
     useMap<TKey extends Extract<keyof TStorage, string>>(
       key: TKey
@@ -657,7 +665,11 @@ export type RoomContextBundle<
      * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
      *
      * @example
-     * const object = useObject("obj");
+     * const object = useObject("obj");                // ❌ No longer recommended
+     * const object = useStorage((root) => root.obj);  // ✅ Do this instead
+     *
+     * @deprecated We no longer recommend using `useObject`. Prefer `useStorage`
+     * for reading and `useMutation` for writing.
      */
     useObject<TKey extends Extract<keyof TStorage, string>>(
       key: TKey
@@ -765,7 +777,11 @@ export type RoomContextBundle<
          * @returns null while the storage is loading, otherwise, returns the LiveList associated to the storage
          *
          * @example
-         * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]
+         * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
+         * const animals = useStorage((root) => root.animals);                    // ✅ Do this instead
+         *
+         * @deprecated We no longer recommend using `useList`. Prefer `useStorage`
+         * for reading and `useMutation` for writing.
          */
         useList<TKey extends Extract<keyof TStorage, string>>(
           key: TKey
@@ -781,7 +797,11 @@ export type RoomContextBundle<
          * @returns null while the storage is loading, otherwise, returns the LiveMap associated to the storage
          *
          * @example
-         * const shapesById = useMap("shapes");
+         * const shapesById = useMap("shapes");                   // ❌ No longer recommended
+         * const shapesById = useStorage((root) => root.shapes);  // ✅ Do this instead
+         *
+         * @deprecated We no longer recommend using `useMap`. Prefer `useStorage`
+         * for reading and `useMutation` for writing.
          */
         useMap<TKey extends Extract<keyof TStorage, string>>(
           key: TKey
@@ -795,7 +815,11 @@ export type RoomContextBundle<
          * @returns null while the storage is loading, otherwise, returns the LveObject associated to the storage
          *
          * @example
-         * const object = useObject("obj");
+         * const object = useObject("obj");                // ❌ No longer recommended
+         * const object = useStorage((root) => root.obj);  // ✅ Do this instead
+         *
+         * @deprecated We no longer recommend using `useObject`. Prefer `useStorage`
+         * for reading and `useMutation` for writing.
          */
         useObject<TKey extends Extract<keyof TStorage, string>>(
           key: TKey


### PR DESCRIPTION
I noticed we never officially marked them as deprecated, although we've no longer been recommending their use since the release of 0.18:

<img width="837" alt="Screen Shot 2023-09-15 at 16 21 29@2x" src="https://github.com/liveblocks/liveblocks/assets/83844/94dee6b0-dc94-4db2-84cb-1d209b775e92">


Users may not realize these helpers are deprecated and still import/use them (like [here](https://discord.com/channels/913109211746009108/1151980952046809180/1152212910425264228)).
