### PR TITLE
Comments: Prevent nested `lb-root` classes

### DIFF
--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -109,6 +109,11 @@ export interface CommentProps extends ComponentPropsWithoutRef<"div"> {
   /**
    * @internal
    */
+  root?: boolean;
+
+  /**
+   * @internal
+   */
   additionalActions?: ReactNode;
 
   /**
@@ -278,6 +283,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
       onCommentEdit,
       onCommentDelete,
       overrides,
+      root = true,
       additionalActions,
       additionalActionsClassName,
       className,
@@ -395,7 +401,8 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
       <TooltipProvider>
         <div
           className={classNames(
-            "lb-root lb-comment",
+            root && "lb-root",
+            "lb-comment",
             indentContent && "lb-comment:indent-content",
             showActions === "hover" && "lb-comment:show-actions-hover",
             (isMoreActionOpen || isReactionActionOpen) &&
@@ -508,6 +515,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
             {isEditing ? (
               <Composer
                 className="lb-comment-composer"
+                root={false}
                 onComposerSubmit={handleEditSubmit}
                 defaultValue={comment.body}
                 placeholder={$.COMMENT_EDIT_COMPOSER_PLACEHOLDER}

--- a/packages/liveblocks-react-comments/src/components/Composer.tsx
+++ b/packages/liveblocks-react-comments/src/components/Composer.tsx
@@ -139,6 +139,11 @@ export type ComposerProps<
     /**
      * @internal
      */
+    root?: boolean;
+
+    /**
+     * @internal
+     */
     actions?: ReactNode;
 
     /**
@@ -281,6 +286,7 @@ const ComposerWithContext = forwardRef<
       actions,
       overrides,
       showAttribution,
+      root = true,
       onFocus,
       onBlur,
       className,
@@ -355,7 +361,8 @@ const ComposerWithContext = forwardRef<
     return (
       <form
         className={classNames(
-          "lb-root lb-composer lb-composer-form",
+          root && "lb-root",
+          "lb-composer lb-composer-form",
           className
         )}
         dir={$.dir}

--- a/packages/liveblocks-react-comments/src/components/Thread.tsx
+++ b/packages/liveblocks-react-comments/src/components/Thread.tsx
@@ -195,6 +195,7 @@ export const Thread = forwardRef(
                 <Comment
                   key={comment.id}
                   className="lb-thread-comment"
+                  root={false}
                   comment={comment}
                   indentContent={indentCommentContent}
                   showDeleted={showDeletedComments}
@@ -247,6 +248,7 @@ export const Thread = forwardRef(
           {showComposer && (
             <Composer
               className="lb-thread-composer"
+              root={false}
               threadId={thread.id}
               defaultCollapsed={showComposer === "collapsed" ? true : undefined}
               overrides={{


### PR DESCRIPTION
Now that tokens are declared on `.lb-root`, having nested `.lb-root` classes means that overriding some tokens on `.lb-thread` for example, won't affect `<Comment />` and `<Composer />` since they also have `.lb-root` classes, which will reset the tokens, that's not great. This PR removes `.lb-root` from components when they are nested.

**Before:**
```
Thread (.lb-root)
├── Comment (.lb-root)
│   └── Composer (.lb-root)
└── Composer (.lb-root)
Comment (.lb-root)
Composer (.lb-root)
```

**After:**
```
Thread (.lb-root)
├── Comment
│   └── Composer
└── Composer
Comment (.lb-root)
Composer (.lb-root)
```