### PR TITLE
Comments: Document `z-index` mirroring on portaled elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.7.1 (not yet released)
+# 1.7.1
 
 ### `@liveblocks/react-comments`
 

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -442,6 +442,22 @@ Classes containing colons `:` are internal and may change over time.
 
 {/* TODO: Think about adding back the browser support section */}
 
+#### Portaled elements
+
+Floating elements within the default components (e.g. tooltips, drowdowns, etc)
+are portaled to the end of the document to avoid `z-index` conflicts and
+`overflow` issues.
+
+When portaled, those elements are also wrapped in a container to handle their
+positioning. These containers don’t have any specific class names or data
+attributes as they shouldn’t be targeted or styled directly, but they will
+mirror whatever `z-index` value is set on their inner element (which would be
+`auto` by default). So if you need to set a specific `z-index` value on floating
+elements, you should set it on the floating elements themselves directly,
+ignoring their containers. You can either target specific floating elements
+(e.g. `.lb-tooltip`, `.lb-dropdown`, etc) or all of them at once via the
+`.lb-portal` class name.
+
 #### Overrides
 
 Overrides can be used to customize components’ strings and localization-related

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -450,13 +450,25 @@ are portaled to the end of the document to avoid `z-index` conflicts and
 
 When portaled, those elements are also wrapped in a container to handle their
 positioning. These containers don’t have any specific class names or data
-attributes as they shouldn’t be targeted or styled directly, but they will
-mirror whatever `z-index` value is set on their inner element (which would be
+attributes so they shouldn’t be targeted or styled directly, but they will
+mirror whichever `z-index` value is set on their inner element (which would be
 `auto` by default). So if you need to set a specific `z-index` value on floating
 elements, you should set it on the floating elements themselves directly,
 ignoring their containers. You can either target specific floating elements
 (e.g. `.lb-tooltip`, `.lb-dropdown`, etc) or all of them at once via the
 `.lb-portal` class name.
+
+```css
+/* Target all floating elements */
+.lb-portal {
+  z-index: 5;
+}
+
+/* Target a specific floating element */
+.lb-tooltip {
+  z-index: 10;
+}
+```
 
 #### Overrides
 


### PR DESCRIPTION
This PR documents how to customize the `z-index` value of portaled elements within the default components.

(Unrelated `CHANGELOG.md` change because I will release 1.7.1 today)