### PR TITLE
Webhooks: add explicit error if body is not a string

### DIFF
--- a/packages/liveblocks-node/src/__tests__/webhooks.test.ts
+++ b/packages/liveblocks-node/src/__tests__/webhooks.test.ts
@@ -295,6 +295,29 @@ describe("WebhookHandler", () => {
       expect(event).toEqual(userEnteredBody);
     });
 
+    it.only("should throw if the rawBody is not a string", () => {
+      jest.useFakeTimers({
+        now: 1674850126000,
+      });
+
+      const webhookHandler = new WebhookHandler(secret);
+      expect(() =>
+        webhookHandler.verifyRequest({
+          headers: {
+            ...userEnteredHeaders,
+            "webhook-signature": generateSignatureWithSvix(
+              secret,
+              userEnteredHeaders["webhook-id"],
+              userEnteredHeaders["webhook-timestamp"],
+              rawUserEnteredBody
+            ),
+          },
+          rawBody: {} as any,
+        })
+      ).toThrowError(`Invalid body, must be a string, got \"object\" instead. 
+      It is likely that you need to JSON.stringify the body before passing it.`);
+    });
+
     it("should throw if the signature is invalid", () => {
       jest.useFakeTimers({
         now: 1674850126000,

--- a/packages/liveblocks-node/src/__tests__/webhooks.test.ts
+++ b/packages/liveblocks-node/src/__tests__/webhooks.test.ts
@@ -315,8 +315,9 @@ describe("WebhookHandler", () => {
           // @ts-expect-error: we want to test invalid rawBody
           rawBody: {},
         })
-      ).toThrowError(`Invalid body, must be a string, got "object" instead. 
-      It is likely that you need to JSON.stringify the body before passing it.`);
+      ).toThrowError(
+        `Invalid rawBody field, must be a string, got "object" instead. It is likely that you need to JSON.stringify the body before passing it.`
+      );
     });
 
     it("should throw if the signature is invalid", () => {

--- a/packages/liveblocks-node/src/__tests__/webhooks.test.ts
+++ b/packages/liveblocks-node/src/__tests__/webhooks.test.ts
@@ -295,7 +295,7 @@ describe("WebhookHandler", () => {
       expect(event).toEqual(userEnteredBody);
     });
 
-    it.only("should throw if the rawBody is not a string", () => {
+    it("should throw if the rawBody is not a string", () => {
       jest.useFakeTimers({
         now: 1674850126000,
       });
@@ -312,9 +312,10 @@ describe("WebhookHandler", () => {
               rawUserEnteredBody
             ),
           },
-          rawBody: {} as any,
+          // @ts-expect-error: we want to test invalid rawBody
+          rawBody: {},
         })
-      ).toThrowError(`Invalid body, must be a string, got \"object\" instead. 
+      ).toThrowError(`Invalid body, must be a string, got "object" instead. 
       It is likely that you need to JSON.stringify the body before passing it.`);
     });
 

--- a/packages/liveblocks-node/src/__tests__/webhooks.test.ts
+++ b/packages/liveblocks-node/src/__tests__/webhooks.test.ts
@@ -316,7 +316,7 @@ describe("WebhookHandler", () => {
           rawBody: {},
         })
       ).toThrowError(
-        `Invalid rawBody field, must be a string, got "object" instead. It is likely that you need to JSON.stringify the body before passing it.`
+        "Invalid rawBody field, must be a string, got \"object\" instead. It is likely that you need to JSON.stringify the body before passing it."
       );
     });
 

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -32,8 +32,9 @@ export class WebhookHandler {
     const { webhookId, timestamp, rawSignatures } = this.verifyHeaders(headers);
 
     if (typeof rawBody !== "string") {
-      throw new Error(`Invalid body, must be a string, got "${typeof rawBody}" instead. 
-      It is likely that you need to JSON.stringify the body before passing it.`);
+      throw new Error(
+        `Invalid rawBody field, must be a string, got "${typeof rawBody}" instead. It is likely that you need to JSON.stringify the body before passing it.`
+      );
     }
 
     this.verifyTimestamp(timestamp);


### PR DESCRIPTION
#### Description

Adds an explicit error when `rawBody` is not a string. It will ensure users have an easier way to debug message verification.