### PR TITLE
Fix `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # v1.8.2 (not yet released)
 
-### `@liveblocks/react-comments`
+### `@liveblocks/react`
 
-- Improve network loss and document visibility handling during comment
-  revalidation.
-- Better error handling on mutations (e.g. thread creation, comment creation,
-  etc.)
+- Improve Comments revalidation when losing network or staying in the
+  background.
+- Improve error handling of Comments mutations. (e.g. thread creation, comment
+  creation, etc.)
 
 # v1.8.1
 


### PR DESCRIPTION
`@liveblocks/react-comments` focuses only on components so we should still document core changes as part of `@liveblocks/react`, and while I was there I tweaked the changes a bit.