### PR TITLE
docs: update Github issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can read our release notes
 
 ## Community and support
 
-- [GitHub issues](./issues) to file bugs and errors you encounter using
+- [GitHub issues](https://github.com/liveblocks/liveblocks/issues) to file bugs and errors you encounter using
   Liveblocks.
 - [Discord](https://liveblocks.io/discord) to get involved with the Liveblocks
   community, ask questions and share tips.


### PR DESCRIPTION
## For Contributors

### Fixing a bug

The previous link was redirecting to the incorrect issues page. The PR fixes the link for the issue page
