### PR TITLE
Fix the node API for sending binary Yjs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.9.1
+
+### `@liveblocks/node`
+
+- Fixes the signature and behavior of the `Liveblocks.sendYjsBinaryUpdate()`
+  API. It now takes a Yjs encoded update (`Uint8Array`) directly.
+
 # v1.9.0
 
 ### `@liveblocks/node`

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -726,7 +726,7 @@ This is a wrapper around the
 and returns no response.
 
 ```ts
-await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
+await liveblocks.sendYjsBinaryUpdate("my-room-id", update);
 ```
 
 Here’s an example of how to update a room’s Yjs document with your changes.

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -741,11 +741,11 @@ const yDoc = new Y.Doc();
 const yText = yDoc.getText("text");
 yText.insert(0, "Hello world");
 
-// Encode the document state as a base64 state update
-const state = Y.encodeStateAsUpdate(yDoc);
+// Encode the document state as an update
+const update = Y.encodeStateAsUpdate(yDoc);
 
 // Send update to Liveblocks
-await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
+await liveblocks.sendYjsBinaryUpdate("my-room-id", update);
 ```
 
 To create a new room and initialize its Yjs document, call
@@ -786,11 +786,11 @@ export async function POST() {
   const insertDelta = slateNodesToInsertDelta(slateDoc);
   (yDoc.get("content", Y.XmlText) as Y.XmlText).applyDelta(insertDelta);
 
-  // Encode the document state as a base64 state update
-  const state = Y.encodeStateAsUpdate(yDoc);
+  // Encode the document state as an update
+  const update = Y.encodeStateAsUpdate(yDoc);
 
   // Send update to Liveblocks
-  await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
+  await liveblocks.sendYjsBinaryUpdate("my-room-id", update);
 }
 ```
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -726,17 +726,13 @@ This is a wrapper around the
 and returns no response.
 
 ```ts
-await liveblocks.sendYjsBinaryUpdate("my-room-id", {
-  // Your yDoc in a base64 binary update string
-  update: yUpdate,
-});
+await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
 ```
 
 Here’s an example of how to update a room’s Yjs document with your changes.
 
 ```ts
 import * as Y from "yjs";
-import { fromUint8Array } from "js-base64";
 
 // Create a Yjs document
 const yDoc = new Y.Doc();
@@ -745,13 +741,11 @@ const yDoc = new Y.Doc();
 const yText = yDoc.getText("text");
 yText.insert(0, "Hello world");
 
-// Encode the document state as a base64 update string
-const yUpdate = fromUint8Array(Y.encodeStateAsUpdate(yDoc));
+// Encode the document state as a base64 state update
+const state = Y.encodeStateAsUpdate(yDoc);
 
 // Send update to Liveblocks
-await liveblocks.sendYjsBinaryUpdate("my-room-id", {
-  update: yUpdate,
-});
+await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
 ```
 
 To create a new room and initialize its Yjs document, call
@@ -762,19 +756,16 @@ To create a new room and initialize its Yjs document, call
 const room = await liveblocks.createRoom("my-room-id");
 
 // Set initial Yjs document value
-await liveblocks.sendYjsBinaryUpdate("my-room-id", {
-  update: yUpdate,
-});
+await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
 ```
 
 Note that each text and code editor handles binary updates in a different way.
 For example, this is how to create a binary update with
 [Slate](https://www.slatejs.org/).
 
-```ts title="Slate binary update" highlight="4,14-18,20-22" isCollapsed isCollapsable
+```ts title="Slate binary update" highlight="3,13-17,19-21" isCollapsed isCollapsable
 import { Liveblocks } from "@liveblocks/node";
 import * as Y from "yjs";
-import { fromUint8Array } from "js-base64";
 import { slateNodesToInsertDelta } from "@slate-yjs/core";
 
 const liveblocks = new Liveblocks({
@@ -795,13 +786,11 @@ export async function POST() {
   const insertDelta = slateNodesToInsertDelta(slateDoc);
   (yDoc.get("content", Y.XmlText) as Y.XmlText).applyDelta(insertDelta);
 
-  // Encode the document state as a base64 update string
-  const yUpdate = fromUint8Array(Y.encodeStateAsUpdate(yDoc));
+  // Encode the document state as a base64 state update
+  const state = Y.encodeStateAsUpdate(yDoc);
 
   // Send update to Liveblocks
-  await liveblocks.sendYjsBinaryUpdate("my-room-id", {
-    update: yUpdate,
-  });
+  await liveblocks.sendYjsBinaryUpdate("my-room-id", state);
 }
 ```
 

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -765,7 +765,7 @@
           }
         },
         "operationId": "put-rooms-roomId-ydoc",
