### PR TITLE
Add explicit I/O gates e2e tests

### DIFF
--- a/e2e/next-sandbox/pages/index.tsx
+++ b/e2e/next-sandbox/pages/index.tsx
@@ -39,6 +39,11 @@ export default function Home() {
                 <a>LiveObject</a>
               </Link>
             </li>
+            <li>
+              <Link href="/storage/gates?room=e2e-storage-gates">
+                <a>Input/output Gates</a>
+              </Link>
+            </li>
           </ul>
         </li>
         <li>

--- a/e2e/next-sandbox/pages/storage/gates.tsx
+++ b/e2e/next-sandbox/pages/storage/gates.tsx
@@ -38,7 +38,7 @@ export default function Home() {
 
 type Internal = {
   _disableThrottle(): void;
-  _serverCtl(cmd: { nextOpSlow: boolean }): Promise<void>;
+  _testCtl(cmd: { nextOpSlow?: boolean; nextOpFail?: boolean }): Promise<void>;
 };
 
 type PrivateRoom = ReturnType<typeof useRoom> & {
@@ -102,7 +102,7 @@ function Sandbox() {
 
         <Button
           id="slow"
-          onClick={() => void room.__internal._serverCtl({ nextOpSlow: true })}
+          onClick={() => void room.__internal._testCtl({ nextOpSlow: true })}
           subtitle="Make next Op slow"
         >
           Slow

--- a/e2e/next-sandbox/pages/storage/gates.tsx
+++ b/e2e/next-sandbox/pages/storage/gates.tsx
@@ -57,6 +57,16 @@ function Sandbox() {
     obj.set(key, value);
   }, []);
 
+  const setInBatch = useMutation(
+    ({ storage }, key: string, values: number[]) => {
+      const obj = storage.get("object");
+      for (const value of values) {
+        obj.set(key, value);
+      }
+    },
+    []
+  );
+
   const clear = useMutation(({ storage }) => {
     const obj = storage.get("object");
     const keys = Object.keys(obj.toObject());
@@ -100,12 +110,24 @@ function Sandbox() {
           Set to 3
         </Button>
 
+        <Button id="set-batch" onClick={() => setInBatch("b", [4, 5])}>
+          Set 4, 5 (in batch)
+        </Button>
+
         <Button
           id="slow"
           onClick={() => void room.__internal._testCtl({ nextOpSlow: true })}
           subtitle="Make next Op slow"
         >
           Slow
+        </Button>
+
+        <Button
+          id="fail-next-batch"
+          onClick={() => void room.__internal._testCtl({ nextOpFail: true })}
+          subtitle="Make next Op batch fail in the middle"
+        >
+          Fail
         </Button>
 
         <Button

--- a/e2e/next-sandbox/pages/storage/gates.tsx
+++ b/e2e/next-sandbox/pages/storage/gates.tsx
@@ -1,0 +1,131 @@
+import { LiveObject } from "@liveblocks/client";
+import { lsonToJson } from "@liveblocks/core";
+import { createRoomContext } from "@liveblocks/react";
+import React from "react";
+
+import { getRoomFromUrl, Row, styles, useRenderCount } from "../../utils";
+import Button from "../../utils/Button";
+import createLiveblocksClient from "../../utils/createClient";
+
+const client = createLiveblocksClient();
+
+const { RoomProvider, useMutation, useRoom, useSelf, useStorage } =
+  createRoomContext<
+    never,
+    {
+      object: LiveObject<{
+        [key: string]: number | LiveObject<{ a: number }>;
+      }>;
+    }
+  >(client);
+
+export default function Home() {
+  const roomId = getRoomFromUrl();
+  return (
+    <RoomProvider
+      id={roomId}
+      initialPresence={{} as never}
+      initialStorage={{
+        object: new LiveObject<{
+          [key: string]: number | LiveObject<{ a: number }>;
+        }>(),
+      }}
+    >
+      <Sandbox />
+    </RoomProvider>
+  );
+}
+
+type Internal = {
+  _disableThrottle(): void;
+  _serverCtl(cmd: { nextOpSlow: boolean }): Promise<void>;
+};
+
+type PrivateRoom = ReturnType<typeof useRoom> & {
+  // Private APIs that aren't officially published (yet)
+  __internal: Internal;
+};
+
+function Sandbox() {
+  const renderCount = useRenderCount();
+  const room = useRoom() as PrivateRoom;
+  const obj = useStorage((root) => root.object);
+  const me = useSelf();
+
+  const setKey = useMutation(({ storage }, key: string, value: number) => {
+    const obj = storage.get("object");
+    obj.set(key, value);
+  }, []);
+
+  const clear = useMutation(({ storage }) => {
+    const obj = storage.get("object");
+    const keys = Object.keys(obj.toObject());
+    let key;
+    while ((key = keys.pop()) !== undefined) {
+      obj.delete(key);
+    }
+  }, []);
+
+  if (obj === null || me === null) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h3>
+        <a href="/">Home</a> › Storage › Input/output gates
+      </h3>
+      <div style={{ display: "flex", margin: "8px 0" }}>
+        <Button
+          id="set-to-one"
+          onClick={() => setKey("a", 1)}
+          subtitle={`${JSON.stringify("a")} → ${JSON.stringify(1)}`}
+        >
+          Set to 1
+        </Button>
+
+        <Button
+          id="set-to-two"
+          onClick={() => setKey("a", 2)}
+          subtitle={`${JSON.stringify("a")} → ${JSON.stringify(2)}`}
+        >
+          Set to 2
+        </Button>
+
+        <Button
+          id="set-to-three"
+          onClick={() => setKey("a", 3)}
+          subtitle={`${JSON.stringify("a")} → ${JSON.stringify(3)}`}
+        >
+          Set to 3
+        </Button>
+
+        <Button
+          id="slow"
+          onClick={() => void room.__internal._serverCtl({ nextOpSlow: true })}
+          subtitle="Make next Op slow"
+        >
+          Slow
+        </Button>
+
+        <Button
+          id="disable-throttling"
+          onClick={() => room.__internal._disableThrottle()}
+        >
+          Disable throttling
+        </Button>
+
+        <Button id="clear" onClick={() => clear()}>
+          Clear
+        </Button>
+      </div>
+
+      <table style={styles.dataTable}>
+        <tbody>
+          <Row id="renderCount" name="Render count" value={renderCount} />
+          <Row id="obj" name="Serialized" value={lsonToJson(obj)} />
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/e2e/next-sandbox/test/storage/gates.test.ts
+++ b/e2e/next-sandbox/test/storage/gates.test.ts
@@ -1,0 +1,96 @@
+import type { Page } from "@playwright/test";
+import { test } from "@playwright/test";
+
+import { genRoomId, preparePages, waitForJson } from "../utils";
+
+test.describe.configure({ mode: "parallel" });
+
+const TEST_URL = "http://localhost:3007/storage/gates";
+
+test.describe("Storage - Input/output Gates (single page)", () => {
+  let page: Page;
+
+  test.beforeEach(async ({}, testInfo) => {
+    const room = genRoomId(testInfo);
+    const pages = await preparePages(
+      `${TEST_URL}?room=${encodeURIComponent(room)}`,
+      { n: 1 }
+    );
+    page = pages[0];
+  });
+
+  test.afterEach(() => page.close());
+
+  test("test input/output gate blocking with a single client", async () => {
+    await page.click("#disable-throttling");
+
+    // Part I
+    await page.click("#clear");
+    await waitForJson(page, "#obj", {});
+
+    // Clicking the buttons serially will cause the last one to win
+    await page.click("#set-to-one");
+    await page.click("#set-to-two");
+    await page.click("#set-to-three");
+    await waitForJson(page, "#obj", { a: 3 });
+
+    // Part II
+    await page.click("#clear");
+    await waitForJson(page, "#obj", {});
+
+    // Clicking the buttons serially will cause the last one to win, even if
+    // the first write is slow
+    await page.click("#slow");
+    await new Promise<void>((res) => setTimeout(() => res(), 500));
+
+    await page.click("#set-to-one"); // This will take longer in the server due to the "slow"
+    await page.click("#set-to-two");
+    await page.click("#set-to-three");
+    await waitForJson(page, "#obj", { a: 3 });
+  });
+});
+
+test.describe("Storage - Input/output Gates (multiple pages)", () => {
+  let pages: [Page, Page];
+
+  test.beforeEach(async ({}, testInfo) => {
+    const room = genRoomId(testInfo);
+    pages = await preparePages(`${TEST_URL}?room=${encodeURIComponent(room)}`);
+  });
+
+  test.afterEach(() =>
+    // Close all pages
+    Promise.all(pages.map((page) => page.close()))
+  );
+
+  test("test input/output gate blocking with a single client", async () => {
+    const [page1, page2] = pages;
+
+    await page1.click("#disable-throttling");
+    await page2.click("#disable-throttling");
+
+    // Part I
+    await page1.click("#clear");
+    await waitForJson(pages, "#obj", {});
+
+    // Clicking the buttons serially will cause the last one to win
+    await page1.click("#set-to-one");
+    await page2.click("#set-to-two");
+    await page1.click("#set-to-three");
+    await waitForJson(pages, "#obj", { a: 3 });
+
+    // Part II
+    await page1.click("#clear");
+    await waitForJson(pages, "#obj", {});
+
+    // Clicking the buttons serially will cause the last one to win, even if
+    // the first write is slow
+    await page1.click("#slow");
+    await new Promise<void>((res) => setTimeout(() => res(), 500));
+
+    await page1.click("#set-to-one"); // This will take longer in the server due to the "slow"
+    await page2.click("#set-to-two");
+    await page2.click("#set-to-three");
+    await waitForJson(pages, "#obj", { a: 3 });
+  });
+});

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -709,6 +709,8 @@ type PrivateRoomAPI = {
     explicitClose(event: IWebSocketCloseEvent): void;
     rawSend(data: string): void;
   };
+
+  _disableThrottle(): void;
 };
 
 // The maximum message size on websockets is 1MB. We'll set the threshold
@@ -2353,6 +2355,8 @@ export function createRoom<
           explicitClose: (event) => managedSocket._privateSendMachineEvent({ type: "EXPLICIT_SOCKET_CLOSE", event }),
           rawSend: (data) => managedSocket.send(data),
         },
+
+        _disableThrottle: () => (config.throttleDelay = 0),
       },
 
       id: config.roomId,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -711,7 +711,10 @@ type PrivateRoomAPI = {
   };
 
   _disableThrottle(): void;
-  _serverCtl: (cmd: { nextOpSlow: boolean }) => Promise<void>;
+  _testCtl: (cmd: {
+    nextOpSlow?: boolean;
+    nextOpFail?: boolean;
+  }) => Promise<void>;
 };
 
 // The maximum message size on websockets is 1MB. We'll set the threshold
@@ -1232,7 +1235,7 @@ export function createRoom<
   };
 
   async function httpPostToRoom(
-    endpoint: "/send-message" | "/_ctl",
+    endpoint: "/send-message" | "/_testCtl",
     body: JsonObject
   ) {
     if (!managedSocket.authValue) {
@@ -1259,8 +1262,8 @@ export function createRoom<
     });
   }
 
-  async function _serverCtl(cmd: { nextOpSlow: boolean }) {
-    await httpPostToRoom("/_ctl", { cmd });
+  async function _testCtl(cmd: { nextOpSlow?: boolean; nextOpFail?: boolean }) {
+    await httpPostToRoom("/_testCtl", { cmd });
   }
 
   function sendMessages(messages: ClientMsg<TPresence, TRoomEvent>[]) {
@@ -2365,7 +2368,7 @@ export function createRoom<
         },
 
         _disableThrottle: () => (config.throttleDelay = 0),
-        _serverCtl,
+        _testCtl,
       },
 
       id: config.roomId,


### PR DESCRIPTION
Part of this duo:
- https://github.com/liveblocks/liveblocks-cloudflare/pull/628
- https://github.com/liveblocks/liveblocks/pull/1333 👈 **this PR**

This adds as a new E2E test to deliberately test I/O gates behavior of storage. The way the test works is that it will tell the server to simulate the next Op processing to be slow (which will trigger a lot of useless writes to storage), effectively ensuring that any concurrently incoming Ops will be blocked.
