### PR TITLE
Comments: Harmonize Suspense API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.3.7
+
+### `@liveblocks/react`
+
+- **Breaking (beta):** Comments' hook `useThreads` now returns an object in its
+  Suspense version. (`const threads = useThreads()` becomes
+  `const { threads } = useThreads()`)
+
 # v1.3.6
 
 ### `@liveblocks/client`

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1130,6 +1130,9 @@ import { useThreads } from "./liveblocks.config";
 const { threads, error, isLoading } = useThreads();
 ```
 
+👉 A [Suspense version][] of this hook is also available, which will never
+return a loading state and will throw when there's an error.
+
 ### useUser
 
 Returns user info from a given user ID.
@@ -1139,6 +1142,9 @@ import { useUser } from "./liveblocks.config";
 
 const { user, error, isLoading } = useUser("user-id");
 ```
+
+👉 A [Suspense version][] of this hook is also available, which will never
+return a loading state and will throw when there's an error.
 
 <Banner title="Providing a resolver function">
 

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -232,7 +232,7 @@ describe("useThreads", () => {
 describe("useThreadsSuspense", () => {
   test("should poll threads", async () => {
     function Threads() {
-      const threads = useThreadsSuspense();
+      const { threads } = useThreadsSuspense();
 
       return <>{threads[0].id}</>;
     }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -36,7 +36,7 @@ import type {
   DeleteCommentOptions,
   EditCommentOptions,
   EditThreadMetadataOptions,
-  RoomThreads,
+  ThreadsState,
 } from "./comments/CommentsRoom";
 import { createCommentsRoom } from "./comments/CommentsRoom";
 import type { CommentsApiError } from "./comments/errors";
@@ -54,7 +54,7 @@ import type {
   RoomContextBundle,
   RoomProviderProps,
   UserState,
-  UserStateSuspense,
+  UserStateSuccess,
 } from "./types";
 
 const noop = () => {};
@@ -859,7 +859,7 @@ export function createRoomContext<
     return commentsRoom;
   }
 
-  function useThreads(): RoomThreads<TThreadMetadata> {
+  function useThreads(): ThreadsState<TThreadMetadata> {
     const room = useRoom();
 
     React.useEffect(() => {
@@ -994,9 +994,8 @@ export function createRoomContext<
 
     return {
       user: state.data,
-      error: state.error,
       isLoading: false,
-    } as UserStateSuspense<TUserMeta["info"]>;
+    } as UserStateSuccess<TUserMeta["info"]>;
   }
 
   const mentionSuggestionsCache = createAsyncCache<string[], unknown>(

--- a/packages/liveblocks-react/src/lib/use-async-cache.ts
+++ b/packages/liveblocks-react/src/lib/use-async-cache.ts
@@ -109,6 +109,10 @@ export function useAsyncCache<T, E, O extends UseAsyncCacheOptions<T>>(
     data = previousData.current.data;
   }
 
+  if (frozenOptions?.suspense && state.error) {
+    throw state.error;
+  }
+
   return {
     isLoading: state.isLoading,
     data,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -28,6 +28,7 @@ import type {
   EditCommentOptions,
   EditThreadMetadataOptions,
   RoomThreads,
+  RoomThreadsSuspense,
 } from "./comments/CommentsRoom";
 
 export type ResolveUserOptions = {
@@ -750,9 +751,9 @@ export type RoomContextBundle<
          * Returns the threads within the current room.
          *
          * @example
-         * const threads = useThreads();
+         * const { threads } = useThreads();
          */
-        useThreads(): ThreadData<TThreadMetadata>[];
+        useThreads(): RoomThreadsSuspense<TThreadMetadata>;
 
         /**
          * @beta
@@ -760,7 +761,7 @@ export type RoomContextBundle<
          * Returns user info from a given user ID.
          *
          * @example
-         * const { user, error, isLoading } = useUser("user-id");
+         * const { user } = useUser("user-id");
          */
         useUser(userId: string): UserStateSuspense<TUserMeta["info"]>;
 

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -27,8 +27,8 @@ import type {
   DeleteCommentOptions,
   EditCommentOptions,
   EditThreadMetadataOptions,
-  RoomThreads,
-  RoomThreadsSuspense,
+  ThreadsState,
+  ThreadsStateSuccess,
 } from "./comments/CommentsRoom";
 
 export type ResolveUserOptions = {
@@ -40,26 +40,28 @@ export type ResolveMentionSuggestionsOptions = {
   text: string;
 };
 
-export type UserState<T> =
-  | {
-      user?: never;
-      isLoading: true;
-      error?: never;
-    }
-  | {
-      user?: T;
-      isLoading: false;
-      error?: never;
-    }
-  | {
-      user?: never;
-      isLoading: false;
-      error: Error;
-    };
+export type UserStateLoading = {
+  isLoading: true;
+  user?: never;
+  error?: never;
+};
 
-export type UserStateSuspense<T> = Resolve<
-  Extract<UserState<T>, { isLoading: false; error?: never }>
->;
+export type UserStateError = {
+  isLoading: false;
+  user?: never;
+  error: Error;
+};
+
+export type UserStateSuccess<T> = {
+  isLoading: false;
+  user: T;
+  error?: never;
+};
+
+export type UserState<T> =
+  | UserStateLoading
+  | UserStateError
+  | UserStateSuccess<T>;
 
 export type RoomProviderProps<
   TPresence extends JsonObject,
@@ -603,7 +605,7 @@ export type RoomContextBundle<
      * @example
      * const { threads, error, isLoading } = useThreads();
      */
-    useThreads(): RoomThreads<TThreadMetadata>;
+    useThreads(): ThreadsState<TThreadMetadata>;
 
     /**
      * @beta
@@ -753,7 +755,7 @@ export type RoomContextBundle<
          * @example
          * const { threads } = useThreads();
          */
-        useThreads(): RoomThreadsSuspense<TThreadMetadata>;
+        useThreads(): ThreadsStateSuccess<TThreadMetadata>;
 
         /**
          * @beta
@@ -763,7 +765,7 @@ export type RoomContextBundle<
          * @example
          * const { user } = useUser("user-id");
          */
-        useUser(userId: string): UserStateSuspense<TUserMeta["info"]>;
+        useUser(userId: string): UserStateSuccess<TUserMeta["info"]>;
 
         //
         // Legacy hooks


### PR DESCRIPTION
This PR harmonizes the Suspense version of `useThreads` and `useUser`.

Both Suspense versions will now:
- Throw on error
- Return the same object as their non-Suspense versions (but typed with `isLoading: false` and `error?: never`)