### PR TITLE
Add `client.logout()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ leave();
     room and an "unsubscribe function" to leave that room again. This newer API
     supports entering/leaving the same room multiple times, making it possible
     to connect to the same room from different parts of your application.
+  - `client.logout()` – Call this on the Liveblocks client when you log out a
+    user in your application. It will purge all auth tokens and force-leave any
+    rooms, if any are still connected.
 - Deprecated APIs:
   - `client.enter(roomId, options)`
   - `client.leave(roomId)`

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -276,6 +276,18 @@ const room = client.getRoom("my-room");
 You’ll likely not need this API if you’re using the newer [`client.enterRoom`][]
 API.
 
+### Client.logout
+
+Purges any auth tokens from the client’s memory. If there are any rooms that are
+still connected, they will be forced to reauthorize.
+
+```ts
+client.logout();
+```
+
+Call this API if you have a single page application (SPA) and you want to log
+your user from your application.
+
 ## Room
 
 Room returned by [`client.enterRoom`][] (or [`client.getRoom`][]).

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -286,7 +286,7 @@ client.logout();
 ```
 
 Call this API if you have a single page application (SPA) and you want to log
-your user from your application.
+your user out.
 
 ## Room
 

--- a/e2e/next-sandbox/pages/multi.tsx
+++ b/e2e/next-sandbox/pages/multi.tsx
@@ -33,8 +33,15 @@ export default function Home() {
   const [numColumns, setNumColumns] = React.useState(1);
   return (
     <>
-      <h3>
-        <a href="/">Home</a> › Multiple rooms
+      <h3 style={{ display: "flex", gap: 12, alignItems: "center" }}>
+        <span>
+          <a href="/">Home</a> › Multiple rooms
+        </span>
+        <span>
+          <Button id="logout" onClick={() => client.logout()}>
+            Logout
+          </Button>
+        </span>
       </h3>
 
       <div style={{ display: "flex", gap: 8 }}>

--- a/e2e/next-sandbox/test/client.test.ts
+++ b/e2e/next-sandbox/test/client.test.ts
@@ -41,9 +41,9 @@ test.describe("Client logout", () => {
     // Connect to two different rooms
     await page.click("#add-column");
     await page.click("#add-column");
-    await page.fill("#input_1", "e2e:multi-A");
-    await page.fill("#input_2", "e2e:multi-B");
-    await page.fill("#input_3", "e2e:multi-B"); // Same room as instance 2
+    await page.fill("#input_1", "e2e:logout-A");
+    await page.fill("#input_2", "e2e:logout-B");
+    await page.fill("#input_3", "e2e:logout-B"); // Same room as instance 2
     await page.click("#mount_1");
     await page.click("#mount_2");
     await page.click("#mount_3");
@@ -72,9 +72,9 @@ test.describe("Client logout", () => {
     // Connect to two different rooms
     await page.click("#add-column");
     await page.click("#add-column");
-    await page.fill("#input_1", "e2e:multi-A");
-    await page.fill("#input_2", "e2e:multi-B");
-    await page.fill("#input_3", "e2e:multi-C");
+    await page.fill("#input_1", "e2e:logout-P");
+    await page.fill("#input_2", "e2e:logout-Q");
+    await page.fill("#input_3", "e2e:logout-R");
     await page.click("#mount_1");
     await page.click("#mount_2");
     await page.click("#disconnect_2"); // Immediately disconnect 2nd room

--- a/e2e/next-sandbox/test/client.test.ts
+++ b/e2e/next-sandbox/test/client.test.ts
@@ -1,0 +1,106 @@
+import type { Page } from "@playwright/test";
+import { test } from "@playwright/test";
+
+import {
+  expectJson,
+  genRoomId,
+  getJson,
+  preparePages,
+  waitForJson,
+} from "./utils";
+
+// NOTE: The tests below don't play well with concurrency just yet. The reason
+// is that they unmount, remount, and then check that the connection ID
+// increased by exactly one. This is not super robust. What matters is that the
+// connection ID increased, but if it increased by more than 1, that could also
+// be just fine. Better to express the conditional like that. For now, just not
+// run them concurrently to avoid it.
+// test.describe.configure({ mode: "parallel" });
+
+const TEST_URL = "http://localhost:3007/multi/";
+
+test.describe("Client logout", () => {
+  let pages: Page[];
+
+  test.beforeEach(async ({}, testInfo) => {
+    const room = genRoomId(testInfo);
+    pages = await preparePages(
+      `${TEST_URL}?room=${encodeURIComponent(room)}`,
+      { n: 1, width: 1024 } // Open only a single, but wider, browser window
+    );
+  });
+
+  test.afterEach(() =>
+    // Close all pages
+    Promise.all(pages.map((page) => page.close()))
+  );
+
+  test("client.logout() will reconnect currently connected rooms", async () => {
+    const page = pages[0];
+
+    // Connect to two different rooms
+    await page.click("#add-column");
+    await page.click("#add-column");
+    await page.fill("#input_1", "e2e:multi-A");
+    await page.fill("#input_2", "e2e:multi-B");
+    await page.fill("#input_3", "e2e:multi-B"); // Same room as instance 2
+    await page.click("#mount_1");
+    await page.click("#mount_2");
+    await page.click("#mount_3");
+
+    await waitForJson(page, "#socketStatus_1", "connected");
+    await waitForJson(page, "#socketStatus_2", "connected");
+    await waitForJson(page, "#socketStatus_3", "connected");
+    const connId1 = (await getJson(page, "#connectionId_1")) as number;
+    const connId2 = (await getJson(page, "#connectionId_2")) as number;
+    const connId3 = (await getJson(page, "#connectionId_3")) as number;
+
+    await page.click("#logout");
+    await waitForJson(page, "#socketStatus_1", "connected");
+    await waitForJson(page, "#socketStatus_2", "connected");
+    await waitForJson(page, "#socketStatus_3", "connected");
+
+    // All three rooms get re-connected (and thus increment their connection ID)
+    await waitForJson(page, "#connectionId_1", connId1 + 1);
+    await waitForJson(page, "#connectionId_2", connId2 + 1);
+    await waitForJson(page, "#connectionId_3", connId3 + 1);
+  });
+
+  test("client.logout() will not reconnect idle rooms", async () => {
+    const page = pages[0];
+
+    // Connect to two different rooms
+    await page.click("#add-column");
+    await page.click("#add-column");
+    await page.fill("#input_1", "e2e:multi-A");
+    await page.fill("#input_2", "e2e:multi-B");
+    await page.fill("#input_3", "e2e:multi-C");
+    await page.click("#mount_1");
+    await page.click("#mount_2");
+    await page.click("#disconnect_2"); // Immediately disconnect 2nd room
+    await page.click("#mount_3");
+
+    await waitForJson(page, "#socketStatus_1", "connected");
+    await waitForJson(page, "#socketStatus_2", "initial");
+
+    // Also disconnect room 3, but only after it has first established
+    // a connection (so in contrast with room 2 it will have a connection ID)
+    await waitForJson(page, "#socketStatus_3", "connected");
+    await page.click("#disconnect_3");
+    await waitForJson(page, "#socketStatus_3", "initial");
+
+    const connId1 = (await getJson(page, "#connectionId_1")) as number;
+    await expectJson(page, "#connectionId_2", undefined); // Room 2 has no connection ID
+    const connId3 = (await getJson(page, "#connectionId_3")) as number;
+
+    await page.click("#logout");
+    await waitForJson(page, "#socketStatus_1", "connected");
+    await waitForJson(page, "#socketStatus_2", "initial"); // Remains in initial
+    await waitForJson(page, "#socketStatus_3", "initial"); // Remains in initial
+
+    // Only room 1 got reconnected (and increased its connection ID)
+    await waitForJson(page, "#connectionId_1", connId1 + 1);
+    await waitForJson(page, "#connectionId_2", undefined);
+    await waitForJson(page, "#connectionId_3", connId3);
+  });
+});

--- a/e2e/next-sandbox/test/utils.ts
+++ b/e2e/next-sandbox/test/utils.ts
@@ -134,13 +134,16 @@ export async function preparePages(
 export async function waitForJson(
   oneOrMorePages: Page | Page[],
   selector: IDSelector,
-  expectedValue: Json
+  expectedValue: Json | undefined
 ) {
   const pages = Array.isArray(oneOrMorePages)
     ? oneOrMorePages
     : [oneOrMorePages];
 
-  const expectedText = JSON.stringify(expectedValue, null, 2);
+  const expectedText =
+    expectedValue === undefined
+      ? "undefined"
+      : JSON.stringify(expectedValue, null, 2);
   return Promise.all(
     pages.map((page) =>
       expect(page.locator(selector)).toHaveText(expectedText, { timeout: 5000 })
@@ -161,12 +164,15 @@ export async function expectJson(
   }
 }
 
-export async function getJson(page: Page, selector: IDSelector): Promise<Json> {
+export async function getJson(
+  page: Page,
+  selector: IDSelector
+): Promise<Json | undefined> {
   const text = await page.locator(selector).innerText();
   if (!text) {
     throw new Error(`Could not find HTML element #${selector}`);
   }
-  return JSON.parse(text) as Json;
+  return text === "undefined" ? undefined : (JSON.parse(text) as Json);
 }
 
 async function getBoth(pages: [Page, Page], selector: IDSelector) {

--- a/packages/liveblocks-core/src/auth-manager.ts
+++ b/packages/liveblocks-core/src/auth-manager.ts
@@ -16,6 +16,7 @@ export type AuthValue =
 export type RequestedScope = "room:read" | "comments:read";
 
 export type AuthManager = {
+  reset(): void;
   getAuthValue(
     requestedScope: RequestedScope,
     roomId: string
@@ -44,6 +45,13 @@ export function createAuthManager(
   const expiryTimes: number[] = []; // Supposed to always contain the same number of elements as `tokens`
 
   const requestPromises = new Map<string, Promise<ParsedAuthToken>>();
+
+  function reset() {
+    seenTokens.clear();
+    tokens.length = 0;
+    expiryTimes.length = 0;
+    requestPromises.clear();
+  }
 
   function hasCorrespondingScopes(
     requestedScope: RequestedScope,
@@ -202,6 +210,7 @@ export function createAuthManager(
   }
 
   return {
+    reset,
     getAuthValue,
   };
 }

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -374,7 +374,7 @@ export function createClient(options: ClientOptions): Client {
     // rooms will get reauthorized now that the auth cache is reset. If that
     // fails, they might disconnect.
     const IDLE_STATES: Status[] = ["initial", "disconnected"];
-    for (const room of roomsById.values()) {
+    for (const { room } of roomsById.values()) {
       if (!IDLE_STATES.includes(room.getStatus())) {
         room.reconnect();
       }

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -1,5 +1,5 @@
 import { createAuthManager } from "./auth-manager";
-import type { Status } from "./connection";
+import { isIdle } from "./connection";
 import type { LsonObject } from "./crdts/Lson";
 import { linkDevTools, setupDevTools, unlinkDevTools } from "./devtools";
 import { deprecateIf } from "./lib/deprecation";
@@ -373,9 +373,8 @@ export function createClient(options: ClientOptions): Client {
     // Reconnect all rooms that aren't idle, if any. This ensures that those
     // rooms will get reauthorized now that the auth cache is reset. If that
     // fails, they might disconnect.
-    const IDLE_STATES: Status[] = ["initial", "disconnected"];
     for (const { room } of roomsById.values()) {
-      if (!IDLE_STATES.includes(room.getStatus())) {
+      if (!isIdle(room.getStatus())) {
         room.reconnect();
       }
     }

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -45,6 +45,15 @@ export type Status =
   | "disconnected";
 
 /**
+ * Whether or not the status is an "idle" state. Here, idle means that nothing
+ * will happen until some action is taken. Unsurprisingly, these statuses match
+ * the start and end states of the state machine.
+ */
+export function isIdle(status: Status): status is "initial" | "disconnected" {
+  return status === "initial" || status === "disconnected";
+}
+
+/**
  * Used to report about app-level reconnection issues.
  *
  * Normal (quick) reconnects won't be reported as a "lost connection". Instead,


### PR DESCRIPTION
This PR introduces a new API on the Client:

```tsx
// Purges the auth token cache. If any rooms are still
// conneced, they are forced to reauthorize.
client.logout()
```

This is a solution for [this support question](https://discord.com/channels/913109211746009108/913158542565994606/1159209059573055498).

Since the Liveblocks `client` is a global that caches auth tokens, whenever you log out a person from your application, you'll need to clear that cache. Force-reloading the page in the client typically works for this, but for SPAs that don't force-reload, there is no way to clear our client's caches.
