### PR TITLE
Add Comments methods to `@liveblocks/node` API reference

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -275,9 +275,10 @@ export default async function auth(req, res) {
 
 ### Liveblocks.getThreads [#get-threads]
 
-Returns a list of threads inside a room. Throws an error if the room isn’t
-found. The return value matches results from the
-[Get Room Threads API](/docs/api-reference/rest-api-endpoints#get-threads).
+Returns a list of threads found inside a room. Throws an error if the room isn’t
+found. This is a wrapper around the
+[Get Room Threads API](/docs/api-reference/rest-api-endpoints#get-threads) and
+returns the same response.
 
 ```ts
 const threads = await liveblocks.getThreads({
@@ -287,9 +288,10 @@ const threads = await liveblocks.getThreads({
 
 ### Liveblocks.getThread [#get-thread]
 
-Returns a thread inside a room. Throws an error if the room isn’t found. The
-return value matches results from the
-[Get Thread API](/docs/api-reference/rest-api-endpoints#get-thread).
+Returns a thread. Throws an error if the room or thread isn’t found. This is a
+wrapper around the
+[Get Thread API](/docs/api-reference/rest-api-endpoints#get-thread) and returns
+the same response.
 
 ```ts
 const thread = await liveblocks.getThread({
@@ -300,10 +302,11 @@ const thread = await liveblocks.getThread({
 
 ### Liveblocks.getThreadParticipants [#get-thread-participants]
 
-Returns a list of participants in a thread. A participant is a user who has
-commented or been mentioned in the thread. Throws an error if the thread isn’t
-found. The return value matches results from the
-[Get Thread Participants API](/docs/api-reference/rest-api-endpoints#get-thread-participants).
+Returns a list of participants found inside a thread. A participant is a user
+who has commented or been mentioned in the thread. Throws an error if the room
+or thread isn’t found. This is a wrapper around the
+[Get Thread Participants API](/docs/api-reference/rest-api-endpoints#get-thread-participants)
+and returns the same response.
 
 ```ts
 const { participantIds } = await liveblocks.getThreadParticipants({
@@ -314,9 +317,10 @@ const { participantIds } = await liveblocks.getThreadParticipants({
 
 ### Liveblocks.getComment [#get-comment]
 
-Returns a comment in a thread. Throws an error if the comment isn’t found. The
-return value matches results from the
-[Get Comment API](/docs/api-reference/rest-api-endpoints#get-comment).
+Returns a comment. Throws an error if the room, thread, or comment isn’t found.
+This is a wrapper around the
+[Get Comment API](/docs/api-reference/rest-api-endpoints#get-comment) and
+returns the same response.
 
 ```ts
 const comment = await liveblocks.getComment({

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -26,7 +26,7 @@ const liveblocks = new Liveblocks({
 To authorize your users with Liveblocks, you have the choice between two
 different APIs.
 
-- [`Liveblocks.prepareSession`](#access-tokens) is recommend for most
+- [`Liveblocks.prepareSession`](#access-tokens) is recommended for most
   applications.
 - [`Liveblocks.identifyUser`](#id-tokens) is best if you’re using fine-grained
   permissions with our REST API.
@@ -272,6 +272,62 @@ export default async function auth(req, res) {
   return new Response(body, { status });
 }
 ```
+
+### Liveblocks.getThreads [#get-threads]
+
+Returns a list of threads in a room.
+
+```ts
+const threads = await liveblocks.getThreads({
+  roomId: "my-room",
+});
+```
+
+See the
+[REST API reference](/docs/api-reference/rest-api-endpoints#get-threads).
+
+### Liveblocks.getThread [#get-thread]
+
+Returns a thread in a room.
+
+```ts
+const thread = await liveblocks.getThread({
+  roomId: "my-room",
+  threadId: "my-thread",
+});
+```
+
+See the [REST API reference](/docs/api-reference/rest-api-endpoints#get-thread).
+
+### Liveblocks.getThreadParticipants [#get-thread-participants]
+
+Returns a list of participants in a thread. Participants are users who have
+either commented or have been mentioned in the thread.
+
+```ts
+const { participantIds } = await liveblocks.getThreadParticipants({
+  roomId: "my-room",
+  threadId: "my-thread",
+});
+```
+
+See the
+[REST API reference](/docs/api-reference/rest-api-endpoints#get-thread-participants).
+
+### Liveblocks.getComment [#get-comment]
+
+Returns a comment in a thread.
+
+```ts
+const comment = await liveblocks.getComment({
+  roomId: "my-room",
+  threadId: "my-thread",
+  commentId: "my-comment",
+});
+```
+
+See the
+[REST API reference](/docs/api-reference/rest-api-endpoints#get-comment).
 
 ---
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -275,7 +275,9 @@ export default async function auth(req, res) {
 
 ### Liveblocks.getThreads [#get-threads]
 
-Returns a list of threads in a room.
+Returns a list of threads inside a room. Throws an error if the room isn’t
+found. The return value matches results from the
+[Get Room Threads API](/docs/api-reference/rest-api-endpoints#get-threads).
 
 ```ts
 const threads = await liveblocks.getThreads({
@@ -283,12 +285,11 @@ const threads = await liveblocks.getThreads({
 });
 ```
 
-See the
-[REST API reference](/docs/api-reference/rest-api-endpoints#get-threads).
-
 ### Liveblocks.getThread [#get-thread]
 
-Returns a thread in a room.
+Returns a thread inside a room. Throws an error if the room isn’t found. The
+return value matches results from the
+[Get Thread API](/docs/api-reference/rest-api-endpoints#get-thread).
 
 ```ts
 const thread = await liveblocks.getThread({
@@ -297,12 +298,12 @@ const thread = await liveblocks.getThread({
 });
 ```
 
-See the [REST API reference](/docs/api-reference/rest-api-endpoints#get-thread).
-
 ### Liveblocks.getThreadParticipants [#get-thread-participants]
 
-Returns a list of participants in a thread. Participants are users who have
-either commented or have been mentioned in the thread.
+Returns a list of participants in a thread. A participant is a user who has
+commented or been mentioned in the thread. Throws an error if the thread isn’t
+found. The return value matches results from the
+[Get Thread Participants API](/docs/api-reference/rest-api-endpoints#get-thread-participants).
 
 ```ts
 const { participantIds } = await liveblocks.getThreadParticipants({
@@ -311,12 +312,11 @@ const { participantIds } = await liveblocks.getThreadParticipants({
 });
 ```
 
-See the
-[REST API reference](/docs/api-reference/rest-api-endpoints#get-thread-participants).
-
 ### Liveblocks.getComment [#get-comment]
 
-Returns a comment in a thread.
+Returns a comment in a thread. Throws an error if the comment isn’t found. The
+return value matches results from the
+[Get Comment API](/docs/api-reference/rest-api-endpoints#get-comment).
 
 ```ts
 const comment = await liveblocks.getComment({
@@ -325,9 +325,6 @@ const comment = await liveblocks.getComment({
   commentId: "my-comment",
 });
 ```
-
-See the
-[REST API reference](/docs/api-reference/rest-api-endpoints#get-comment).
 
 ---
 


### PR DESCRIPTION
### Description

Adds documentation for the Comments functions in the node Liveblocks client

#### Related issue(s)
https://github.com/liveblocks/liveblocks.io/issues/1632
