### PR TITLE
Comments: Improve `CommentBody` (de-)serialization

### DIFF
--- a/packages/liveblocks-react-comments/src/primitives/Comment/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Comment/index.tsx
@@ -88,7 +88,7 @@ const CommentBody = forwardRef<HTMLDivElement, CommentBodyProps>(
       [components]
     );
 
-    if (!body) {
+    if (!body || !body?.content) {
       return null;
     }
 

--- a/packages/liveblocks-react-comments/src/primitives/Composer/utils.ts
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/utils.ts
@@ -72,16 +72,16 @@ export function composerBodyToCommentBody(body: ComposerBody): CommentBody {
     content: body.map((block) => {
       const children = block.children
         .map((inline) => {
-          if (SlateText.isText(inline)) {
-            return inline as CommentBodyText;
-          }
-
           if (isComposerBodyMention(inline)) {
             return composerBodyMentionToCommentBodyMention(inline);
           }
 
           if (isComposerBodyAutoLink(inline)) {
             return composerBodyAutoLinkToCommentBodyLink(inline);
+          }
+
+          if (SlateText.isText(inline)) {
+            return inline as CommentBodyText;
           }
 
           return null;
@@ -100,16 +100,16 @@ export function commentBodyToComposerBody(body: CommentBody): ComposerBody {
   return body.content.map((block) => {
     const children = block.children
       .map((inline) => {
-        if (isCommentBodyText(inline)) {
-          return inline as ComposerBodyText;
-        }
-
         if (isCommentBodyMention(inline)) {
           return commentBodyMentionToComposerBodyMention(inline);
         }
 
         if (isCommentBodyLink(inline)) {
           return commentBodyLinkToComposerBodyLink(inline);
+        }
+
+        if (isCommentBodyText(inline)) {
+          return inline as ComposerBodyText;
         }
 
         return null;

--- a/packages/liveblocks-react-comments/src/primitives/Composer/utils.ts
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/utils.ts
@@ -96,7 +96,13 @@ export function composerBodyToCommentBody(body: ComposerBody): CommentBody {
   };
 }
 
+const emptyComposerBody: ComposerBody = [];
+
 export function commentBodyToComposerBody(body: CommentBody): ComposerBody {
+  if (!body || !body?.content) {
+    return emptyComposerBody;
+  }
+
   return body.content.map((block) => {
     const children = block.children
       .map((inline) => {


### PR DESCRIPTION
This PR checks if a comment's body does exist instead of assuming it does, even with server validation it's still best not to assume too much from what we receive.