### PR TITLE
Docs: Add note to primitives API reference about common error

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -293,6 +293,16 @@ behavior and call the mutation methods (e.g. `createThread`) manually.
 Primitives are headless/unstyled components that can be used to create custom
 experiences with full control.
 
+<Banner title="Using primitives with TypeScript">
+
+If you run into the
+`Cannot find module '@liveblocks/react-comments/primitives' or its corresponding type declarations`
+error, you should update your `tsconfig.json`’s `moduleResolution`
+[property](https://www.typescriptlang.org/tsconfig#moduleResolution) to
+`"node16"` or `"nodenext"` (or `"bundler"` if you’re on TS >=5).
+
+</Banner>
+
 ### Composition
 
 All primitives are composable: they forward their props and refs, merge their


### PR DESCRIPTION
We might still want to make a lengthier guide in the future about module resolution but since it's a pretty common error we should at least have a small note with the fix in situ.

![](https://github.com/liveblocks/liveblocks/assets/6959425/850cf027-f875-497b-b9ff-944e9008afce)
