### PR TITLE
Fix Monaco error

### DIFF
--- a/examples/nextjs-yjs-monaco/src/components/CollaborativeEditor.tsx
+++ b/examples/nextjs-yjs-monaco/src/components/CollaborativeEditor.tsx
@@ -68,6 +68,7 @@ export function CollaborativeEditor() {
           defaultValue=""
           options={{
             tabSize: 2,
+            padding: { top: 20 },
           }}
         />
       </div>

--- a/examples/nextjs-yjs-monaco/src/globals.css
+++ b/examples/nextjs-yjs-monaco/src/globals.css
@@ -66,9 +66,3 @@ main {
   user-select: none;
   z-index: 1000;
 }
-
-/* Move the editor down so cursors aren't hidden by overflow */
-.monaco-editor .overflow-guard > .margin,
-.monaco-editor .lines-content > * {
-  top: 20px !important;
-}

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
@@ -268,6 +268,7 @@ export function CollaborativeEditor() {
           defaultValue=""
           options={{
             tabSize: 2,
+            padding: { top: 20 },
           }}
         />
       </div>
@@ -432,12 +433,6 @@ a global CSS file:
   user-select: none;
   z-index: 1000;
 }
-
-/* Move the editor down so cursors aren't hidden by overflow */
-.monaco-editor .overflow-guard > .margin,
-.monaco-editor .lines-content > * {
-  top: 20px !important;
-}
 ```
 
 You can then import this into your editor to enable live cursors:
@@ -462,6 +457,7 @@ export function CollaborativeEditor() {
           defaultValue=""
           options={{
             tabSize: 2,
+            padding: { top: 20 },
           }}
         />
       </div>
@@ -699,6 +695,7 @@ export function CollaborativeEditor() {
           defaultValue=""
           options={{
             tabSize: 2,
+            padding: { top: 20 },
           }}
         />
       </div>

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
@@ -567,6 +567,7 @@ export function CollaborativeEditor() {
           defaultValue=""
           options={{
             tabSize: 2,
+            padding: { top: 20 },
           }}
         />
       </div>


### PR DESCRIPTION
Fixes a weird UI error cause by custom CSS. Uses a Monaco option instead. Updates the guide too.