### PR TITLE
Add new hook: `useOthersListener()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ leave();
   the same room ID.
 - Renamed `RoomProvider` prop: `shouldInitiallyConnect` → `autoConnect`. Its
   meaning or working did not change.
+- New hook:
+  - `useOthersListener({ type, user, others })`, see
+    [docs](https://liveblocks.io/docs/api-reference/liveblocks-react#useOthersListener)
 
 ### `@liveblocks/redux`
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -281,8 +281,9 @@ are:
 
 - `enter` – A user has entered the room.
 - `leave` – A user has left the room.
-- `reset` – The others list has been emptied. This is the first event that occurs
-  when the room is entered. It also occurs when you’ve lost connection to the room.
+- `reset` – The others list has been emptied. This is the first event that
+  occurs when the room is entered. It also occurs when you’ve lost connection to
+  the room.
 - `update` – A user’s presence data has been updated.
 
 ```ts

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -276,7 +276,7 @@ The possible value are: `initial`, `connecting`, `connected`, `reconnecting`, or
 
 ### useOthersListener
 
-Calls the given callback when an "others" event happens. Possible event types
+Calls the given callback when an “others” event occurs. Possible event types
 are:
 
 - `enter` – A new User entered the room. The others list grew by one.

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -302,7 +302,7 @@ function App() {
         break;
 
       case "reset":
-        // Others list was emptied
+        // Others list has been emptied
         break;
     }
   });

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -298,7 +298,7 @@ function App() {
         break;
 
       case "update":
-        // Presence for `user` was updated
+        // Presence for `user` has updated
         break;
 
       case "reset":

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -287,22 +287,23 @@ are:
 - `update` – Presence data of one of the Users was updated.
 
 ```ts
-import { toast } from "my-preferred-toast-library";
-
 function App() {
   useOthersListener(({ type, user, others }) => {
     switch (type) {
       case "enter":
-        toast.info(`${user.info.name} has joined the room`);
+        // `user` has entered the room
         break;
 
       case "leave":
-        toast.info(`${user.info.name} has left the room`);
+        // `user` has left the room
+        break;
+
+      case "update":
+        // Presence for `user` was updated
         break;
 
       case "reset":
-      case "update":
-        /* Do nothing */
+        // Others list was emptied
         break;
     }
   });

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -274,6 +274,41 @@ const status = useStatus();
 The possible value are: `initial`, `connecting`, `connected`, `reconnecting`, or
 `disconnected`.
 
+### useOthersListener
+
+Calls the given callback when an "others" event happens. Possible event types
+are:
+
+- `enter` – A new User entered the room. The others list grew by one.
+- `leave` – A User left the room. The others list shrunk by one.
+- `reset` – The others list is emptied. Typically the first event that happens
+  when the room is just entered, or when there is a connection loss on your own
+  end.
+- `update` – Presence data of one of the Users was updated.
+
+```ts
+import { toast } from "my-preferred-toast-library";
+
+function App() {
+  useOthersListener(({ type, user, others }) => {
+    switch (type) {
+      case "enter":
+        toast.info(`${user.info.name} has joined the room`);
+        break;
+
+      case "leave":
+        toast.info(`${user.info.name} has left the room`);
+        break;
+
+      case "reset":
+      case "update":
+        /* Do nothing */
+        break;
+    }
+  });
+}
+```
+
 ### useLostConnectionListener
 
 Calls the given callback in the exceptional situation that a connection is lost

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -279,12 +279,11 @@ The possible value are: `initial`, `connecting`, `connected`, `reconnecting`, or
 Calls the given callback when an “others” event occurs. Possible event types
 are:
 
-- `enter` – A new User entered the room. The others list grew by one.
-- `leave` – A User left the room. The others list shrunk by one.
-- `reset` – The others list is emptied. Typically the first event that happens
-  when the room is just entered, or when there is a connection loss on your own
-  end.
-- `update` – Presence data of one of the Users was updated.
+- `enter` – A user has entered the room.
+- `leave` – A user has left the room.
+- `reset` – The others list has been emptied. This is the first event that occurs
+  when the room is entered. It also occurs when you’ve lost connection to the room.
+- `update` – A user’s presence data has been updated.
 
 ```ts
 function App() {

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint src/",
     "lint:package": "publint --strict && attw --pack",
     "test": "jest --silent --verbose --color=always --passWithNoTests",
+    "test:types": "tsd",
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"
   },
   "dependencies": {

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -25,6 +25,7 @@ export type {
   Lson,
   LsonObject,
   Others,
+  OthersEvent,
   Room,
   Status,
   StorageStatus,

--- a/packages/liveblocks-client/test-d/room-api.test-d.ts
+++ b/packages/liveblocks-client/test-d/room-api.test-d.ts
@@ -1,0 +1,72 @@
+import { createClient } from "@liveblocks/client";
+import type {
+  BaseUserMeta,
+  Json,
+  JsonObject,
+  LsonObject,
+  User,
+} from "@liveblocks/client";
+import { expectType } from "tsd";
+
+type Presence = JsonObject;
+type Storage = LsonObject;
+type UserMeta = BaseUserMeta;
+type RoomEvent = Json;
+
+type P = Presence;
+type S = Storage;
+type U = UserMeta;
+type E = RoomEvent;
+
+const client = createClient({ publicApiKey: "pk_whatever" });
+
+// Test some Room types
+const { room, leave } = client.enterRoom<P, S, U, E>("my-room", {
+  initialPresence: {},
+});
+expectType<string>(room.id);
+expectType<void>(leave());
+
+// "Others" events through classic subscribe function
+room.subscribe("others", (others, event) => {
+  expectType<readonly User<P, U>[]>(others);
+  switch (event.type) {
+    case "enter":
+      expectType<User<P, U>>(event.user);
+      return;
+    case "leave":
+      expectType<User<P, U>>(event.user);
+      return;
+    case "update":
+      expectType<User<P, U>>(event.user);
+      expectType<Partial<P>>(event.updates);
+      return;
+    case "reset":
+      // No extra fields on reset
+      return;
+    default:
+      expectType<never>(event);
+  }
+});
+
+// "Others" events through event hub API
+room.events.others.subscribe(({ others, event }) => {
+  expectType<readonly User<P, U>[]>(others);
+  switch (event.type) {
+    case "enter":
+      expectType<User<P, U>>(event.user);
+      return;
+    case "leave":
+      expectType<User<P, U>>(event.user);
+      return;
+    case "update":
+      expectType<User<P, U>>(event.user);
+      expectType<Partial<P>>(event.updates);
+      return;
+    case "reset":
+      // No extra fields on reset
+      return;
+    default:
+      expectType<never>(event);
+  }
+});

--- a/packages/liveblocks-client/test-d/room-api.test-d.ts
+++ b/packages/liveblocks-client/test-d/room-api.test-d.ts
@@ -50,8 +50,8 @@ room.subscribe("others", (others, event) => {
 });
 
 // "Others" events through event hub API
-room.events.others.subscribe(({ others, event }) => {
-  expectType<readonly User<P, U>[]>(others);
+room.events.others.subscribe((event) => {
+  expectType<readonly User<P, U>[]>(event.others);
   switch (event.type) {
     case "enter":
       expectType<User<P, U>>(event.user);

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -153,7 +153,7 @@ export type {
 } from "./types/IWebSocket";
 export { WebsocketCloseCodes } from "./types/IWebSocket";
 export type { NodeMap, ParentToChildNodeMap } from "./types/NodeMap";
-export type { Others } from "./types/Others";
+export type { Others, OthersEvent } from "./types/Others";
 export type {
   PlainLson,
   PlainLsonFields,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -60,7 +60,7 @@ import type {
   IWebSocketMessageEvent,
 } from "./types/IWebSocket";
 import type { NodeMap } from "./types/NodeMap";
-import type { LegacyOthersEvent } from "./types/Others";
+import type { LegacyOthersEvent, NewStyleOthersEvent } from "./types/Others";
 import type { User } from "./types/User";
 import { PKG_VERSION } from "./version";
 
@@ -591,10 +591,7 @@ export type Room<
     readonly customEvent: Observable<RoomEventMessage<TPresence, TUserMeta, TRoomEvent>>; // prettier-ignore
     readonly self: Observable<User<TPresence, TUserMeta>>;
     readonly myPresence: Observable<TPresence>;
-    // XXX Udpate
-    readonly others: Observable<{ others: readonly User<TPresence, TUserMeta>[]; event: 
-      // XXX Make modern!
-      LegacyOthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
+    readonly others: Observable<NewStyleOthersEvent<TPresence, TUserMeta>>;
     readonly error: Observable<Error>;
     readonly storage: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -60,15 +60,33 @@ import type {
   IWebSocketMessageEvent,
 } from "./types/IWebSocket";
 import type { NodeMap } from "./types/NodeMap";
-import type {
-  InternalOthersEvent,
-  LegacyOthersEvent,
-  NewStyleOthersEvent,
-} from "./types/Others";
+import type { InternalOthersEvent, NewStyleOthersEvent } from "./types/Others";
 import type { User } from "./types/User";
 import { PKG_VERSION } from "./version";
 
 type TimeoutID = ReturnType<typeof setTimeout>;
+
+//
+// NOTE:
+// This type looks an awful lot like InternalOthersEvent, but don't change this
+// type definition or DRY this up!
+// The type LegacyOthersEvent is used in the signature of some public APIs, and
+// as such should remain backward compatible.
+//
+// XXX Probably better to codify this knowledge as a tsd test instead!
+//
+type LegacyOthersEvent<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+> =
+  | { type: "leave"; user: User<TPresence, TUserMeta> }
+  | { type: "enter"; user: User<TPresence, TUserMeta> }
+  | {
+      type: "update";
+      user: User<TPresence, TUserMeta>;
+      updates: Partial<TPresence>;
+    }
+  | { type: "reset" };
 
 type LegacyOthersEventCallback<
   TPresence extends JsonObject,
@@ -119,7 +137,7 @@ type RoomEventCallbackMap<
   event: Callback<RoomEventMessage<TPresence, TUserMeta, TRoomEvent>>;
   "my-presence": Callback<TPresence>;
   //
-  // NOTE: LegacyOthersEventCallback  is the only one not taking a Callback<T>
+  // NOTE: LegacyOthersEventCallback is the only one not taking a Callback<T>
   // shape, since this API historically has taken _two_ callback arguments
   // instead of just one.
   others: LegacyOthersEventCallback<TPresence, TUserMeta>;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -73,8 +73,6 @@ type TimeoutID = ReturnType<typeof setTimeout>;
 // The type LegacyOthersEvent is used in the signature of some public APIs, and
 // as such should remain backward compatible.
 //
-// XXX Probably better to codify this knowledge as a tsd test instead!
-//
 type LegacyOthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -60,7 +60,7 @@ import type {
   IWebSocketMessageEvent,
 } from "./types/IWebSocket";
 import type { NodeMap } from "./types/NodeMap";
-import type { InternalOthersEvent, NewStyleOthersEvent } from "./types/Others";
+import type { InternalOthersEvent, OthersEvent } from "./types/Others";
 import type { User } from "./types/User";
 import { PKG_VERSION } from "./version";
 
@@ -613,7 +613,7 @@ export type Room<
     readonly customEvent: Observable<RoomEventMessage<TPresence, TUserMeta, TRoomEvent>>; // prettier-ignore
     readonly self: Observable<User<TPresence, TUserMeta>>;
     readonly myPresence: Observable<TPresence>;
-    readonly others: Observable<NewStyleOthersEvent<TPresence, TUserMeta>>;
+    readonly others: Observable<OthersEvent<TPresence, TUserMeta>>;
     readonly error: Observable<Error>;
     readonly storage: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
@@ -1220,7 +1220,7 @@ export function createRoom<
       makeEventSource<RoomEventMessage<TPresence, TUserMeta, TRoomEvent>>(),
     self: makeEventSource<User<TPresence, TUserMeta>>(),
     myPresence: makeEventSource<TPresence>(),
-    others: makeEventSource<NewStyleOthersEvent<TPresence, TUserMeta>>(),
+    others: makeEventSource<OthersEvent<TPresence, TUserMeta>>(),
     error: makeEventSource<Error>(),
     storage: makeEventSource<StorageUpdate[]>(),
     history: makeEventSource<HistoryEvent>(),

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1383,7 +1383,7 @@ export function createRoom<
     }
   }
 
-  type NotifyBatch = {
+  type NotifyUpdates = {
     storageUpdates?: Map<string, StorageUpdate>;
     presence?: boolean;
     // XXX Likely make modern? If 100% private.
@@ -1391,17 +1391,16 @@ export function createRoom<
   };
 
   function notify(
-    updates: NotifyBatch,
+    updates: NotifyUpdates,
     batchedUpdatesWrapper: (cb: () => void) => void
   ) {
-    const storageUpdates: Map<string, StorageUpdate> =
-      updates.storageUpdates ?? new Map();
-    const othersEvents = updates.others ?? [];
+    const storageUpdates = updates.storageUpdates;
+    const othersUpdates = updates.others;
 
     batchedUpdatesWrapper(() => {
-      if (othersEvents.length > 0) {
+      if (othersUpdates !== undefined && othersUpdates.length > 0) {
         const others = context.others.current;
-        for (const event of othersEvents) {
+        for (const event of othersUpdates) {
           eventHub.others.notify({ others, event });
         }
       }
@@ -1411,7 +1410,7 @@ export function createRoom<
         eventHub.myPresence.notify(context.myPresence.current);
       }
 
-      if (storageUpdates.size > 0) {
+      if (storageUpdates !== undefined && storageUpdates.size > 0) {
         const updates = Array.from(storageUpdates.values());
         eventHub.storage.notify(updates);
       }
@@ -1824,7 +1823,6 @@ export function createRoom<
 
     const updates = {
       storageUpdates: new Map<string, StorageUpdate>(),
-      // XXX Rename to othersUpdates?
       others: [] as LegacyOthersEvent<TPresence, TUserMeta>[],
     };
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -60,7 +60,7 @@ import type {
   IWebSocketMessageEvent,
 } from "./types/IWebSocket";
 import type { NodeMap } from "./types/NodeMap";
-import type { OthersEvent } from "./types/Others";
+import type { LegacyOthersEvent } from "./types/Others";
 import type { User } from "./types/User";
 import { PKG_VERSION } from "./version";
 
@@ -112,7 +112,7 @@ type RoomEventCallbackMap<
   // just one.
   others: (
     others: readonly User<TPresence, TUserMeta>[],
-    event: OthersEvent<TPresence, TUserMeta>
+    event: LegacyOthersEvent<TPresence, TUserMeta>
   ) => void;
   error: Callback<Error>;
   history: Callback<HistoryEvent>;
@@ -280,7 +280,7 @@ type SubscribeFn<
     type: "others",
     listener: (
       others: readonly User<TPresence, TUserMeta>[],
-      event: OthersEvent<TPresence, TUserMeta>
+      event: LegacyOthersEvent<TPresence, TUserMeta>
     ) => void
   ): () => void;
 
@@ -590,7 +590,7 @@ export type Room<
     readonly self: Observable<User<TPresence, TUserMeta>>;
     readonly myPresence: Observable<TPresence>;
     // XXX Udpate
-    readonly others: Observable<{ others: readonly User<TPresence, TUserMeta>[]; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
+    readonly others: Observable<{ others: readonly User<TPresence, TUserMeta>[]; event: LegacyOthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
     readonly storage: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
@@ -1199,7 +1199,7 @@ export function createRoom<
     myPresence: makeEventSource<TPresence>(),
     others: makeEventSource<{
       others: readonly User<TPresence, TUserMeta>[];
-      event: OthersEvent<TPresence, TUserMeta>;
+      event: LegacyOthersEvent<TPresence, TUserMeta>;
     }>(),
     error: makeEventSource<Error>(),
     storage: makeEventSource<StorageUpdate[]>(),
@@ -1386,7 +1386,7 @@ export function createRoom<
     }: {
       storageUpdates?: Map<string, StorageUpdate>;
       presence?: boolean;
-      others?: OthersEvent<TPresence, TUserMeta>[];
+      others?: LegacyOthersEvent<TPresence, TUserMeta>[];
     },
     batchedUpdatesWrapper: (cb: () => void) => void
   ) {
@@ -1636,7 +1636,7 @@ export function createRoom<
 
   function onUpdatePresenceMessage(
     message: UpdatePresenceServerMsg<TPresence>
-  ): OthersEvent<TPresence, TUserMeta> | undefined {
+  ): LegacyOthersEvent<TPresence, TUserMeta> | undefined {
     if (message.targetActor !== undefined) {
       // The incoming message is a full presence update. We are obliged to
       // handle it if `targetActor` matches our own connection ID, but we can
@@ -1670,7 +1670,7 @@ export function createRoom<
 
   function onUserLeftMessage(
     message: UserLeftServerMsg
-  ): OthersEvent<TPresence, TUserMeta> | null {
+  ): LegacyOthersEvent<TPresence, TUserMeta> | null {
     const user = context.others.getUser(message.actor);
     if (user) {
       context.others.removeConnection(message.actor);
@@ -1682,7 +1682,7 @@ export function createRoom<
   function onRoomStateMessage(
     message: RoomStateServerMsg<TUserMeta>,
     batchedUpdatesWrapper: (cb: () => void) => void
-  ): OthersEvent<TPresence, TUserMeta> {
+  ): LegacyOthersEvent<TPresence, TUserMeta> {
     // The server will inform the client about its assigned actor ID and scopes
     context.dynamicSessionInfo.set({
       actor: message.actor,
@@ -1728,7 +1728,7 @@ export function createRoom<
 
   function onUserJoinedMessage(
     message: UserJoinServerMsg<TUserMeta>
-  ): OthersEvent<TPresence, TUserMeta> | undefined {
+  ): LegacyOthersEvent<TPresence, TUserMeta> | undefined {
     context.others.setConnection(
       message.actor,
       message.id,
@@ -1816,7 +1816,7 @@ export function createRoom<
 
     const updates = {
       storageUpdates: new Map<string, StorageUpdate>(),
-      others: [] as OthersEvent<TPresence, TUserMeta>[],
+      others: [] as LegacyOthersEvent<TPresence, TUserMeta>[],
     };
 
     batchUpdates(() => {
@@ -2465,7 +2465,7 @@ function makeClassicSubscribeFn<
           // exposed on the outside takes _two_ callback arguments!
           const cb = callback as (
             others: readonly User<TPresence, TUserMeta>[],
-            event: OthersEvent<TPresence, TUserMeta>
+            event: LegacyOthersEvent<TPresence, TUserMeta>
           ) => void;
           return events.others.subscribe(
             // XXX Udpate unpacking here

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1415,7 +1415,7 @@ export function createRoom<
       if (othersUpdates !== undefined && othersUpdates.length > 0) {
         const others = context.others.current;
         for (const event of othersUpdates) {
-          eventHub.others.notify({ others, event });
+          eventHub.others.notify({ ...event, others });
         }
       }
 
@@ -2488,10 +2488,10 @@ function makeClassicSubscribeFn<
             TPresence,
             TUserMeta
           >;
-          return events.others.subscribe(
-            // XXX Udpate unpacking here
-            ({ others, event }) => cb(others, event)
-          );
+          return events.others.subscribe((event) => {
+            const { others, ...internalEvent } = event;
+            return cb(others, internalEvent);
+          });
         }
 
         case "error":

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -592,7 +592,9 @@ export type Room<
     readonly self: Observable<User<TPresence, TUserMeta>>;
     readonly myPresence: Observable<TPresence>;
     // XXX Udpate
-    readonly others: Observable<{ others: readonly User<TPresence, TUserMeta>[]; event: LegacyOthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
+    readonly others: Observable<{ others: readonly User<TPresence, TUserMeta>[]; event: 
+      // XXX Make modern!
+      LegacyOthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
     readonly storage: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
@@ -1201,6 +1203,7 @@ export function createRoom<
     myPresence: makeEventSource<TPresence>(),
     others: makeEventSource<{
       others: readonly User<TPresence, TUserMeta>[];
+      // XXX Make modern!
       event: LegacyOthersEvent<TPresence, TUserMeta>;
     }>(),
     error: makeEventSource<Error>(),
@@ -1381,6 +1384,7 @@ export function createRoom<
   }
 
   function notify(
+    // XXX Don't do unpacking inline! Make more readable
     {
       storageUpdates = new Map<string, StorageUpdate>(),
       presence = false,
@@ -1388,6 +1392,7 @@ export function createRoom<
     }: {
       storageUpdates?: Map<string, StorageUpdate>;
       presence?: boolean;
+      // XXX Likely make modern? If 100% private.
       others?: LegacyOthersEvent<TPresence, TUserMeta>[];
     },
     batchedUpdatesWrapper: (cb: () => void) => void
@@ -1818,6 +1823,7 @@ export function createRoom<
 
     const updates = {
       storageUpdates: new Map<string, StorageUpdate>(),
+      // XXX Rename to othersUpdates?
       others: [] as LegacyOthersEvent<TPresence, TUserMeta>[],
     };
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -589,6 +589,7 @@ export type Room<
     readonly customEvent: Observable<RoomEventMessage<TPresence, TUserMeta, TRoomEvent>>; // prettier-ignore
     readonly self: Observable<User<TPresence, TUserMeta>>;
     readonly myPresence: Observable<TPresence>;
+    // XXX Udpate
     readonly others: Observable<{ others: readonly User<TPresence, TUserMeta>[]; event: OthersEvent<TPresence, TUserMeta>; }>; // prettier-ignore
     readonly error: Observable<Error>;
     readonly storage: Observable<StorageUpdate[]>;
@@ -2466,8 +2467,9 @@ function makeClassicSubscribeFn<
             others: readonly User<TPresence, TUserMeta>[],
             event: OthersEvent<TPresence, TUserMeta>
           ) => void;
-          return events.others.subscribe(({ others, event }) =>
-            cb(others, event)
+          return events.others.subscribe(
+            // XXX Udpate unpacking here
+            ({ others, event }) => cb(others, event)
           );
         }
 

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -30,3 +30,28 @@ export type LegacyOthersEvent<
   | {
       type: "reset";
     };
+
+export type ModernOthersEvent<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+> =
+  | {
+      type: "leave";
+      user: User<TPresence, TUserMeta>;
+      others: readonly User<TPresence, TUserMeta>[];
+    }
+  | {
+      type: "enter";
+      user: User<TPresence, TUserMeta>;
+      others: readonly User<TPresence, TUserMeta>[];
+    }
+  | {
+      type: "update";
+      user: User<TPresence, TUserMeta>;
+      updates: Partial<TPresence>;
+      others: readonly User<TPresence, TUserMeta>[];
+    }
+  | {
+      type: "reset";
+      others: readonly User<TPresence, TUserMeta>[];
+    };

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -10,6 +10,7 @@ export type Others<
   TUserMeta extends BaseUserMeta,
 > = readonly User<TPresence, TUserMeta>[];
 
+// XXX Rename to LegacyOthersEvent
 export type OthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -28,13 +28,8 @@ export type InternalOthersEvent<
 export type NewStyleOthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
-> = {
-  event: InternalOthersEvent<TPresence, TUserMeta>;
-  others: readonly User<TPresence, TUserMeta>[];
-};
-// XXX Eventually change to this type definition instead, and fix all call sites!
-// Resolve<
-//   InternalOthersEvent<TPresence, TUserMeta> & {
-//     others: readonly User<TPresence, TUserMeta>[];
-//   }
-// >;
+> = Resolve<
+  InternalOthersEvent<TPresence, TUserMeta> & {
+    others: readonly User<TPresence, TUserMeta>[];
+  }
+>;

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -24,8 +24,7 @@ export type InternalOthersEvent<
     }
   | { type: "reset" };
 
-// XXX Rename this to OthersEvent eventually again
-export type NewStyleOthersEvent<
+export type OthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
 > = Resolve<

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../lib/Json";
+import type { Resolve } from "../lib/Resolve";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import type { User } from "./User";
 
@@ -10,48 +11,47 @@ export type Others<
   TUserMeta extends BaseUserMeta,
 > = readonly User<TPresence, TUserMeta>[];
 
+export type InternalOthersEvent<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+> =
+  | { type: "leave"; user: User<TPresence, TUserMeta> }
+  | { type: "enter"; user: User<TPresence, TUserMeta> }
+  | {
+      type: "update";
+      user: User<TPresence, TUserMeta>;
+      updates: Partial<TPresence>;
+    }
+  | { type: "reset" };
+
+// XXX Rename this to OthersEvent eventually again
+export type ModernOthersEvent<
+  TPresence extends JsonObject,
+  TUserMeta extends BaseUserMeta,
+> = Resolve<
+  InternalOthersEvent<TPresence, TUserMeta> & {
+    others: readonly User<TPresence, TUserMeta>[];
+  }
+>;
+
+//
+// NOTE:
+// This type looks an awful lot like InternalOthersEvent, but don't change this
+// type definition or DRY this up!
+// The type LegacyOthersEvent is used in the signature of some public APIs, and
+// as such should remain backward compatible.
+//
+// XXX Probably better to codify this knowledge as a tsd test instead!
+//
 export type LegacyOthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
 > =
-  | {
-      type: "leave";
-      user: User<TPresence, TUserMeta>;
-    }
-  | {
-      type: "enter";
-      user: User<TPresence, TUserMeta>;
-    }
+  | { type: "leave"; user: User<TPresence, TUserMeta> }
+  | { type: "enter"; user: User<TPresence, TUserMeta> }
   | {
       type: "update";
       user: User<TPresence, TUserMeta>;
       updates: Partial<TPresence>;
     }
-  | {
-      type: "reset";
-    };
-
-export type ModernOthersEvent<
-  TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta,
-> =
-  | {
-      type: "leave";
-      user: User<TPresence, TUserMeta>;
-      others: readonly User<TPresence, TUserMeta>[];
-    }
-  | {
-      type: "enter";
-      user: User<TPresence, TUserMeta>;
-      others: readonly User<TPresence, TUserMeta>[];
-    }
-  | {
-      type: "update";
-      user: User<TPresence, TUserMeta>;
-      updates: Partial<TPresence>;
-      others: readonly User<TPresence, TUserMeta>[];
-    }
-  | {
-      type: "reset";
-      others: readonly User<TPresence, TUserMeta>[];
-    };
+  | { type: "reset" };

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -28,11 +28,16 @@ export type InternalOthersEvent<
 export type NewStyleOthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
-> = Resolve<
-  InternalOthersEvent<TPresence, TUserMeta> & {
-    others: readonly User<TPresence, TUserMeta>[];
-  }
->;
+> = {
+  event: InternalOthersEvent<TPresence, TUserMeta>;
+  others: readonly User<TPresence, TUserMeta>[];
+};
+// XXX Eventually change to this type definition instead, and fix all call sites!
+// Resolve<
+//   InternalOthersEvent<TPresence, TUserMeta> & {
+//     others: readonly User<TPresence, TUserMeta>[];
+//   }
+// >;
 
 //
 // NOTE:

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -10,8 +10,7 @@ export type Others<
   TUserMeta extends BaseUserMeta,
 > = readonly User<TPresence, TUserMeta>[];
 
-// XXX Rename to LegacyOthersEvent
-export type OthersEvent<
+export type LegacyOthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
 > =

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -38,25 +38,3 @@ export type NewStyleOthersEvent<
 //     others: readonly User<TPresence, TUserMeta>[];
 //   }
 // >;
-
-//
-// NOTE:
-// This type looks an awful lot like InternalOthersEvent, but don't change this
-// type definition or DRY this up!
-// The type LegacyOthersEvent is used in the signature of some public APIs, and
-// as such should remain backward compatible.
-//
-// XXX Probably better to codify this knowledge as a tsd test instead!
-//
-export type LegacyOthersEvent<
-  TPresence extends JsonObject,
-  TUserMeta extends BaseUserMeta,
-> =
-  | { type: "leave"; user: User<TPresence, TUserMeta> }
-  | { type: "enter"; user: User<TPresence, TUserMeta> }
-  | {
-      type: "update";
-      user: User<TPresence, TUserMeta>;
-      updates: Partial<TPresence>;
-    }
-  | { type: "reset" };

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -25,7 +25,7 @@ export type InternalOthersEvent<
   | { type: "reset" };
 
 // XXX Rename this to OthersEvent eventually again
-export type ModernOthersEvent<
+export type NewStyleOthersEvent<
   TPresence extends JsonObject,
   TUserMeta extends BaseUserMeta,
 > = Resolve<

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint src/",
     "lint:package": "publint --strict && attw --pack",
     "test": "jest --silent --verbose --color=always",
+    "test:types": "tsd",
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -8,6 +8,7 @@ import type {
   LiveObject,
   LostConnectionEvent,
   LsonObject,
+  OthersEvent,
   Room,
   Status,
   User,
@@ -547,6 +548,19 @@ export function createRoomContext<
         room.broadcastEvent(event, options);
       },
       [room]
+    );
+  }
+
+  function useOthersListener(
+    callback: (event: OthersEvent<TPresence, TUserMeta>) => void
+  ) {
+    const room = useRoom();
+    const savedCallback = useLatest(callback);
+
+    React.useEffect(
+      () =>
+        room.events.others.subscribe((event) => savedCallback.current(event)),
+      [room, savedCallback]
     );
   }
 
@@ -1130,6 +1144,7 @@ export function createRoomContext<
 
     useBatch,
     useBroadcastEvent,
+    useOthersListener,
     useLostConnectionListener,
     useErrorListener,
     useEventListener,
@@ -1178,6 +1193,7 @@ export function createRoomContext<
 
       useBatch,
       useBroadcastEvent,
+      useOthersListener,
       useLostConnectionListener,
       useErrorListener,
       useEventListener,

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -558,7 +558,7 @@ export function createRoomContext<
 
     React.useEffect(
       () =>
-        room.events.lostConnection.subscribe((event: LostConnectionEvent) =>
+        room.events.lostConnection.subscribe((event) =>
           savedCallback.current(event)
         ),
       [room, savedCallback]
@@ -570,7 +570,7 @@ export function createRoomContext<
     const savedCallback = useLatest(callback);
 
     React.useEffect(
-      () => room.events.error.subscribe((e: Error) => savedCallback.current(e)),
+      () => room.events.error.subscribe((e) => savedCallback.current(e)),
       [room, savedCallback]
     );
   }

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -7,6 +7,7 @@ import type {
   LiveObject,
   LostConnectionEvent,
   LsonObject,
+  OthersEvent,
   Room,
   Status,
   User,
@@ -202,6 +203,22 @@ type RoomContextBundleShared<
    * broadcast({ type: "CUSTOM_EVENT", data: { x: 0, y: 0 } });
    */
   useBroadcastEvent(): (event: TRoomEvent, options?: BroadcastOptions) => void;
+
+  /**
+   * Get informed when users enter or leave the room, as an event.
+   *
+   * @example
+   * useOthersListener({ type, user, others }) => {
+   *   if (type === 'enter') {
+   *     // `user` has joined the room
+   *   } else if (type === 'leave') {
+   *     // `user` has left the room
+   *   }
+   * })
+   */
+  useOthersListener(
+    callback: (event: OthersEvent<TPresence, TUserMeta>) => void
+  ): void;
 
   /**
    * Get informed when reconnecting to the Liveblocks servers is taking

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -245,7 +245,7 @@ type RoomContextBundleShared<
   ): void;
 
   /**
-   * useErrorListener is a React hook that lets you react to potential room
+   * useErrorListener is a React hook that allows you to respond to potential room
    * connection errors.
    *
    * @example
@@ -256,7 +256,7 @@ type RoomContextBundleShared<
   useErrorListener(callback: (err: Error) => void): void;
 
   /**
-   * useEventListener is a React hook that lets you react to event broadcasted
+   * useEventListener is a React hook that allows you to respond to events broadcast
    * by other users in the room.
    *
    * @example

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -228,7 +228,8 @@ type RoomContextBundleShared<
   ): void;
 
   /**
-   * useErrorListener is a react hook that lets you react to potential room connection errors.
+   * useErrorListener is a React hook that lets you react to potential room
+   * connection errors.
    *
    * @example
    * useErrorListener(er => {
@@ -238,7 +239,8 @@ type RoomContextBundleShared<
   useErrorListener(callback: (err: Error) => void): void;
 
   /**
-   * useEventListener is a react hook that lets you react to event broadcasted by other users in the room.
+   * useEventListener is a React hook that lets you react to event broadcasted
+   * by other users in the room.
    *
    * @example
    * useEventListener(({ connectionId, event }) => {

--- a/packages/liveblocks-react/test-d/hooks.test-d.ts
+++ b/packages/liveblocks-react/test-d/hooks.test-d.ts
@@ -1,0 +1,35 @@
+import type {
+  BaseUserMeta,
+  Json,
+  JsonObject,
+  LsonObject,
+  Room,
+  User,
+} from "@liveblocks/client";
+import { createClient } from "@liveblocks/client";
+import { createRoomContext } from "@liveblocks/react";
+import { expectType } from "tsd";
+
+type Presence = JsonObject;
+type Storage = LsonObject;
+type UserMeta = BaseUserMeta;
+type RoomEvent = Json;
+
+type P = Presence;
+type S = Storage;
+type U = UserMeta;
+type E = RoomEvent;
+
+const client = createClient({ publicApiKey: "pk_whatever" });
+
+const ctx = createRoomContext<P, S, U, E>(client);
+
+// ---------------------------------------------------------
+// Hook APIs
+// ---------------------------------------------------------
+
+// The useRoom() hook
+expectType<Room<P, S, U, E>>(ctx.useRoom());
+
+// The useOthers() hook
+expectType<readonly User<P, U>[]>(ctx.useOthers());

--- a/packages/liveblocks-react/test-d/hooks.test-d.ts
+++ b/packages/liveblocks-react/test-d/hooks.test-d.ts
@@ -33,3 +33,25 @@ expectType<Room<P, S, U, E>>(ctx.useRoom());
 
 // The useOthers() hook
 expectType<readonly User<P, U>[]>(ctx.useOthers());
+
+// The useOthersListener() hook
+ctx.useOthersListener((event) => {
+  expectType<readonly User<P, U>[]>(event.others);
+  switch (event.type) {
+    case "enter":
+      expectType<User<P, U>>(event.user);
+      return;
+    case "leave":
+      expectType<User<P, U>>(event.user);
+      return;
+    case "update":
+      expectType<User<P, U>>(event.user);
+      expectType<Partial<P>>(event.updates);
+      return;
+    case "reset":
+      // No extra fields on reset
+      return;
+    default:
+      expectType<never>(event);
+  }
+});


### PR DESCRIPTION
Fixes https://github.com/liveblocks/liveblocks.io/issues/1582.

First and foremost, this PR introduces a new React hook:

```tsx
function Component() {
  useOthersListener(({ type, user, others }) => {
    switch (type) {
      case "enter":
        // `user` has entered the room
        break;

      case "leave":
        // `user` has left the room
        break;

      case "update":
        // Presence for `user` was updated
        break;

      case "reset":
        // Others list was emptied
        break;
    }
  });
}
```

However, it does a few extra things.

### Type-level tests
We've sparingly used `tsd` before, but I've always wanted to add more of these, as they are an excellent way to ensure we're not accidentally changing out outer API if we make an internal refactoring and our outer types would reference them as a "DRY" way of avoiding duplication.

You can see I'm explicitly testing the APIs for the `room.subscribe("others", (others, event) => ...)` callback [here](https://github.com/liveblocks/liveblocks/blob/c1e56b03518dffcb7cb7df3a6db82394d7536421/packages/liveblocks-client/test-d/room-api.test-d.ts#L30-L50).

### Changing the "others" event type
I've used the opportunity here to make one final change to the `room.events.others` event hub type that I've always wanted to do to make it consistent with our other event types. Since this API isn't public/documented yet, I think this is fine to do now and I don't consider it a breaking change. This small change makes the API more intuitive and match all of our other event types better.

Here is the outer change of affected APIs, as a Liveblocks user would use them:

```tsx
// ❌ New/future/undocumented API (before this PR)
room.events.others.subscribe(({ event, others }) => { /* ... */ });

// New/future/undocumented API (after this PR)
room.events.others.subscribe(({ type, user, others }) => { /* ... */ });
//                            ^^^^^^^^^^^^^^^^^^^^^^
//                            This object itself is the `event` itself!

// ✅ New hook from this PR is consistent with that API
useOthersListener(({ type, user, others }) => { /* ... */ });

// ✅ The classic room.subscribe API is untouched (no breaking change)
room.subscribe("others", (others, event) => { /* ... */ });
//                        ^^^^^^^^^^^^^ NOTE!
//                        No unpacking! This has always been the only odd
//                        event that sends two args instead of one event
```
