### PR TITLE
Add query options to useThreads

### DIFF
--- a/examples/nextjs-comments/liveblocks.config.ts
+++ b/examples/nextjs-comments/liveblocks.config.ts
@@ -5,40 +5,44 @@ import { createRoomContext } from "@liveblocks/react";
 
 export const client = createClient({
   authEndpoint: "/api/liveblocks-auth",
+  baseUrl: "https://dev.dev-liveblocks5948.workers.dev/",
 });
 
 const {
   suspense: { RoomProvider, useThreads },
-} = createRoomContext(client, {
-  // Get users' info from their ID
-  resolveUsers: async ({ userIds }) => {
-    const searchParams = new URLSearchParams(
-      userIds.map((userId) => ["userIds", userId])
-    );
+} = createRoomContext<never, never, never, never, { resolved: boolean }>(
+  client,
+  {
+    // Get users' info from their ID
+    resolveUsers: async ({ userIds }) => {
+      const searchParams = new URLSearchParams(
+        userIds.map((userId) => ["userIds", userId])
+      );
 
-    try {
-      const response = await fetch(`/api/users?${searchParams}`);
+      try {
+        const response = await fetch(`/api/users?${searchParams}`);
 
-      return response.json();
-    } catch (error) {
-      console.error(123, error);
-    }
-  },
+        return response.json();
+      } catch (error) {
+        console.error(123, error);
+      }
+    },
 
-  // Find a list of users that match the current search term
-  resolveMentionSuggestions: async ({ text }) => {
-    const searchParams = new URLSearchParams({ text });
+    // Find a list of users that match the current search term
+    resolveMentionSuggestions: async ({ text }) => {
+      const searchParams = new URLSearchParams({ text });
 
-    try {
-      const response = await fetch(`/api/users/search?${searchParams}`);
+      try {
+        const response = await fetch(`/api/users/search?${searchParams}`);
 
-      return response.json();
-    } catch (error) {
-      console.error(456, error);
+        return response.json();
+      } catch (error) {
+        console.error(456, error);
 
-      return [];
-    }
-  },
-});
+        return [];
+      }
+    },
+  }
+);
 
 export { RoomProvider, useThreads };

--- a/examples/nextjs-comments/src/app/page.tsx
+++ b/examples/nextjs-comments/src/app/page.tsx
@@ -14,15 +14,53 @@ import { ErrorBoundary } from "react-error-boundary";
  */
 
 function Example() {
-  const { threads } = useThreads();
-
   return (
     <main>
+      <div style={{ color: "white" }}>RESOLVED</div>
+      <ResolveThreads />
+      <div style={{ color: "white" }}>NOT RESOLVED</div>
+      <UnresolvedThreads />
+      <div style={{ color: "white" }}>ALL THREADS</div>
+      <AllThreads />
+      <Composer className="composer" />
+    </main>
+  );
+}
+
+function AllThreads() {
+  const { threads } = useThreads();
+  return (
+    <>
       {threads.map((thread) => (
         <Thread key={thread.id} thread={thread} className="thread" />
       ))}
-      <Composer className="composer" />
-    </main>
+    </>
+  );
+}
+
+function ResolveThreads() {
+  const { threads } = useThreads({
+    query: { metadata: { resolved: true } },
+  });
+  return (
+    <>
+      {threads.map((thread) => (
+        <Thread key={thread.id} thread={thread} className="thread" />
+      ))}
+    </>
+  );
+}
+
+function UnresolvedThreads() {
+  const { threads } = useThreads({
+    query: { metadata: { resolved: false } },
+  });
+  return (
+    <>
+      {threads.map((thread) => (
+        <Thread key={thread.id} thread={thread} className="thread" />
+      ))}
+    </>
   );
 }
 

--- a/packages/liveblocks-core/src/comments/index.ts
+++ b/packages/liveblocks-core/src/comments/index.ts
@@ -31,7 +31,9 @@ type PartialNullable<T> = {
 };
 
 export type CommentsApi<TThreadMetadata extends BaseMetadata> = {
-  getThreads(): Promise<ThreadData<TThreadMetadata>[]>;
+  getThreads(
+    query: Partial<TThreadMetadata>
+  ): Promise<ThreadData<TThreadMetadata>[]>;
   createThread(options: {
     threadId: string;
     commentId: string;
@@ -140,8 +142,15 @@ export function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     });
   }
 
