### PR TITLE
Comments: Document `CommentsConfig`

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -306,6 +306,12 @@ export function App() {
 }
 ```
 
+| Prop        | Type                                                | Description              |
+| ----------- | --------------------------------------------------- | ------------------------ |
+| `overrides` | <code>Partial&lt;\Overrides&gt; \| undefined</code> | The overrides to be set. |
+
+</Table>
+
 ## Primitives
 
 Primitives are headless/unstyled components that can be used to create custom

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -145,7 +145,8 @@ scales. If you need to support browser versions that don’t support
 Overrides can be used to customize the components’ strings and
 localization-related properties like the locale and reading direction.
 
-They can be set globally once for all components using `CommentsConfig`:
+They can be set globally once for all components using
+[`CommentsConfig`](#CommentsConfig):
 
 ```tsx
 import { CommentsConfig } from "@liveblocks/react-comments";
@@ -285,6 +286,25 @@ behavior and call the mutation methods (e.g. `createThread`) manually.
 </Table>
 
 {/* TODO: Document classes and data attributes */}
+
+### CommentsConfig
+
+Set configuration options (e.g. [overrides](#Overrides)) for all Comments
+components.
+
+```tsx
+import { CommentsConfig } from "@liveblocks/react-comments";
+
+export function App() {
+  return (
+    <CommentsConfig
+      overrides={{ locale: "fr", UNKNOWN_USER: "Anonyme" /* ... */ }}
+    >
+      {/* ... */}
+    </CommentsConfig>
+  );
+}
+```
 
 ## Primitives
 

--- a/packages/liveblocks-react-comments/src/config.tsx
+++ b/packages/liveblocks-react-comments/src/config.tsx
@@ -7,6 +7,9 @@ import type { Overrides } from "./overrides";
 import { OverridesProvider } from "./overrides";
 
 type CommentsConfigProps = PropsWithChildren<{
+  /**
+   * The overrides to be set.
+   */
   overrides?: Partial<Overrides>;
 }>;
 


### PR DESCRIPTION
`CommentsConfig` is currently only mentioned in the `Overrides` section but not fully documented.