### PR TITLE
Fix "ghosting bug" caused by using tuples in Zustand and Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22689,7 +22689,7 @@
       }
     },
     "packages/create-liveblocks-app": {
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -22864,10 +22864,10 @@
     },
     "packages/liveblocks-client": {
       "name": "@liveblocks/client",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "1.4.0"
+        "@liveblocks/core": "1.4.1-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -22880,7 +22880,7 @@
     },
     "packages/liveblocks-core": {
       "name": "@liveblocks/core",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23022,7 +23022,7 @@
     },
     "packages/liveblocks-node": {
       "name": "@liveblocks/node",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
@@ -23030,7 +23030,7 @@
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/node": "^20.7.1",
@@ -23046,11 +23046,11 @@
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "nanoid": "^3",
         "use-sync-external-store": "^1.2.0"
       },
@@ -23069,13 +23069,13 @@
     },
     "packages/liveblocks-react-comments": {
       "name": "@liveblocks/react-comments",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.1",
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
-        "@liveblocks/react": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
+        "@liveblocks/react": "1.4.1-test1",
         "@radix-ui/react-dropdown-menu": "^2.0.5",
         "@radix-ui/react-popover": "^1.0.6",
         "@radix-ui/react-slot": "^1.0.2",
@@ -23477,11 +23477,11 @@
     },
     "packages/liveblocks-redux": {
       "name": "@liveblocks/redux",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0"
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23602,11 +23602,11 @@
     },
     "packages/liveblocks-yjs": {
       "name": "@liveblocks/yjs",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "js-base64": "^3.7.5"
       },
       "devDependencies": {
@@ -23620,11 +23620,11 @@
     },
     "packages/liveblocks-zustand": {
       "name": "@liveblocks/zustand",
-      "version": "1.4.0",
+      "version": "1.4.1-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0"
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23772,6 +23772,11 @@
         "@liveblocks/jest-config": "*",
         "@types/pluralize": "^0.0.29"
       }
