### PR TITLE
Extend `urljoin` with ability to handle query params safely

### DIFF
--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -70,7 +70,7 @@ function toURLSearchParams(
 ): URLSearchParams {
   const result = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
-    if (value != null) {
+    if (value !== undefined && value !== null) {
       result.set(key, value.toString());
     }
   }

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -42,11 +42,55 @@ export function normalizeStatusCode(statusCode: number): number {
   }
 }
 
+type QueryParams =
+  | Record<string, string | number | null | undefined>
+  | URLSearchParams;
+
 /**
- * Concatenates a path to a URL.
+ * Safely but conveniently build a URLSearchParams instance from a given
+ * dictionary of values. For example:
+ *
+ *   {
+ *     "foo": "bar+qux/baz",
+ *     "empty": "",
+ *     "n": 42,
+ *     "nope": undefined,
+ *     "alsonope": null,
+ *   }
+ *
+ * Will produce a value that will get serialized as
+ * `foo=bar%2Bqux%2Fbaz&empty=&n=42`.
+ *
+ * Notice how the number is converted to its string representation
+ * automatically and the `null`/`undefined` values simply don't end up in the
+ * URL.
  */
-export function urljoin(baseUrl: string | URL, path: string): string {
-  const url = new URL(baseUrl);
-  url.pathname = path;
+function toURLSearchParams(
+  params: Record<string, string | number | null | undefined>
+): URLSearchParams {
+  const result = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) {
+      result.set(key, value.toString());
+    }
+  }
+  return result;
+}
+
+/**
+ * Concatenates a path to an existing URL.
+ */
+export function urljoin(
+  baseUrl: string | URL,
+  path: string,
+  params?: QueryParams
+): string {
+  // First, sanitize by removing user/passwd/search/hash parts from the URL
+  const url = new URL(path, baseUrl);
+  if (params !== undefined) {
+    url.search = (
+      params instanceof URLSearchParams ? params : toURLSearchParams(params)
+    ).toString();
+  }
   return url.toString();
 }


### PR DESCRIPTION
Adds a third param to `urljoin` to safely yet conveniently build URLs with query params.