### PR TITLE
Comments: Reactions fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v1.4.4
+
+### `@liveblocks/react`
+
+- Fix `removeReaction` not removing reactions which led to reactions displaying
+  a count of 0.
+
+### `@liveblocks/react-comments`
+
+- Fix reactions list (and its add button) showing on all comments.
+- Improve emoji rendering on Windows.
+
 # v1.4.3
 
 ### `@liveblocks/react`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix reactions list (and its add button) showing on all comments.
 - Improve emoji rendering on Windows.
+- Hide country flag emojis when unsupported. (e.g. on Windows)
 
 # v1.4.3
 

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -35,7 +35,6 @@ import type {
   CommentMentionProps,
 } from "../primitives/Comment/types";
 import * as ComposerPrimitive from "../primitives/Composer";
-import { Emoji } from "../primitives/internal/Emoji";
 import { Timestamp } from "../primitives/Timestamp";
 import { MENTION_CHARACTER } from "../slate/plugins/mentions";
 import { classNames } from "../utils/class-names";
@@ -43,6 +42,7 @@ import { Composer } from "./Composer";
 import { Avatar } from "./internal/Avatar";
 import { Button } from "./internal/Button";
 import { Dropdown, DropdownItem, DropdownTrigger } from "./internal/Dropdown";
+import { Emoji } from "./internal/Emoji";
 import { EmojiPicker, EmojiPickerTrigger } from "./internal/EmojiPicker";
 import { List } from "./internal/List";
 import {

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -562,7 +562,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
                     Link: CommentLink,
                   }}
                 />
