### PR TITLE
Upgrade card for 1.5

### DIFF
--- a/docs/pages/platform/upgrading.mdx
+++ b/docs/pages/platform/upgrading.mdx
@@ -2,13 +2,20 @@
 meta:
   title: "Upgrading Liveblocks"
   parentTitle: "Platform"
-  description: "Select your the version you want to upgrade Liveblocks to"
+  description: "Select the Liveblocks version you’d like to update to"
 ---
 
-Select the version you want to upgrade Liveblocks to. When upgrading, please
-note that all packages should be upgraded to the same version.
+Select the version you’d like to update to. When upgrading, please note that all
+packages should be upgraded to the same version. If a version isn’t mentioned,
+there are no breaking changes.
 
 <ListGrid>
+  <DocsCard
+    type="image"
+    title="Upgrading to 1.5"
+    href="/docs/platform/upgrading/1.5"
+    visual={<DocsCardGradientText>1.5</DocsCardGradientText>}
+  />
   <DocsCard
     type="image"
     title="Upgrading to 1.2"


### PR DESCRIPTION
We missed the card for 1.5:
![image](https://github.com/liveblocks/liveblocks/assets/33033422/1104c030-9765-4810-9760-224bb966bc22)
