### PR TITLE
Fix room encoding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.5
+
+### `@liveblocks/node`
+
+- Fix URL encoding bug
+
 # v1.4.4
 
 ### `@liveblocks/react`

--- a/packages/liveblocks-node/src/__tests__/authorize.test.ts
+++ b/packages/liveblocks-node/src/__tests__/authorize.test.ts
@@ -17,6 +17,22 @@ describe("authorize (legacy API)", () => {
     }
   );
 
+  test.each([
+    "foo",
+    "slashes/are/fine",
+    "so/is-punctuation, and whitespace!@#$%^&()_ ",
+    "emojis, too! 🐯🤘",
+  ])("works with various room IDs", async (room) => {
+    await authorize({
+      room,
+      userId: "user1",
+      secret: "sk_xxx",
+    }).then((response) => {
+      expect(response.status).toBe(403);
+      expect(response.body).toMatch(/Invalid secret key/);
+    });
+  });
+
   test.each([null, "", undefined, {}])(
     "should check that userId is a non-empty string",
     async (userId) => {

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -138,7 +138,10 @@ function buildLiveblocksAuthorizeEndpoint(
   roomId: string
 ): string {
   if (options.liveblocksAuthorizeEndpoint) {
-    return options.liveblocksAuthorizeEndpoint.replace("{roomId}", roomId);
+    return options.liveblocksAuthorizeEndpoint.replace(
+      "{roomId}",
+      encodeURIComponent(roomId)
+    );
   }
 
   return `https://api.liveblocks.io/v2/rooms/${encodeURIComponent(


### PR DESCRIPTION
This fixes a room encoding bug in old-style authorize URLs. (This was done correctly for all public APIs, but this encoding bug happened only when using the internal `liveblocksAuthorizeEndpoint` override option.)