### PR TITLE
Fix overlay comments firefox bugs

### DIFF
--- a/examples/nextjs-comments-overlay/src/components/comments/NewThread.tsx
+++ b/examples/nextjs-comments-overlay/src/components/comments/NewThread.tsx
@@ -142,7 +142,16 @@ export function NewThread({ children }: Props) {
       setAllowUseComposer(true);
     }
 
+    // Right click to cancel placing
+    function handleContextMenu(e: Event) {
+      if (creatingCommentState === "placing") {
+        e.preventDefault();
+        setCreatingCommentState("complete");
+      }
+    }
+
     document.documentElement.addEventListener("pointerdown", handlePointerDown);
+    document.documentElement.addEventListener("contextmenu", handleContextMenu);
 
     return () => {
       document.documentElement.removeEventListener(

--- a/examples/nextjs-comments-overlay/src/components/comments/NewThread.tsx
+++ b/examples/nextjs-comments-overlay/src/components/comments/NewThread.tsx
@@ -144,7 +144,6 @@ export function NewThread({ children }: Props) {
 
     // Right click to cancel placing
     function handleContextMenu(e: Event) {
-      console.log(creatingCommentState);
       if (creatingCommentState === "placing") {
         e.preventDefault();
         setCreatingCommentState("complete");

--- a/examples/nextjs-comments-overlay/src/components/comments/NewThread.tsx
+++ b/examples/nextjs-comments-overlay/src/components/comments/NewThread.tsx
@@ -144,6 +144,7 @@ export function NewThread({ children }: Props) {
 
     // Right click to cancel placing
     function handleContextMenu(e: Event) {
+      console.log(creatingCommentState);
       if (creatingCommentState === "placing") {
         e.preventDefault();
         setCreatingCommentState("complete");
@@ -157,6 +158,10 @@ export function NewThread({ children }: Props) {
       document.documentElement.removeEventListener(
         "pointerdown",
         handlePointerDown
+      );
+      document.documentElement.removeEventListener(
+        "contextmenu",
+        handleContextMenu
       );
     };
   }, [creatingCommentState]);

--- a/examples/nextjs-comments-overlay/src/components/comments/PinnedThread.tsx
+++ b/examples/nextjs-comments-overlay/src/components/comments/PinnedThread.tsx
@@ -71,7 +71,13 @@ export function PinnedThread({
         onPointerUp={handlePointerUp}
         data-draggable={true}
       >
-        <img src={user.avatar} alt={user.name} width="28px" height="28px" />
+        <img
+          src={user.avatar}
+          alt={user.name}
+          width="28px"
+          height="28px"
+          draggable={false}
+        />
       </div>
       {!minimized ? (
         <div className={styles.pinnedContent}>

--- a/examples/nextjs-comments-overlay/src/styles/comments.css
+++ b/examples/nextjs-comments-overlay/src/styles/comments.css
@@ -21,3 +21,7 @@
 .lb-portal {
   z-index: var(--z-above-comments-sidemenu);
 }
+
+.lb-composer .lb-composer-editor {
+  outline: none;
+}


### PR DESCRIPTION
- You couldn't always drag pinned threads
- There was a focus outline
- Now right-click dismisses new threads