-        "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document. Read the [Yjs documentation](https://docs.yjs.dev/api/document-updates) to learn how to create a binary update. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).",
+        "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document.\n\nThe update is typically obtained by calling `Y.encodeStateAsUpdate(doc)`. See the [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more details. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc). When manually making this HTTP call, set the HTTP header `Content-Type` to `application/octet-stream`, and send the binary update (a `Uint8Array`) in the body of the HTTP request. This endpoint does not accept JSON, unlike most other endpoints.",
         "requestBody": {
           "content": {
             "application/octet-stream": {

--- a/e2e/next-sandbox/test/offline.test.ts
+++ b/e2e/next-sandbox/test/offline.test.ts
@@ -16,6 +16,13 @@ test.describe.configure({ mode: "parallel" });
 
 const TEST_URL = "http://localhost:3007/offline/";
 
+// These load tests sometimes fail on CI, possibly because they're too
+// resource-intensive for the limited GitHub Actions runners (too many tabs
+// open, or too slow, hitting the timeout limit). So for now, we'll just skip
+// them on CI, but still keep running them locally.
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const skipOnCI = process.env.CI ? test.skip : test;
+
 test.describe("Offline", () => {
   let pages: [Page, Page];
 
@@ -284,7 +291,7 @@ test.describe("Offline", () => {
     await waitForJson(page2, "#numOthers", 0);
   });
 
-  test("fuzzy", async () => {
+  skipOnCI("fuzzy", async () => {
     const [page1, page2] = pages;
     await waitForJson(pages, "#socketStatus", "connected");
     await page1.click("#clear");

--- a/e2e/next-sandbox/test/offline.test.ts
+++ b/e2e/next-sandbox/test/offline.test.ts
@@ -7,6 +7,7 @@ import {
   nanoSleep,
   pickFrom,
   preparePages,
+  sleep,
   waitForJson,
   waitUntilEqualOnAllPages,
 } from "./utils";
@@ -207,6 +208,7 @@ test.describe("Offline", () => {
 
     await page1.click("#push");
     await page1.click("#send-invalid-data");
+    await sleep(300); // give the server a few millis to disconnect
     await page1.click("#push");
     await page1.click("#push");
     await waitForJson(page1, "#socketStatus", "disconnected");

--- a/e2e/next-sandbox/test/utils.ts
+++ b/e2e/next-sandbox/test/utils.ts
@@ -237,7 +237,7 @@ export async function waitUntilEqualOnAllPages(
   await expectJsonEqualOnAllPages(pages, selector);
 }
 
-function sleep(ms: number) {
+export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/guides/pages/modifying-yjs-document-data-with-the-rest-api.mdx
+++ b/guides/pages/modifying-yjs-document-data-with-the-rest-api.mdx
@@ -16,13 +16,11 @@ Updating a Yjs document requires you to create a
 [binary update](https://docs.yjs.dev/api/document-updates), before sending it to
 Liveblocks using
 [`Liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).
-We recommend installing `js-base64` to use its `fromUint8Array` utility. Here’s
-an example in a serverless endpoint.
+Here’s an example in a serverless endpoint.
 
 ```ts
 import * as Y from "yjs";
 import { Liveblocks } from "@liveblocks/node";
-import { fromUint8Array } from "js-base64";
 
 const liveblocks = new Liveblocks({
   secret: "{{SECRET_KEY}}",
@@ -37,13 +35,11 @@ export async function POST() {
   const yText = yDoc.getText("text");
   yText.insert(0, "Hello world");
 
-  // Encode the document state as a base64 update string
-  const yUpdate = fromUint8Array(Y.encodeStateAsUpdate(yDoc));
+  // Encode the document state as an update
+  const yUpdate = Y.encodeStateAsUpdate(yDoc);
 
   // Insert the update
-  await liveblocks.sendYjsBinaryUpdate(roomId, {
-    update: yUpdate,
-  });
+  await liveblocks.sendYjsBinaryUpdate(roomId, yUpdate);
 }
 ```
 
@@ -57,7 +53,6 @@ send the update as before.
 ```ts highlight="21-24"
 import * as Y from "yjs";
 import { Liveblocks } from "@liveblocks/node";
-import { fromUint8Array } from "js-base64";
 
 const liveblocks = new Liveblocks({
   secret: "{{SECRET_KEY}}",
@@ -72,8 +67,8 @@ export async function POST() {
   const yText = yDoc.getText("text");
   yText.insert(0, "Hello world");
 
-  // Encode the document state as a base64 update string
-  const yUpdate = fromUint8Array(Y.encodeStateAsUpdate(yDoc));
+  // Encode the document state as an update
+  const yUpdate = Y.encodeStateAsUpdate(yDoc);
 
   // Create the new room
   const room = await liveblocks.createRoom(roomId, {
@@ -81,9 +76,7 @@ export async function POST() {
   });
 
   // Initialize the Yjs document with the update
-  await liveblocks.sendYjsBinaryUpdate(roomId, {
-    update: yUpdate,
-  });
+  await liveblocks.sendYjsBinaryUpdate(roomId, yUpdate);
 }
 ```
 
@@ -96,7 +89,6 @@ initialize a [Slate](/docs/get-started/yjs-slate-react) document.
 ```ts highlight="4,15-19,21-23"
 import * as Y from "yjs";
 import { Liveblocks } from "@liveblocks/node";
-import { fromUint8Array } from "js-base64";
 import { slateNodesToInsertDelta } from "@slate-yjs/core";
 
 const liveblocks = new Liveblocks({
@@ -118,8 +110,8 @@ export async function POST() {
   const insertDelta = slateNodesToInsertDelta(slateDoc);
   (yDoc.get("content", Y.XmlText) as Y.XmlText).applyDelta(insertDelta);
 
-  // Encode the document state as a base64 update string
-  const yUpdate = fromUint8Array(Y.encodeStateAsUpdate(yDoc));
+  // Encode the document state as an update
+  const yUpdate = Y.encodeStateAsUpdate(yDoc);
 
   // Create the new room
   const room = await liveblocks.createRoom(roomId, {
@@ -127,8 +119,6 @@ export async function POST() {
   });
 
   // Initialize the Yjs document with the update
-  await liveblocks.sendYjsBinaryUpdate(roomId, {
-    update: yUpdate,
-  });
+  await liveblocks.sendYjsBinaryUpdate(roomId, yUpdate);
 }
 ```

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -554,8 +554,7 @@ export type Room<
   ): void;
 
   /**
-   *
-   * Sends Yjs document updates to liveblocks server
+   * Sends Yjs document updates to Liveblocks server.
    *
    * @param {string} data the doc update to send to the server, base64 encoded uint8array
    */

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -508,4 +508,34 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(false);
     }
   });
+
+  test("should successfully send a Yjs update", async () => {
+    const update = new Uint8Array([21, 31]);
+    server.use(
+      http.put(
+        `${DEFAULT_BASE_URL}/v2/rooms/:roomId/ydoc`,
+        async ({ request }) => {
+          const buffer = await request.arrayBuffer();
+          const data = new Uint8Array(buffer);
+
+          // Return void if the data is the same as the update.
+          if (data.length === update.length) {
+            for (let i = 0; i < data.length; i++) {
+              if (data[i] !== update[i]) {
+                return HttpResponse.error();
+              }
+            }
+          }
+
+          return HttpResponse.json(null);
+        }
+      )
+    );
+
+    const client = new Liveblocks({ secret: "sk_xxx" });
+
+    await expect(
+      client.sendYjsBinaryUpdate("roomId", update)
+    ).resolves.not.toThrow();
+  });
 });


### PR DESCRIPTION
This patches the `@liveblocks/node` to send the Yjs updates over as binary, the way the server expects them.

There was some confusion about how this was supposed to work, and https://github.com/liveblocks/liveblocks/pull/1346 just got merged, which we'll have to undo, because it's not the correct advice. Encoding as base64 should not be necessary.

Separately from this change, it will be nice to add an explicit check on the server side to reject any request made that doesn't have the `application/octet-stream` header, as that would have made it easy to spot this bug. I'll make a note to do that later.

Also, let's add a unit test to this PR that uses this to make sure there won't be any regressions here. @nimeshnayaju Would you be able to add that to this PR?
