### PR TITLE
Comments: Support `null` when editing thread metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - `resolveUsers` and `resolveMentionSuggestions` now accept synchronous
   functions.
 - `resolveUsers` now also provides the current room ID.
+- `editThreadMetadata` now correctly allows `null` to be set on a property.
+  Doing so deletes existing metadata properties.
 
 ### `@liveblocks/react-comments`
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1187,6 +1187,12 @@ const thread = createThread({ body: {}, metadata: {} });
 
 Returns a function that edits a thread’s metadata.
 
+<Banner title="Deleting properties">
+
+To delete an existing metadata property, set its value to `null`.
+
+</Banner>
+
 ```tsx
 const editThreadMetadata = useEditThreadMetadata();
 const thread = editThreadMetadata({ threadId: "th_xxx", metadata: {} });

--- a/packages/liveblocks-core/src/comments/index.ts
+++ b/packages/liveblocks-core/src/comments/index.ts
@@ -16,6 +16,10 @@ function getAuthBearerHeaderFromAuthValue(authValue: AuthValue) {
   }
 }
 
+type PartialNullable<T> = {
+  [P in keyof T]?: T[P] | null | undefined;
+};
+
 export type CommentsApi<ThreadMetadata extends BaseMetadata> = {
   getThreads(): Promise<ThreadData<ThreadMetadata>[]>;
   createThread(options: {
@@ -25,7 +29,7 @@ export type CommentsApi<ThreadMetadata extends BaseMetadata> = {
     body: CommentBody;
   }): Promise<ThreadData<ThreadMetadata>>;
   editThreadMetadata(options: {
-    metadata: Partial<ThreadMetadata>;
+    metadata: PartialNullable<ThreadMetadata>;
     threadId: string;
   }): Promise<ThreadData<ThreadMetadata>>;
   createComment(options: {
@@ -160,7 +164,7 @@ export function createCommentsApi<ThreadMetadata extends BaseMetadata>(
     threadId,
   }: {
     roomId: string;
-    metadata: Partial<ThreadMetadata>;
+    metadata: PartialNullable<ThreadMetadata>;
     threadId: string;
   }) {
     return fetchJson<ThreadData<ThreadMetadata>>(

--- a/packages/liveblocks-react-comments/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/types.ts
@@ -2,7 +2,6 @@ import type { CommentBody } from "@liveblocks/core";
 import type {
   ComponentPropsWithoutRef,
   ComponentType,
-  CSSProperties,
   FormEvent,
   ReactNode,
 } from "react";

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -8,6 +8,7 @@ import type {
   Json,
   JsonObject,
   LsonObject,
+  Resolve,
   Room,
   ThreadData,
 } from "@liveblocks/core";
@@ -69,7 +70,7 @@ export type EditThreadMetadataOptions<TMetadata extends BaseMetadata> = [
   ? {
       threadId: string;
     }
-  : { threadId: string; metadata: PartialNullable<TMetadata> };
+  : { threadId: string; metadata: Resolve<PartialNullable<TMetadata>> };
 
 export type CreateCommentOptions = {
   threadId: string;

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -37,6 +37,10 @@ const THREAD_ID_PREFIX = "th";
 const COMMENT_ID_PREFIX = "cm";
 const DEDUPING_INTERVAL = 1000;
 
+type PartialNullable<T> = {
+  [P in keyof T]?: T[P] | null | undefined;
+};
+
 export type CommentsRoom<TThreadMetadata extends BaseMetadata> = {
   useThreads(): ThreadsState<TThreadMetadata>;
   useThreadsSuspense(): ThreadsStateSuccess<TThreadMetadata>;
@@ -65,7 +69,7 @@ export type EditThreadMetadataOptions<TMetadata extends BaseMetadata> = [
   ? {
       threadId: string;
     }
-  : { threadId: string; metadata: Partial<TMetadata> };
+  : { threadId: string; metadata: PartialNullable<TMetadata> };
 
 export type CreateCommentOptions = {
   threadId: string;
@@ -321,7 +325,7 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
     options: EditThreadMetadataOptions<TThreadMetadata>
   ) {
     const threadId = options.threadId;
-    const metadata: Partial<TThreadMetadata> =
+    const metadata: PartialNullable<TThreadMetadata> =
       "metadata" in options ? options.metadata : {};
     const threads = getThreads();
 

--- a/packages/liveblocks-react/src/comments/errors.ts
+++ b/packages/liveblocks-react/src/comments/errors.ts
@@ -1,5 +1,9 @@
 import type { BaseMetadata, CommentBody } from "@liveblocks/core";
 
+type PartialNullable<T> = {
+  [P in keyof T]?: T[P] | null | undefined;
+};
+
 export class CreateThreadError<TMetadata extends BaseMetadata> extends Error {
   constructor(
     public cause: Error,
@@ -24,7 +28,7 @@ export class EditThreadMetadataError<
     public context: {
       roomId: string;
       threadId: string;
-      metadata: Partial<TMetadata>;
+      metadata: PartialNullable<TMetadata>;
     }
   ) {
     super("Edit thread metadata failed.");

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -497,6 +497,7 @@ type RoomContextBundleShared<
    * @beta
    *
    * Returns a function that edits a thread's metadata.
+   * To delete an existing metadata property, set its value to `null`.
    *
    * @example
    * const editThreadMetadata = useEditThreadMetadata();


### PR DESCRIPTION
This PR fixes the types around `editThreadMetadata` to allow `null`, which can be set to delete keys.