### PR TITLE
add a note to e2e readme

### DIFF
--- a/e2e/next-sandbox/README.md
+++ b/e2e/next-sandbox/README.md
@@ -10,7 +10,9 @@ Made with
 - Install Playwright: `npx playwright install`
 - At the root level, add a file `.env.local`
 - Go to https://liveblocks.io/dashboard/apikeys, copy your secret key
-- In `.env.local`, add the the env variable: `LIVEBLOCKS_SECRET_KEY=YOUR_SECRET_KEY`
+- In `.env.local`, add the the env variable:
+  `LIVEBLOCKS_SECRET_KEY=YOUR_SECRET_KEY` and
+  `NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=https://api.liveblocks.io/v7`
 - run `npm install`
 - run `npm run dev`
 - In another terminal, run `npm run test`

--- a/e2e/next-sandbox/pages/api/auth/access-token.ts
+++ b/e2e/next-sandbox/pages/api/auth/access-token.ts
@@ -4,10 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { randomUser } from "../_utils";
 
-const SECRET_KEY = process.env.LIVEBLOCKS_SECRET_KEY;
-if (!SECRET_KEY) {
-  throw new Error("Please specify LIVEBLOCKS_SECRET_KEY in env");
-}
+const SECRET_KEY = nn(
+  process.env.LIVEBLOCKS_SECRET_KEY,
+  "Please specify LIVEBLOCKS_SECRET_KEY env var"
+);
 
 const liveblocks = new Liveblocks({
   secret: SECRET_KEY,
@@ -15,7 +15,7 @@ const liveblocks = new Liveblocks({
   // @ts-expect-error - Hidden setting
   baseUrl: nn(
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
-    "Missing env var: NEXT_PUBLIC_LIVEBLOCKS_BASE_URL"
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
   ),
 });
 

--- a/e2e/next-sandbox/pages/api/auth/id-token.ts
+++ b/e2e/next-sandbox/pages/api/auth/id-token.ts
@@ -4,10 +4,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { randomUser } from "../_utils";
 
-const SECRET_KEY = process.env.LIVEBLOCKS_SECRET_KEY;
-if (!SECRET_KEY) {
-  throw new Error("Please specify LIVEBLOCKS_SECRET_KEY in env");
-}
+const SECRET_KEY = nn(
+  process.env.LIVEBLOCKS_SECRET_KEY,
+  "Please specify LIVEBLOCKS_SECRET_KEY env var"
+);
 
 const liveblocks = new Liveblocks({
   secret: SECRET_KEY,
@@ -15,7 +15,7 @@ const liveblocks = new Liveblocks({
   // @ts-expect-error - Hidden setting
   baseUrl: nn(
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
-    "Missing env var: NEXT_PUBLIC_LIVEBLOCKS_BASE_URL"
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
   ),
 });
 

--- a/e2e/next-sandbox/pages/api/auth/legacy-token.ts
+++ b/e2e/next-sandbox/pages/api/auth/legacy-token.ts
@@ -1,18 +1,18 @@
+import { nn } from "@liveblocks/core";
 import { authorize } from "@liveblocks/node";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { randomUser } from "../_utils";
 
-const API_KEY = process.env.LIVEBLOCKS_SECRET_KEY;
+const SECRET_KEY = nn(
+  process.env.LIVEBLOCKS_SECRET_KEY,
+  "Please specify LIVEBLOCKS_SECRET_KEY env var"
+);
 
 export default async function legacyAuth(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (!API_KEY) {
-    return res.status(403).end();
-  }
-
   const room = (req.body as { room: string }).room;
   const user = randomUser();
 
@@ -23,10 +23,13 @@ export default async function legacyAuth(
       name: user.name,
       issuedBy: "/api/auth/legacy-token",
     },
-    secret: API_KEY,
+    secret: SECRET_KEY,
 
     // @ts-expect-error - Hidden setting
-    baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+    baseUrl: nn(
+      process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+      "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
+    ),
   });
   return res.status(response.status).end(response.body);
 }

--- a/e2e/next-sandbox/pages/auth/acc-token.tsx
+++ b/e2e/next-sandbox/pages/auth/acc-token.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@liveblocks/client";
+import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
@@ -9,7 +10,10 @@ const client = createClient({
   authEndpoint: "/api/auth/access-token",
 
   // @ts-expect-error - Hidden setting
-  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+  baseUrl: nn(
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
+  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/id-token.tsx
+++ b/e2e/next-sandbox/pages/auth/id-token.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@liveblocks/client";
+import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
@@ -9,7 +10,10 @@ const client = createClient({
   authEndpoint: "/api/auth/id-token",
 
   // @ts-expect-error - Hidden setting
-  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+  baseUrl: nn(
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
+  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/pubkey.tsx
+++ b/e2e/next-sandbox/pages/auth/pubkey.tsx
@@ -9,11 +9,14 @@ import { getRoomFromUrl } from "../../utils";
 const client = createClient({
   publicApiKey: nn(
     process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY,
-    "Please set NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY in the env"
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY env var"
   ),
 
   // @ts-expect-error - Hidden setting
-  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+  baseUrl: nn(
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
+  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/secret-legacy.tsx
+++ b/e2e/next-sandbox/pages/auth/secret-legacy.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@liveblocks/client";
+import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
@@ -9,7 +10,10 @@ const client = createClient({
   authEndpoint: "/api/auth/legacy-token",
 
   // @ts-expect-error - Hidden setting
-  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+  baseUrl: nn(
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
+  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/utils/createClient.ts
+++ b/e2e/next-sandbox/utils/createClient.ts
@@ -1,11 +1,15 @@
 import { createClient } from "@liveblocks/client";
+import { nn } from "@liveblocks/core";
 
 export default function createLiveblocksClient() {
   return createClient({
     authEndpoint: "/api/auth/access-token",
 
     // @ts-expect-error - Hidden settings
-    baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+    baseUrl: nn(
+      process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+      "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
+    ),
     enableDebugLogging: true,
   });
 }


### PR DESCRIPTION
since 1.5, we require NEXT_PUBLIC_LIVEBLOCKS_BASE_URL to be defined for e2e tests to work, just documenting that.