-                {showReactions && comment.reactions && (
+                {showReactions && comment.reactions.length > 0 && (
                   <div className="lb-comment-reactions">
                     {comment.reactions.map((reaction) => (
                       <CommentReaction

--- a/packages/liveblocks-react-comments/src/components/internal/Emoji.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/Emoji.tsx
@@ -1,0 +1,17 @@
+import React, { forwardRef } from "react";
+
+import type { EmojiProps as EmojiPrimitiveProps } from "../../primitives/internal/Emoji";
+import { Emoji as EmojiPrimitive } from "../../primitives/internal/Emoji";
+import { classNames } from "../../utils/class-names";
+
+export const Emoji = forwardRef<HTMLSpanElement, EmojiPrimitiveProps>(
+  ({ className, ...props }, forwardedRef) => {
+    return (
+      <EmojiPrimitive
+        className={classNames("lb-emoji", className)}
+        {...props}
+        ref={forwardedRef}
+      />
+    );
+  }
+);

--- a/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx
@@ -19,8 +19,8 @@ import type {
   EmojiPickerContentLoadingProps,
   EmojiPickerContentRowProps,
 } from "../../primitives/EmojiPicker/types";
-import { Emoji } from "../../primitives/internal/Emoji";
 import { classNames } from "../../utils/class-names";
+import { Emoji } from "../internal/Emoji";
 
 export interface EmojiPickerProps extends ComponentPropsWithoutRef<"div"> {
   onOpenChange?: (open: boolean) => void;

--- a/packages/liveblocks-react-comments/src/components/internal/QuickEmojiPicker.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/QuickEmojiPicker.tsx
@@ -6,8 +6,8 @@ import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
 } from "../../constants";
-import { Emoji } from "../../primitives/internal/Emoji";
 import { classNames } from "../../utils/class-names";
+import { Emoji } from "../internal/Emoji";
 
 export interface QuickEmojiPickerProps extends ComponentPropsWithoutRef<"div"> {
   onOpenChange?: (open: boolean) => void;

--- a/packages/liveblocks-react-comments/src/constants.ts
+++ b/packages/liveblocks-react-comments/src/constants.ts
@@ -2,4 +2,4 @@ export const FLOATING_ELEMENT_SIDE_OFFSET = 6;
 export const FLOATING_ELEMENT_COLLISION_PADDING = 10;
 
 export const EMOJI_FONT_FAMILY =
-  "'Apple Color Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Android Emoji', EmojiSymbols, sans-serif";
+  "'Apple Color Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', 'Android Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', EmojiSymbols, sans-serif";

--- a/packages/liveblocks-react-comments/src/overrides.tsx
+++ b/packages/liveblocks-react-comments/src/overrides.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren, ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 import * as React from "react";
 
-import { Emoji } from "./primitives/internal/Emoji";
+import { Emoji } from "./components/internal/Emoji";
 import type { Direction } from "./types";
 
 export interface LocalizationOverrides {

--- a/packages/liveblocks-react-comments/src/primitives/EmojiPicker/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/EmojiPicker/index.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../utils/request-idle-callback";
 import { useTransition } from "../../utils/use-transition";
 import { visuallyHidden } from "../../utils/visually-hidden";
-import { Emoji as AccessibleEmoji } from "../internal/Emoji";
+import { Emoji as EmojiPrimitive } from "../internal/Emoji";
 import { EmojiPickerContext, useEmojiPicker } from "./contexts";
 import type {
   EmojiData,
@@ -346,7 +346,7 @@ const defaultContentComponents: EmojiPickerContentComponents = {
   Row: ({ children, attributes, ...props }) => <div {...props}>{children}</div>,
   Emoji: ({ emoji, ...props }) => (
     <button {...props}>
-      <AccessibleEmoji emoji={emoji} />
+      <EmojiPrimitive emoji={emoji} />
     </button>
   ),
   Loading: (props) => <div {...props} />,

--- a/packages/liveblocks-react-comments/src/primitives/EmojiPicker/types.ts
+++ b/packages/liveblocks-react-comments/src/primitives/EmojiPicker/types.ts
@@ -11,6 +11,7 @@ export type Emoji = {
   category: number;
   name: string;
   version: number;
+  countryFlag?: true;
   tags?: string[];
 };
 

--- a/packages/liveblocks-react-comments/src/primitives/EmojiPicker/utils.ts
+++ b/packages/liveblocks-react-comments/src/primitives/EmojiPicker/utils.ts
@@ -262,6 +262,24 @@ function detectEmojiSupport(
   return true;
 }
 
+function getEmojiFontFamily() {
+  try {
+    const element = document.createElement("span");
+    element.style.display = "none";
+    element.dataset.emoji = "";
+
+    document.body.appendChild(element);
+
+    const computedFontFamily = window.getComputedStyle(element).fontFamily;
+
+    document.body.removeChild(element);
+
+    return computedFontFamily;
+  } catch {
+    return EMOJI_FONT_FAMILY;
+  }
+}
+
 function getEmojiSessionMetadata(emojis: Emoji[]): EmojiSessionMetadata {
   const versions = new Map<number, string>();
 
@@ -281,9 +299,11 @@ function getEmojiSessionMetadata(emojis: Emoji[]): EmojiSessionMetadata {
     return { emojiVersion: descendingVersions[0], countryFlags: true };
   }
 
+  console.log(getEmojiFontFamily());
+
   canvasContext.font = `${Math.floor(
     EMOJI_DETECTION_CANVAS_HEIGHT / 2
-  )}px ${EMOJI_FONT_FAMILY}`;
+  )}px ${getEmojiFontFamily()}`;
   canvasContext.textBaseline = "top";
   canvasContext.canvas.width = EMOJI_DETECTION_CANVAS_WIDTH * 2;
   canvasContext.canvas.height = EMOJI_DETECTION_CANVAS_HEIGHT;

--- a/packages/liveblocks-react-comments/src/primitives/EmojiPicker/utils.ts
+++ b/packages/liveblocks-react-comments/src/primitives/EmojiPicker/utils.ts
@@ -57,6 +57,7 @@ const CACHE_EMOJI_SESSION_METADATA_KEY = "lb-emoji-metadata";
 
 const EMOJI_DETECTION_CANVAS_WIDTH = 20;
 const EMOJI_DETECTION_CANVAS_HEIGHT = 25;
+const EMOJI_DETECTION_COUNTRY_FLAG = "🇫🇷";
 
 type EmojiMetadata = {
   emojisEtag: string | null;
@@ -65,6 +66,7 @@ type EmojiMetadata = {
 
 type EmojiSessionMetadata = {
   emojiVersion: number;
+  countryFlags: boolean;
 };
 
 function generateRangeIndices(start: number, end: number) {
@@ -143,6 +145,9 @@ async function fetchEmojibaseEtags(locale: EmojibaseLocale) {
 async function fetchEmojiData(locale: EmojibaseLocale): Promise<EmojiData> {
   const { emojis, emojisEtag, messages, messagesEtag } =
     await fetchEmojibaseData(locale);
+  const countryFlagsSubgroup = messages.subgroups.find(
+    (subgroup) => subgroup.key === "subdivision-flag"
+  );
 
   // Filter out component/modifier category and emojis
   const filteredGroups = messages.groups.filter(
@@ -161,13 +166,21 @@ async function fetchEmojiData(locale: EmojibaseLocale): Promise<EmojiData> {
     key: skinTone.key,
     name: capitalize(skinTone.message),
   }));
-  const compactEmojis = filteredEmojis.map((emoji) => ({
-    emoji: emoji.emoji,
-    category: emoji.group!,
-    version: emoji.version,
-    name: capitalize(emoji.label),
-    tags: emoji.tags,
-  }));
+  const compactEmojis = filteredEmojis.map((emoji) => {
+    const compactEmoji: Emoji = {
+      emoji: emoji.emoji,
+      category: emoji.group!,
+      version: emoji.version,
+      name: capitalize(emoji.label),
+      tags: emoji.tags,
+    };
+
+    if (countryFlagsSubgroup && emoji.subgroup === countryFlagsSubgroup.order) {
+      compactEmoji.countryFlag = true;
+    }
+
+    return compactEmoji;
+  });
 
   const emojiData = {
     emojis: compactEmojis,
@@ -249,7 +262,7 @@ function detectEmojiSupport(
   return true;
 }
 
-function detectEmojiVersion(emojis: Emoji[]): number {
+function getEmojiSessionMetadata(emojis: Emoji[]): EmojiSessionMetadata {
   const versions = new Map<number, string>();
 
   for (const emoji of emojis) {
@@ -265,7 +278,7 @@ function detectEmojiVersion(emojis: Emoji[]): number {
     .getContext("2d", { willReadFrequently: true });
 
   if (!canvasContext) {
-    return descendingVersions[0];
+    return { emojiVersion: descendingVersions[0], countryFlags: true };
   }
 
   canvasContext.font = `${Math.floor(
@@ -275,16 +288,27 @@ function detectEmojiVersion(emojis: Emoji[]): number {
   canvasContext.canvas.width = EMOJI_DETECTION_CANVAS_WIDTH * 2;
   canvasContext.canvas.height = EMOJI_DETECTION_CANVAS_HEIGHT;
 
+  const supportsCountryFlags = detectEmojiSupport(
+    canvasContext,
+    EMOJI_DETECTION_COUNTRY_FLAG
+  );
+
   for (const version of descendingVersions) {
     const emoji = versions.get(version)!;
     const isSupported = detectEmojiSupport(canvasContext, emoji);
 
     if (isSupported) {
-      return version;
+      return {
+        emojiVersion: version,
+        countryFlags: supportsCountryFlags,
+      };
     }
   }
 
-  return descendingVersions[0];
+  return {
+    emojiVersion: descendingVersions[0],
+    countryFlags: supportsCountryFlags,
+  };
 }
 
 export async function getEmojiData(locale: string): Promise<EmojiData> {
@@ -328,17 +352,22 @@ export async function getEmojiData(locale: string): Promise<EmojiData> {
     data = await fetchEmojiData(emojibaseLocale);
   }
 
-  const emojiVersion =
-    sessionMetadata?.emojiVersion ?? detectEmojiVersion(data.emojis);
-  setStorageItem(sessionStorage, CACHE_EMOJI_SESSION_METADATA_KEY, {
-    ...sessionMetadata,
-    emojiVersion,
-  });
+  const newSessionMetadata =
+    sessionMetadata ?? getEmojiSessionMetadata(data.emojis);
+  setStorageItem(
+    sessionStorage,
+    CACHE_EMOJI_SESSION_METADATA_KEY,
+    newSessionMetadata
+  );
 
   // Filter out unsupported emojis
-  const filteredEmojis = data.emojis.filter(
-    (emoji) => emoji.version <= emojiVersion
-  );
+  const filteredEmojis = data.emojis.filter((emoji) => {
+    const isSupportedVersion = emoji.version <= newSessionMetadata.emojiVersion;
+
+    return emoji.countryFlag
+      ? isSupportedVersion && newSessionMetadata.countryFlags
+      : isSupportedVersion;
+  });
 
   return {
     emojis: filteredEmojis,

--- a/packages/liveblocks-react-comments/src/primitives/internal/Emoji.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/internal/Emoji.tsx
@@ -19,8 +19,10 @@ export const Emoji = forwardRef<HTMLSpanElement, Props>(
         style={{
           ...style,
           fontFamily: EMOJI_FONT_FAMILY,
-          lineHeight: "1em",
-          width: "1ch",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "1em",
           whiteSpace: "nowrap",
         }}
         {...props}

--- a/packages/liveblocks-react-comments/src/primitives/internal/Emoji.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/internal/Emoji.tsx
@@ -16,6 +16,7 @@ export const Emoji = forwardRef<HTMLSpanElement, Props>(
       <Component
         role="img"
         aria-label={emoji}
+        data-emoji={emoji}
         style={{
           ...style,
           fontFamily: EMOJI_FONT_FAMILY,

--- a/packages/liveblocks-react-comments/src/primitives/internal/Emoji.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/internal/Emoji.tsx
@@ -4,11 +4,11 @@ import React, { forwardRef } from "react";
 import { EMOJI_FONT_FAMILY } from "../../constants";
 import type { ComponentPropsWithSlot } from "../../types";
 
-interface Props extends ComponentPropsWithSlot<"span"> {
+export interface EmojiProps extends ComponentPropsWithSlot<"span"> {
   emoji: string;
 }
 
-export const Emoji = forwardRef<HTMLSpanElement, Props>(
+export const Emoji = forwardRef<HTMLSpanElement, EmojiProps>(
   ({ emoji, style, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "span";
 

--- a/packages/liveblocks-react-comments/src/styles/index.scss
+++ b/packages/liveblocks-react-comments/src/styles/index.scss
@@ -831,18 +831,9 @@
     }
   }
 
-  .lb-comment-reaction-emoji,
-  .lb-comment-reaction-count {
-    font-size: 0.75em;
-  }
-
-  .lb-comment-reaction-emoji {
-    text-align: center;
-    transform: scale(1.125);
-  }
-
   .lb-comment-reaction-count {
     font-weight: 500;
+    font-size: 0.75em;
     font-variant-numeric: tabular-nums;
   }
 

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -730,7 +730,7 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
               const reactionIndex = comment.reactions.findIndex(
                 (reaction) => reaction.emoji === emoji
               );
-              const reactions: CommentReaction[] = comment.reactions;
+              let reactions: CommentReaction[] = comment.reactions;
 
               if (
                 reactionIndex > 0 &&
@@ -738,12 +738,17 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
                   (user) => user.id === userId
                 )
               ) {
-                reactions[reactionIndex] = {
-                  ...reactions[reactionIndex],
-                  users: reactions[reactionIndex].users.filter(
-                    (user) => user.id !== userId
-                  ),
-                };
+                if (comment.reactions[reactionIndex].users.length <= 1) {
+                  reactions = [...comment.reactions];
+                  reactions.splice(reactionIndex, 1);
+                } else {
+                  reactions[reactionIndex] = {
+                    ...reactions[reactionIndex],
+                    users: reactions[reactionIndex].users.filter(
+                      (user) => user.id !== userId
+                    ),
+                  };
+                }
               }
 
               return {


### PR DESCRIPTION
This PR fixes a couple of things about reactions:
- Only show reactions under the comment body if there are any
- Fix emoji rendering (mainly for Windows)
- Hide country flag emojis when not supported
- Fix `removeReaction` optimistic update that would only decrement the count but not remove a reaction completely if the count is at 0