### PR TITLE
Remove CreateRootObjectOp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22143,7 +22143,7 @@
       }
     },
     "packages/create-liveblocks-app": {
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -22318,10 +22318,10 @@
     },
     "packages/liveblocks-client": {
       "name": "@liveblocks/client",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "1.5.2"
+        "@liveblocks/core": "1.5.3-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -22334,7 +22334,7 @@
     },
     "packages/liveblocks-core": {
       "name": "@liveblocks/core",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -22476,7 +22476,7 @@
     },
     "packages/liveblocks-node": {
       "name": "@liveblocks/node",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",
@@ -22484,7 +22484,7 @@
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/node": "^20.7.1",
@@ -22500,11 +22500,11 @@
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "nanoid": "^3",
         "use-sync-external-store": "^1.2.0"
       },
@@ -22523,13 +22523,13 @@
     },
     "packages/liveblocks-react-comments": {
       "name": "@liveblocks/react-comments",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.2",
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
-        "@liveblocks/react": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
+        "@liveblocks/react": "1.5.3-test1",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
@@ -22918,11 +22918,11 @@
     },
     "packages/liveblocks-redux": {
       "name": "@liveblocks/redux",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2"
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23043,11 +23043,11 @@
     },
     "packages/liveblocks-yjs": {
       "name": "@liveblocks/yjs",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "js-base64": "^3.7.5"
       },
       "devDependencies": {
@@ -23061,11 +23061,11 @@
     },
     "packages/liveblocks-zustand": {
       "name": "@liveblocks/zustand",
-      "version": "1.5.2",
+      "version": "1.5.3-test1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2"
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23213,6 +23213,11 @@
         "@liveblocks/jest-config": "*",
         "@types/pluralize": "^0.0.29"
       }
