### PR TITLE
Add `.clone()` method to Live structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,18 +26,27 @@ leave();
   milliseconds). See
   [docs](https://liveblocks.io/docs/api-reference/liveblocks-client#createClientBackgroundKeepAliveTimeout).
 - New APIs:
-  - `client.enterRoom(roomId, options)` – enters the room and return both the
+  - `Client.enterRoom(roomId, options)` – enters the room and return both the
     room and an "unsubscribe function" to leave that room again. This newer API
     supports entering/leaving the same room multiple times, making it possible
     to connect to the same room from different parts of your application.
-  - `client.logout()` – Call this on the Liveblocks client when you log out a
+  - `Client.logout()` – Call this on the Liveblocks client when you log out a
     user in your application. It will purge all auth tokens and force-leave any
     rooms, if any are still connected.
+  - `LiveList.clone()` – see
+    [docs](https://liveblocks.io/docs/api-reference/liveblocks-client#LiveList.clone).
+  - `LiveMap.clone()` – see
+    [docs](https://liveblocks.io/docs/api-reference/liveblocks-client#LiveMap.clone).
+  - `LiveObject.clone()` – see
+    [docs](https://liveblocks.io/docs/api-reference/liveblocks-client#LiveObject.clone).
 - Deprecated APIs:
   - `client.enter(roomId, options)`
   - `client.leave(roomId)`
 - Renamed enter option: `shouldInitiallyConnect` → `autoConnect`. Its meaning or
   working did not change.
+- Fixes a potential `Cannot set parent: node already has a parent` error when
+  initializing storage with Live datastructures that are already tied to a
+  Storage tree.
 
 ### `@liveblocks/react`
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -1021,6 +1021,17 @@ liveObject.toImmutable();
 // }
 ```
 
+### clone [#LiveObject.clone]
+
+Returns a deep copy of the `LiveObject` that can be inserted elsewhere in the
+Storage tree.
+
+```ts
+const obj = new LiveObject(/* ... */);
+root.set("a", obj);
+root.set("b", obj.clone());
+```
+
 ## LiveMap
 
 The `LiveMap` class is similar to a
@@ -1200,6 +1211,17 @@ map.toImmutable();
 //   'abc' => { firstName: 'Grace', lastName: 'Hopper' },
 //   'pqr' => { firstName: 'Ada', lastName: 'Lovelace' }
 // }
+```
+
+### clone [#LiveMap.clone]
+
+Returns a deep copy of the `LiveMap` that can be inserted elsewhere in the
+Storage tree.
+
+```ts
+const map = new LiveMap(/* ... */);
+root.set("a", map);
+root.set("b", map.clone());
 ```
 
 ## LiveList
@@ -1434,6 +1456,17 @@ const list = new LiveList([
 ]);
 list.toImmutable();
 // [ { firstName: "Grace", lastName: "Hopper" } ]
+```
+
+### clone [#LiveList.clone]
+
+Returns a deep copy of the `LiveList` that can be inserted elsewhere in the
+Storage tree.
+
+```ts
+const list = new LiveList(/* ... */);
+root.set("a", list);
+root.set("b", list.clone());
 ```
 
 [`atob`]: https://developer.mozilla.org/en-US/docs/Web/API/atob

--- a/package-lock.json
+++ b/package-lock.json
@@ -12599,7 +12599,9 @@
       "license": "MIT"
     },
     "node_modules/fast-check": {
-      "version": "3.10.0",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.13.1.tgz",
+      "integrity": "sha512-Xp00tFuWd83i8rbG/4wU54qU+yINjQha7bXH2N4ARNTkyOimzHtUBJ5+htpdXk7RMaCOD/j2jxSjEt9u9ZPNeQ==",
       "funding": [
         {
           "type": "individual",
@@ -12610,7 +12612,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "pure-rand": "^6.0.0"
       },
@@ -24196,7 +24197,7 @@
       "name": "@liveblocks/jest-config",
       "dependencies": {
         "@types/jest": "^29.5.2",
-        "fast-check": "^3.10.0",
+        "fast-check": "^3.13.1",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "ts-jest": "^29.1.1",
@@ -25496,7 +25497,7 @@
       "version": "file:shared/jest-config",
       "requires": {
         "@types/jest": "^29.5.2",
-        "fast-check": "^3.10.0",
+        "fast-check": "^3.13.1",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "ts-jest": "^29.1.1",
@@ -32694,7 +32695,9 @@
       "dev": true
     },
     "fast-check": {
-      "version": "3.10.0",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.13.1.tgz",
+      "integrity": "sha512-Xp00tFuWd83i8rbG/4wU54qU+yINjQha7bXH2N4ARNTkyOimzHtUBJ5+htpdXk7RMaCOD/j2jxSjEt9u9ZPNeQ==",
       "requires": {
         "pure-rand": "^6.0.0"
       }

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -959,7 +959,7 @@ describe("room", () => {
     const initialPresence = {};
     const initialStorage = {
       list: new LiveList([13, 42]),
-      map: new LiveMap([["a", 1]]),
+      map: new LiveMap([["a" as string, 1 as number]]),
       obj: new LiveObject({ x: 0 }),
     };
 
@@ -987,7 +987,18 @@ describe("room", () => {
       });
       room.connect();
       try {
-        await room.getStorage();
+        const { root } = await room.getStorage();
+        expect(root.toImmutable()).toEqual({
+          list: [13, 42],
+          map: new Map([["a", 1]]),
+          obj: { x: 0 },
+        });
+
+        // Now start mutating these Live structures (the point being that those
+        // mutations should not be observable in the second loop)
+        root.get("list").push(13);
+        root.get("map").set("b", 2);
+        root.get("obj").set("x", 42);
       } finally {
         room.destroy();
       }

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1,4 +1,5 @@
 import { nn } from "..";
+import { LiveMap } from "../crdts/LiveMap";
 import type { AuthValue } from "../auth-manager";
 import { StopRetrying } from "../connection";
 import { DEFAULT_BASE_URL } from "../constants";
@@ -952,6 +953,45 @@ describe("room", () => {
     expect(storage.root.toObject()).toEqual({ foo: 1234 });
     //                                        ^^^ Added by the client, from initialStorage
     expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("missing storage keys are properly initialized using initialStorage, even when they are already part of the storage tree", async () => {
+    const initialPresence = {};
+    const initialStorage = {
+      list: new LiveList([13, 42]),
+      map: new LiveMap([["a", 1]]),
+      obj: new LiveObject({ x: 0 }),
+    };
+
+    // Create the same room instance twice (using the same, global,
+    // initialStorage instance)
+    for (let i = 0; i < 2; i++) {
+      const { room, wss } = createTestableRoom(
+        initialPresence,
+        undefined,
+        undefined,
+        undefined,
+        initialStorage
+      );
+      wss.onConnection((conn) => {
+        conn.server.send(
+          serverMessage({
+            type: ServerMsgCode.INITIAL_STORAGE_STATE,
+            items: [["root", { type: CrdtType.OBJECT, data: {} }]],
+            //                                              ^^
+            //                                   NOTE: Storage is initially
+            //                                   empty, so initialStorage keys
+            //                                   will get added
+          })
+        );
+      });
+      room.connect();
+      try {
+        await room.getStorage();
+      } finally {
+        room.destroy();
+      }
+    }
   });
 
   test("storage should be initialized properly", async () => {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1,9 +1,9 @@
 import { nn } from "..";
-import { LiveMap } from "../crdts/LiveMap";
 import type { AuthValue } from "../auth-manager";
 import { StopRetrying } from "../connection";
 import { DEFAULT_BASE_URL } from "../constants";
 import { LiveList } from "../crdts/LiveList";
+import { LiveMap } from "../crdts/LiveMap";
 import { LiveObject } from "../crdts/LiveObject";
 import type { LsonObject } from "../crdts/Lson";
 import type { StorageUpdate } from "../crdts/StorageUpdates";

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -6,7 +6,7 @@ import { OpCode } from "../protocol/Op";
 import type { SerializedCrdt } from "../protocol/SerializedCrdt";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { Immutable } from "../types/Immutable";
-import type { LiveNode } from "./Lson";
+import type { LiveNode, Lson } from "./Lson";
 import type { StorageUpdate } from "./StorageUpdates";
 
 export type ApplyResult =
@@ -368,4 +368,10 @@ export abstract class AbstractCrdt {
     // Return cached version
     return this._cachedImmutable;
   }
+
+  /**
+   * Returns a deep clone of the current LiveStructure, suitable for insertion
+   * in the tree elsewhere.
+   */
+  abstract clone(): Lson;
 }

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -1281,6 +1281,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       process.env.NODE_ENV === "production" ? result : Object.freeze(result)
     ) as readonly ToImmutable<TItem>[];
   }
+
+  clone(): LiveList<TItem> {
+    return new LiveList(this._items.map((item) => item.clone() as TItem));
+  }
 }
 
 class LiveListIterator<T extends Lson> implements IterableIterator<T> {

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -21,26 +21,10 @@ import type { LiveNode, Lson } from "./Lson";
 import type { ToImmutable } from "./utils";
 
 export type LiveListUpdateDelta =
-  | {
-      index: number;
-      item: Lson;
-      type: "insert";
-    }
-  | {
-      index: number;
-      type: "delete";
-    }
-  | {
-      index: number;
-      previousIndex: number;
-      item: Lson;
-      type: "move";
-    }
-  | {
-      index: number;
-      item: Lson;
-      type: "set";
-    };
+  | { type: "insert"; index: number; item: Lson }
+  | { type: "delete"; index: number }
+  | { type: "move"; index: number; previousIndex: number; item: Lson }
+  | { type: "set"; index: number; item: Lson };
 
 /**
  * A LiveList notification that is sent in-client to any subscribers whenever

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -476,4 +476,10 @@ export class LiveMap<
     }
     return freeze(result);
   }
+
+  clone(): LiveMap<TKey, TValue> {
+    return new LiveMap(
+      Array.from(this._map).map(([key, node]) => [key, node.clone() as TValue])
+    );
+  }
 }

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -52,13 +52,12 @@ export class LiveMap<
     this.unacknowledgedSet = new Map<TKey, string>();
 
     if (entries) {
-      const mappedEntries: Array<[TKey, LiveNode]> = [];
-      for (const entry of entries) {
-        const value = lsonToLiveNode(entry[1]);
-        value._setParentLink(this, entry[0]);
-        mappedEntries.push([entry[0], value]);
+      const mappedEntries: [TKey, LiveNode][] = [];
+      for (const [key, value] of entries) {
+        const node = lsonToLiveNode(value);
+        node._setParentLink(this, key);
+        mappedEntries.push([key, node]);
       }
-
       this._map = new Map(mappedEntries);
     } else {
       this._map = new Map();

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -2,6 +2,7 @@ import type { LiveNode, Lson, LsonObject } from "../crdts/Lson";
 import { nn } from "../lib/assert";
 import type { JsonObject } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
+import { deepClone } from "../lib/utils";
 import type {
   CreateChildOp,
   CreateObjectOp,
@@ -716,5 +717,16 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     return (
       process.env.NODE_ENV === "production" ? result : Object.freeze(result)
     ) as ToImmutable<O>;
+  }
+
+  clone(): LiveObject<O> {
+    return new LiveObject(
+      Object.fromEntries(
+        Array.from(this._map).map(([key, value]) => [
+          key,
+          isLiveStructure(value) ? value.clone() : deepClone(value),
+        ])
+      ) as O
+    );
   }
 }

--- a/packages/liveblocks-core/src/crdts/LiveRegister.ts
+++ b/packages/liveblocks-core/src/crdts/LiveRegister.ts
@@ -2,6 +2,7 @@ import type { LiveNode } from "../crdts/Lson";
 import { nn } from "../lib/assert";
 import type { Json } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
+import { deepClone } from "../lib/utils";
 import type { CreateChildOp, CreateRegisterOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedRegister } from "../protocol/SerializedCrdt";
@@ -105,5 +106,9 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   /** @internal */
   _toImmutable(): Immutable {
     return this._data;
+  }
+
+  clone(): TValue {
+    return deepClone(this.data);
   }
 }

--- a/packages/liveblocks-core/src/crdts/__tests__/_arbitraries.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/_arbitraries.ts
@@ -1,0 +1,33 @@
+import * as fc from "fast-check";
+
+import type { Json } from "../../lib/Json";
+import { LiveList } from "../LiveList";
+import { LiveMap } from "../LiveMap";
+import { LiveObject } from "../LiveObject";
+import type { LiveStructure, Lson } from "../Lson";
+
+// NOTE: Ignoring __proto__ keys for now, there may be an issue there?
+export const key = fc.string().filter((s) => s !== "__proto__");
+
+export const json = fc
+  .jsonValue()
+  // Replace all -0 values inside the JSON with normal zeroes
+  .map((x) => JSON.parse(JSON.stringify(x).replace(/-0/g, "0")) as Json);
+
+export const { liveList, liveMap, liveObject, liveStructure, lson } = fc.letrec(
+  (tie) => ({
+    lson: fc.oneof(json, tie("liveStructure")).map((x) => x as Lson),
+    liveStructure: fc
+      .oneof(tie("liveList"), tie("liveMap"), tie("liveObject"))
+      .map((x) => x as LiveStructure),
+    liveList: fc.array(tie("lson")).map((x) => new LiveList(x as Lson[])),
+    liveMap: fc
+      .array(fc.tuple(key, tie("lson")))
+      .map((pairs) => new LiveMap(pairs as [string, Lson][])),
+    liveObject: fc
+      .array(fc.tuple(key, tie("lson")))
+      .map(
+        (pairs) => new LiveObject(Object.fromEntries(pairs as [string, Lson][]))
+      ),
+  })
+);

--- a/packages/liveblocks-core/src/crdts/__tests__/cloning.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/cloning.test.ts
@@ -1,0 +1,106 @@
+import * as fc from "fast-check";
+
+import {
+  listUpdate,
+  listUpdateInsert,
+  objectUpdate,
+} from "../../__tests__/_updatesUtils";
+import {
+  createSerializedList,
+  createSerializedObject,
+  prepareStorageUpdateTest,
+} from "../../__tests__/_utils";
+import type { LiveList } from "../LiveList";
+import { liveStructure } from "./_arbitraries";
+
+describe("cloning LiveStructures", () => {
+  it("basic cloning logic", async () => {
+    const { root, expectUpdates, room } = await prepareStorageUpdateTest<{
+      list1: LiveList<string>;
+      list2: LiveList<string>;
+    }>([
+      createSerializedObject("0:0", {}),
+      createSerializedList("0:1", "0:0", "list1"),
+    ]);
+
+    const list1 = root.get("list1");
+    list1.push("a");
+    list1.push("b");
+    list1.push("c");
+    root.set("list2", list1.clone());
+
+    room.history.undo();
+    room.history.redo();
+
+    expectUpdates([
+      // List creation
+      [listUpdate(["a"], [listUpdateInsert(0, "a")])],
+      [listUpdate(["a", "b"], [listUpdateInsert(1, "b")])],
+      [listUpdate(["a", "b", "c"], [listUpdateInsert(2, "c")])],
+
+      // Clone
+      [
+        objectUpdate(
+          { list1: ["a", "b", "c"], list2: ["a", "b", "c"] },
+          { list2: { type: "update" } }
+        ),
+      ],
+
+      // Undo
+      [
+        objectUpdate({ list1: ["a", "b", "c"] }, {
+          list2: { type: "delete" },
+        } as any),
+      ],
+
+      // Redo
+      [
+        objectUpdate(
+          { list1: ["a", "b", "c"], list2: ["a", "b", "c"] },
+          { list2: { type: "update" } }
+        ),
+      ],
+    ]);
+  });
+
+  it("deep cloning of LiveStructures", () =>
+    fc.assert(
+      fc.asyncProperty(
+        liveStructure,
+
+        async (data) => {
+          const { root } = await prepareStorageUpdateTest([
+            createSerializedObject("0:0", {}),
+          ]);
+
+          // Clone "a" to "b"
+          root.set("a", data);
+          root.set("b", data.clone());
+
+          const imm = root.toImmutable();
+          expect(imm.a).toEqual(imm.b);
+        }
+      )
+    ));
+
+  it("deep cloning of LiveStructures (twice)", () =>
+    fc.assert(
+      fc.asyncProperty(
+        liveStructure,
+
+        async (data) => {
+          const { root } = await prepareStorageUpdateTest([
+            createSerializedObject("0:0", {}),
+          ]);
+
+          // Clone "a" to "b"
+          root.set("a", data);
+          root.set("b", data.clone().clone());
+          //                        ^^^^^^^^ Deliberately cloning twice in this test
+
+          const imm = root.toImmutable();
+          expect(imm.a).toEqual(imm.b);
+        }
+      )
+    ));
+});

--- a/packages/liveblocks-core/src/crdts/__tests__/cloning.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/cloning.test.ts
@@ -10,8 +10,9 @@ import {
   createSerializedObject,
   prepareStorageUpdateTest,
 } from "../../__tests__/_utils";
+import { cloneLson } from "../../crdts/liveblocks-helpers";
 import type { LiveList } from "../LiveList";
-import { liveStructure } from "./_arbitraries";
+import { liveStructure, lson } from "./_arbitraries";
 
 describe("cloning LiveStructures", () => {
   it("basic cloning logic", async () => {
@@ -97,6 +98,29 @@ describe("cloning LiveStructures", () => {
           root.set("a", data);
           root.set("b", data.clone().clone());
           //                        ^^^^^^^^ Deliberately cloning twice in this test
+
+          const imm = root.toImmutable();
+          expect(imm.a).toEqual(imm.b);
+        }
+      )
+    ));
+
+  it("deep cloning of LSON data (= LiveStructures or JSON)", () =>
+    fc.assert(
+      fc.asyncProperty(
+        lson,
+
+        async (data) => {
+          const { root } = await prepareStorageUpdateTest([
+            createSerializedObject("0:0", {}),
+          ]);
+
+          // Clone "a" to "b"
+          root.set("a", data);
+          root.set("b", cloneLson(data));
+          //            ^^^^^^^^^ Much like data.clone(), but generalized to
+          //                      work on _any_ LSON value, even if data is
+          //                      a JSON value
 
           const imm = root.toImmutable();
           expect(imm.a).toEqual(imm.b);

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -1,6 +1,6 @@
 import { assertNever, nn } from "../lib/assert";
 import type { Json } from "../lib/Json";
-import { entries, isPlainObject } from "../lib/utils";
+import { deepClone, entries, isPlainObject } from "../lib/utils";
 import type { CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedCrdt } from "../protocol/SerializedCrdt";
@@ -113,6 +113,14 @@ export function isLiveObject(value: unknown): value is LiveObject<LsonObject> {
 
 export function isLiveRegister(value: unknown): value is LiveRegister<Json> {
   return value instanceof LiveRegister;
+}
+
+export function cloneLson<L extends Lson | undefined>(value: L): L {
+  return value === undefined
+    ? (undefined as L)
+    : isLiveStructure(value)
+    ? (value.clone() as L)
+    : (deepClone(value) as L);
 }
 
 export function liveNodeToLson(obj: LiveNode): Lson {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -24,7 +24,7 @@ export type {
   LostConnectionEvent,
   Status,
 } from "./connection";
-export { isLiveNode } from "./crdts/liveblocks-helpers";
+export { cloneLson, isLiveNode } from "./crdts/liveblocks-helpers";
 export { LiveList } from "./crdts/LiveList";
 export { LiveMap } from "./crdts/LiveMap";
 export { LiveObject } from "./crdts/LiveObject";

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -83,11 +83,11 @@ export function tryParseJson(rawMessage: string): Json | undefined {
  * NOTE: We should be able to replace `deepClone` by `structuredClone` once
  * we've upgraded to Node 18.
  */
-export function deepClone<T extends Json>(items: T): T {
+export function deepClone<T extends Json>(value: T): T {
   // NOTE: In this case, the combination of JSON.parse() and JSON.stringify
   // won't lead to type unsafety, so this use case is okay.
   // eslint-disable-next-line no-restricted-syntax
-  return JSON.parse(JSON.stringify(items)) as T;
+  return JSON.parse(JSON.stringify(value)) as T;
 }
 
 /**

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -11,6 +11,7 @@ import { ManagedSocket, newToLegacyStatus, StopRetrying } from "./connection";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { OpSource } from "./crdts/AbstractCrdt";
 import {
+  cloneLson,
   getTreesDiffOperations,
   isLiveList,
   isLiveNode,
@@ -1341,7 +1342,7 @@ export function createRoom<
     const stackSizeBefore = context.undoStack.length;
     for (const key in context.initialStorage) {
       if (context.root.get(key) === undefined) {
-        context.root.set(key, context.initialStorage[key]);
+        context.root.set(key, cloneLson(context.initialStorage[key]));
       }
     }
 

--- a/shared/jest-config/package.json
+++ b/shared/jest-config/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "@types/jest": "^29.5.2",
-    "fast-check": "^3.10.0",
+    "fast-check": "^3.13.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
Fixes https://github.com/liveblocks/liveblocks.io/issues/1594, #560, and #1000.

This adds a `.clone()` method to `LiveMap`, `LiveList`, and `LiveObject`, to make a deep clone of those values that are not attached to the pool, and thus are suitable for injection into another document, or in a different part of the Storage tree. Previously, users have been using this community-provided [code snippet](https://discord.com/channels/913109211746009108/913157273046646795/944290231065149461).

This method can be useful to implement features like "duplicate selected layers" in a drawing app, for example.

Usage:

```tsx
const shapes = root.get("shapes");
const shape1 = shapes.get("shape1");
shapes.set("shape2", shape1.clone());
```

## TODO

- [x] [~Only clone when needed, and issue a warning when we do~](https://github.com/liveblocks/liveblocks/pull/1245/files#r1367162560) **Update:** decided not to
- [x] Unit test this
- [x] Check if this can be a good default solution to avoid #1000
- [x] Documentation
