### PR TITLE
Add `portalContainer` prop to `CommentsConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.9.2
+
+### `@liveblocks/react-comments`
+
+- Add `portalContainer` prop to `CommentsConfig` to customize where floating
+  elements (e.g. tooltips, dropdowns, etc) are portaled into.
+
 # v1.9.1
 
 ### `@liveblocks/node`

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -470,6 +470,30 @@ function Component({ thread }: { thread: ThreadData }) {
 
 {/* TODO: Document classes and data attributes */}
 
+### CommentsConfig
+
+Set configuration options for all Comments components, such as
+[overrides](#overrides).
+
+```tsx
+<CommentsConfig overrides={{ locale: "fr", UNKNOWN_USER: "Anonyme" }} />
+```
+
+#### Props [#commentsconfig-props]
+
+<PropertiesList>
+  <PropertiesListItem name="overrides" type="Partial<Overrides>">
+    Override the components’ strings.
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="portalContainer"
+    type="HTMLElement"
+    defaultValue="document.body"
+  >
+    The container to render the portal into.
+  </PropertiesListItem>
+</PropertiesList>
+
 ### Styling and customization
 
 #### Default styles

--- a/package-lock.json
+++ b/package-lock.json
@@ -23137,7 +23137,7 @@
       }
     },
     "packages/create-liveblocks-app": {
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
@@ -23312,10 +23312,10 @@
     },
     "packages/liveblocks-client": {
       "name": "@liveblocks/client",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "1.9.1"
+        "@liveblocks/core": "1.9.2-portal1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23328,7 +23328,7 @@
     },
     "packages/liveblocks-core": {
       "name": "@liveblocks/core",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -23470,10 +23470,10 @@
     },
     "packages/liveblocks-node": {
       "name": "@liveblocks/node",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@stablelib/base64": "^1.0.1",
         "fast-sha256": "^1.3.0",
         "node-fetch": "^2.6.1"
@@ -23617,11 +23617,11 @@
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "nanoid": "^3",
         "use-sync-external-store": "^1.2.0"
       },
@@ -23640,13 +23640,13 @@
     },
     "packages/liveblocks-react-comments": {
       "name": "@liveblocks/react-comments",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.2",
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
-        "@liveblocks/react": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
+        "@liveblocks/react": "1.9.2-portal1",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
@@ -24037,11 +24037,11 @@
     },
     "packages/liveblocks-redux": {
       "name": "@liveblocks/redux",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1"
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -24162,11 +24162,11 @@
     },
     "packages/liveblocks-yjs": {
       "name": "@liveblocks/yjs",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "js-base64": "^3.7.5"
       },
       "devDependencies": {
@@ -24180,11 +24180,11 @@
     },
     "packages/liveblocks-zustand": {
       "name": "@liveblocks/zustand",
-      "version": "1.9.1",
+      "version": "1.9.2-portal1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1"
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -24332,6 +24332,11 @@
         "@liveblocks/jest-config": "*",
         "@types/pluralize": "^0.0.29"
       }
+    },
+    "schema-lang/infer-schema/node_modules/@liveblocks/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-D44JLvkxIJYg52WbrfB0pum15FZQ1QtwNHSAsmmJ8QioANjLMsXxYkYTn0GWL1oIDYHp8xbZlSXeYfsmnMtR9A=="
     },
     "schema-lang/liveblocks-schema": {
       "name": "@liveblocks/schema",
@@ -26019,7 +26024,7 @@
     "@liveblocks/client": {
       "version": "file:packages/liveblocks-client",
       "requires": {
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/ws": "^8.5.3",
@@ -26162,6 +26167,13 @@
         "@types/pluralize": "^0.0.29",
         "decoders": "^2.2.0",
         "pluralize": "^8.0.0"
+      },
+      "dependencies": {
+        "@liveblocks/core": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-1.9.1.tgz",
+          "integrity": "sha512-D44JLvkxIJYg52WbrfB0pum15FZQ1QtwNHSAsmmJ8QioANjLMsXxYkYTn0GWL1oIDYHp8xbZlSXeYfsmnMtR9A=="
+        }
       }
     },
     "@liveblocks/jest-config": {
@@ -26204,7 +26216,7 @@
     "@liveblocks/node": {
       "version": "file:packages/liveblocks-node",
       "requires": {
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@stablelib/base64": "^1.0.1",
@@ -26312,8 +26324,8 @@
     "@liveblocks/react": {
       "version": "file:packages/liveblocks-react",
       "requires": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -26395,11 +26407,11 @@
       "version": "file:packages/liveblocks-react-comments",
       "requires": {
         "@floating-ui/react-dom": "^2.0.2",
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/react": "1.9.1",
+        "@liveblocks/react": "1.9.2-portal1",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
@@ -26595,8 +26607,8 @@
     "@liveblocks/redux": {
       "version": "file:packages/liveblocks-redux",
       "requires": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
@@ -26919,8 +26931,8 @@
     "@liveblocks/yjs": {
       "version": "file:packages/liveblocks-yjs",
       "requires": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
@@ -26930,8 +26942,8 @@
     "@liveblocks/zustand": {
       "version": "file:packages/liveblocks-zustand",
       "requires": {
-        "@liveblocks/client": "1.9.1",
-        "@liveblocks/core": "1.9.1",
+        "@liveblocks/client": "1.9.2-portal1",
+        "@liveblocks/core": "1.9.2-portal1",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",

--- a/packages/create-liveblocks-app/package.json
+++ b/packages/create-liveblocks-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-liveblocks-app",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "An installer for Liveblocks projects, including various examples and a Next.js starter kit. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "bin": "dist/index.cjs",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/client",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "A client that lets you interact with Liveblocks servers. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,7 +33,7 @@
     "test:watch": "jest --silent --verbose --color=always --passWithNoTests --watch"
   },
   "dependencies": {
-    "@liveblocks/core": "1.9.1"
+    "@liveblocks/core": "1.9.2-portal1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/core",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "Private internals for Liveblocks. DO NOT import directly from this package!",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/node",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "A server-side utility that lets you set up a Liveblocks authentication endpoint. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,7 +33,7 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/core": "1.9.1",
+    "@liveblocks/core": "1.9.2-portal1",
     "@stablelib/base64": "^1.0.1",
     "fast-sha256": "^1.3.0",
     "node-fetch": "^2.6.1"

--- a/packages/liveblocks-react-comments/package.json
+++ b/packages/liveblocks-react-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react-comments",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "A set of React components to add real time comments a la Notion, Figma, Google Docs in your product.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -49,9 +49,9 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.2",
-    "@liveblocks/client": "1.9.1",
-    "@liveblocks/core": "1.9.1",
-    "@liveblocks/react": "1.9.1",
+    "@liveblocks/client": "1.9.2-portal1",
+    "@liveblocks/core": "1.9.2-portal1",
+    "@liveblocks/react": "1.9.2-portal1",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -518,7 +518,6 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
                 root={false}
                 onComposerSubmit={handleEditSubmit}
                 defaultValue={comment.body}
-                placeholder={$.COMMENT_EDIT_COMPOSER_PLACEHOLDER}
                 autoFocus
                 showAttribution={false}
                 actions={

--- a/packages/liveblocks-react-comments/src/components/internal/Dropdown.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/Dropdown.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import type { ReactNode } from "react";
 import React, { forwardRef } from "react";
 
+import { useCommentsConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -31,6 +32,7 @@ export function Dropdown({
   ...props
 }: DropdownProps) {
   const $ = useOverrides();
+  const { portalContainer } = useCommentsConfig();
 
   return (
     <DropdownMenuPrimitive.Root
@@ -40,7 +42,7 @@ export function Dropdown({
       dir={$.dir}
     >
       {children}
-      <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Portal container={portalContainer}>
         <DropdownMenuPrimitive.Content
           className={classNames(
             "lb-root lb-portal lb-elevation lb-dropdown",

--- a/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type { ComponentPropsWithoutRef } from "react";
 import React, { forwardRef, useCallback, useMemo, useState } from "react";
 
+import { useCommentsConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -143,6 +144,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
     forwardedRef
   ) => {
     const [isOpen, setOpen] = useState(false);
+    const { portalContainer } = useCommentsConfig();
     const $ = useOverrides();
 
     const handleOpenChange = useCallback(
@@ -164,7 +166,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
     return (
       <PopoverPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
         {children}
-        <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Portal container={portalContainer}>
           <PopoverPrimitive.Content
             side="top"
             align="center"

--- a/packages/liveblocks-react-comments/src/components/internal/QuickEmojiPicker.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/QuickEmojiPicker.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type { ComponentPropsWithoutRef } from "react";
 import React, { forwardRef, useCallback, useState } from "react";
 
+import { useCommentsConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -27,6 +28,7 @@ export const QuickEmojiPicker = forwardRef<
     forwardedRef
   ) => {
     const [isOpen, setOpen] = useState(false);
+    const { portalContainer } = useCommentsConfig();
 
     const handleOpenChange = useCallback(
       (isOpen: boolean) => {
@@ -39,7 +41,7 @@ export const QuickEmojiPicker = forwardRef<
     return (
       <PopoverPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
         {children}
-        <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Portal container={portalContainer}>
           <PopoverPrimitive.Content
             side="top"
             align="center"

--- a/packages/liveblocks-react-comments/src/components/internal/Tooltip.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/Tooltip.tsx
@@ -4,6 +4,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import type { ComponentProps, ReactNode } from "react";
 import React, { forwardRef, useMemo } from "react";
 
+import { useCommentsConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -40,12 +41,14 @@ export interface ShortcutTooltipKeyProps extends ComponentProps<"abbr"> {
 
 export const Tooltip = forwardRef<HTMLButtonElement, TooltipProps>(
   ({ children, content, multiline, className, ...props }, forwardedRef) => {
+    const { portalContainer } = useCommentsConfig();
+
     return (
       <TooltipPrimitive.Root disableHoverableContent>
         <TooltipPrimitive.Trigger asChild ref={forwardedRef}>
           {children}
         </TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Portal container={portalContainer}>
           <TooltipPrimitive.Content
             className={classNames(
               "lb-root lb-portal lb-tooltip",

--- a/packages/liveblocks-react-comments/src/config.tsx
+++ b/packages/liveblocks-react-comments/src/config.tsx
@@ -1,14 +1,25 @@
 "use client";
 
 import type { PropsWithChildren } from "react";
-import React from "react";
+import React, { createContext, useContext, useMemo } from "react";
 
 import type { Overrides } from "./overrides";
 import { OverridesProvider } from "./overrides";
 
 type CommentsConfigProps = PropsWithChildren<{
   overrides?: Partial<Overrides>;
+  portalContainer?: HTMLElement;
 }>;
+
+interface CommentsConfigContext {
+  portalContainer?: HTMLElement;
+}
+
+const CommentsConfigContext = createContext<CommentsConfigContext>({});
+
+export function useCommentsConfig() {
+  return useContext(CommentsConfigContext);
+}
 
 /**
  * Set configuration options for all Comments components.
@@ -18,8 +29,19 @@ type CommentsConfigProps = PropsWithChildren<{
  *   <App />
  * </CommentsConfig>
  */
-export function CommentsConfig({ overrides, children }: CommentsConfigProps) {
+export function CommentsConfig({
+  overrides,
+  portalContainer,
+  children,
+}: CommentsConfigProps) {
+  const commentsConfig = useMemo(
+    () => ({ portalContainer }),
+    [portalContainer]
+  );
+
   return (
-    <OverridesProvider overrides={overrides}>{children}</OverridesProvider>
+    <CommentsConfigContext.Provider value={commentsConfig}>
+      <OverridesProvider overrides={overrides}>{children}</OverridesProvider>
+    </CommentsConfigContext.Provider>
   );
 }

--- a/packages/liveblocks-react-comments/src/config.tsx
+++ b/packages/liveblocks-react-comments/src/config.tsx
@@ -7,7 +7,14 @@ import type { Overrides } from "./overrides";
 import { OverridesProvider } from "./overrides";
 
 type CommentsConfigProps = PropsWithChildren<{
+  /**
+   * Override the components' strings.
+   */
   overrides?: Partial<Overrides>;
+
+  /**
+   * The container to render the portal into.
+   */
   portalContainer?: HTMLElement;
 }>;
 

--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -58,6 +58,7 @@ import {
   withReact,
 } from "slate-react";
 
+import { useCommentsConfig } from "../../config";
 import { FLOATING_ELEMENT_COLLISION_PADDING } from "../../constants";
 import { withAutoFormatting } from "../../slate/plugins/auto-formatting";
 import { withAutoLinks } from "../../slate/plugins/auto-links";
@@ -198,6 +199,7 @@ function ComposerEditorMentionSuggestionsWrapper({
   const [content, setContent] = useState<HTMLDivElement | null>(null);
   const [contentZIndex, setContentZIndex] = useState<string>();
   const contentRef = useCallback(setContent, [setContent]);
+  const { portalContainer } = useCommentsConfig();
   const floatingOptions: UseFloatingOptions = useMemo(() => {
     const detectOverflowOptions: DetectOverflowOptions = {
       padding: FLOATING_ELEMENT_COLLISION_PADDING,
@@ -279,6 +281,7 @@ function ComposerEditorMentionSuggestionsWrapper({
         >
           <Portal
             ref={setFloating}
+            container={portalContainer}
             style={{
               position: strategy,
               top: 0,

--- a/packages/liveblocks-react-comments/src/utils/Portal.tsx
+++ b/packages/liveblocks-react-comments/src/utils/Portal.tsx
@@ -8,15 +8,21 @@ import type { ComponentPropsWithSlot } from "../types";
 
 const PORTAL_NAME = "Portal";
 
-const Portal = forwardRef<HTMLDivElement, ComponentPropsWithSlot<"div">>(
-  ({ asChild, ...props }, forwardedRef) => {
+interface PortalProps extends ComponentPropsWithSlot<"div"> {
+  /**
+   * The container to render the portal into.
+   */
+  container?: HTMLElement | null;
+}
+
+const Portal = forwardRef<HTMLDivElement, PortalProps>(
+  ({ container, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
-    const container = document?.body;
 
     return container
       ? createPortal(
           <Component data-liveblocks-portal="" {...props} ref={forwardedRef} />,
-          container
+          container ?? document?.body
         )
       : null;
   }

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/react",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "A set of React hooks and providers to use Liveblocks declaratively. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -34,8 +34,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.9.1",
-    "@liveblocks/core": "1.9.1",
+    "@liveblocks/client": "1.9.2-portal1",
+    "@liveblocks/core": "1.9.2-portal1",
     "nanoid": "^3",
     "use-sync-external-store": "^1.2.0"
   },

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/redux",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "A store enhancer to integrate Liveblocks into Redux stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,8 +32,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.9.1",
-    "@liveblocks/core": "1.9.1"
+    "@liveblocks/client": "1.9.2-portal1",
+    "@liveblocks/core": "1.9.2-portal1"
   },
   "peerDependencies": {
     "redux": "^4"

--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/yjs",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "An integration with . Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -32,8 +32,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.9.1",
-    "@liveblocks/core": "1.9.1",
+    "@liveblocks/client": "1.9.2-portal1",
+    "@liveblocks/core": "1.9.2-portal1",
     "js-base64": "^3.7.5"
   },
   "peerDependencies": {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/zustand",
-  "version": "1.9.1",
+  "version": "1.9.2-portal1",
   "description": "A middleware to integrate Liveblocks into Zustand stores. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -33,8 +33,8 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@liveblocks/client": "1.9.1",
-    "@liveblocks/core": "1.9.1"
+    "@liveblocks/client": "1.9.2-portal1",
+    "@liveblocks/core": "1.9.2-portal1"
   },
   "peerDependencies": {
     "zustand": "^4.1.3"


### PR DESCRIPTION
This PR adds a `portalContainer` prop to `CommentsConfig` to customize where floating elements (e.g. tooltips, dropdowns, etc) are portaled into.

Closes https://github.com/liveblocks/liveblocks.io/issues/1608.

![usage](https://github.com/liveblocks/liveblocks/assets/6959425/364581e0-aa7c-4696-8df7-e1834e4f5638)

https://github.com/liveblocks/liveblocks/assets/6959425/75e83f2d-0b70-4256-a639-f699234087fa