### PR TITLE
Fix `resolveUsers` return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.5.2
+
+### `@liveblocks/react`
+
+- Fix return type of `resolveUsers`.
+
 # v1.5.1
 
 - Fixes a bug in the bounds check of the `backgroundKeepAliveTimeout` option.

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -155,7 +155,7 @@ type Options<TUserMeta extends BaseUserMeta> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => PromiseOrNot<(TUserMeta["info"] | undefined)[]>;
+  ) => PromiseOrNot<(TUserMeta["info"] | undefined)[] | undefined>;
 
   /**
    * @beta

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -155,7 +155,7 @@ type Options<TUserMeta extends BaseUserMeta> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => PromiseOrNot<TUserMeta["info"] | undefined>;
+  ) => PromiseOrNot<(TUserMeta["info"] | undefined)[]>;
 
   /**
    * @beta


### PR DESCRIPTION
This PR fixes the return type of `resolveUsers` which wasn't updated to an array when it changed from `resolveUser` to `resolveUsers`.