### PR TITLE
Fix `useThreads`, `useEditThreadMetada`, etc comment hooks  not working on non-suspense export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   JSDoc comments (we stopped recommending them since the release of 0.18)
 - Deduplicate Comments requests and improve how race conditions are handled
   during mutations.
+- Fix non-Suspense Comments hooks not working properly in some situations.
 
 ### `@liveblocks/react-comments`
 

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -555,30 +555,37 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
       room.getStatus
     );
 
-    useEffect(() => {
-      const interval =
-        status === "connected" ? POLLING_INTERVAL_REALTIME : POLLING_INTERVAL;
+    useEffect(
+      () => {
+        const interval =
+          status === "connected" ? POLLING_INTERVAL_REALTIME : POLLING_INTERVAL;
 
-      let revalidationTimerId: number;
-      function scheduleRevalidation() {
-        revalidationTimerId = window.setTimeout(executeRevalidation, interval);
-      }
+        let revalidationTimerId: number;
+        function scheduleRevalidation() {
+          revalidationTimerId = window.setTimeout(
+            executeRevalidation,
+            interval
+          );
+        }
 
-      function executeRevalidation() {
-        // Revalidate cache and then schedule the next revalidation
-        void revalidateCache(true).then(scheduleRevalidation);
-      }
+        function executeRevalidation() {
+          // Revalidate cache and then schedule the next revalidation
+          void revalidateCache(true).then(scheduleRevalidation);
+        }
 
-      scheduleRevalidation();
+        scheduleRevalidation();
 
-      return () => {
-        window.clearTimeout(revalidationTimerId);
-      };
-    }, [status]);
+        return () => {
+          window.clearTimeout(revalidationTimerId);
+        };
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- ESLint recommends against adding `revalidateCache` as a dependency, but not doing so causes the code inside `useEffect` to reference an outdated version of `revalidateCache`
+      [status, revalidateCache]
+    );
   }
 
   function useThreadsInternal(): RoomThreads<TThreadMetadata> {
-    useEffect(_subscribe, []);
+    useEffect(_subscribe, [_subscribe]);
 
     usePolling();
 
@@ -592,9 +599,13 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
   }
 
   function useThreads() {
-    useEffect(() => {
-      void revalidateCache(true);
-    }, []);
+    useEffect(
+      () => {
+        void revalidateCache(true);
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- ESLint recommends against adding `revalidateCache` as a dependency, but not doing so causes the code inside `useEffect` to reference an outdated version of `revalidateCache`
+      [revalidateCache]
+    );
 
     return useThreadsInternal();
   }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -296,9 +296,9 @@ export function createRoomContext<
       setRoom(room);
 
       return () => {
-        const commentsRoom = commentsRooms.get(roomId);
+        const commentsRoom = commentsRooms.get(room);
         if (commentsRoom) {
-          commentsRooms.delete(roomId);
+          commentsRooms.delete(room);
         }
         client.leave(roomId);
       };
@@ -843,15 +843,18 @@ export function createRoomContext<
 
   const commentsErrorEventSource =
     makeEventSource<CommentsApiError<TThreadMetadata>>();
-  const commentsRooms = new Map<string, CommentsRoom<TThreadMetadata>>();
+  const commentsRooms = new Map<
+    Room<TPresence, TStorage, TUserMeta, TRoomEvent>,
+    CommentsRoom<TThreadMetadata>
+  >();
 
   function getCommentsRoom(
     room: Room<TPresence, TStorage, TUserMeta, TRoomEvent>
   ) {
-    let commentsRoom = commentsRooms.get(room.id);
+    let commentsRoom = commentsRooms.get(room);
     if (commentsRoom === undefined) {
       commentsRoom = createCommentsRoom(room, commentsErrorEventSource);
-      commentsRooms.set(room.id, commentsRoom);
+      commentsRooms.set(room, commentsRoom);
     }
     return commentsRoom;
   }


### PR DESCRIPTION
`useThreads`, `useEditThreadMetada`, etc comment hooks were not working on non-suspense export because the room reference inside the hook  used was an outdated one.

Fixes: https://github.com/liveblocks/liveblocks/issues/1143