+    },
+    "schema-lang/infer-schema/node_modules/@liveblocks/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-LIgLLFyf4r9dyafGUmt+Dh3uGADwIlEIWVS4t0pbv7N4AGO6hXQ99igf7AczblhRoQlbCgVj4WGHhyqKMdXh6A=="
     },
     "schema-lang/liveblocks-schema": {
       "name": "@liveblocks/schema",
@@ -25388,7 +25393,7 @@
     "@liveblocks/client": {
       "version": "file:packages/liveblocks-client",
       "requires": {
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/ws": "^8.5.3",
@@ -25531,6 +25536,13 @@
         "@types/pluralize": "^0.0.29",
         "decoders": "^2.0.3",
         "pluralize": "^8.0.0"
+      },
+      "dependencies": {
+        "@liveblocks/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-LIgLLFyf4r9dyafGUmt+Dh3uGADwIlEIWVS4t0pbv7N4AGO6hXQ99igf7AczblhRoQlbCgVj4WGHhyqKMdXh6A=="
+        }
       }
     },
     "@liveblocks/jest-config": {
@@ -25571,7 +25583,7 @@
     "@liveblocks/node": {
       "version": "file:packages/liveblocks-node",
       "requires": {
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@stablelib/base64": "^1.0.1",
@@ -25593,8 +25605,8 @@
     "@liveblocks/react": {
       "version": "file:packages/liveblocks-react",
       "requires": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -25676,11 +25688,11 @@
       "version": "file:packages/liveblocks-react-comments",
       "requires": {
         "@floating-ui/react-dom": "^2.0.1",
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/react": "1.4.0",
+        "@liveblocks/react": "1.4.1-test1",
         "@radix-ui/react-dropdown-menu": "^2.0.5",
         "@radix-ui/react-popover": "^1.0.6",
         "@radix-ui/react-slot": "^1.0.2",
@@ -25876,8 +25888,8 @@
     "@liveblocks/redux": {
       "version": "file:packages/liveblocks-redux",
       "requires": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
@@ -26200,8 +26212,8 @@
     "@liveblocks/yjs": {
       "version": "file:packages/liveblocks-yjs",
       "requires": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -26211,8 +26223,8 @@
     "@liveblocks/zustand": {
       "version": "file:packages/liveblocks-zustand",
       "requires": {
-        "@liveblocks/client": "1.4.0",
-        "@liveblocks/core": "1.4.0",
+        "@liveblocks/client": "1.4.1-test1",
+        "@liveblocks/core": "1.4.1-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",

--- a/packages/create-liveblocks-app/package.json
+++ b/packages/create-liveblocks-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-liveblocks-app",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "An installer for Liveblocks projects, including various examples and a Next.js starter kit. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "bin": "dist/index.cjs",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/client",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "A client that lets you interact with Liveblocks servers. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,7 +32,7 @@
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"
   },
   "dependencies": {
-    "@liveblocks/core": "1.4.0"
+    "@liveblocks/core": "1.4.1-test1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",

--- a/packages/liveblocks-core/e2e/list.test.ts
+++ b/packages/liveblocks-core/e2e/list.test.ts
@@ -820,4 +820,28 @@ describe("LiveList single client", () => {
       }
     )
   );
+
+  test(
+    "create list with item + set",
+    prepareSingleClientTest(
+      {
+        list: null,
+      } as { list: LiveList<string> | null },
+      async ({ root, flushSocketMessages, room }) => {
+        const states: Json[] = [];
+        room.subscribe(root, () => states.push(lsonToJson(root)), {
+          isDeep: true,
+        });
+
+        const liveList = new LiveList<string>(["A"]);
+        root.set("list", liveList);
+
+        liveList.set(0, "B");
+
+        await flushSocketMessages();
+
+        expect(states).toEqual([{ list: ["A"] }, { list: ["B"] }]);
+      }
+    )
+  );
 });

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/core",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "Private internals for Liveblocks. DO NOT import directly from this package!",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -134,7 +134,16 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     ops.push(op);
 
     for (const item of this._items) {
-      ops.push(...item._toOps(this._id, item._getParentKeyOrThrow(), pool));
+      const parentKey = item._getParentKeyOrThrow();
+      const childOps = HACK_addIntentAndDeletedIdToOperation(
+        item._toOps(this._id, parentKey, pool),
+        undefined
+      );
+      const childOpId = childOps[0].opId;
+      if (childOpId !== undefined) {
+        this._unacknowledgedSets.set(parentKey, childOpId);
+      }
+      ops.push(...childOps);
     }
 
     return ops;

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/node",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "A server-side utility that lets you set up a Liveblocks authentication endpoint. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -37,7 +37,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@liveblocks/core": "1.4.0",
+    "@liveblocks/core": "1.4.1-test1",
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/node": "^20.7.1",

--- a/packages/liveblocks-react-comments/package.json
+++ b/packages/liveblocks-react-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react-comments",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "A set of React components to add real time comments a la Notion, Figma, Google Docs in your product.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -49,9 +49,9 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.1",
-    "@liveblocks/client": "1.4.0",
-    "@liveblocks/core": "1.4.0",
-    "@liveblocks/react": "1.4.0",
+    "@liveblocks/client": "1.4.1-test1",
+    "@liveblocks/core": "1.4.1-test1",
+    "@liveblocks/react": "1.4.1-test1",
     "@radix-ui/react-dropdown-menu": "^2.0.5",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-slot": "^1.0.2",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "A set of React hooks and providers to use Liveblocks declaratively. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,8 +33,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.4.0",
-    "@liveblocks/core": "1.4.0",
+    "@liveblocks/client": "1.4.1-test1",
+    "@liveblocks/core": "1.4.1-test1",
     "nanoid": "^3",
     "use-sync-external-store": "^1.2.0"
   },

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/redux",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "A store enhancer to integrate Liveblocks into Redux stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,8 +32,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.4.0",
-    "@liveblocks/core": "1.4.0"
+    "@liveblocks/client": "1.4.1-test1",
+    "@liveblocks/core": "1.4.1-test1"
   },
   "peerDependencies": {
     "redux": "^4"

--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/yjs",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "An integration with . Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,8 +32,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.4.0",
-    "@liveblocks/core": "1.4.0",
+    "@liveblocks/client": "1.4.1-test1",
+    "@liveblocks/core": "1.4.1-test1",
     "js-base64": "^3.7.5"
   },
   "peerDependencies": {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "1.4.0",
+  "version": "1.4.1-test1",
   "description": "A middleware to integrate Liveblocks into Zustand stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,8 +33,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.4.0",
-    "@liveblocks/core": "1.4.0"
+    "@liveblocks/client": "1.4.1-test1",
+    "@liveblocks/core": "1.4.1-test1"
   },
   "peerDependencies": {
     "zustand": "^4.1.3"


### PR DESCRIPTION
### Description

Fixes the "ghosting bug" caused by using tuples in Zustand.

If a Zustand state contains arrays used as tuples, they are backed by `LiveList` under the hood. Updating the value of a tuple right after creating it can cause [LiveList.insert + LiveList.set conflicts](https://github.com/liveblocks/liveblocks/pull/1002) issues. This PR is not an attempt to fix the `LiveList.insert` + `LiveList.set` issue. This PR specifically fixes the issue for Zustand and Redux users by serializing the newly created `LiveList` children as `set` operations instead of `inserts`.

I locally updated the `zustand-whiteboard` example to use tuples instead of objects for coordinates and added a feature to insert on click to reproduce the issue. If a coordinates tuple contains more than 2 numbers, I show an error in the console.

### Before

https://github.com/liveblocks/liveblocks/assets/7273466/2b9424f2-6027-4f60-9be9-b5c853aff1a0

### After

https://github.com/liveblocks/liveblocks/assets/7273466/9ef9f8ba-8d3b-4484-aafa-1b67064e269f


