### PR TITLE
Log details about `FORBIDDEN` errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-# 1.7.0 (not yet released)
+# 1.7.0
 
 [Liveblocks Comments](https://liveblocks.io/comments) is now available for
 everyone as a public beta, learn more about this
 [in the announcement](https://liveblocks.io/blog/liveblocks-comments-is-available-for-everyone).
+
+### `@liveblocks/react`
+
+- Improve Comments-specific error logging.
 
 ### `@liveblocks/react-comments`
 

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -187,7 +187,7 @@ export type { DevTools };
 
 // Comments
 export type { CommentsApi } from "./comments";
-export { createCommentsApi } from "./comments";
+export { CommentsApiError, createCommentsApi } from "./comments";
 export type { BaseMetadata } from "./comments/types/BaseMetadata";
 export type {
   CommentBody,

--- a/packages/liveblocks-react-comments/src/errors.ts
+++ b/packages/liveblocks-react-comments/src/errors.ts
@@ -76,7 +76,7 @@ export class DeleteCommentError extends Error {
   }
 }
 
-export type CommentsApiError<TThreadMetadata extends BaseMetadata> =
+export type CommentsError<TThreadMetadata extends BaseMetadata> =
   | CreateThreadError<TThreadMetadata>
   | EditThreadMetadataError<TThreadMetadata>
   | CreateCommentError

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -4,7 +4,6 @@ import type {
   CommentBody,
   CommentData,
   CommentReaction,
-  CommentsApiError,
   EventSource,
   Json,
   JsonObject,
@@ -13,7 +12,7 @@ import type {
   Room,
   ThreadData,
 } from "@liveblocks/core";
-import { console, makeEventSource } from "@liveblocks/core";
+import { CommentsApiError, console, makeEventSource } from "@liveblocks/core";
 import { nanoid } from "nanoid";
 import { useEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
@@ -360,7 +359,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.editThreadMetadata({ metadata, threadId }), {
       optimisticData,
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new EditThreadMetadataError(error, {
@@ -405,7 +408,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.createThread({ threadId, commentId, body, metadata }), {
       optimisticData: [...threads, newThread],
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new CreateThreadError(error, {
@@ -452,7 +459,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.createComment({ threadId, commentId, body }), {
       optimisticData,
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new CreateCommentError(error, {
@@ -490,7 +501,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.editComment({ threadId, commentId, body }), {
       optimisticData,
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new EditCommentError(error, {
@@ -536,7 +551,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.deleteComment({ threadId, commentId }), {
       optimisticData: newThreads,
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new DeleteCommentError(error, {
@@ -726,7 +745,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.addReaction({ threadId, commentId, emoji }), {
       optimisticData,
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new AddReactionError(error, {
@@ -791,7 +814,11 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.removeReaction({ threadId, commentId, emoji }), {
       optimisticData,
-    }).catch((err: CommentsApiError) => {
+    }).catch((err: unknown) => {
+      if (!(err instanceof CommentsApiError)) {
+        throw err;
+      }
+
       const error = handleCommentsApiError(err);
       errorEventSource.notify(
         new RemoveReactionError(error, {

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -4,6 +4,7 @@ import type {
   CommentBody,
   CommentData,
   CommentReaction,
+  CommentsApiError,
   EventSource,
   Json,
   JsonObject,
@@ -12,14 +13,14 @@ import type {
   Room,
   ThreadData,
 } from "@liveblocks/core";
-import { makeEventSource } from "@liveblocks/core";
+import { console, makeEventSource } from "@liveblocks/core";
 import { nanoid } from "nanoid";
 import { useEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 
 import {
   AddReactionError,
-  type CommentsApiError,
+  type CommentsError,
   CreateCommentError,
   CreateThreadError,
   DeleteCommentError,
@@ -174,6 +175,21 @@ function createThreadsManager<TThreadMetadata extends BaseMetadata>() {
   };
 }
 
+function handleCommentsApiError(err: CommentsApiError): Error {
+  const message = `Request failed with status ${err.status}: ${err.message}`;
+
+  // Log details about FORBIDDEN errors
+  if (err.details?.error === "FORBIDDEN") {
+    const detailedMessage = [message, err.details.suggestion, err.details.docs]
+      .filter(Boolean)
+      .join("\n");
+
+    console.error(detailedMessage);
+  }
+
+  return new Error(message);
+}
+
 /**
  * This implementation is inspired by the `swr` library.
  * Additional modifications were made to adapt it to our specific needs.
@@ -182,7 +198,7 @@ function createThreadsManager<TThreadMetadata extends BaseMetadata>() {
  */
 export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json>,
-  errorEventSource: EventSource<CommentsApiError<TThreadMetadata>>
+  errorEventSource: EventSource<CommentsError<TThreadMetadata>>
 ): CommentsRoom<TThreadMetadata> {
   const manager = createThreadsManager<TThreadMetadata>();
 
@@ -344,9 +360,10 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.editThreadMetadata({ metadata, threadId }), {
       optimisticData,
-    }).catch((err: Error) => {
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new EditThreadMetadataError(err, {
+        new EditThreadMetadataError(error, {
           roomId: room.id,
           threadId,
           metadata,
@@ -388,17 +405,18 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.createThread({ threadId, commentId, body, metadata }), {
       optimisticData: [...threads, newThread],
-    }).catch((er: Error) =>
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new CreateThreadError(er, {
+        new CreateThreadError(error, {
           roomId: room.id,
           threadId,
           commentId,
           body,
           metadata,
         })
-      )
-    );
+      );
+    });
 
     return newThread;
   }
@@ -434,16 +452,17 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.createComment({ threadId, commentId, body }), {
       optimisticData,
-    }).catch((er: Error) =>
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new CreateCommentError(er, {
+        new CreateCommentError(error, {
           roomId: room.id,
           threadId,
           commentId,
           body,
         })
-      )
-    );
+      );
+    });
 
     return comment;
   }
@@ -471,16 +490,17 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.editComment({ threadId, commentId, body }), {
       optimisticData,
-    }).catch((er: Error) =>
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new EditCommentError(er, {
+        new EditCommentError(error, {
           roomId: room.id,
           threadId,
           commentId,
           body,
         })
-      )
-    );
+      );
+    });
   }
 
   function deleteComment({ threadId, commentId }: DeleteCommentOptions): void {
@@ -516,15 +536,16 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.deleteComment({ threadId, commentId }), {
       optimisticData: newThreads,
-    }).catch((er: Error) =>
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new DeleteCommentError(er, {
+        new DeleteCommentError(error, {
           roomId: room.id,
           threadId,
           commentId,
         })
-      )
-    );
+      );
+    });
   }
 
   function getCurrentUserId() {
@@ -705,9 +726,10 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.addReaction({ threadId, commentId, emoji }), {
       optimisticData,
-    }).catch((err: Error) => {
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new AddReactionError(err, {
+        new AddReactionError(error, {
           roomId: room.id,
           threadId,
           commentId,
@@ -769,9 +791,10 @@ export function createCommentsRoom<TThreadMetadata extends BaseMetadata>(
 
     mutate(room.removeReaction({ threadId, commentId, emoji }), {
       optimisticData,
-    }).catch((err: Error) => {
+    }).catch((err: CommentsApiError) => {
+      const error = handleCommentsApiError(err);
       errorEventSource.notify(
-        new RemoveReactionError(err, {
+        new RemoveReactionError(error, {
           roomId: room.id,
           threadId,
           commentId,

--- a/packages/liveblocks-react/src/comments/errors.ts
+++ b/packages/liveblocks-react/src/comments/errors.ts
@@ -110,7 +110,7 @@ export class RemoveReactionError extends Error {
   }
 }
 
-export type CommentsApiError<TThreadMetadata extends BaseMetadata> =
+export type CommentsError<TThreadMetadata extends BaseMetadata> =
   | CreateThreadError<TThreadMetadata>
   | EditThreadMetadataError<TThreadMetadata>
   | CreateCommentError

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -44,7 +44,7 @@ import type {
   ThreadsState,
 } from "./comments/CommentsRoom";
 import { createCommentsRoom } from "./comments/CommentsRoom";
-import type { CommentsApiError } from "./comments/errors";
+import type { CommentsError } from "./comments/errors";
 import { useDebounce } from "./comments/lib/use-debounce";
 import { useAsyncCache } from "./lib/use-async-cache";
 import { useInitial } from "./lib/use-initial";
@@ -904,7 +904,7 @@ export function createRoomContext<
   }
 
   const commentsErrorEventSource =
-    makeEventSource<CommentsApiError<TThreadMetadata>>();
+    makeEventSource<CommentsError<TThreadMetadata>>();
   const commentsRooms = new Map<
     Room<JsonObject, LsonObject, BaseUserMeta, Json>,
     CommentsRoom<TThreadMetadata>


### PR DESCRIPTION
This PR logs details (if available) about `FORBIDDEN` errors before they're sent to `useErrorListener`.

![error](https://github.com/liveblocks/liveblocks/assets/6959425/f769b143-6f95-468f-ad5c-ba875f4833a5)