+    },
+    "schema-lang/infer-schema/node_modules/@liveblocks/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-BX8rer/W/Scu3kSX64eryPqO4Rt96vuRivBovvclyJoz5tyx3R8beQIzBZauy0g7W1MG3vJYiiEGycW8sMzMHA=="
     },
     "schema-lang/liveblocks-schema": {
       "name": "@liveblocks/schema",
@@ -24733,7 +24738,7 @@
     "@liveblocks/client": {
       "version": "file:packages/liveblocks-client",
       "requires": {
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/ws": "^8.5.3",
@@ -24876,6 +24881,13 @@
         "@types/pluralize": "^0.0.29",
         "decoders": "^2.0.3",
         "pluralize": "^8.0.0"
+      },
+      "dependencies": {
+        "@liveblocks/core": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.5.2.tgz",
+          "integrity": "sha512-BX8rer/W/Scu3kSX64eryPqO4Rt96vuRivBovvclyJoz5tyx3R8beQIzBZauy0g7W1MG3vJYiiEGycW8sMzMHA=="
+        }
       }
     },
     "@liveblocks/jest-config": {
@@ -24917,7 +24929,7 @@
     "@liveblocks/node": {
       "version": "file:packages/liveblocks-node",
       "requires": {
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@stablelib/base64": "^1.0.1",
@@ -24939,8 +24951,8 @@
     "@liveblocks/react": {
       "version": "file:packages/liveblocks-react",
       "requires": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -25022,11 +25034,11 @@
       "version": "file:packages/liveblocks-react-comments",
       "requires": {
         "@floating-ui/react-dom": "^2.0.2",
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/react": "1.5.2",
+        "@liveblocks/react": "1.5.3-test1",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
@@ -25220,8 +25232,8 @@
     "@liveblocks/redux": {
       "version": "file:packages/liveblocks-redux",
       "requires": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
@@ -25544,8 +25556,8 @@
     "@liveblocks/yjs": {
       "version": "file:packages/liveblocks-yjs",
       "requires": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -25555,8 +25567,8 @@
     "@liveblocks/zustand": {
       "version": "file:packages/liveblocks-zustand",
       "requires": {
-        "@liveblocks/client": "1.5.2",
-        "@liveblocks/core": "1.5.2",
+        "@liveblocks/client": "1.5.3-test1",
+        "@liveblocks/core": "1.5.3-test1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",

--- a/packages/create-liveblocks-app/package.json
+++ b/packages/create-liveblocks-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-liveblocks-app",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "An installer for Liveblocks projects, including various examples and a Next.js starter kit. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "bin": "dist/index.cjs",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/client",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "A client that lets you interact with Liveblocks servers. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,7 +33,7 @@
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"
   },
   "dependencies": {
-    "@liveblocks/core": "1.5.2"
+    "@liveblocks/core": "1.5.3-test1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/core",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "Private internals for Liveblocks. DO NOT import directly from this package!",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -1,7 +1,7 @@
 import { assertNever } from "../lib/assert";
 import type { Pos } from "../lib/position";
 import { asPos } from "../lib/position";
-import type { CreateChildOp, Op } from "../protocol/Op";
+import type { CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { SerializedCrdt } from "../protocol/SerializedCrdt";
 import type * as DevTools from "../types/DevToolsTreeNode";
@@ -256,7 +256,7 @@ export abstract class AbstractCrdt {
   }
 
   /** @internal */
-  abstract _attachChild(op: CreateChildOp, source: OpSource): ApplyResult;
+  abstract _attachChild(op: CreateOp, source: OpSource): ApplyResult;
 
   /** @internal */
   _detach(): void {
@@ -295,7 +295,7 @@ export abstract class AbstractCrdt {
     parentId: string,
     parentKey: string,
     pool?: ManagedPool
-  ): CreateChildOp[];
+  ): CreateOp[];
 
   /** @internal */
   abstract _serialize(): SerializedCrdt;

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -2,7 +2,7 @@ import { nn } from "../lib/assert";
 import { nanoid } from "../lib/nanoid";
 import type { Pos } from "../lib/position";
 import { asPos, makePosition } from "../lib/position";
-import type { CreateChildOp, CreateListOp, CreateOp, Op } from "../protocol/Op";
+import type { CreateListOp, CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedList } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
@@ -105,16 +105,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * This is quite unintuitive and should disappear as soon as
    * we introduce an explicit LiveList.Set operation
    */
-  _toOps(
-    parentId: string,
-    parentKey: string,
-    pool?: ManagedPool
-  ): CreateChildOp[] {
+  _toOps(parentId: string, parentKey: string, pool?: ManagedPool): CreateOp[] {
     if (this._id === undefined) {
       throw new Error("Cannot serialize item is not attached");
     }
 
-    const ops: CreateChildOp[] = [];
+    const ops: CreateOp[] = [];
     const op: CreateListOp = {
       id: this._id,
       opId: pool?.generateOpId(),
@@ -183,7 +179,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applySetRemote(op: CreateChildOp): ApplyResult {
+  private _applySetRemote(op: CreateOp): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -264,7 +260,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applySetAck(op: CreateChildOp): ApplyResult {
+  private _applySetAck(op: CreateOp): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -400,7 +396,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applyRemoteInsert(op: CreateChildOp): ApplyResult {
+  private _applyRemoteInsert(op: CreateOp): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -424,7 +420,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applyInsertAck(op: CreateChildOp): ApplyResult {
+  private _applyInsertAck(op: CreateOp): ApplyResult {
     const existingItem = this._items.find((item) => item._id === op.id);
     const key = asPos(op.parentKey);
 
@@ -489,7 +485,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applyInsertUndoRedo(op: CreateChildOp): ApplyResult {
+  private _applyInsertUndoRedo(op: CreateOp): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
@@ -523,7 +519,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  private _applySetUndoRedo(op: CreateChildOp): ApplyResult {
+  private _applySetUndoRedo(op: CreateOp): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
@@ -581,7 +577,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  _attachChild(op: CreateChildOp, source: OpSource): ApplyResult {
+  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -1368,9 +1364,9 @@ function moveDelta(
  * serializing a LiveStructure should not know anything about intent
  */
 function HACK_addIntentAndDeletedIdToOperation(
-  ops: CreateChildOp[],
+  ops: CreateOp[],
   deletedId: string | undefined
-): CreateChildOp[] {
+): CreateOp[] {
   return ops.map((op, index) => {
     if (index === 0) {
       // NOTE: Only patch the first Op here

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -1,7 +1,7 @@
 import { nn } from "../lib/assert";
 import { freeze } from "../lib/freeze";
 import { nanoid } from "../lib/nanoid";
-import type { CreateChildOp, CreateMapOp, Op } from "../protocol/Op";
+import type { CreateOp, CreateMapOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedMap } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
@@ -67,16 +67,12 @@ export class LiveMap<
   /**
    * @internal
    */
-  _toOps(
-    parentId: string,
-    parentKey: string,
-    pool?: ManagedPool
-  ): CreateChildOp[] {
+  _toOps(parentId: string, parentKey: string, pool?: ManagedPool): CreateOp[] {
     if (this._id === undefined) {
       throw new Error("Cannot serialize item is not attached");
     }
 
-    const ops: CreateChildOp[] = [];
+    const ops: CreateOp[] = [];
     const op: CreateMapOp = {
       id: this._id,
       opId: pool?.generateOpId(),
@@ -136,7 +132,7 @@ export class LiveMap<
   /**
    * @internal
    */
-  _attachChild(op: CreateChildOp, source: OpSource): ApplyResult {
+  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -1,7 +1,7 @@
 import { nn } from "../lib/assert";
 import { freeze } from "../lib/freeze";
 import { nanoid } from "../lib/nanoid";
-import type { CreateOp, CreateMapOp, Op } from "../protocol/Op";
+import type { CreateMapOp, CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedMap } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -7,7 +7,6 @@ import type {
   CreateChildOp,
   CreateObjectOp,
   CreateOp,
-  CreateRootObjectOp,
   DeleteObjectKeyOp,
   Op,
   UpdateObjectOp,
@@ -124,19 +123,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     parentId: string,
     parentKey: string,
     pool?: ManagedPool
-  ): CreateChildOp[];
-  /** @internal */
-  _toOps(
-    parentId?: undefined,
-    parentKey?: undefined,
-    pool?: ManagedPool
-  ): CreateOp[];
-  /** @internal */
-  _toOps(
-    parentId?: string,
-    parentKey?: string,
-    pool?: ManagedPool
-  ): CreateOp[] {
+  ): CreateChildOp[] {
     if (this._id === undefined) {
       throw new Error("Cannot serialize item is not attached");
     }
@@ -144,18 +131,14 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     const opId = pool?.generateOpId();
 
     const ops: CreateOp[] = [];
-    const op: CreateObjectOp | CreateRootObjectOp =
-      parentId !== undefined && parentKey !== undefined
-        ? {
-            type: OpCode.CREATE_OBJECT,
-            id: this._id,
-            opId,
-            parentId,
-            parentKey,
-            data: {},
-          }
-        : // Root object
-          { type: OpCode.CREATE_OBJECT, id: this._id, opId, data: {} };
+    const op: CreateObjectOp = {
+      type: OpCode.CREATE_OBJECT,
+      id: this._id,
+      opId,
+      parentId,
+      parentKey,
+      data: {},
+    };
 
     ops.push(op);
 

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -4,7 +4,6 @@ import type { JsonObject } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
 import { deepClone } from "../lib/utils";
 import type {
-  CreateChildOp,
   CreateObjectOp,
   CreateOp,
   DeleteObjectKeyOp,
@@ -119,11 +118,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   }
 
   /** @internal */
-  _toOps(
-    parentId: string,
-    parentKey: string,
-    pool?: ManagedPool
-  ): CreateChildOp[] {
+  _toOps(parentId: string, parentKey: string, pool?: ManagedPool): CreateOp[] {
     if (this._id === undefined) {
       throw new Error("Cannot serialize item is not attached");
     }
@@ -199,7 +194,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   }
 
   /** @internal */
-  _attachChild(op: CreateChildOp, source: OpSource): ApplyResult {
+  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }

--- a/packages/liveblocks-core/src/crdts/LiveRegister.ts
+++ b/packages/liveblocks-core/src/crdts/LiveRegister.ts
@@ -3,7 +3,7 @@ import { nn } from "../lib/assert";
 import type { Json } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
 import { deepClone } from "../lib/utils";
-import type { CreateChildOp, CreateRegisterOp, Op } from "../protocol/Op";
+import type { CreateOp, CreateRegisterOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
 import type { IdTuple, SerializedRegister } from "../protocol/SerializedCrdt";
 import { CrdtType } from "../protocol/SerializedCrdt";
@@ -79,7 +79,7 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   }
 
   /** @internal */
-  _attachChild(_op: CreateChildOp): ApplyResult {
+  _attachChild(_op: CreateOp): ApplyResult {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -208,18 +208,18 @@ export function getTreesDiffOperations(
           });
           break;
         case CrdtType.OBJECT:
-          ops.push(
-            crdt.parentId
-              ? {
-                  type: OpCode.CREATE_OBJECT,
-                  id,
-                  parentId: crdt.parentId,
-                  parentKey: crdt.parentKey,
-                  data: crdt.data,
-                }
-              : // Root object
-                { type: OpCode.CREATE_OBJECT, id, data: crdt.data }
-          );
+          if (crdt.parentId === undefined || crdt.parentKey === undefined) {
+            throw new Error(
+              "Internal error. Cannot serialize storage root into an operation"
+            );
+          }
+          ops.push({
+            type: OpCode.CREATE_OBJECT,
+            id,
+            parentId: crdt.parentId,
+            parentKey: crdt.parentKey,
+            data: crdt.data,
+          });
           break;
         case CrdtType.MAP:
           ops.push({

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -96,7 +96,6 @@ export type {
 export { ClientMsgCode } from "./protocol/ClientMsg";
 export type {
   AckOp,
-  CreateChildOp,
   CreateListOp,
   CreateMapOp,
   CreateObjectOp,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -76,9 +76,11 @@ export { asPos, makePosition } from "./lib/position";
 export type { Resolve } from "./lib/Resolve";
 export { shallow } from "./lib/shallow";
 export { stringify } from "./lib/stringify";
+export type { Brand } from "./lib/utils";
 export {
   b64decode,
   isPlainObject,
+  raise,
   tryParseJson,
   withTimeout,
 } from "./lib/utils";

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -102,7 +102,6 @@ export type {
   CreateObjectOp,
   CreateOp,
   CreateRegisterOp,
-  CreateRootObjectOp,
   DeleteCrdtOp,
   DeleteObjectKeyOp,
   Op,

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -3,6 +3,13 @@ import type { Json } from "./Json";
 declare const brand: unique symbol;
 export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };
 
+/**
+ * Throw an error, but as an expression instead of a statement.
+ */
+export function raise(msg: string): never {
+  throw new Error(msg);
+}
+
 export function isPlainObject(
   blob: unknown
 ): blob is { [key: string]: unknown } {

--- a/packages/liveblocks-core/src/protocol/Op.ts
+++ b/packages/liveblocks-core/src/protocol/Op.ts
@@ -24,7 +24,7 @@ export type Op =
   | SetParentKeyOp // Only for lists!
   | DeleteObjectKeyOp;
 
-export type CreateOp = CreateRootObjectOp | CreateChildOp;
+export type CreateOp = CreateChildOp;
 
 export type CreateChildOp =
   | CreateObjectOp
@@ -48,15 +48,6 @@ export type CreateObjectOp = {
   readonly parentId: string;
   readonly parentKey: string;
   readonly data: JsonObject;
-};
-
-export type CreateRootObjectOp = {
-  readonly opId?: string;
-  readonly id: string;
-  readonly type: OpCode.CREATE_OBJECT;
-  readonly data: JsonObject;
-  readonly parentId?: never;
-  readonly parentKey?: never;
 };
 
 export type CreateListOp = {

--- a/packages/liveblocks-core/src/protocol/Op.ts
+++ b/packages/liveblocks-core/src/protocol/Op.ts
@@ -24,9 +24,7 @@ export type Op =
   | SetParentKeyOp // Only for lists!
   | DeleteObjectKeyOp;
 
-export type CreateOp = CreateChildOp;
-
-export type CreateChildOp =
+export type CreateOp =
   | CreateObjectOp
   | CreateRegisterOp
   | CreateMapOp

--- a/packages/liveblocks-core/src/types/Brand.ts
+++ b/packages/liveblocks-core/src/types/Brand.ts
@@ -1,2 +1,0 @@
-declare const brand: unique symbol;
-export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/node",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "A server-side utility that lets you set up a Liveblocks authentication endpoint. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -37,7 +37,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@liveblocks/core": "1.5.2",
+    "@liveblocks/core": "1.5.3-test1",
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/node": "^20.7.1",

--- a/packages/liveblocks-react-comments/package.json
+++ b/packages/liveblocks-react-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react-comments",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "A set of React components to add real time comments a la Notion, Figma, Google Docs in your product.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -49,9 +49,9 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.2",
-    "@liveblocks/client": "1.5.2",
-    "@liveblocks/core": "1.5.2",
-    "@liveblocks/react": "1.5.2",
+    "@liveblocks/client": "1.5.3-test1",
+    "@liveblocks/core": "1.5.3-test1",
+    "@liveblocks/react": "1.5.3-test1",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "A set of React hooks and providers to use Liveblocks declaratively. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -34,8 +34,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.5.2",
-    "@liveblocks/core": "1.5.2",
+    "@liveblocks/client": "1.5.3-test1",
+    "@liveblocks/core": "1.5.3-test1",
     "nanoid": "^3",
     "use-sync-external-store": "^1.2.0"
   },

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/redux",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "A store enhancer to integrate Liveblocks into Redux stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,8 +32,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.5.2",
-    "@liveblocks/core": "1.5.2"
+    "@liveblocks/client": "1.5.3-test1",
+    "@liveblocks/core": "1.5.3-test1"
   },
   "peerDependencies": {
     "redux": "^4"

--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/yjs",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "An integration with . Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,8 +32,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.5.2",
-    "@liveblocks/core": "1.5.2",
+    "@liveblocks/client": "1.5.3-test1",
+    "@liveblocks/core": "1.5.3-test1",
     "js-base64": "^3.7.5"
   },
   "peerDependencies": {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "1.5.2",
+  "version": "1.5.3-test1",
   "description": "A middleware to integrate Liveblocks into Zustand stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,8 +33,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.5.2",
-    "@liveblocks/core": "1.5.2"
+    "@liveblocks/client": "1.5.3-test1",
+    "@liveblocks/core": "1.5.3-test1"
   },
   "peerDependencies": {
     "zustand": "^4.1.3"


### PR DESCRIPTION
We're no longing supporting the ws protocol that relied on `CreateRootObjectOp`, so we can safely remove it.