### PR TITLE
Fix `getActiveUsers` return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.8.3 (Unreleased)
+
+### `@liveblocks/node`
+
+- Fixes the return type of `getActiveUsers` to match the data returned from the
+  endpoint.
+
 # v1.8.2
 
 ### `@liveblocks/react`

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -475,7 +475,7 @@ and returns the same response.
 ```ts
 const activeUsers = await liveblocks.getActiveUsers("my-room-id");
 
-// [{ type: "user", id: "my-user-id", ... }, ...]
+// { data: [{ type: "user", id: "my-user-id", ... }, ...] }
 console.log(activeUsers);
 ```
 
@@ -500,7 +500,7 @@ import { UserMeta } from "../liveblocks.config";
 const activeUsers =
   await liveblocks.getActiveUsers<UserMeta["info"]>("my-room-id");
 
-// [{ ..., info: { name: "Nimesh", avatar: "https://..." }, ...]
+// { data: [{ ..., info: { name: "Nimesh", avatar: "https://..." }, ...] }
 console.log(activeUsers);
 ```
 

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -25,6 +25,17 @@ describe("client", () => {
     },
   };
 
+  const activeUsers = [
+    {
+      type: "user",
+      id: "alice",
+      connectionId: 123,
+      info: {
+        name: "Alice",
+      },
+    },
+  ];
+
   const server = setupServer(
     http.get(`${DEFAULT_BASE_URL}/v2/rooms`, () => {
       return HttpResponse.json(
@@ -37,6 +48,12 @@ describe("client", () => {
     }),
     http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId`, () => {
       return HttpResponse.json(room, { status: 200 });
+    }),
+    http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/active_users`, () => {
+      console.log("Hii");
+      return HttpResponse.json({
+        data: activeUsers,
+      });
     })
   );
 
@@ -132,6 +149,13 @@ describe("client", () => {
   test("should return room data when getRoom receives a successful response", async () => {
     const client = new Liveblocks({ secret: "sk_xxx" });
     await expect(client.getRoom("123")).resolves.toEqual(room);
+  });
+
+  test("should return active users when getActiveUsers receives a successful response", async () => {
+    const client = new Liveblocks({ secret: "sk_xxx" });
+    await expect(client.getActiveUsers("123")).resolves.toEqual({
+      data: activeUsers,
+    });
   });
 
   test("should throw an ApiError when getRoom receives an error response", async () => {

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -50,7 +50,6 @@ describe("client", () => {
       return HttpResponse.json(room, { status: 200 });
     }),
     http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/active_users`, () => {
-      console.log("Hii");
       return HttpResponse.json({
         data: activeUsers,
       });

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -500,7 +500,7 @@ export class Liveblocks {
    */
   public async getActiveUsers<T = unknown>(
     roomId: string
-  ): Promise<RoomUser<T>[]> {
+  ): Promise<{ data: RoomUser<T>[] }> {
     const res = await this.get(url`/v2/rooms/${roomId}/active_users`);
 
     if (!res.ok) {
@@ -508,7 +508,7 @@ export class Liveblocks {
       throw new LiveblocksError(res.status, text);
     }
 
-    return (await res.json()) as Promise<RoomUser<T>[]>;
+    return (await res.json()) as Promise<{ data: RoomUser<T>[] }>;
   }
 
   /**


### PR DESCRIPTION
Fixes the return type of `getActiveUsers` to match the data returned from the endpoint.

Original discussion: https://github.com/liveblocks/liveblocks/pull/1316