### PR TITLE
Rename `BaseUserInfo` → `IUserInfo` and expose it

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -85,7 +85,7 @@ export {
   withTimeout,
 } from "./lib/utils";
 export type { CustomAuthenticationResult } from "./protocol/Authentication";
-export type { BaseUserMeta } from "./protocol/BaseUserMeta";
+export type { BaseUserMeta, IUserInfo } from "./protocol/BaseUserMeta";
 export type {
   BroadcastEventClientMsg,
   ClientMsg,

--- a/packages/liveblocks-core/src/protocol/AuthToken.ts
+++ b/packages/liveblocks-core/src/protocol/AuthToken.ts
@@ -1,6 +1,6 @@
 import type { Json } from "../lib/Json";
 import { b64decode, isPlainObject, tryParseJson } from "../lib/utils";
-import type { BaseUserInfo } from "./BaseUserMeta";
+import type { IUserInfo } from "./BaseUserMeta";
 
 export enum Permission {
   Read = "room:read",
@@ -48,7 +48,7 @@ export type LegacySecretToken = {
 
   // Extra payload as defined by the customer's own authorization
   id?: string;
-  info?: BaseUserInfo;
+  info?: IUserInfo;
 
   // IMPORTANT: All other fields on the JWT token are deliberately treated as
   // opaque, and not relied on by the client.
@@ -63,7 +63,7 @@ export type AccessToken = {
   pid: string; // project id
   uid: string; // user id
   perms: LiveblocksPermissions; // permissions
-  ui?: BaseUserInfo; // user info
+  ui?: IUserInfo; // user info
 } & JwtMeta;
 
 /**
@@ -74,7 +74,7 @@ export type IDToken = {
   pid: string; // project id
   uid: string; // user id
   gids?: string[]; // group ids
-  ui?: BaseUserInfo; // user info
+  ui?: IUserInfo; // user info
 } & JwtMeta;
 
 export type AuthToken = AccessToken | IDToken | LegacySecretToken;

--- a/packages/liveblocks-core/src/protocol/BaseUserMeta.ts
+++ b/packages/liveblocks-core/src/protocol/BaseUserMeta.ts
@@ -1,6 +1,11 @@
 import type { Json } from "../lib/Json";
 
-export type BaseUserInfo = {
+/**
+ * Represents some constraints for user info. Basically read this as: "any JSON
+ * object is fine, but _if_ it has a name field, it _must_ be a string."
+ * (Ditto for avatar.)
+ */
+export type IUserInfo = {
   [key: string]: Json | undefined;
   name?: string;
   avatar?: string;
@@ -19,5 +24,5 @@ export type BaseUserMeta = {
   /**
    * Additional user information that has been set in the authentication endpoint.
    */
-  info?: BaseUserInfo;
+  info?: IUserInfo;
 };

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -32,7 +32,7 @@ import { asPos } from "./lib/position";
 import type { Resolve } from "./lib/Resolve";
 import { compact, deepClone, tryParseJson } from "./lib/utils";
 import { canComment, canWriteStorage, TokenKind } from "./protocol/AuthToken";
-import type { IUserInfo, BaseUserMeta } from "./protocol/BaseUserMeta";
+import type { BaseUserMeta, IUserInfo } from "./protocol/BaseUserMeta";
 import type { ClientMsg, UpdateYDocClientMsg } from "./protocol/ClientMsg";
 import { ClientMsgCode } from "./protocol/ClientMsg";
 import type { Op } from "./protocol/Op";

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -32,7 +32,7 @@ import { asPos } from "./lib/position";
 import type { Resolve } from "./lib/Resolve";
 import { compact, deepClone, tryParseJson } from "./lib/utils";
 import { canComment, canWriteStorage, TokenKind } from "./protocol/AuthToken";
-import type { BaseUserInfo, BaseUserMeta } from "./protocol/BaseUserMeta";
+import type { IUserInfo, BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { ClientMsg, UpdateYDocClientMsg } from "./protocol/ClientMsg";
 import { ClientMsgCode } from "./protocol/ClientMsg";
 import type { Op } from "./protocol/Op";
@@ -733,7 +733,7 @@ type IdFactory = () => string;
 
 type StaticSessionInfo = {
   readonly userId?: string;
-  readonly userInfo?: BaseUserInfo;
+  readonly userInfo?: IUserInfo;
 };
 
 type DynamicSessionInfo = {


### PR DESCRIPTION
Exposes our private `BaseUserInfo` type in `@liveblocks/core`. Not intended for public consumption, but I need it for a cool new library I'm working on… 🥁😇

While at it, I've renamed it to `IUserInfo` here, because I want to avoid confusion with the `BaseUserMeta` type that users would be directly exposed at and work with and see in our examples. They're too easy to mix up if you don't read closely enough.
