### PR TITLE
Comments: Add `onThreadDelete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 - Export `ComposerSubmitComment` type from root too, in addition to
   `/primitives`.
 - Add `onThreadDelete` to `Thread`.
-- Add support for specifying a custom `ThreadMetadata` type on `Thread`.
+- Add `metadata` to `Composer` to attach custom metadata to new threads.
+- Add support for specifying a custom `ThreadMetadata` type on `Thread` and
+  `Composer`.
 - **Breaking (beta):** `Comment`’s `onEdit` and `onDelete` were renamed to
   `onEditComment` and `onDeleteComment` respectively.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.4.6 (not released yet)
+# v1.4.6
 
 ### `@liveblocks/react`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Export `ComposerSubmitComment` type from root too, in addition to
   `/primitives`.
+- Add `onThreadDelete` to `Thread`.
+- Add support for specifying a custom `ThreadMetadata` type on `Thread`.
+- **Breaking (beta):** `Comment`’s `onEdit` and `onDelete` were renamed to
+  `onEditComment` and `onDeleteComment` respectively.
 
 # v1.4.5
 

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -1,6 +1,6 @@
 ---
 meta:
-  title: "Comments"
+  title: "@liveblocks/react-comments"
   parentTitle: "API Reference"
   description: "API Reference for the @liveblocks/react-comments package"
 alwaysShowAllNavigationLevels: false

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -188,21 +188,22 @@ Displays a thread of comments, with a composer to reply to it.
 
 <Table columns={["26%", "32%", "42%"]}>
 
-| Prop                   | Type                                                                                              | Description                                                                             |
-| ---------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `thread`               | <code>ThreadData&lt;\{ resolved?: boolean \}&gt;</code>                                           | The thread to display.                                                                  |
-| `showComposer`         | `boolean \| "collapsed" \| undefined`                                                             | How to show or hide the composer to reply to the thread.<br/>Defaults to `"collapsed"`. |
-| `showActions`          | `boolean \| "hover" \| undefined`                                                                 | How to show or hide the actions.<br/>Defaults to `"hover"`.                             |
-| `showReactions`        | `boolean \| undefined`                                                                            | Whether to show reactions.<br/>Defaults to `true`.                                      |
-| `showResolveAction`    | `boolean \| undefined`                                                                            | Whether to show the action to resolve the thread.<br/>Defaults to `true`.               |
-| `indentCommentContent` | `boolean \| undefined`                                                                            | Whether to indent the comments’ content.<br/>Defaults to `true`.                        |
-| `showDeletedComments`  | `boolean \| undefined`                                                                            | Whether to show deleted comments.<br/>Defaults to `false`.                              |
-| `onResolvedChange`     | `(resolved: boolean) => void`                                                                     | The event handler called when changing the resolved status.                             |
-| `onCommentEdit`        | `(comment: CommentData) => void`                                                                  | The event handler called when a comment is edited.                                      |
-| `onCommentDelete`      | `(comment: CommentData) => void`                                                                  | The event handler called when a comment is deleted.                                     |
-| `onAuthorClick`        | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code>          | The event handler called when clicking on a comment’s author.                           |
-| `onMentionClick`       | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code>          | The event handler called when clicking on a mention.                                    |
-| `overrides`            | <code>Partial&lt;ThreadOverrides \& CommentOverrides \& ComposerOverrides&gt; \| undefined</code> | Override the component’s strings.                                                       |
+| Prop                   | Type                                                                                              | Description                                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `thread`               | <code>ThreadData&lt;\{ resolved?: boolean \}&gt;</code>                                           | The thread to display.                                                                                      |
+| `showComposer`         | `boolean \| "collapsed" \| undefined`                                                             | How to show or hide the composer to reply to the thread.<br/>Defaults to `"collapsed"`.                     |
+| `showActions`          | `boolean \| "hover" \| undefined`                                                                 | How to show or hide the actions.<br/>Defaults to `"hover"`.                                                 |
+| `showReactions`        | `boolean \| undefined`                                                                            | Whether to show reactions.<br/>Defaults to `true`.                                                          |
+| `showResolveAction`    | `boolean \| undefined`                                                                            | Whether to show the action to resolve the thread.<br/>Defaults to `true`.                                   |
+| `indentCommentContent` | `boolean \| undefined`                                                                            | Whether to indent the comments’ content.<br/>Defaults to `true`.                                            |
+| `showDeletedComments`  | `boolean \| undefined`                                                                            | Whether to show deleted comments.<br/>Defaults to `false`.                                                  |
+| `onResolvedChange`     | `(resolved: boolean) => void`                                                                     | The event handler called when changing the resolved status.                                                 |
+| `onThreadDelete`       | `(thread: ThreadData) => void`                                                                    | The event handler called when the thread is deleted. A thread is deleted when all its comments are deleted. |
+| `onCommentEdit`        | `(comment: CommentData) => void`                                                                  | The event handler called when a comment is edited.                                                          |
+| `onCommentDelete`      | `(comment: CommentData) => void`                                                                  | The event handler called when a comment is deleted.                                                         |
+| `onAuthorClick`        | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code>          | The event handler called when clicking on a comment’s author.                                               |
+| `onMentionClick`       | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code>          | The event handler called when clicking on a mention.                                                        |
+| `overrides`            | <code>Partial&lt;ThreadOverrides \& CommentOverrides \& ComposerOverrides&gt; \| undefined</code> | Override the component’s strings.                                                                           |
 
 </Table>
 

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -222,18 +222,18 @@ Displays a single comment.
 
 <Table columns={["26%", "32%", "42%"]}>
 
-| Prop             | Type                                                                                     | Description                                                                                                                           |
-| ---------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `comment`        | `CommentData`                                                                            | The thread to display.                                                                                                                |
-| `showActions`    | `boolean \| "hover" \| undefined`                                                        | How to show or hide the actions.<br/>Defaults to `"hover"`.                                                                           |
-| `showReactions`  | `boolean \| undefined`                                                                   | Whether to show reactions.<br/>Defaults to `true`.                                                                                    |
-| `indentContent`  | `boolean \| undefined`                                                                   | Whether to indent the comment’s content.<br/>Defaults to `true`.                                                                      |
-| `showDeleted`    | `boolean \| undefined`                                                                   | Whether to show the comment if it was deleted. If set to `false`, it will render deleted comments as `null`.<br/>Defaults to `false`. |
-| `onEdit`         | `(comment: CommentData) => void`                                                         | The event handler called when the comment is edited.                                                                                  |
-| `onDelete`       | `(comment: CommentData) => void`                                                         | The event handler called when the comment is deleted.                                                                                 |
-| `onAuthorClick`  | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code> | The event handler called when clicking on the author.                                                                                 |
-| `onMentionClick` | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code> | The event handler called when clicking on a mention.                                                                                  |
-| `overrides`      | <code>Partial&lt;CommentOverrides \& ComposerOverrides&gt; \| undefined</code>           | Override the component’s strings.                                                                                                     |
+| Prop              | Type                                                                                     | Description                                                                                                                           |
+| ----------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `comment`         | `CommentData`                                                                            | The thread to display.                                                                                                                |
+| `showActions`     | `boolean \| "hover" \| undefined`                                                        | How to show or hide the actions.<br/>Defaults to `"hover"`.                                                                           |
+| `showReactions`   | `boolean \| undefined`                                                                   | Whether to show reactions.<br/>Defaults to `true`.                                                                                    |
+| `indentContent`   | `boolean \| undefined`                                                                   | Whether to indent the comment’s content.<br/>Defaults to `true`.                                                                      |
+| `showDeleted`     | `boolean \| undefined`                                                                   | Whether to show the comment if it was deleted. If set to `false`, it will render deleted comments as `null`.<br/>Defaults to `false`. |
+| `onCommentEdit`   | `(comment: CommentData) => void`                                                         | The event handler called when the comment is edited.                                                                                  |
+| `onCommentDelete` | `(comment: CommentData) => void`                                                         | The event handler called when the comment is deleted.                                                                                 |
+| `onAuthorClick`   | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code> | The event handler called when clicking on the author.                                                                                 |
+| `onMentionClick`  | <code>(userId: string, event: MouseEvent&lt;HTMLElement&gt;) => void \| undefined</code> | The event handler called when clicking on a mention.                                                                                  |
+| `overrides`       | <code>Partial&lt;CommentOverrides \& ComposerOverrides&gt; \| undefined</code>           | Override the component’s strings.                                                                                                     |
 
 </Table>
 
@@ -526,11 +526,11 @@ The components displayed within the editor.
 
 <Table columns={["26%", "32%", "42%"]}>
 
-| Component            | Type                                                         | Description                                                                                             |
-| -------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `Mention`            | <code>ComponentType&lt;ComposerEditorMentionProps&gt;</code> | The component used to display mentions.<br/>Defaults to the mention’s `userId` prefixed by an @.        |
+| Component            | Type                                                                   | Description                                                                                             |
+| -------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `Mention`            | <code>ComponentType&lt;ComposerEditorMentionProps&gt;</code>           | The component used to display mentions.<br/>Defaults to the mention’s `userId` prefixed by an @.        |
 | `MentionSuggestions` | <code>ComponentType&lt;ComposerEditorMentionSuggestionProps&gt;</code> | The component used to display mention suggestions.<br/>Defaults to a list of the suggestions’ `userId`. |
-| `Link`               | <code>ComponentType&lt;ComposerEditorLinkProps&gt;</code>    | The component used to display links.<br/>Defaults to the link’s `children` property.                    |
+| `Link`               | <code>ComponentType&lt;ComposerEditorLinkProps&gt;</code>              | The component used to display links.<br/>Defaults to the link’s `children` property.                    |
 
 </Table>
 

--- a/packages/liveblocks-core/src/comments/index.ts
+++ b/packages/liveblocks-core/src/comments/index.ts
@@ -16,18 +16,18 @@ function getAuthBearerHeaderFromAuthValue(authValue: AuthValue) {
   }
 }
 
-export type CommentsApi<ThreadMetadata extends BaseMetadata> = {
-  getThreads(): Promise<ThreadData<ThreadMetadata>[]>;
+export type CommentsApi<TThreadMetadata extends BaseMetadata> = {
+  getThreads(): Promise<ThreadData<TThreadMetadata>[]>;
   createThread(options: {
     threadId: string;
     commentId: string;
-    metadata: ThreadMetadata | undefined;
+    metadata: TThreadMetadata | undefined;
     body: CommentBody;
-  }): Promise<ThreadData<ThreadMetadata>>;
+  }): Promise<ThreadData<TThreadMetadata>>;
   editThreadMetadata(options: {
-    metadata: Partial<ThreadMetadata>;
+    metadata: Partial<TThreadMetadata>;
     threadId: string;
-  }): Promise<ThreadData<ThreadMetadata>>;
+  }): Promise<ThreadData<TThreadMetadata>>;
   createComment(options: {
     threadId: string;
     commentId: string;
@@ -54,11 +54,11 @@ export type CommentsApi<ThreadMetadata extends BaseMetadata> = {
   }): Promise<CommentData>;
 };
 
-export function createCommentsApi<ThreadMetadata extends BaseMetadata>(
+export function createCommentsApi<TThreadMetadata extends BaseMetadata>(
   roomId: string,
   getAuthValue: () => Promise<AuthValue>,
   { serverEndpoint }: Options
-): CommentsApi<ThreadMetadata> {
+): CommentsApi<TThreadMetadata> {
   async function fetchJson<T>(
     endpoint: string,
     options?: RequestInit
@@ -112,12 +112,12 @@ export function createCommentsApi<ThreadMetadata extends BaseMetadata>(
     });
   }
 
-  async function getThreads(): Promise<ThreadData<ThreadMetadata>[]> {
+  async function getThreads(): Promise<ThreadData<TThreadMetadata>[]> {
     const response = await fetchApi(roomId, "/threads");
 
     if (response.ok) {
       const json = await (response.json() as Promise<{
-        data: ThreadData<ThreadMetadata>[];
+        data: ThreadData<TThreadMetadata>[];
       }>);
       return json.data;
     } else if (response.status === 404) {
@@ -136,10 +136,10 @@ export function createCommentsApi<ThreadMetadata extends BaseMetadata>(
     roomId: string;
     threadId: string;
     commentId: string;
-    metadata: ThreadMetadata | undefined;
+    metadata: TThreadMetadata | undefined;
     body: CommentBody;
   }) {
-    return fetchJson<ThreadData<ThreadMetadata>>("/threads", {
+    return fetchJson<ThreadData<TThreadMetadata>>("/threads", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -160,10 +160,10 @@ export function createCommentsApi<ThreadMetadata extends BaseMetadata>(
     threadId,
   }: {
     roomId: string;
-    metadata: Partial<ThreadMetadata>;
+    metadata: Partial<TThreadMetadata>;
     threadId: string;
   }) {
-    return fetchJson<ThreadData<ThreadMetadata>>(
+    return fetchJson<ThreadData<TThreadMetadata>>(
       `/threads/${encodeURIComponent(threadId)}/metadata`,
       {
         method: "POST",

--- a/packages/liveblocks-core/src/comments/types/ThreadData.ts
+++ b/packages/liveblocks-core/src/comments/types/ThreadData.ts
@@ -4,14 +4,14 @@ import type { CommentData } from "./CommentData";
 /**
  * Represents a thread of comments.
  */
-export type ThreadData<ThreadMetadata extends BaseMetadata = never> = {
+export type ThreadData<TThreadMetadata extends BaseMetadata = never> = {
   type: "thread";
   id: string;
   roomId: string;
   createdAt: string;
   updatedAt?: string;
   comments: CommentData[];
-  metadata: [ThreadMetadata] extends [never]
+  metadata: [TThreadMetadata] extends [never]
     ? Record<string, never>
-    : ThreadMetadata;
+    : TThreadMetadata;
 };

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -84,12 +84,12 @@ export interface CommentProps extends ComponentPropsWithoutRef<"div"> {
   /**
    * The event handler called when the comment is edited.
    */
-  onEdit?: (comment: CommentData) => void;
+  onCommentEdit?: (comment: CommentData) => void;
 
   /**
    * The event handler called when the comment is deleted.
    */
-  onDelete?: (comment: CommentData) => void;
+  onCommentDelete?: (comment: CommentData) => void;
 
   /**
    * The event handler called when clicking on the author.
@@ -275,8 +275,8 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
       showReactions = true,
       onAuthorClick,
       onMentionClick,
-      onEdit,
-      onDelete,
+      onCommentEdit,
+      onCommentDelete,
       overrides,
       additionalActions,
       additionalActionsClassName,
@@ -321,7 +321,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
     const handleEditSubmit = useCallback(
       ({ body }: ComposerSubmitComment, event: FormEvent<HTMLFormElement>) => {
         // TODO: Add a way to preventDefault from within this callback, to override the default behavior (e.g. showing a confirmation dialog)
-        onEdit?.(comment);
+        onCommentEdit?.(comment);
 
         event.preventDefault();
         setEditing(false);
@@ -331,18 +331,18 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
           body,
         });
       },
-      [comment, editComment, onEdit]
+      [comment, editComment, onCommentEdit]
     );
 
     const handleDelete = useCallback(() => {
       // TODO: Add a way to preventDefault from within this callback, to override the default behavior (e.g. showing a confirmation dialog)
-      onDelete?.(comment);
+      onCommentDelete?.(comment);
 
       deleteComment({
         commentId: comment.id,
         threadId: comment.threadId,
       });
-    }, [comment, deleteComment, onDelete]);
+    }, [comment, deleteComment, onCommentDelete]);
 
     const handleAuthorClick = useCallback(
       (event: MouseEvent<HTMLElement>) => {

--- a/packages/liveblocks-react-comments/src/components/Composer.tsx
+++ b/packages/liveblocks-react-comments/src/components/Composer.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import type { BaseMetadata } from "@liveblocks/core";
 import { useRoomContextBundle } from "@liveblocks/react";
 import type {
   ComponentPropsWithoutRef,
   FocusEvent,
   FormEvent,
+  ForwardedRef,
   MouseEvent,
   ReactNode,
+  RefAttributes,
   SyntheticEvent,
 } from "react";
 import React, { forwardRef, useCallback, useState } from "react";
@@ -26,6 +29,7 @@ import type {
   ComposerSubmitComment,
 } from "../primitives/Composer/types";
 import { MENTION_CHARACTER } from "../slate/plugins/mentions";
+import type { ThreadMetadata } from "../types";
 import { classNames } from "../utils/class-names";
 import { useControllableState } from "../utils/use-controllable-state";
 import { Attribution } from "./internal/Attribution";
@@ -49,9 +53,14 @@ interface EmojiEditorActionProps extends EditorActionProps {
   onPickerOpenChange?: EmojiPickerProps["onOpenChange"];
 }
 
-type ComposerCreateThreadProps = {
+type ComposerCreateThreadProps<TThreadMetadata extends BaseMetadata> = {
   threadId?: never;
   commentId?: never;
+
+  /**
+   * The metadata of the thread to create.
+   */
+  metadata?: TThreadMetadata;
 };
 
 type ComposerCreateCommentProps = {
@@ -60,6 +69,7 @@ type ComposerCreateCommentProps = {
    */
   threadId: string;
   commentId?: never;
+  metadata?: never;
 };
 
 type ComposerEditCommentProps = {
@@ -72,14 +82,14 @@ type ComposerEditCommentProps = {
    * The ID of the comment to edit.
    */
   commentId: string;
+  metadata?: never;
 };
 
-export type ComposerProps = Omit<
-  ComponentPropsWithoutRef<"form">,
-  "defaultValue"
-> &
+export type ComposerProps<
+  TThreadMetadata extends BaseMetadata = ThreadMetadata,
+> = Omit<ComponentPropsWithoutRef<"form">, "defaultValue"> &
   (
-    | ComposerCreateThreadProps
+    | ComposerCreateThreadProps<TThreadMetadata>
     | ComposerCreateCommentProps
     | ComposerEditCommentProps
   ) & {
@@ -414,8 +424,17 @@ const ComposerWithContext = forwardRef<
  * @example
  * <Composer />
  */
-export const Composer = forwardRef<HTMLFormElement, ComposerProps>(
-  ({ threadId, commentId, onComposerSubmit, ...props }, forwardedRef) => {
+export const Composer = forwardRef(
+  <TThreadMetadata extends BaseMetadata = ThreadMetadata>(
+    {
+      threadId,
+      commentId,
+      metadata,
+      onComposerSubmit,
+      ...props
+    }: ComposerProps<TThreadMetadata>,
+    forwardedRef: ForwardedRef<HTMLFormElement>
+  ) => {
     const { useCreateThread, useCreateComment, useEditComment } =
       useRoomContextBundle();
     const createThread = useCreateThread();
@@ -444,7 +463,7 @@ export const Composer = forwardRef<HTMLFormElement, ComposerProps>(
         } else {
           createThread({
             body: comment.body,
-            metadata: {},
+            metadata: metadata ?? {},
           });
         }
       },
@@ -453,6 +472,7 @@ export const Composer = forwardRef<HTMLFormElement, ComposerProps>(
         createComment,
         createThread,
         editComment,
+        metadata,
         onComposerSubmit,
         threadId,
       ]
@@ -466,4 +486,6 @@ export const Composer = forwardRef<HTMLFormElement, ComposerProps>(
       </TooltipProvider>
     );
   }
-);
+) as <TThreadMetadata extends BaseMetadata = ThreadMetadata>(
+  props: ComposerProps<TThreadMetadata> & RefAttributes<HTMLFormElement>
+) => JSX.Element;

--- a/packages/liveblocks-react-comments/src/components/Thread.tsx
+++ b/packages/liveblocks-react-comments/src/components/Thread.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import type { ThreadData } from "@liveblocks/core";
+import type { BaseMetadata, CommentData, ThreadData } from "@liveblocks/core";
 import { useRoomContextBundle } from "@liveblocks/react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
-import type { ComponentPropsWithoutRef, SyntheticEvent } from "react";
+import type {
+  ComponentPropsWithoutRef,
+  ForwardedRef,
+  RefAttributes,
+  SyntheticEvent,
+} from "react";
 import React, { forwardRef, useCallback, useMemo } from "react";
 
 import { ResolveIcon } from "../icons/Resolve";
@@ -14,6 +19,7 @@ import {
   type ThreadOverrides,
   useOverrides,
 } from "../overrides";
+import type { ThreadMetadata } from "../types";
 import { classNames } from "../utils/class-names";
 import type { CommentProps } from "./Comment";
 import { Comment } from "./Comment";
@@ -21,11 +27,13 @@ import { Composer } from "./Composer";
 import { Button } from "./internal/Button";
 import { Tooltip, TooltipProvider } from "./internal/Tooltip";
 
-export interface ThreadProps extends ComponentPropsWithoutRef<"div"> {
+export interface ThreadProps<
+  TThreadMetadata extends BaseMetadata = ThreadMetadata,
+> extends ComponentPropsWithoutRef<"div"> {
   /**
    * The thread to display.
    */
-  thread: ThreadData<{ resolved?: boolean }>;
+  thread: ThreadData<TThreadMetadata>;
 
   /**
    * How to show or hide the composer to reply to the thread.
@@ -65,12 +73,17 @@ export interface ThreadProps extends ComponentPropsWithoutRef<"div"> {
   /**
    * The event handler called when a comment is edited.
    */
-  onCommentEdit?: CommentProps["onEdit"];
+  onCommentEdit?: CommentProps["onCommentEdit"];
 
   /**
    * The event handler called when a comment is deleted.
    */
-  onCommentDelete?: CommentProps["onDelete"];
+  onCommentDelete?: CommentProps["onCommentDelete"];
+
+  /**
+   * The event handler called when a comment is deleted.
+   */
+  onThreadDelete?: (thread: ThreadData<TThreadMetadata>) => void;
 
   /**
    * The event handler called when clicking on a comment's author.
@@ -100,7 +113,7 @@ export interface ThreadProps extends ComponentPropsWithoutRef<"div"> {
  * </>
  */
 export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
-  (
+  <TThreadMetadata extends BaseMetadata = ThreadMetadata>(
     {
       thread,
       indentCommentContent = true,
@@ -112,13 +125,14 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
       onResolvedChange,
       onCommentEdit,
       onCommentDelete,
+      onThreadDelete,
       onAuthorClick,
       onMentionClick,
       overrides,
       className,
       ...props
-    },
-    forwardedRef
+    }: ThreadProps<TThreadMetadata>,
+    forwardedRef: ForwardedRef<HTMLDivElement>
   ) => {
     const { useEditThreadMetadata } = useRoomContextBundle();
     const editThreadMetadata = useEditThreadMetadata();
@@ -142,6 +156,21 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
       [editThreadMetadata, onResolvedChange, thread.id]
     );
 
+    const handleCommentDelete = useCallback(
+      (comment: CommentData) => {
+        onCommentDelete?.(comment);
+
+        const filteredComments = thread.comments.filter(
+          (comment) => comment.body
+        );
+
+        if (filteredComments.length <= 1) {
+          onThreadDelete?.(thread);
+        }
+      },
+      [onCommentDelete, onThreadDelete, thread]
+    );
+
     return (
       <TooltipProvider>
         <div
@@ -150,7 +179,9 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
             showActions === "hover" && "lb-thread:show-actions-hover",
             className
           )}
-          data-resolved={thread.metadata.resolved ? "" : undefined}
+          data-resolved={
+            (thread.metadata as ThreadMetadata).resolved ? "" : undefined
+          }
           dir={$.dir}
           {...props}
           ref={forwardedRef}
@@ -168,8 +199,8 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
                   showDeleted={showDeletedComments}
                   showActions={showActions}
                   showReactions={showReactions}
-                  onEdit={onCommentEdit}
-                  onDelete={onCommentDelete}
+                  onCommentEdit={onCommentEdit}
+                  onCommentDelete={handleCommentDelete}
                   onAuthorClick={onAuthorClick}
                   onMentionClick={onMentionClick}
                   additionalActionsClassName={
@@ -179,13 +210,13 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
                     isFirstComment && showResolveAction ? (
                       <Tooltip
                         content={
-                          thread.metadata.resolved
+                          (thread.metadata as ThreadMetadata).resolved
                             ? $.THREAD_UNRESOLVE
                             : $.THREAD_RESOLVE
                         }
                       >
                         <TogglePrimitive.Root
-                          pressed={thread.metadata?.resolved}
+                          pressed={(thread.metadata as ThreadMetadata).resolved}
                           onPressedChange={handleResolvedChange}
                           asChild
                         >
@@ -193,12 +224,12 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
                             className="lb-comment-action"
                             onClick={stopPropagation}
                             aria-label={
-                              thread.metadata.resolved
+                              (thread.metadata as ThreadMetadata).resolved
                                 ? $.THREAD_UNRESOLVE
                                 : $.THREAD_RESOLVE
                             }
                           >
-                            {thread.metadata.resolved ? (
+                            {(thread.metadata as ThreadMetadata).resolved ? (
                               <ResolvedIcon className="lb-button-icon" />
                             ) : (
                               <ResolveIcon className="lb-button-icon" />
@@ -227,4 +258,6 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
       </TooltipProvider>
     );
   }
-);
+) as <TThreadMetadata extends BaseMetadata = ThreadMetadata>(
+  props: ThreadProps<TThreadMetadata> & RefAttributes<HTMLDivElement>
+) => JSX.Element;

--- a/packages/liveblocks-react-comments/src/components/Thread.tsx
+++ b/packages/liveblocks-react-comments/src/components/Thread.tsx
@@ -81,7 +81,8 @@ export interface ThreadProps<
   onCommentDelete?: CommentProps["onCommentDelete"];
 
   /**
-   * The event handler called when a comment is deleted.
+   * The event handler called when the thread is deleted.
+   * A thread is deleted when all its comments are deleted.
    */
   onThreadDelete?: (thread: ThreadData<TThreadMetadata>) => void;
 

--- a/packages/liveblocks-react-comments/src/components/Thread.tsx
+++ b/packages/liveblocks-react-comments/src/components/Thread.tsx
@@ -113,7 +113,7 @@ export interface ThreadProps<
  *   ))}
  * </>
  */
-export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
+export const Thread = forwardRef(
   <TThreadMetadata extends BaseMetadata = ThreadMetadata>(
     {
       thread,

--- a/packages/liveblocks-react-comments/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/types.ts
@@ -2,7 +2,6 @@ import type { CommentBody } from "@liveblocks/core";
 import type {
   ComponentPropsWithoutRef,
   ComponentType,
-  CSSProperties,
   FormEvent,
   ReactNode,
 } from "react";

--- a/packages/liveblocks-react-comments/src/types.ts
+++ b/packages/liveblocks-react-comments/src/types.ts
@@ -6,6 +6,10 @@ export type SlotProp = {
   asChild?: boolean;
 };
 
+export type ThreadMetadata = {
+  resolved?: boolean;
+};
+
 export type ComponentPropsWithSlot<TElement extends ElementType<any>> =
   ComponentPropsWithoutRef<TElement> & SlotProp;
 


### PR DESCRIPTION
This PR fixes https://github.com/liveblocks/liveblocks.io/issues/1598.

- **Breaking:** Rename `onEdit` and `onDelete` on `<Comment />` to `onCommentEdit` and `onCommentDelete` respectively
- Add `onThreadDelete` to `<Thread />`
- Add support for generic metadata type to `<Thread />`

Regarding the last point, components don't have access to the types given to `createRoomContext` since they don't come from it (they're just normal imports). To offer a better way than having to manually type `thread` within `onThreadDelete`, `<Thread />` now supports a generic type. It's opt-in so it can be used only when needed.

```tsx
import type { MyThreadMetadata } from "../liveblocks.config.ts"

<Thread<MyThreadMetadata> onThreadDelete={(thread) => console.log(thread)}  />
// thread: ThreadData<MyThreadMetadata>
```

It looks weird but if it's opt-in there's no harm? I could also add the same thing to `<Composer />` so that a `metadata` prop can be specified which would remove the need to resort to `onComposerSubmit` (while still being possible of course) just to set custom metadata when creating comments.