### PR TITLE
Fix bug in `between()` edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.2
+
+### `@liveblocks/client`
+
+- Fix a bug where calculating the insertion position between two existing elements could happen incorrectly in a small edge case
+
 # v1.4.0
 
 ### DevTools

--- a/packages/liveblocks-core/src/lib/__tests__/position.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/position.test.ts
@@ -393,6 +393,9 @@ describe("makePosition", () => {
   test("before .1 lies .09", () =>
     expect(makePosition(undefined, ONE)).toBe(ZERO + NINE));
 
+  test("between .1 and .11 lies .105", () =>
+    expect(makePosition(ONE, asPos(ONE + ONE))).toBe(ONE + ZERO + MID));
+
   test("between .1 and .3 lies .2", () =>
     expect(makePosition(ONE, THREE)).toBe(TWO));
 

--- a/packages/liveblocks-core/src/lib/__tests__/position.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/position.test.ts
@@ -1,5 +1,6 @@
 import * as fc from "fast-check";
 
+import type { Pos } from "../position";
 import {
   __after as after,
   __before as before,
@@ -503,7 +504,15 @@ describe("comparePosition", () => {
           expect(mid > lo).toBe(true);
           expect(hi > mid).toBe(true);
         }
-      )
+      ),
+
+      {
+        examples: [
+          // Found these as counter examples once, adding them here to prevent regressions in the future
+          [["a", "a!"] as Pos[]],
+          [["a", "a                             !"] as Pos[]],
+        ],
+      }
     );
   });
 });

--- a/packages/liveblocks-core/src/lib/position.ts
+++ b/packages/liveblocks-core/src/lib/position.ts
@@ -247,8 +247,12 @@ function _between(lo: Pos, hi: Pos | ""): Pos {
 
     // Difference of only 1 means we'll have to settle this in the next digit
     if (hiCode - loCode === 1) {
-      const prefix = lo.substring(0, index + 1);
-      const suffix = lo.substring(index + 1) as Pos;
+      const size = index + 1;
+      let prefix = lo.substring(0, size);
+      if (prefix.length < size) {
+        prefix += ZERO.repeat(size - prefix.length);
+      }
+      const suffix = lo.substring(size) as Pos;
       const nines = ""; // Will get interpreted like .999999…
       return (prefix + _between(suffix, nines)) as Pos;
     } else {


### PR DESCRIPTION
This PR fixes a bug in `between()`, where it could generate a position value that wasn't alphabetically between the two given values. Fast-check randomly found this counter example this morning! ❤️ 

`between("a", "a!")` would incorrectly return `"a0"` instead of `"a 0"`
