### PR TITLE
add reaction events to hub

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1874,7 +1874,8 @@ export function createRoom<
 
           case ServerMsgCode.THREAD_CREATED:
           case ServerMsgCode.THREAD_METADATA_UPDATED:
-          case ServerMsgCode.COMMENT_CREATED:
+          case ServerMsgCode.COMMENT_REACTION_ADDED:
+          case ServerMsgCode.COMMENT_REACTION_REMOVED:
           case ServerMsgCode.COMMENT_EDITED:
           case ServerMsgCode.COMMENT_DELETED: {
             eventHub.comments.notify(message);

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1876,6 +1876,7 @@ export function createRoom<
           case ServerMsgCode.THREAD_METADATA_UPDATED:
           case ServerMsgCode.COMMENT_REACTION_ADDED:
           case ServerMsgCode.COMMENT_REACTION_REMOVED:
+          case ServerMsgCode.COMMENT_CREATED:
           case ServerMsgCode.COMMENT_EDITED:
           case ServerMsgCode.COMMENT_DELETED: {
             eventHub.comments.notify(message);

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -192,6 +192,8 @@ type WebhookEvent =
   | CommentCreatedEvent
   | CommentEditedEvent
   | CommentDeletedEvent
+  | CommentReactionAdded
+  | CommentReactionRemoved
   | ThreadMetadataUpdatedEvent
   | ThreadCreatedEvent
   | YDocUpdatedEvent;


### PR DESCRIPTION
### Description

- Enables comment cache to revalidate on reaction events

#### Related issue(s)

https://github.com/liveblocks/liveblocks.io/issues/1533
