### PR TITLE
Fix broken E2E test config

### DIFF
--- a/e2e/next-sandbox/pages/comments/index.tsx
+++ b/e2e/next-sandbox/pages/comments/index.tsx
@@ -1,4 +1,5 @@
 import { createRoomContext } from "@liveblocks/react";
+import * as React from "react";
 import { useRef } from "react";
 
 import { getRoomFromUrl, Row } from "../../utils";

--- a/e2e/next-sandbox/pages/comments/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/comments/with-suspense.tsx
@@ -1,4 +1,5 @@
 import { ClientSideSuspense, createRoomContext } from "@liveblocks/react";
+import * as React from "react";
 import { useRef } from "react";
 
 import { getRoomFromUrl, Row } from "../../utils";


### PR DESCRIPTION
This fixes an issue where the Next.js production build fails for the E2E test app, because it requires `React` to be imported in all JSX files. Maybe this is a misconfigured linter, though — my bad. I don't think it's actually needed anymore.
