### PR TITLE
Add support for exit animations to `ComposerSuggestions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
-# v1.8.3 (Unreleased)
+# v1.9.0 (Unreleased)
 
 ### `@liveblocks/node`
 
-- Implement Comments Write REST APIs as fully typed methods. (includes
+- Add the Comments write REST APIs as fully typed methods. (includes
   `createThread`, `editThreadMetadata`, `createComment`, `editComment`,
   `deleteComment`, `addCommentReaction`, and `removeCommentReaction` methods)
-- Fixes the return type of `getActiveUsers` to match the data returned from the
+- Fix the return type of `getActiveUsers` to match the data returned from the
   endpoint.
+
+### `@liveblocks/react-comments`
+
+- Add support for exit animations to `ComposerSuggestions`.
 
 # v1.8.2
 

--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -79,6 +79,7 @@ import type {
   ComposerBodyMention,
 } from "../../types";
 import { isKey } from "../../utils/is-key";
+import { Persist, useAnimationPersist, usePersist } from "../../utils/Persist";
 import { Portal } from "../../utils/Portal";
 import { requestSubmit } from "../../utils/request-submit";
 import { useId } from "../../utils/use-id";
@@ -197,42 +198,38 @@ function ComposerEditorMentionSuggestionsWrapper({
   const [content, setContent] = useState<HTMLDivElement | null>(null);
   const [contentZIndex, setContentZIndex] = useState<string>();
   const contentRef = useCallback(setContent, [setContent]);
-  const floatingMiddlewares: UseFloatingOptions["middleware"] = useMemo(() => {
+  const floatingOptions: UseFloatingOptions = useMemo(() => {
     const detectOverflowOptions: DetectOverflowOptions = {
       padding: FLOATING_ELEMENT_COLLISION_PADDING,
     };
 
-    return [
-      flip({ ...detectOverflowOptions, crossAxis: false }),
-      hide(detectOverflowOptions),
-      shift({
-        ...detectOverflowOptions,
-        limiter: limitShift(),
-      }),
-      size({
-        ...detectOverflowOptions,
-        apply({ availableWidth, availableHeight, elements }) {
-          elements.floating.style.setProperty(
-            "--lb-composer-suggestions-available-width",
-            `${availableWidth}px`
-          );
-          elements.floating.style.setProperty(
-            "--lb-composer-suggestions-available-height",
-            `${availableHeight}px`
-          );
-        },
-      }),
-    ];
-  }, []);
-  const floatingOptions: UseFloatingOptions = useMemo(() => {
     return {
       strategy: "fixed",
-      open: Boolean(mentionDraft?.range && isFocused),
       placement: getPlacementFromPosition(position, dir),
-      middleware: floatingMiddlewares,
+      middleware: [
+        flip({ ...detectOverflowOptions, crossAxis: false }),
+        hide(detectOverflowOptions),
+        shift({
+          ...detectOverflowOptions,
+          limiter: limitShift(),
+        }),
+        size({
+          ...detectOverflowOptions,
+          apply({ availableWidth, availableHeight, elements }) {
+            elements.floating.style.setProperty(
+              "--lb-composer-suggestions-available-width",
+              `${availableWidth}px`
+            );
+            elements.floating.style.setProperty(
+              "--lb-composer-suggestions-available-height",
+              `${availableHeight}px`
+            );
+          },
+        }),
+      ],
       whileElementsMounted: autoUpdate,
     };
-  }, [floatingMiddlewares, isFocused, position, dir, mentionDraft?.range]);
+  }, [position, dir]);
   const {
     refs: { setReference, setFloating },
     strategy,
@@ -250,8 +247,12 @@ function ComposerEditorMentionSuggestionsWrapper({
     }
   }, [content]);
 
-  useEffect(() => {
-    const domRange = getDOMRange(editor, mentionDraft?.range);
+  useLayoutEffect(() => {
+    if (!mentionDraft) {
+      return;
+    }
+
+    const domRange = getDOMRange(editor, mentionDraft.range);
 
     if (domRange) {
       setReference({
@@ -259,38 +260,45 @@ function ComposerEditorMentionSuggestionsWrapper({
         getClientRects: () => domRange.getClientRects(),
       });
     }
-  }, [setReference, editor, mentionDraft?.range]);
+  }, [setReference, editor, mentionDraft]);
 
-  return isFocused && userIds ? (
-    <ComposerSuggestionsContext.Provider
-      value={{
-        id,
-        itemId,
-        selectedValue: selectedUserId,
-        setSelectedValue: setSelectedUserId,
-        onItemSelect,
-        placement,
-        dir,
-        ref: contentRef,
-      }}
-    >
-      <Portal
-        ref={setFloating}
-        style={{
-          position: strategy,
-          top: 0,
-          left: 0,
-          transform: isPositioned
-            ? `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`
-            : "translate3d(0, -200%, 0)",
-          minWidth: "max-content",
-          zIndex: contentZIndex,
-        }}
-      >
-        <MentionSuggestions userIds={userIds} selectedUserId={selectedUserId} />
-      </Portal>
-    </ComposerSuggestionsContext.Provider>
-  ) : null;
+  return (
+    <Persist>
+      {mentionDraft?.range && isFocused && userIds ? (
+        <ComposerSuggestionsContext.Provider
+          value={{
+            id,
+            itemId,
+            selectedValue: selectedUserId,
+            setSelectedValue: setSelectedUserId,
+            onItemSelect,
+            placement,
+            dir,
+            ref: contentRef,
+          }}
+        >
+          <Portal
+            ref={setFloating}
+            style={{
+              position: strategy,
+              top: 0,
+              left: 0,
+              transform: isPositioned
+                ? `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`
+                : "translate3d(0, -200%, 0)",
+              minWidth: "max-content",
+              zIndex: contentZIndex,
+            }}
+          >
+            <MentionSuggestions
+              userIds={userIds}
+              selectedUserId={selectedUserId}
+            />
+          </Portal>
+        </ComposerSuggestionsContext.Provider>
+      ) : null}
+    </Persist>
+  );
 }
 
 function ComposerEditorElement({
@@ -414,20 +422,26 @@ const ComposerSuggestions = forwardRef<
   HTMLDivElement,
   ComposerSuggestionsProps
 >(({ children, style, asChild, ...props }, forwardedRef) => {
-  const { ref, placement, dir } = useComposerSuggestionsContext(
-    COMPOSER_SUGGESTIONS_NAME
-  );
-  const mergedRefs = useRefs(forwardedRef, ref);
+  const [isPresent] = usePersist();
+  const ref = useRef<HTMLDivElement>(null);
+  const {
+    ref: contentRef,
+    placement,
+    dir,
+  } = useComposerSuggestionsContext(COMPOSER_SUGGESTIONS_NAME);
+  const mergedRefs = useRefs(forwardedRef, contentRef, ref);
   const [side, align] = useMemo(
     () => getSideAndAlignFromPlacement(placement),
     [placement]
   );
   const Component = asChild ? Slot : "div";
+  useAnimationPersist(ref);
 
   return (
     <Component
       dir={dir}
       {...props}
+      data-state={isPresent ? "open" : "closed"}
       data-side={side}
       data-align={align}
       style={{
@@ -883,19 +897,17 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
           renderLeaf={ComposerEditorLeaf}
           renderPlaceholder={ComposerEditorPlaceholder}
         />
-        {mentionDraft && (
-          <ComposerEditorMentionSuggestionsWrapper
-            dir={dir}
-            mentionDraft={mentionDraft}
-            selectedUserId={selectedMentionSuggestionUserId}
-            setSelectedUserId={setSelectedMentionSuggestionUserId}
-            userIds={mentionSuggestions}
-            id={suggestionsListId}
-            itemId={suggestionsListItemId}
-            onItemSelect={createMention}
-            MentionSuggestions={MentionSuggestions}
-          />
-        )}
+        <ComposerEditorMentionSuggestionsWrapper
+          dir={dir}
+          mentionDraft={mentionDraft}
+          selectedUserId={selectedMentionSuggestionUserId}
+          setSelectedUserId={setSelectedMentionSuggestionUserId}
+          userIds={mentionSuggestions}
+          id={suggestionsListId}
+          itemId={suggestionsListItemId}
+          onItemSelect={createMention}
+          MentionSuggestions={MentionSuggestions}
+        />
       </Slate>
     );
   }

--- a/packages/liveblocks-react-comments/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/types.ts
@@ -152,7 +152,7 @@ export interface ComposerEditorMentionSuggestionsWrapperProps {
   dir?: ComposerEditorProps["dir"];
   id: string;
   itemId: (userId?: string) => string | undefined;
-  mentionDraft: MentionDraft;
+  mentionDraft?: MentionDraft;
   userIds?: string[];
   selectedUserId?: string;
   setSelectedUserId: (userId: string) => void;

--- a/packages/liveblocks-react-comments/src/styles/index.css
+++ b/packages/liveblocks-react-comments/src/styles/index.css
@@ -993,10 +993,6 @@
   &:where(:last-of-type) {
     padding-block-end: var(--lb-spacing);
 
-    :where(.lb-comment-body) {
-      margin-block-end: calc(0.25 * var(--lb-spacing));
-    }
-
     &:where(.lb-comment\:indent-content) {
       min-block-size: calc(
         var(--lb-comment-avatar-size) + 1.75 * var(--lb-spacing)
@@ -1112,7 +1108,8 @@
     .lb-dropdown,
     .lb-emoji-picker,
     .lb-quick-emoji-picker,
-    .lb-tooltip:where([data-state="delayed-open"])
+    .lb-tooltip:where([data-state="delayed-open"]),
+    .lb-composer-suggestions
   ) {
   &:where([data-side="top"]) {
     animation-name: lb-animation-slide-up;
@@ -1123,22 +1120,15 @@
   }
 }
 
-:is(.lb-dropdown, .lb-emoji-picker, .lb-quick-emoji-picker, .lb-tooltip) {
+:is(
+    .lb-dropdown,
+    .lb-emoji-picker,
+    .lb-quick-emoji-picker,
+    .lb-tooltip,
+    .lb-composer-suggestions
+  ) {
   &:where([data-state="closed"]) {
     animation-name: lb-animation-disappear;
-  }
-}
-
-/**
- * TODO: Support exit animations like Radix' Dropdown and Tooltip with data-state="closed"
- */
-.lb-composer-suggestions {
-  &:where([data-side="top"]) {
-    animation-name: lb-animation-slide-up;
-  }
-
-  &:where([data-side="bottom"]) {
-    animation-name: lb-animation-slide-down;
   }
 }
 
@@ -1147,7 +1137,7 @@
   .lb-emoji-picker:where(:not([data-state="closed"])),
   .lb-quick-emoji-picker:where(:not([data-state="closed"])),
   .lb-tooltip:where([data-state="delayed-open"]:not([data-state="closed"])),
-  .lb-composer-suggestions {
+  .lb-composer-suggestions:where(:not([data-state="closed"])) {
     animation-name: lb-animation-appear;
   }
 }

--- a/packages/liveblocks-react-comments/src/utils/Persist.tsx
+++ b/packages/liveblocks-react-comments/src/utils/Persist.tsx
@@ -54,6 +54,14 @@ export function useAnimationPersist(ref: RefObject<HTMLElement>) {
       return;
     }
 
+    /**
+     * Stop persisting at the end of the last animation.
+     *
+     * We keep track of all ending animations because animations stay
+     * on getComputedStyle(element).animationName even if they're over,
+     * so we need to keep track of previous animations to truly know if
+     * an animation should be waited on.
+     */
     const handleAnimationEnd = (event: AnimationEvent) => {
       if (event.animationName === unmountAnimationName.current) {
         unmount();
@@ -80,6 +88,8 @@ export function useAnimationPersist(ref: RefObject<HTMLElement>) {
     }
 
     if (!isPresent) {
+      // If the element should be unmounting, wait for a repaint and check
+      // if it is visible and has an animation. If not, unmount immediately.
       animationFrameId = requestAnimationFrame(() => {
         const styles = getComputedStyle(element);
         unmountAnimationName.current = styles.animationName;

--- a/packages/liveblocks-react-comments/src/utils/Persist.tsx
+++ b/packages/liveblocks-react-comments/src/utils/Persist.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { nn } from "@liveblocks/core";
+import type { ReactNode, RefObject } from "react";
+import React, {
+  Children,
+  createContext,
+  isValidElement,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+
+import { flushSync } from "./flush-sync";
+import { useLayoutEffect } from "./use-layout-effect";
+
+// Persist is an overly simplified version of Framer Motion's AnimatePresence,
+// mostly mimicking its usePresence API: https://github.com/framer/motion/blob/main/packages/framer-motion/src/components/AnimatePresence/use-presence.ts
+
+const PERSIST_NAME = "Persist";
+
+interface PersistProps {
+  children: Exclude<ReactNode, Iterable<ReactNode>>;
+}
+
+type PersistContext = [boolean, () => void];
+
+const PersistContext = createContext<PersistContext | null>(null);
+
+export function usePersist() {
+  const persistContext = useContext(PersistContext);
+
+  return nn(persistContext, "Persist is missing from the React tree.");
+}
+
+function getChild(children: ReactNode) {
+  const child: ReactNode = Array.isArray(children)
+    ? Children.only(children)
+    : children;
+
+  return isValidElement(child) ? child : undefined;
+}
+
+export function useAnimationPersist(ref: RefObject<HTMLElement>) {
+  const [isPresent, unmount] = usePersist();
+  const previousAnimationName = useRef<string | null>(null);
+  const unmountAnimationName = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      return;
+    }
+
+    const handleAnimationEnd = (event: AnimationEvent) => {
+      if (event.animationName === unmountAnimationName.current) {
+        unmount();
+      }
+
+      previousAnimationName.current = event.animationName;
+    };
+
+    element.addEventListener("animationcancel", handleAnimationEnd);
+    element.addEventListener("animationend", handleAnimationEnd);
+
+    return () => {
+      element.removeEventListener("animationcancel", handleAnimationEnd);
+      element.removeEventListener("animationend", handleAnimationEnd);
+    };
+  }, [ref, unmount]);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    let animationFrameId: number;
+
+    if (!element) {
+      return;
+    }
+
+    if (!isPresent) {
+      animationFrameId = requestAnimationFrame(() => {
+        const styles = getComputedStyle(element);
+        unmountAnimationName.current = styles.animationName;
+
+        if (
+          styles.animationName === "none" ||
+          styles.animationName === previousAnimationName.current ||
+          styles.display === "none"
+        ) {
+          unmount();
+        }
+      });
+    }
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [isPresent, ref, unmount]);
+}
+
+/**
+ * Persist a component until it decides to unmount by
+ * itself (instead of orchestrating the unmount from the parent).
+ */
+export function Persist({ children }: PersistProps) {
+  const [isPersisting, setPersisting] = useState(true);
+  const lastPresentChild = useRef<ReactNode>(null);
+  const child = getChild(children);
+
+  const unmount = useCallback(() => {
+    flushSync(() => setPersisting(false));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (child) {
+      setPersisting(true);
+      lastPresentChild.current = child;
+    }
+  }, [child]);
+
+  return (
+    <PersistContext.Provider value={[Boolean(child), unmount]}>
+      {child ?? (isPersisting ? lastPresentChild.current : null)}
+    </PersistContext.Provider>
+  );
+}
+
+if (process.env.NODE_ENV !== "production") {
+  Persist.displayName = PERSIST_NAME;
+}

--- a/packages/liveblocks-react-comments/src/utils/flush-sync.ts
+++ b/packages/liveblocks-react-comments/src/utils/flush-sync.ts
@@ -1,0 +1,17 @@
+import ReactDOM from "react-dom";
+
+// Prevent bundlers from importing `flushSync` directly
+// See https://github.com/radix-ui/primitives/pull/1028
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const useReactFlushSync: typeof ReactDOM.flushSync = (ReactDOM as any)[
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  "flushSync".toString()
+];
+
+function flushSyncFallback<R>(fn: () => R) {
+  return fn();
+}
+
+// React's `flushSync` is only available in React >=17.
+export const flushSync: typeof ReactDOM.flushSync =
+  useReactFlushSync ?? flushSyncFallback;


### PR DESCRIPTION
As part of https://github.com/liveblocks/liveblocks/tree/comments-unread, we needed a way to better control component unmounting (for the unread indicator). Once we had that, I noticed that we could also use it to add support for exit animations (stay mounted until the exit animation has finished) to `ComposerSuggestions`. All other floating elements use [Radix' Popover](https://www.radix-ui.com/primitives/docs/components/popover) which supports exit animations so this makes all floating elements consistent.

https://github.com/liveblocks/liveblocks/assets/6959425/08d2ed1e-025f-4d8a-a582-1248eb73bce3

I'm extracting those changes into this PR to simplify the future PR of https://github.com/liveblocks/liveblocks/tree/comments-unread, especially since it might be a large one so if we can remove this `Persist` noise that'd be nice.