### PR TITLE
Fix freezing bug during loading in Suspense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### `@liveblocks/react`
 
+- Fix a race condition that could cause a Liveblocks client to hang during
+  loading when using Suspense.
 - Fix `useStatus` return value on SSR responses.
 
 # v1.4.5

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -761,6 +761,7 @@ export function createRoomContext<
     // promise resolves (aka until storage has loaded). After that, it will
     // render this component tree again.
     throw new Promise<void>((res) => {
+      room.events.self.subscribeOnce(() => res());
       room.events.status.subscribeOnce(() => res());
     });
   }

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -757,9 +757,11 @@ export function createRoomContext<
 
     ensureNotServerSide();
 
-    // Throw a _promise_. Suspense will suspend the component tree until this
-    // promise resolves (aka until storage has loaded). After that, it will
-    // render this component tree again.
+    // Throw a _promise_. Suspense will suspend the component tree until either
+    // until either a presence update event, or a connection status change has
+    // happened. After that, it will render this component tree again and
+    // re-evaluate the .getSelf() condition above, or re-suspend again until
+    // such event happens.
     throw new Promise<void>((res) => {
       room.events.self.subscribeOnce(() => res());
       room.events.status.subscribeOnce(() => res());


### PR DESCRIPTION
This PR fixes a small bug that I have been able to manually replicate in Firefox only, but I've also seen this happen in E2E test runs in Chromium _very, very, rarely_[^1].

In Firefox, somehow it's easier to trigger the condition if you're really fast:

1. Open http://localhost:3007/presence/with-suspense?bg=white&room=e2e-ff-bug
1. Open the same URL in another tab
2. Very quickly switch to that new tab until "Loading..." appears, but then switch back to the first tab before it finishes loading
3. Wait one second
4. Switch back to the "Loading" tab. It now indefinitely stays stuck in "Loading…".

The fix here is to trigger evaluation of the Suspense promise more often. Previously the Suspense bounary was only reevaluated if the socket status changed (aiming to catch a change from "connecting" to "connected"). This PR fixes it more robustly by _also_ triggering a re-evaluation of the Suspense condition if a `self` event happens. This makes it rely less on which order these events happen in.

## Before

Sometimes it was possible to trigger this race condition when switching tabs real quickly. (May be a bit unclear in this screen recording, because I'm using the keyboard for speed.)

https://github.com/liveblocks/liveblocks/assets/83844/202e8071-259d-4b39-9924-db32d01efdce

## After

Can no longer be triggered ¯\\\_(ツ)\_/¯

[^1]: [This random failure](https://github.com/liveblocks/liveblocks/actions/runs/6457662769/job/17529697384?pr=1211#step:6:192) is likely caused by this bug.
