### PR TITLE
Comments: Fix `createThread` not creating valid comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.6
+
+### `@liveblocks/react`
+
+- Fix `createThread` not creating valid comment.
+
 # v1.4.5
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -362,21 +362,23 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
     const commentId = createOptimisticId(COMMENT_ID_PREFIX);
     const now = new Date().toISOString();
 
+    const newComment: CommentData = {
+      id: commentId,
+      threadId,
+      roomId: room.id,
+      createdAt: now,
+      type: "comment",
+      userId: getCurrentUserId(),
+      body,
+      reactions: [],
+    };
     const newThread = {
       id: threadId,
       type: "thread",
       createdAt: now,
       roomId: room.id,
       metadata,
-      comments: [
-        {
-          id: commentId,
-          createdAt: now,
-          type: "comment",
-          userId: getCurrentUserId(),
-          body,
-        },
-      ],
+      comments: [newComment],
     } as ThreadData<TThreadMetadata>;
 
     mutate(room.createThread({ threadId, commentId, body, metadata }), {


### PR DESCRIPTION
This PR fixes https://github.com/liveblocks/liveblocks.io/issues/1590. `createThread`'s optimistic update isn't currently creating valid comments.