### PR TITLE
Comments: Fix composer focus issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### `@liveblocks/react-comments`
 
+- Fix `Composer` focus issues.
 - Improve relative date formatting for some locales. (e.g. the `"fr"`` locale
   formatted “1h ago” as “-1 h” instead of “il y a 1 h”)
 - Improve default monospace font for inline code blocks.

--- a/packages/liveblocks-react-comments/src/primitives/Composer/contexts.ts
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/contexts.ts
@@ -27,6 +27,11 @@ export type ComposerContext = {
   clear: () => void;
 
   /**
+   * Select the editor programmatically.
+   */
+  select: () => void;
+
+  /**
    * Focus the editor programmatically.
    */
   focus: () => void;

--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -854,9 +854,7 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
     // Manually add a selection in the editor if the selection
     // is still empty after being focused
     useEffect(() => {
-      console.log("effect");
       if (isFocused && editor.selection === null) {
-        console.log("calling select()");
         select();
       }
     }, [editor, select, isFocused]);

--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -851,7 +851,7 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
       }
     }, [autoFocus, editor, focus]);
 
-    // Manually adding a selection in the editor if the selection
+    // Manually add a selection in the editor if the selection
     // is still empty after being focused
     useEffect(() => {
       console.log("effect");

--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -614,7 +614,7 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
       [disabled, self?.canComment]
     );
     const { editor, validate, setFocused } = useComposerEditorContext();
-    const { submit, focus, isEmpty, isFocused } = useComposer();
+    const { submit, focus, select, isEmpty, isFocused } = useComposer();
     const initialBody = useInitial(defaultValue ?? emptyCommentBody);
     const initialEditorValue = useMemo(() => {
       return commentBodyToComposerBody(initialBody);
@@ -844,11 +844,22 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
       [editor]
     );
 
+    // Manually focus the editor when `autoFocus` is true
     useEffect(() => {
       if (autoFocus) {
         focus();
       }
     }, [autoFocus, editor, focus]);
+
+    // Manually adding a selection in the editor if the selection
+    // is still empty after being focused
+    useEffect(() => {
+      console.log("effect");
+      if (isFocused && editor.selection === null) {
+        console.log("calling select()");
+        select();
+      }
+    }, [editor, select, isFocused]);
 
     return (
       <Slate
@@ -935,6 +946,13 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
       });
     }, [editor]);
 
+    const select = useCallback(() => {
+      SlateTransforms.select(editor, {
+        anchor: SlateEditor.end(editor, []),
+        focus: SlateEditor.end(editor, []),
+      });
+    }, [editor]);
+
     const focus = useCallback(
       (resetSelection = true) => {
         if (!ReactEditor.isFocused(editor)) {
@@ -1012,6 +1030,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
             isEmpty,
             submit,
             clear,
+            select,
             focus,
             blur,
             createMention,


### PR DESCRIPTION
This PR fixes an issue that could happen sometimes in Chrome/Safari, and always in Firefox: focusing the composer's editor would focus it as expected but then wouldn't create a selection in it meaning that it was impossible to interact before clicking on it manually again (to create a selection).

Fixes https://github.com/liveblocks/liveblocks.io/issues/1721.