### PR TITLE
Comments: Various improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.7.1 (not yet released)
+
+### `@liveblocks/react-comments`
+
+- Improve relative date formatting for some locales. (e.g. the `"fr"`` locale
+  formatted “1h ago” as “-1 h” instead of “il y a 1 h”)
+- Improve default monospace font for inline code blocks.
+
 # 1.7.0
 
 [Liveblocks Comments](https://liveblocks.io/comments) is now available for

--- a/packages/liveblocks-react-comments/src/primitives/Timestamp.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Timestamp.tsx
@@ -80,12 +80,38 @@ function formatShortDate(date: Date, locale?: string) {
   return capitalize(formatter.format(date));
 }
 
+// Some locales' relative formatting can be broken (e.g. "-1h") when using the narrow style.
+const localesWithBrokenNarrowRelativeFormatting = [
+  "br",
+  "fr",
+  "nb",
+  "nn",
+  "no",
+  "ro",
+  "sv",
+];
+
 /**
  * Formats a date relatively.
  */
 function formatRelativeDate(date: Date, locale?: string) {
-  const formatter = relativeTimeFormat(locale, {
-    style: "narrow",
+  let resolvedLocale: string;
+
+  if (locale) {
+    resolvedLocale = locale;
+  } else {
+    const formatter = relativeTimeFormat();
+
+    resolvedLocale = formatter.resolvedOptions().locale;
+  }
+
+  const isBrokenWhenNarrow = localesWithBrokenNarrowRelativeFormatting.some(
+    (locale) =>
+      resolvedLocale === locale || resolvedLocale.startsWith(`${locale}-`)
+  );
+
+  const formatter = relativeTimeFormat(resolvedLocale, {
+    style: isBrokenWhenNarrow ? "short" : "narrow",
     numeric: "auto",
   });
 

--- a/packages/liveblocks-react-comments/src/styles/color-mix-scale.ts
+++ b/packages/liveblocks-react-comments/src/styles/color-mix-scale.ts
@@ -28,7 +28,9 @@ export function colorMixScale(
   increment: string
 ) {
   const index = Math.max(Math.floor(Number(increment) / 100) - 1, 0);
-  const percentage = `calc(100% - (${contrast} + ${index} * ((100% - ${contrast}) / 9)))`;
+  const percentage = index
+    ? `calc(100% - (${contrast} + ${index} * ((100% - ${contrast}) / 9)))`
+    : `calc(100% - ${contrast})`;
 
   return `color-mix(in srgb, ${to}, ${from} ${percentage})`;
 }

--- a/packages/liveblocks-react-comments/src/styles/index.css
+++ b/packages/liveblocks-react-comments/src/styles/index.css
@@ -639,6 +639,12 @@
   }
 }
 
+/* 0,0,0 specificity to inherit any styles applied to `code` elements */
+:where(:is(.lb-comment-body, .lb-composer-editor) code) {
+  font-family: ui-monospace, Menlo, Monaco, "Roboto Mono", "Cascadia Code",
+    "Source Code Pro", Consolas, "DejaVu Sans Mono", monospace;
+}
+
 .lb-comment-mention,
 .lb-composer-mention {
   color: var(--lb-accent);


### PR DESCRIPTION
This PR adds a few small improvements to Comments:

- Remove unnecessary calculations in "subtle" tokens (since their `index` is 0)
- Improve relative date formatting again: we recently switched from the `"short"` style to the `"narrow"` one ("1 hour ago" became "1h ago") but in some locales that resulted in weird formatting like in French where it formatted as "-1 h". I made a quick sandbox (https://xhqmwd.csb.app/) to compare all locales and identified where the `"narrow"` style was broken but not the `"short"` one, and made it so that we use the `"short"` one for these locales only, otherwise we keep `"narrow"`.
- I like our setup where we don't explicitly set fonts and only inherit from the context, I think it's easier that way compared to forcing an arbitrary list and forcing people (who already have a specific font that they want to apply to Comments as well) to specify their font a second time just for us. That said, I think we can do it for monospace fonts used in inline code blocks, especially since the default `monospace` doesn't look great. I've set it with a specificity of `0,0,0` which means that it will override the browser's default, but anything will be able to override it, even something like `code { font-family: "My Code Font" }` so I think it's an ideal way to set a better default without added complexity.
  - **Before:** ![Before](https://github.com/liveblocks/liveblocks/assets/6959425/58c1cfcb-1927-4bb8-a909-a1d427bbae05)
  - **After:** ![After](https://github.com/liveblocks/liveblocks/assets/6959425/62d6deba-348e-4723-afed-e01adb30e9bc)
