### PR TITLE
Fix history `pause` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.8.1
+
+- Fix a bug where pausing history more than once can lead to history loss
+
 # v1.8.0
 
 This release adds all the REST APIs as fully typed methods, and utilities to

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2269,7 +2269,9 @@ export function createRoom<
   }
 
   function pauseHistory() {
-    context.pausedHistory = [];
+    if (context.pausedHistory === null) {
+      context.pausedHistory = [];
+    }
   }
 
   function resumeHistory() {


### PR DESCRIPTION
This fixes a bug where calling `room.history.pause()` more than once could lead to history loss.

This happens in the following sequence:

```tsx
room.history.pause();
/* mutation 1 */
room.history.pause();
/* mutation 2 */
room.history.resume();
```

The second "pause" call here will unintentionally lose the addition of the inverse operation of mutation 1 to the undo stack.

This PR fixes this by making any `.pause()` call beyond the first a no-op.