-  async function getThreads(): Promise<ThreadData<TThreadMetadata>[]> {
-    const response = await fetchApi(roomId, "/threads");
+  async function getThreads(
+    query: Partial<TThreadMetadata>
+  ): Promise<ThreadData<TThreadMetadata>[]> {
+    const response = await fetchApi(
+      roomId,
+      `/threads?${Array.from(Object.entries(query))
+        .map((entry) => `metadata.${entry[0]}=${entry[1]}`)
+        .join("&")}`
+    );
 
     if (response.ok) {
       const json = await (response.json() as Promise<{

--- a/packages/liveblocks-react/src/comments/CommentsRoom.ts
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.ts
@@ -47,8 +47,12 @@ type PartialNullable<T> = {
 };
 
 export type CommentsRoom<TThreadMetadata extends BaseMetadata> = {
-  useThreads(): ThreadsState<TThreadMetadata>;
-  useThreadsSuspense(): ThreadsStateSuccess<TThreadMetadata>;
+  useThreads(
+    options?: useThreadsOptions<TThreadMetadata>
+  ): ThreadsState<TThreadMetadata>;
+  useThreadsSuspense(
+    options?: useThreadsOptions<TThreadMetadata>
+  ): ThreadsStateSuccess<TThreadMetadata>;
   useCreateThread(): (
     options: CreateThreadOptions<TThreadMetadata>
   ) => ThreadData<TThreadMetadata>;
@@ -60,6 +64,10 @@ export type CommentsRoom<TThreadMetadata extends BaseMetadata> = {
   useDeleteComment(): (options: DeleteCommentOptions) => void;
   useAddReaction(): (options: CommentReactionOptions) => void;
   useRemoveReaction(): (options: CommentReactionOptions) => void;
+};
+
+export type useThreadsOptions<TMetadata extends BaseMetadata> = {
+  query: { metadata: Partial<TMetadata> };
 };
 
 export type CreateThreadOptions<TMetadata extends BaseMetadata> = [

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -38,6 +38,7 @@ import type {
   CreateCommentOptions,
   EditCommentOptions,
   ThreadsState,
+  useThreadsOptions,
 } from "./comments/CommentsRoom";
 import { createCommentsRoom } from "./comments/CommentsRoom";
 import type { CommentsError } from "./comments/errors";
@@ -917,14 +918,16 @@ export function createRoomContext<
     return commentsRoom;
   }
 
-  function useThreads(): ThreadsState<TThreadMetadata> {
+  function useThreads(
+    options?: useThreadsOptions<TThreadMetadata>
+  ): ThreadsState<TThreadMetadata> {
     const room = useRoom();
-    return getCommentsRoom(room).useThreads();
+    return getCommentsRoom(room).useThreads(options);
   }
 
-  function useThreadsSuspense() {
+  function useThreadsSuspense(options?: useThreadsOptions<TThreadMetadata>) {
     const room = useRoom();
-    return getCommentsRoom(room).useThreadsSuspense();
+    return getCommentsRoom(room).useThreadsSuspense(options);
   }
 
   function useCreateThread() {

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -667,7 +667,9 @@ export type RoomContextBundle<
      * @example
      * const { threads, error, isLoading } = useThreads();
      */
-    useThreads(): ThreadsState<TThreadMetadata>;
+    useThreads(options?: {
+      query: Partial<TThreadMetadata>;
+    }): ThreadsState<TThreadMetadata>;
 
     /**
      * @beta
@@ -817,7 +819,9 @@ export type RoomContextBundle<
          * @example
          * const { threads } = useThreads();
          */
-        useThreads(): ThreadsStateSuccess<TThreadMetadata>;
+        useThreads(options?: {
+          query: Partial<TThreadMetadata>;
+        }): ThreadsStateSuccess<TThreadMetadata>;
 
         /**
          * @beta

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -31,6 +31,7 @@ import type {
   EditThreadMetadataOptions,
   ThreadsState,
   ThreadsStateSuccess,
+  useThreadsOptions,
 } from "./comments/CommentsRoom";
 
 export type PromiseOrNot<T> = T | Promise<T>;
@@ -667,9 +668,9 @@ export type RoomContextBundle<
      * @example
      * const { threads, error, isLoading } = useThreads();
      */
-    useThreads(options?: {
-      query?: { metadata?: Partial<TThreadMetadata> };
-    }): ThreadsState<TThreadMetadata>;
+    useThreads(
+      options?: useThreadsOptions<TThreadMetadata>
+    ): ThreadsState<TThreadMetadata>;
 
     /**
      * @beta
@@ -819,9 +820,9 @@ export type RoomContextBundle<
          * @example
          * const { threads } = useThreads();
          */
-        useThreads(options?: {
-          query?: { metadata?: Partial<TThreadMetadata> };
-        }): ThreadsStateSuccess<TThreadMetadata>;
+        useThreads(
+          options?: useThreadsOptions<TThreadMetadata>
+        ): ThreadsStateSuccess<TThreadMetadata>;
 
         /**
          * @beta

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -668,7 +668,7 @@ export type RoomContextBundle<
      * const { threads, error, isLoading } = useThreads();
      */
     useThreads(options?: {
-      query: Partial<TThreadMetadata>;
+      query?: { metadata?: Partial<TThreadMetadata> };
     }): ThreadsState<TThreadMetadata>;
 
     /**
@@ -820,7 +820,7 @@ export type RoomContextBundle<
          * const { threads } = useThreads();
          */
         useThreads(options?: {
-          query: Partial<TThreadMetadata>;
+          query?: { metadata?: Partial<TThreadMetadata> };
         }): ThreadsStateSuccess<TThreadMetadata>;
 
         /**


### PR DESCRIPTION
Add an option to `useThreads` to filter threads based on their metadata.

## Definition

```typescript
useThreads(options?: { query?: { metadata?: Partial<TThreadMetadata> }});
```

## Usage

```typescript
// ./liveblocks.config.ts
type ThreadMetadata = {
  pageId: string,
  foo: string
}

// Usage
// Get threads where metadata.pageId === "xxx" && foo === "bar"
const { threads } = useThreads({ query: { metadata: { pageId: "xxx", foo: "bar" }});
```

## Implementation

- The logic operator `&&` (`AND`) is used when the query contains multiple fields

### Client REST API

- `GET https://liveblocks.io/v2/c/rooms/:roomId/threads?query=metadata.pageId:'xxx' metadata.foo:'bar'`

*If it's taking too long to do the query parsing, we can take a shortcut and use `metadata.pageId=xxx` for our client REST API since it's considered an internal API*

### Not supported for now 

- `||` (`OR`) logic operator is not supported. An optional field operator could be added later to support `OR` on the `query` object. Combining `AND` and `OR` will not be supported for a long time (if ever). [Stripe metadata model does not allow it.](https://stripe.com/docs/search#query-structure-and-terminology)
- Only strict equality is supported. Other types of comparisons (`>`, `!=`, etc) can be added without breaking change by mapping `TThreadMetadata` values to a more complex object.
- No sort options. We can support it later by adding a new field on `query`.
- No pagination support. We can support it later by adding a new field on `options`.

