### PR TITLE
Fix `useStatus()` SSR response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.6
+
+### `@liveblocks/react`
+
+- Fix `useStatus` return value on SSR responses.
+
 # v1.4.5
 
 ### `@liveblocks/react`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.4.6
+# v1.4.6 (not released yet)
 
 ### `@liveblocks/react`
 

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -103,6 +103,12 @@ function alwaysNull() {
   return null;
 }
 
+// Don't try to inline this. This function is intended to be a stable
+// reference, to avoid a React.useCallback() wrapper.
+function alwaysConnecting() {
+  return "connecting" as const;
+}
+
 function makeMutationContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
@@ -352,7 +358,8 @@ export function createRoomContext<
     const room = useRoom();
     const subscribe = room.events.status.subscribe;
     const getSnapshot = room.getStatus;
-    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+    const getServerSnapshot = alwaysConnecting;
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   }
 
   function useMyPresence(): [


### PR DESCRIPTION
This small "fix" will make the `useStatus()` hook return `"connecting"` in SSR responses (instead of `"initial"`), to match the most typical same value that would happen after hydration/initial render in the client. After all, in 95% of cases, the client will also be `"connecting"` on the first render of `useStatus`, and not `"initial"`.

Technically this isn't really a "proper fix", because there can still be cases that will cause a mismatch. However, such cases should be contrived or at least are by far in the minority.
