### PR TITLE
Fix bug in `toPlainLson` around falsey values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.8.1
+
+- Fixes a bug in `toPlainLson` helper (#1304)
+
 # v1.8.0
 
 This release adds all the REST APIs as fully typed methods, and utilities to

--- a/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
@@ -300,4 +300,27 @@ describe("toPlainLson", () => {
     const lsonToPlain = toPlainLson(mockLsonObject);
     expect(lsonObject).toEqual(lsonToPlain);
   });
+
+  // See https://github.com/liveblocks/liveblocks/issues/1304
+  it("toPlainLson regression #1", () => {
+    const mockLsonObject = new LiveObject({
+      a: null,
+      b: 0,
+      c: false,
+      d: undefined,
+    });
+
+    // What the Plain Lson should look like if the util works
+    const lsonObject = {
+      liveblocksType: "LiveObject",
+      data: {
+        a: null,
+        b: 0,
+        c: false,
+      },
+    };
+
+    const lsonToPlain = toPlainLson(mockLsonObject);
+    expect(lsonObject).toEqual(lsonToPlain);
+  });
 });

--- a/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
@@ -269,8 +269,7 @@ describe("toPlainLson", () => {
       fruits: ["strawberry", "apple", "mango"],
       vegetables: { broccoli: "delicious", spinach: "also tasty" },
     };
-    const plainToPlain = toPlainLson(mockPlainObject);
-    expect(mockPlainObject).toEqual(plainToPlain);
+    expect(toPlainLson(mockPlainObject)).toEqual(mockPlainObject);
   });
 
   it("toPlainLson with a liveStructure object should return plain lson object", () => {
@@ -283,7 +282,7 @@ describe("toPlainLson", () => {
     });
 
     // What the Plain Lson should look like if the util works
-    const lsonObject = {
+    const plainLsonValue = {
       liveblocksType: "LiveObject",
       data: {
         fruits: {
@@ -297,8 +296,7 @@ describe("toPlainLson", () => {
       },
     };
 
-    const lsonToPlain = toPlainLson(mockLsonObject);
-    expect(lsonObject).toEqual(lsonToPlain);
+    expect(toPlainLson(mockLsonObject)).toEqual(plainLsonValue);
   });
 
   // See https://github.com/liveblocks/liveblocks/issues/1304
@@ -311,7 +309,7 @@ describe("toPlainLson", () => {
     });
 
     // What the Plain Lson should look like if the util works
-    const lsonObject = {
+    const plainLsonValue = {
       liveblocksType: "LiveObject",
       data: {
         a: null,
@@ -320,7 +318,6 @@ describe("toPlainLson", () => {
       },
     };
 
-    const lsonToPlain = toPlainLson(mockLsonObject);
-    expect(lsonObject).toEqual(lsonToPlain);
+    expect(toPlainLson(mockLsonObject)).toEqual(plainLsonValue);
   });
 });

--- a/packages/liveblocks-core/src/crdts/utils.ts
+++ b/packages/liveblocks-core/src/crdts/utils.ts
@@ -51,10 +51,9 @@ export function toPlainLson(lson: Lson): PlainLson {
     return {
       liveblocksType: "LiveObject",
       data: Object.fromEntries(
-        Object.entries(lson.toObject()).map(([key, value]) => [
-          key,
-          value ? toPlainLson(value) : "",
-        ])
+        Object.entries(lson.toObject()).flatMap(([key, value]) =>
+          value !== undefined ? [[key, toPlainLson(value)]] : []
+        )
       ),
     };
   } else if (lson instanceof LiveMap) {


### PR DESCRIPTION
This fixes the following incorrect output:

<img width="426" alt="Screen Shot 2023-11-22 at 14 09 44@2x" src="https://github.com/liveblocks/liveblocks/assets/83844/8f9e0f40-f4e5-40a5-a55e-6f75060e9571">

Fixes #1304.
