### PR TITLE
fix(docs): documentation typo

### DIFF
--- a/docs/pages/api-reference/liveblocks-zustand.mdx
+++ b/docs/pages/api-reference/liveblocks-zustand.mdx
@@ -6,7 +6,7 @@ meta:
 alwaysShowAllNavigationLevels: false
 ---
 
-`@liveblocks/redux` provides you with [Zustand](https://docs.pmnd.rs/zustand)
+`@liveblocks/zustand` provides you with [Zustand](https://docs.pmnd.rs/zustand)
 bindings for our real-time collaboration APIs, built on top of WebSockets. Read
 our [getting started](/docs/get-started) guides to learn more.
 


### PR DESCRIPTION
Fixing a documentation typo. `@liveblocks/zustand` provides you with Zustand bindings, not `@liveblocks/redux`.