### PR TITLE
Improve timeout error logging in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.6.1
+
+### `@liveblocks/client`
+
+- Improve some internal logging
+
 # v1.6.0
 
 ### `@liveblocks/yjs`

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -487,7 +487,12 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
     .onEnterAsync(
       "@auth.busy",
 
-      () => withTimeout(delegates.authenticate(), AUTH_TIMEOUT),
+      () =>
+        withTimeout(
+          delegates.authenticate(),
+          AUTH_TIMEOUT,
+          "Timed out during auth"
+        ),
 
       // On successful authentication
       (okEvent) => ({
@@ -673,7 +678,11 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
           }
         );
 
-        return withTimeout(connect$, SOCKET_CONNECT_TIMEOUT).then(
+        return withTimeout(
+          connect$,
+          SOCKET_CONNECT_TIMEOUT,
+          "Timed out during websocket connection"
+        ).then(
           //
           // Part 3:
           // By now, our "open" event has fired, and the promise has been

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -602,8 +602,8 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
 
             const [actor$, didReceiveActor] = controlledPromise<void>();
             if (!options.waitForActorId) {
-              // Just mark the promise as "resolved" immediately, so it won't
-              // be a blocker.
+              // Mark the promise as "resolved" immediately, so we won't wait
+              // for a ROOM_STATE message to happen.
               didReceiveActor();
             }
 

--- a/packages/liveblocks-core/src/lib/controlledPromise.ts
+++ b/packages/liveblocks-core/src/lib/controlledPromise.ts
@@ -16,8 +16,5 @@ export function controlledPromise<T>(): [
   const promise = new Promise<T>((res) => {
     flagger = res;
   });
-  if (!flagger) {
-    throw new Error("Should never happen");
-  }
-  return [promise, flagger];
+  return [promise, flagger!];
 }

--- a/packages/liveblocks-core/src/lib/controlledPromise.ts
+++ b/packages/liveblocks-core/src/lib/controlledPromise.ts
@@ -16,5 +16,8 @@ export function controlledPromise<T>(): [
   const promise = new Promise<T>((res) => {
     flagger = res;
   });
-  return [promise, flagger!];
+  if (!flagger) {
+    throw new Error("Should never happen");
+  }
+  return [promise, flagger];
 }

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -164,7 +164,7 @@ export function compactObject<O extends Record<string, unknown>>(obj: O): O {
 export async function withTimeout<T>(
   promise: Promise<T>,
   millis: number,
-  errmsg = "Timed out"
+  errmsg: string
 ): Promise<T> {
   let timerID: ReturnType<typeof setTimeout> | undefined;
   const timer$ = new Promise<never>((_, reject) => {


### PR DESCRIPTION
We've gotten some bug reports where in some cases the client fails to connect to the servers, and shows a generic "Timed out" error. This could be coming from 2 places, so let's make sure to distinguish them to get better info, so we can rule out one of these possible sources.
