### PR TITLE
Comments: Fix `userIds` type in `resolveUsers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.7
+
+### `@liveblocks/react`
+
+- Fix `userIds` type in `ResolveUsersArgs`.
+
 # v1.4.6
 
 ### `@liveblocks/react`
@@ -11,8 +17,8 @@
   user info of a single user ID, this function will now expect a list of users'
   info matching the provided list of user IDs.
 - **Breaking (beta):** The `ResolveUserOptions` and
-  `ResolveMentionSuggestionsOptions` types were renamed to `ResolveUserArgs` and
-  `ResolveMentionSuggestionsArgs` respectively.
+  `ResolveMentionSuggestionsOptions` types were renamed to `ResolveUsersArgs`
+  and `ResolveMentionSuggestionsArgs` respectively.
 - `resolveUsers` and `resolveMentionSuggestions` now accept synchronous
   functions.
 - `resolveUsers` now also provides the current room ID.

--- a/examples/nextjs-comments-primitives/liveblocks.config.ts
+++ b/examples/nextjs-comments-primitives/liveblocks.config.ts
@@ -18,7 +18,9 @@ const {
 } = createRoomContext(client, {
   // Get users' info from their ID
   resolveUsers: async ({ userIds }) => {
-    const searchParams = new URLSearchParams({ userIds });
+    const searchParams = new URLSearchParams(
+      userIds.map((userId) => ["userIds", userId])
+    );
 
     try {
       const response = await fetch(`/api/users?${searchParams}`);

--- a/examples/nextjs-comments/liveblocks.config.ts
+++ b/examples/nextjs-comments/liveblocks.config.ts
@@ -12,7 +12,9 @@ const {
 } = createRoomContext(client, {
   // Get users' info from their ID
   resolveUsers: async ({ userIds }) => {
-    const searchParams = new URLSearchParams({ userIds });
+    const searchParams = new URLSearchParams(
+      userIds.map((userId) => ["userIds", userId])
+    );
 
     try {
       const response = await fetch(`/api/users?${searchParams}`);

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -42,9 +42,9 @@ export type ResolveUsersArgs = {
   roomId: string;
 
   /**
-   * The ID of the users to resolve.
+   * The IDs of the users to resolve.
    */
-  userIds: string;
+  userIds: string[];
 };
 
 export type ResolveMentionSuggestionsArgs = {


### PR DESCRIPTION
This PR fixes an important issue where the `userIds` property within `ResolveUsersArgs` was incorrectly typed as `string` instead of `string[]`.

We use `URLSearchParams` in the examples and because that worked, we missed this obvious mistake earlier.