### PR TITLE
Let link-locally script downgrade TypeScript version back to 4.7

### DIFF
--- a/scripts/link-example-locally.sh
+++ b/scripts/link-example-locally.sh
@@ -57,6 +57,8 @@ fi
 
 ( cd ../../ && npm i > /dev/null )
 
+npm i
+
 err "All good! Current example is now a local NPM workspace."
 
 # Step 5: Capture these changes in a Git commit, so you can easily undo this


### PR DESCRIPTION
This updates the `link-locally.sh` helper script to re-run `npm i` inside the current example again too. This is important now that the TypeScript versions differ between the packages and the examples. Not running `npm i` inside the example will not respect the correct TypeScript version here.
