### PR TITLE
Use typed REST APIs in Yjs guide

### DIFF
--- a/guides/pages/modifying-yjs-document-data-with-the-rest-api.mdx
+++ b/guides/pages/modifying-yjs-document-data-with-the-rest-api.mdx
@@ -7,19 +7,24 @@ meta:
 
 Liveblocks allows you to update your Yjs document data, or `yDoc`, from the REST
 API, helpful for sending updates from the server. This is made possible through
-the
-[Send a binary Yjs update API](/docs/api-reference/rest-api-endpoints#put-rooms-roomId-ydoc).
+[`Liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc)
+in [`@liveblocks/node`](/docs/api-reference/liveblocks-node).
 
 ## Updating a Yjs document
 
 Updating a Yjs document requires you to create a
 [binary update](https://docs.yjs.dev/api/document-updates), before sending it to
-the REST API. Here’s an example in a serverless endpoint.
+Liveblocks using
+[`Liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).
+Here’s an example in a serverless endpoint.
 
 ```ts
 import * as Y from "yjs";
+import { Liveblocks } from "@liveblocks/node";
 
-const SECRET_KEY = "{{SECRET_KEY}}";
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
 const roomId = "my-room-name";
 
 export async function POST() {
@@ -34,12 +39,8 @@ export async function POST() {
   const yUpdate = Y.encodeStateAsUpdate(yDoc);
 
   // Insert the update
-  await fetch(`https://api.liveblocks.io/v2/rooms/${roomId}/ydoc`, {
-    method: "PUT",
-    headers: {
-      "Authorization:": `Bearer ${SECRET_KEY}`,
-    },
-    body: yUpdate,
+  await liveblocks.sendYjsBinaryUpdate(roomId, {
+    update: yUpdate,
   });
 }
 ```
@@ -47,14 +48,17 @@ export async function POST() {
 ## Initializing a Yjs document
 
 It’s also possible to create a new room with an initial Yjs document. To do
-this, call the
-[Create room API](/docs/api-reference/rest-api-endpoints#post-rooms), then send
-the update as before.
+this, call
+[`Liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms), then
+send the update as before.
 
-```ts highlight="17-27"
+```ts highlight="20-23"
 import * as Y from "yjs";
+import { Liveblocks } from "@liveblocks/node";
 
-const SECRET_KEY = "{{SECRET_KEY}}";
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
 const roomId = "my-room-name";
 
 export async function POST() {
@@ -69,24 +73,13 @@ export async function POST() {
   const yUpdate = Y.encodeStateAsUpdate(yDoc);
 
   // Create the new room
-  await fetch(`https://api.liveblocks.io/v2/rooms/`, {
-    method: "POST",
-    headers: {
-      "Authorization:": `Bearer ${SECRET_KEY}`,
-    },
-    body: JSON.stringify({
-      id: roomId,
-      defaultAccesses: ["room:write"],
-    }),
+  const room = await liveblocks.createRoom(roomId, {
+    defaultAccesses: ["room:write"],
   });
 
   // Initialize the Yjs document with the update
-  await fetch(`https://api.liveblocks.io/v2/rooms/${roomId}/ydoc`, {
-    method: "PUT",
-    headers: {
-      "Authorization:": `Bearer ${SECRET_KEY}`,
-    },
-    body: yUpdate,
+  await liveblocks.sendYjsBinaryUpdate(roomId, {
+    update: yUpdate,
   });
 }
 ```
@@ -95,13 +88,16 @@ export async function POST() {
 
 Note that each text and code editor may work differently, and may include
 specific functions for creating binary updates. For example, this is how to
-initialize a [Slate](/docs/get-started/yjs-slate-react) document:
+initialize a [Slate](/docs/get-started/yjs-slate-react) document.
 
-```ts highlight="2,11-15,17-19"
+```ts highlight="3,14-18,20-22"
 import * as Y from "yjs";
+import { Liveblocks } from "@liveblocks/node";
 import { slateNodesToInsertDelta } from "@slate-yjs/core";
 
-const SECRET_KEY = "{{SECRET_KEY}}";
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
 const roomId = "my-room-name";
 
 export async function POST() {
@@ -122,24 +118,13 @@ export async function POST() {
   const yUpdate = Y.encodeStateAsUpdate(yDoc);
 
   // Create the new room
-  await fetch(`https://api.liveblocks.io/v2/rooms/`, {
-    method: "POST",
-    headers: {
-      "Authorization:": `Bearer ${SECRET_KEY}`,
-    },
-    body: JSON.stringify({
-      id: roomId,
-      defaultAccesses: ["room:write"],
-    }),
+  const room = await liveblocks.createRoom(roomId, {
+    defaultAccesses: ["room:write"],
   });
 
   // Initialize the Yjs document with the update
-  await fetch(`https://api.liveblocks.io/v2/rooms/${roomId}/ydoc`, {
-    method: "PUT",
-    headers: {
-      "Authorization:": `Bearer ${SECRET_KEY}`,
-    },
-    body: yUpdate,
+  await liveblocks.sendYjsBinaryUpdate(roomId, {
+    update: yUpdate,
   });
 }
 ```


### PR DESCRIPTION
This Yjs guide still used `fetch` instead of our typed functions.