### PR TITLE
Make E2E tests more robust

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
       LIVEBLOCKS_SERVER: ${{ secrets.E2E_TEST_LIVEBLOCKS_SERVER }}
       LIVEBLOCKS_AUTHORIZE_ENDPOINT:
         ${{ secrets.E2E_TEST_LIVEBLOCKS_AUTHORIZE_ENDPOINT }}
+      NEXT_PUBLIC_GITHUB_SHA: ${{ github.sha }}
 
     steps:
       - name: Checkout

--- a/e2e/next-sandbox/pages/batching/index.tsx
+++ b/e2e/next-sandbox/pages/batching/index.tsx
@@ -2,6 +2,7 @@ import { LiveMap } from "@liveblocks/client";
 import { createRoomContext } from "@liveblocks/react";
 import React from "react";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -21,7 +22,7 @@ const {
 } = createRoomContext<Presence, { liveMap: LiveMap<string, number> }>(client);
 
 export default function Home() {
-  let roomId = "e2e-batching-presence-storage";
+  let roomId = genRoomId("e2e-batching-presence-storage");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/offline/index.tsx
+++ b/e2e/next-sandbox/pages/offline/index.tsx
@@ -3,6 +3,7 @@ import { LiveList } from "@liveblocks/client";
 import { createRoomContext } from "@liveblocks/react";
 import React, { useState } from "react";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -17,7 +18,7 @@ type Internal = {
 };
 
 export default function Home() {
-  let roomId = "e2e-offline";
+  let roomId = genRoomId("offline");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {
@@ -30,7 +31,7 @@ export default function Home() {
       initialPresence={{} as never}
       initialStorage={{ items: new LiveList() }}
     >
-      <Sandbox />
+      <Sandbox roomId={roomId} />
     </RoomProvider>
   );
 }
@@ -47,7 +48,7 @@ function generateRandomNumber(max: number, ignore?: number) {
   }
 }
 
-function Sandbox() {
+function Sandbox({ roomId }: { roomId: string }) {
   const [status, setStatus] = useState("connected");
   const room = useRoom();
   const internals = (room as Record<string, unknown>).__internal as Internal;
@@ -71,7 +72,7 @@ function Sandbox() {
 
   return (
     <div>
-      <h1>Storage sandbox- Offline</h1>
+      <h1>Storage sandbox - Offline</h1>
       <h2>
         Websocket status:{" "}
         <span style={{ color: status === "offline" ? "red" : "black" }}>

--- a/e2e/next-sandbox/pages/presence/index.tsx
+++ b/e2e/next-sandbox/pages/presence/index.tsx
@@ -1,6 +1,7 @@
 import { Json, createRoomContext } from "@liveblocks/react";
 import React from "react";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -26,7 +27,7 @@ const {
 export default function Home() {
   const [isVisible, setIsVisible] = React.useState(true);
 
-  let roomId = "e2e-presence";
+  let roomId = genRoomId("e2e-presence");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/presence/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/presence/with-suspense.tsx
@@ -1,6 +1,7 @@
 import { Json, createRoomContext, ClientSideSuspense } from "@liveblocks/react";
 import React from "react";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -28,7 +29,7 @@ const {
 export default function Home() {
   const [isVisible, setIsVisible] = React.useState(true);
 
-  let roomId = "e2e-presence-with-suspense";
+  let roomId = genRoomId("e2e-presence-with-suspense");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/redux/index.tsx
+++ b/e2e/next-sandbox/pages/redux/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "./hooks";
 import { Provider } from "react-redux";
 import { actions } from "@liveblocks/redux";
+import { genRoomId } from "../../utils";
 
 import store, { client, addItem, deleteItem, clear } from "./store";
 
@@ -19,7 +20,7 @@ function List() {
   const items = useAppSelector((state) => state.items);
   const dispatch = useAppDispatch();
 
-  let roomId = "e2e-redux-basic";
+  let roomId = genRoomId("e2e-redux-basic");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/storage/list.tsx
+++ b/e2e/next-sandbox/pages/storage/list.tsx
@@ -2,6 +2,7 @@ import { createRoomContext } from "@liveblocks/react";
 import { LiveList } from "@liveblocks/client";
 import React from "react";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -11,7 +12,7 @@ const { RoomProvider, useList, useRedo, useSelf, useUndo } = createRoomContext<
 >(client);
 
 export default function Home() {
-  let roomId = "e2e-storage-list";
+  let roomId = genRoomId("e2e-storage-list");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/storage/map.tsx
+++ b/e2e/next-sandbox/pages/storage/map.tsx
@@ -3,6 +3,7 @@ import { LiveMap } from "@liveblocks/client";
 import React from "react";
 import randomNumber from "../../utils/randomNumber";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -12,7 +13,7 @@ const { RoomProvider, useMap, useRedo, useUndo } = createRoomContext<
 >(client);
 
 export default function Home() {
-  let roomId = "e2e-storage-map";
+  let roomId = genRoomId("e2e-storage-map");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/storage/object.tsx
+++ b/e2e/next-sandbox/pages/storage/object.tsx
@@ -1,6 +1,7 @@
 import { createRoomContext } from "@liveblocks/react";
 import randomNumber from "../../utils/randomNumber";
 import React from "react";
+import { genRoomId } from "../../utils";
 import { LiveObject } from "@liveblocks/client";
 import { lsonToJson } from "@liveblocks/core";
 import createLiveblocksClient from "../../utils/createClient";
@@ -18,7 +19,7 @@ const { RoomProvider, useObject, useRedo, useSelf, useUndo } =
   >(client);
 
 export default function Home() {
-  let roomId = "e2e-storage-object";
+  let roomId = genRoomId("e2e-storage-object");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/storage/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/storage/with-suspense.tsx
@@ -1,6 +1,7 @@
 import { createRoomContext, ClientSideSuspense } from "@liveblocks/react";
 import { LiveList } from "@liveblocks/client";
 import React from "react";
+import { genRoomId } from "../../utils";
 import createLiveblocksClient from "../../utils/createClient";
 
 const client = createLiveblocksClient();
@@ -10,7 +11,7 @@ const {
 } = createRoomContext<never, { items: LiveList<string> }>(client);
 
 export default function Home() {
-  let roomId = "e2e-storage-with-suspense";
+  let roomId = genRoomId("e2e-storage-with-suspense");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/pages/zustand/index.tsx
+++ b/e2e/next-sandbox/pages/zustand/index.tsx
@@ -4,6 +4,7 @@ import create from "zustand";
 import { liveblocks } from "@liveblocks/zustand";
 import type { WithLiveblocks } from "@liveblocks/zustand";
 import createLiveblocksClient from "../../utils/createClient";
+import { genRoomId } from "../../utils";
 
 const client = createLiveblocksClient();
 
@@ -44,7 +45,7 @@ export default function Home() {
     liveblocks: { enterRoom, leaveRoom, isStorageLoading, room, others },
   } = useStore();
 
-  let roomId = "e2e-zustand-basic";
+  let roomId = genRoomId("e2e-zustand-basic");
   if (typeof window !== "undefined") {
     const queryParam = window.location.search;
     if (queryParam.split("room=").length > 1) {

--- a/e2e/next-sandbox/test/storage/list.test.ts
+++ b/e2e/next-sandbox/test/storage/list.test.ts
@@ -1,13 +1,14 @@
 import { Page, test, expect } from "@playwright/test";
 
 import {
-  delay,
   assertContainText,
-  pickRandomItem,
+  delay,
   pickNumberOfUnderRedo,
-  waitForContentToBeEquals,
+  pickRandomItem,
   preparePages,
+  waitForContentToBeEquals,
 } from "../utils";
+import { genRoomId } from "../../utils";
 
 function pickRandomAction() {
   return pickRandomItem(["#push", "#delete", "#move", "#set"]);
@@ -19,7 +20,7 @@ test.describe("Storage - LiveList", () => {
   let pages: Page[];
 
   test.beforeEach(async ({}, testInfo) => {
-    const roomName = `e2e-list-${testInfo.title.replaceAll(" ", "-")}`;
+    const roomName = genRoomId(testInfo.title);
     pages = await preparePages(`${TEST_URL}?room=${roomName}`);
   });
 

--- a/e2e/next-sandbox/utils/index.ts
+++ b/e2e/next-sandbox/utils/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Generates a stable yet unique key to use for this test run, so it won't
+ * conflict with other E2E tests running simultaneously.
+ */
+export function genRoomId(testTitle: string) {
+  testTitle = testTitle.toLowerCase();
+  if (testTitle.startsWith("e2e-")) {
+    testTitle = testTitle.slice(4);
+  }
+  const prefix = process.env.NEXT_PUBLIC_GITHUB_SHA
+    ? `${process.env.NEXT_PUBLIC_GITHUB_SHA.slice(0, 2)}`
+    : "local";
+  return `e2e-${prefix.toLowerCase()}-${testTitle
+    .replaceAll(/[^\w_-]+/g, "-")
+    .replaceAll(/--+/g, "-")}`;
+}


### PR DESCRIPTION
Using room IDs based on the first two digits of the Git SHA creating at most 256 room copies in this test account that will keep being recycled. The aim is to reduce the chance of conflicts when two E2E CI run at the same time.