### PR TITLE
Refresh threads and notifications cache when receiving comment websocket message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       }
     },
     "examples/nextjs-comments": {
+      "name": "@liveblocks-examples/nextjs-comments",
       "license": "Apache-2.0",
       "dependencies": {
         "@liveblocks/client": "*",
@@ -316,9 +317,10 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -11308,6 +11310,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/date-fns": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
+      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "license": "MIT",
@@ -14083,9 +14095,10 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
+      "dev": true
     },
     "node_modules/headers-utils": {
       "version": "1.2.5",
@@ -23953,11 +23966,12 @@
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.1.1",
+        "@testing-library/jest-dom": "6.1.6",
+        "@testing-library/react": "14.1.2",
         "@types/use-sync-external-store": "^0.0.3",
+        "date-fns": "^3.0.6",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "1.2.3"
+        "msw": "1.3.2"
       },
       "peerDependencies": {
         "react": "^16.14.0 || ^17 || ^18"
@@ -24244,15 +24258,16 @@
       }
     },
     "packages/liveblocks-react/node_modules/@mswjs/interceptors": {
-      "version": "0.17.9",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@open-draft/until": "^1.0.3",
         "@types/debug": "^4.1.7",
         "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.1.0",
+        "headers-polyfill": "3.2.5",
         "outvariant": "^1.2.1",
         "strict-event-emitter": "^0.2.4",
         "web-encoding": "^1.1.5"
@@ -24261,10 +24276,102 @@
         "node": ">=14"
       }
     },
+    "packages/liveblocks-react/node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/liveblocks-react/node_modules/@testing-library/jest-dom": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.6.tgz",
+      "integrity": "sha512-YwuiOdYEcxhfC2u5iNKlvg2Q5MgbutovP6drq7J1HrCbvR+G58BbtoCoq+L/kNlrNFsu2Kt3jaFAviLVxYHJZg==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.2",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "packages/liveblocks-react/node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/liveblocks-react/node_modules/@testing-library/react": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
+      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "packages/liveblocks-react/node_modules/@xmldom/xmldom": {
       "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -24285,21 +24392,22 @@
       }
     },
     "packages/liveblocks-react/node_modules/msw": {
-      "version": "1.2.3",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+      "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
+        "@mswjs/interceptors": "^0.17.10",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "chalk": "^4.1.1",
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "3.2.5",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -24321,7 +24429,7 @@
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.1.x"
+        "typescript": ">= 4.4.x <= 5.2.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -24348,6 +24456,38 @@
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
+    },
+    "packages/liveblocks-react/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "packages/liveblocks-react/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/liveblocks-react/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "packages/liveblocks-react/node_modules/type-fest": {
       "version": "2.19.0",
@@ -25155,7 +25295,9 @@
       "version": "1.2.6"
     },
     "@adobe/css-tools": {
-      "version": "4.0.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "@alloc/quick-lru": {
@@ -26774,31 +26916,91 @@
         "@liveblocks/core": "1.9.0",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.1.1",
+        "@testing-library/jest-dom": "6.1.6",
+        "@testing-library/react": "14.1.2",
         "@types/use-sync-external-store": "^0.0.3",
+        "date-fns": "^3.0.6",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "1.2.3",
+        "msw": "1.3.2",
         "nanoid": "^3",
         "use-sync-external-store": "^1.2.0"
       },
       "dependencies": {
         "@mswjs/interceptors": {
-          "version": "0.17.9",
+          "version": "0.17.10",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+          "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
           "dev": true,
           "requires": {
             "@open-draft/until": "^1.0.3",
             "@types/debug": "^4.1.7",
             "@xmldom/xmldom": "^0.8.3",
             "debug": "^4.3.3",
-            "headers-polyfill": "^3.1.0",
+            "headers-polyfill": "3.2.5",
             "outvariant": "^1.2.1",
             "strict-event-emitter": "^0.2.4",
             "web-encoding": "^1.1.5"
           }
         },
+        "@testing-library/dom": {
+          "version": "9.3.4",
+          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+          "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/runtime": "^7.12.5",
+            "@types/aria-query": "^5.0.1",
+            "aria-query": "5.1.3",
+            "chalk": "^4.1.0",
+            "dom-accessibility-api": "^0.5.9",
+            "lz-string": "^1.5.0",
+            "pretty-format": "^27.0.2"
+          }
+        },
+        "@testing-library/jest-dom": {
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.6.tgz",
+          "integrity": "sha512-YwuiOdYEcxhfC2u5iNKlvg2Q5MgbutovP6drq7J1HrCbvR+G58BbtoCoq+L/kNlrNFsu2Kt3jaFAviLVxYHJZg==",
+          "dev": true,
+          "requires": {
+            "@adobe/css-tools": "^4.3.2",
+            "@babel/runtime": "^7.9.2",
+            "aria-query": "^5.0.0",
+            "chalk": "^3.0.0",
+            "css.escape": "^1.5.1",
+            "dom-accessibility-api": "^0.5.6",
+            "lodash": "^4.17.15",
+            "redent": "^3.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
+          }
+        },
+        "@testing-library/react": {
+          "version": "14.1.2",
+          "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
+          "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@testing-library/dom": "^9.0.0",
+            "@types/react-dom": "^18.0.0"
+          }
+        },
         "@xmldom/xmldom": {
           "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
           "dev": true
         },
         "chalk": {
@@ -26810,19 +27012,21 @@
           }
         },
         "msw": {
-          "version": "1.2.3",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+          "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
           "dev": true,
           "requires": {
             "@mswjs/cookies": "^0.2.2",
-            "@mswjs/interceptors": "^0.17.5",
+            "@mswjs/interceptors": "^0.17.10",
             "@open-draft/until": "^1.0.3",
             "@types/cookie": "^0.4.1",
             "@types/js-levenshtein": "^1.1.1",
-            "chalk": "4.1.1",
+            "chalk": "^4.1.1",
             "chokidar": "^3.4.2",
             "cookie": "^0.4.2",
-            "graphql": "^15.0.0 || ^16.0.0",
-            "headers-polyfill": "^3.1.2",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "3.2.5",
             "inquirer": "^8.2.0",
             "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
@@ -26842,6 +27046,31 @@
         },
         "nanoid": {
           "version": "3.3.6"
+        },
+        "pretty-format": {
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
         },
         "type-fest": {
           "version": "2.19.0",
@@ -33009,6 +33238,12 @@
         "whatwg-url": "^11.0.0"
       }
     },
+    "date-fns": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
+      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.4",
       "requires": {
@@ -34780,7 +35015,9 @@
       }
     },
     "headers-polyfill": {
-      "version": "3.1.2",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
       "dev": true
     },
     "headers-utils": {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -151,6 +151,7 @@ export type {
   UserJoinServerMsg,
   UserLeftServerMsg,
   YDocUpdateServerMsg,
+  CommentsEventServerMsg,
 } from "./protocol/ServerMsg";
 export { ServerMsgCode } from "./protocol/ServerMsg";
 export type {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -142,6 +142,7 @@ export { CrdtType } from "./protocol/SerializedCrdt";
 export { isChildCrdt, isRootCrdt } from "./protocol/SerializedCrdt";
 export type {
   BroadcastedEventServerMsg,
+  CommentsEventServerMsg,
   InitialDocumentStateServerMsg,
   RejectedStorageOpServerMsg,
   RoomStateServerMsg,
@@ -151,7 +152,6 @@ export type {
   UserJoinServerMsg,
   UserLeftServerMsg,
   YDocUpdateServerMsg,
-  CommentsEventServerMsg,
 } from "./protocol/ServerMsg";
 export { ServerMsgCode } from "./protocol/ServerMsg";
 export type {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1146,17 +1146,16 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     const response = await fetchCommentsApi(`/threads/${threadId}`);
 
     if (response.ok) {
-      const json = await (response.json() as Promise<
-        ThreadDataPlain<TThreadMetadata> & {
-          inboxNotification?: PartialInboxNotificationDataPlain;
-        }
-      >);
+      const json = await (response.json() as Promise<{
+        thread: ThreadDataPlain<TThreadMetadata>;
+        inboxNotification?: PartialInboxNotificationDataPlain;
+      }>);
       const inboxNotification = json.inboxNotification
         ? convertToPartialInboxNotificationData(json.inboxNotification)
         : undefined;
 
       return {
-        thread: convertToThreadData(json),
+        thread: convertToThreadData(json.thread),
         inboxNotification,
       };
     } else if (response.status === 404) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1146,16 +1146,17 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     const response = await fetchCommentsApi(`/threads/${threadId}`);
 
     if (response.ok) {
-      const json = await (response.json() as Promise<{
-        thread: ThreadDataPlain<TThreadMetadata>;
-        inboxNotification?: PartialInboxNotificationDataPlain;
-      }>);
+      const json = await (response.json() as Promise<
+        ThreadDataPlain<TThreadMetadata> & {
+          inboxNotification?: PartialInboxNotificationDataPlain;
+        }
+      >);
       const inboxNotification = json.inboxNotification
         ? convertToPartialInboxNotificationData(json.inboxNotification)
         : undefined;
 
       return {
-        thread: convertToThreadData(json.thread),
+        thread: convertToThreadData(json),
         inboxNotification,
       };
     } else if (response.status === 404) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1142,14 +1142,8 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     }
   }
 
-  async function getThread({
-    roomId,
-    threadId,
-  }: {
-    roomId: string;
-    threadId: string;
-  }) {
-    const response = await fetchCommentsApi(`/threads/${roomId}/${threadId}`);
+  async function getThread({ threadId }: { threadId: string }) {
+    const response = await fetchCommentsApi(`/threads/${threadId}`);
 
     if (response.ok) {
       const json = await (response.json() as Promise<
@@ -1157,7 +1151,6 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
           inboxNotification?: PartialInboxNotificationDataPlain;
         }
       >);
-
       const inboxNotification = json.inboxNotification
         ? convertToPartialInboxNotificationData(json.inboxNotification)
         : undefined;
@@ -1169,7 +1162,7 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     } else if (response.status === 404) {
       return;
     } else {
-      throw new Error("There was an error while getting threads.");
+      throw new Error(`There was an error while getting thread ${threadId}.`);
     }
   }
 

--- a/packages/liveblocks-react/src/__tests__/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/_dummies.ts
@@ -43,5 +43,3 @@ export function dummyCommentData(): CommentData {
     reactions: [],
   };
 }
-
-export function dummyInboxNotificationDataPlain() {}

--- a/packages/liveblocks-react/src/__tests__/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/_dummies.ts
@@ -1,35 +1,32 @@
-import type {
-  BaseMetadata,
-  CommentDataPlain,
-  ThreadDataPlain,
-} from "@liveblocks/core";
+import type { BaseMetadata, CommentData, ThreadData } from "@liveblocks/core";
 
 import { createCommentId, createThreadId } from "../comments/lib/createIds";
 
-export function dummyThreadDataPlain<
+export function dummyThreadData<
   TThreadMetadata extends BaseMetadata = BaseMetadata,
->(): ThreadDataPlain<TThreadMetadata> {
-  const createdAt = new Date().toISOString();
+>(): ThreadData<TThreadMetadata> {
+  const now = new Date();
   const threadId = createThreadId();
 
-  const comment = dummyCommentDataPlain();
-  (comment.threadId = threadId), (comment.createdAt = createdAt);
+  const comment = dummyCommentData();
+  comment.threadId = threadId;
+  comment.createdAt = now;
 
   return {
     id: threadId,
     type: "thread",
     roomId: "room-id",
-    createdAt,
+    createdAt: now,
     metadata: {}, // TODO Fix type
     updatedAt: undefined,
     comments: [comment],
-  } as ThreadDataPlain<TThreadMetadata>;
+  } as ThreadData<TThreadMetadata>;
 }
 
-export function dummyCommentDataPlain(): CommentDataPlain {
+export function dummyCommentData(): CommentData {
   const id = createCommentId();
   const threadId = createThreadId();
-  const now = new Date().toISOString();
+  const now = new Date();
 
   return {
     id,
@@ -46,3 +43,5 @@ export function dummyCommentDataPlain(): CommentDataPlain {
     reactions: [],
   };
 }
+
+export function dummyInboxNotificationDataPlain() {}

--- a/packages/liveblocks-react/src/__tests__/_restMocks.ts
+++ b/packages/liveblocks-react/src/__tests__/_restMocks.ts
@@ -1,7 +1,7 @@
 import type {
-  CommentDataPlain,
-  PartialInboxNotificationDataPlain,
-  ThreadDataPlain,
+  CommentData,
+  PartialInboxNotificationData,
+  ThreadData,
 } from "@liveblocks/core";
 import type { ResponseResolver, RestContext, RestRequest } from "msw";
 import { rest } from "msw";
@@ -11,7 +11,7 @@ export function mockGetThreads(
     RestRequest<never, never>,
     RestContext,
     {
-      data: ThreadDataPlain<any>[];
+      data: ThreadData<any>[];
       inboxNotifications: any[];
     }
   >
@@ -27,8 +27,8 @@ export function mockGetThread(
   resolver: ResponseResolver<
     RestRequest<never, never>,
     RestContext,
-    ThreadDataPlain<any> & {
-      inboxNotification?: PartialInboxNotificationDataPlain;
+    ThreadData<any> & {
+      inboxNotification?: PartialInboxNotificationData;
     }
   >
 ) {
@@ -42,7 +42,7 @@ export function mockCreateThread(
   resolver: ResponseResolver<
     RestRequest<never, never>,
     RestContext,
-    ThreadDataPlain<any>
+    ThreadData<any>
   >
 ) {
   return rest.post(
@@ -56,7 +56,7 @@ export function mockCreateComment(
   resolver: ResponseResolver<
     RestRequest<never, never>,
     RestContext,
-    CommentDataPlain
+    CommentData
   >
 ) {
   return rest.post(

--- a/packages/liveblocks-react/src/__tests__/_restMocks.ts
+++ b/packages/liveblocks-react/src/__tests__/_restMocks.ts
@@ -1,4 +1,8 @@
-import type { CommentDataPlain, ThreadDataPlain } from "@liveblocks/core";
+import type {
+  CommentDataPlain,
+  PartialInboxNotificationDataPlain,
+  ThreadDataPlain,
+} from "@liveblocks/core";
 import type { ResponseResolver, RestContext, RestRequest } from "msw";
 import { rest } from "msw";
 
@@ -14,6 +18,22 @@ export function mockGetThreads(
 ) {
   return rest.post(
     "https://api.liveblocks.io/v2/c/rooms/room-id/threads/search",
+    resolver
+  );
+}
+
+export function mockGetThread(
+  params: { threadId: string },
+  resolver: ResponseResolver<
+    RestRequest<never, never>,
+    RestContext,
+    ThreadDataPlain<any> & {
+      inboxNotification?: PartialInboxNotificationDataPlain;
+    }
+  >
+) {
+  return rest.get(
+    `https://api.liveblocks.io/v2/c/rooms/room-id/threads/${params.threadId}`,
     resolver
   );
 }

--- a/packages/liveblocks-react/src/__tests__/compareThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/compareThreads.test.ts
@@ -1,4 +1,5 @@
 import type { ThreadData } from "@liveblocks/core";
+
 import { compareThreads } from "../comments/store";
 
 describe("compareThreads", () => {

--- a/packages/liveblocks-react/src/__tests__/compareThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/compareThreads.test.ts
@@ -1,0 +1,70 @@
+import type { ThreadData } from "@liveblocks/core";
+import { compareThreads } from "../comments/store";
+
+describe("compareThreads", () => {
+  const thread1: ThreadData = {
+    type: "thread" as const,
+    id: "th_1",
+    createdAt: new Date("2024-01-01"),
+    roomId: "room_1",
+    comments: [],
+    metadata: {},
+  };
+
+  const thread2: ThreadData = {
+    type: "thread" as const,
+    id: "th_1",
+    createdAt: new Date("2024-01-01"),
+    roomId: "room_1",
+    comments: [],
+    metadata: {},
+  };
+
+  it("should return 1 when thread1 is updated more recently than thread2", () => {
+    thread1.updatedAt = new Date("2024-01-02");
+    thread2.updatedAt = new Date("2024-01-01");
+    expect(compareThreads(thread1, thread2)).toBe(1);
+  });
+
+  it("should return -1 when thread2 is updated more recently than thread1", () => {
+    thread1.updatedAt = new Date("2024-01-01");
+    thread2.updatedAt = new Date("2024-01-02");
+    expect(compareThreads(thread1, thread2)).toBe(-1);
+  });
+
+  it("should return 1 when only thread1 has an updatedAt", () => {
+    thread1.updatedAt = new Date("2024-01-02");
+    thread2.updatedAt = undefined;
+    expect(compareThreads(thread1, thread2)).toBe(1);
+  });
+
+  it("should return -1 when only thread2 has an updatedAt", () => {
+    thread1.updatedAt = undefined;
+    thread2.updatedAt = new Date("2024-01-02");
+    expect(compareThreads(thread1, thread2)).toBe(-1);
+  });
+
+  it("should return 1 when thread1 is created more recently and no updatedAt is present", () => {
+    thread1.createdAt = new Date("2024-01-02");
+    thread2.createdAt = new Date("2024-01-01");
+
+    thread1.updatedAt = undefined;
+    thread2.updatedAt = undefined;
+    expect(compareThreads(thread1, thread2)).toBe(1);
+  });
+
+  it("should return -1 when thread2 is created more recently and no updatedAt is present", () => {
+    thread1.createdAt = new Date("2024-01-01");
+    thread2.createdAt = new Date("2024-01-02");
+
+    thread1.updatedAt = undefined;
+    thread2.updatedAt = undefined;
+    expect(compareThreads(thread1, thread2)).toBe(-1);
+  });
+
+  it("should return 0 when both threads have the same updatedAt and createdAt", () => {
+    thread1.updatedAt = new Date("2024-01-01");
+    thread2.updatedAt = new Date("2024-01-01");
+    expect(compareThreads(thread1, thread2)).toBe(0);
+  });
+});

--- a/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
@@ -1,4 +1,4 @@
-import type { CommentBody, ThreadDataPlain } from "@liveblocks/core";
+import type { CommentBody, ThreadData } from "@liveblocks/core";
 import { createClient } from "@liveblocks/core";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { addMinutes } from "date-fns";
@@ -7,7 +7,7 @@ import { setupServer } from "msw/node";
 import React from "react";
 
 import { createRoomContext } from "../room";
-import { dummyCommentDataPlain, dummyThreadDataPlain } from "./_dummies";
+import { dummyCommentData, dummyThreadData } from "./_dummies";
 import MockWebSocket from "./_MockWebSocket";
 import { mockCreateThread, mockGetThreads } from "./_restMocks";
 
@@ -54,7 +54,7 @@ describe("useCreateThread", () => {
       mockCreateThread(
         async (
           req: RestRequest,
-          res: ResponseComposition<ThreadDataPlain<any>>,
+          res: ResponseComposition<ThreadData<any>>,
           ctx: RestContext
         ) => {
           const json = await req.json<{
@@ -62,16 +62,16 @@ describe("useCreateThread", () => {
             comment: { id: string; body: CommentBody };
           }>();
 
-          const comment = dummyCommentDataPlain();
+          const comment = dummyCommentData();
           comment.threadId = json.id;
           comment.id = json.comment.id;
           comment.body = json.comment.body;
-          comment.createdAt = fakeCreatedAt.toISOString();
+          comment.createdAt = fakeCreatedAt;
 
-          const thread = dummyThreadDataPlain();
+          const thread = dummyThreadData();
           thread.id = json.id;
           thread.comments = [comment];
-          thread.createdAt = fakeCreatedAt.toISOString();
+          thread.createdAt = fakeCreatedAt;
 
           return res(ctx.json(thread));
         }

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -5,6 +5,7 @@ import {
   ServerMsgCode,
 } from "@liveblocks/core";
 import { renderHook, waitFor } from "@testing-library/react";
+import { addSeconds } from "date-fns";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
 
@@ -12,7 +13,6 @@ import { createRoomContext } from "../room";
 import { dummyThreadDataPlain } from "./_dummies";
 import MockWebSocket, { websocketSimulator } from "./_MockWebSocket";
 import { mockGetThread, mockGetThreads } from "./_restMocks";
-import { addSeconds } from "date-fns";
 
 const server = setupServer();
 

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1,16 +1,12 @@
 import type { BaseMetadata, JsonObject } from "@liveblocks/core";
-import {
-  convertToThreadData,
-  createClient,
-  ServerMsgCode,
-} from "@liveblocks/core";
+import { createClient, ServerMsgCode } from "@liveblocks/core";
 import { renderHook, waitFor } from "@testing-library/react";
 import { addSeconds } from "date-fns";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
 
 import { createRoomContext } from "../room";
-import { dummyThreadDataPlain } from "./_dummies";
+import { dummyThreadData } from "./_dummies";
 import MockWebSocket, { websocketSimulator } from "./_MockWebSocket";
 import { mockGetThread, mockGetThreads } from "./_restMocks";
 
@@ -47,7 +43,7 @@ function createRoomContextForTest<
 
 describe("useThreads", () => {
   test("should fetch threads", async () => {
-    const threads = [dummyThreadDataPlain()];
+    const threads = [dummyThreadData()];
 
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
@@ -75,7 +71,7 @@ describe("useThreads", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: threads.map(convertToThreadData),
+        threads,
       })
     );
 
@@ -85,7 +81,7 @@ describe("useThreads", () => {
   test("multiple instances of useThreads should not fetch threads multiple times (dedupe requests)", async () => {
     let getThreadsReqCount = 0;
 
-    const threads = [dummyThreadDataPlain()];
+    const threads = [dummyThreadData()];
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
         getThreadsReqCount++;
@@ -125,12 +121,12 @@ describe("useThreads", () => {
   });
 
   test("should fetch threads for a given query", async () => {
-    const resolvedThread = dummyThreadDataPlain();
+    const resolvedThread = dummyThreadData();
     resolvedThread.metadata = {
       resolved: true,
     };
 
-    const unresolvedThread = dummyThreadDataPlain();
+    const unresolvedThread = dummyThreadData();
     unresolvedThread.metadata = {
       resolved: false,
     };
@@ -169,7 +165,7 @@ describe("useThreads", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [resolvedThread].map(convertToThreadData),
+        threads: [resolvedThread],
       })
     );
 
@@ -179,7 +175,7 @@ describe("useThreads", () => {
   test("should dedupe fetch threads for a given query", async () => {
     let getThreadsReqCount = 0;
 
-    const threads = [dummyThreadDataPlain()];
+    const threads = [dummyThreadData()];
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
         getThreadsReqCount++;
@@ -216,12 +212,12 @@ describe("useThreads", () => {
   });
 
   test("should refetch threads if query changed dynamically and should display threads instantly if query already been done in the past", async () => {
-    const resolvedThread = dummyThreadDataPlain();
+    const resolvedThread = dummyThreadData();
     resolvedThread.metadata = {
       resolved: true,
     };
 
-    const unresolvedThread = dummyThreadDataPlain();
+    const unresolvedThread = dummyThreadData();
     unresolvedThread.metadata = {
       resolved: false,
     };
@@ -262,7 +258,7 @@ describe("useThreads", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [resolvedThread].map(convertToThreadData),
+        threads: [resolvedThread],
       })
     );
 
@@ -273,7 +269,7 @@ describe("useThreads", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [unresolvedThread].map(convertToThreadData),
+        threads: [unresolvedThread],
       })
     );
 
@@ -282,7 +278,7 @@ describe("useThreads", () => {
     // Resolved threads are displayed instantly because we already fetched them previously
     expect(result.current).toEqual({
       isLoading: false,
-      threads: [resolvedThread].map(convertToThreadData),
+      threads: [resolvedThread],
     });
 
     unmount();
@@ -291,7 +287,7 @@ describe("useThreads", () => {
 
 describe("WebSocket events", () => {
   test("COMMENT_CREATED event should refresh thread", async () => {
-    const newThread = dummyThreadDataPlain();
+    const newThread = dummyThreadData();
 
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
@@ -340,7 +336,7 @@ describe("WebSocket events", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [convertToThreadData(newThread)],
+        threads: [newThread],
       })
     );
 
@@ -348,7 +344,7 @@ describe("WebSocket events", () => {
   });
 
   test("COMMENT_DELETED event should delete thread if getThread return 404", async () => {
-    const newThread = dummyThreadDataPlain();
+    const newThread = dummyThreadData();
 
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
@@ -379,7 +375,7 @@ describe("WebSocket events", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [newThread].map(convertToThreadData),
+        threads: [newThread],
       })
     );
 
@@ -402,19 +398,19 @@ describe("WebSocket events", () => {
 
   test("Websocket event should not refresh thread if updatedAt is earlier than the cached updatedAt", async () => {
     const now = new Date();
-    const initialThread = dummyThreadDataPlain();
-    initialThread.updatedAt = now.toISOString();
+    const initialThread = dummyThreadData();
+    initialThread.updatedAt = now;
     initialThread.metadata = { counter: 0 };
 
     const delayedThread = {
       ...initialThread,
-      updatedAt: addSeconds(now, 1).toISOString(),
+      updatedAt: addSeconds(now, 1),
       metadata: { counter: 1 },
     };
 
     const latestThread = {
       ...initialThread,
-      updatedAt: addSeconds(now, 2).toISOString(),
+      updatedAt: addSeconds(now, 2),
       metadata: { counter: 2 },
     };
 
@@ -467,7 +463,7 @@ describe("WebSocket events", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [convertToThreadData(initialThread)],
+        threads: [initialThread],
       })
     );
 
@@ -486,7 +482,7 @@ describe("WebSocket events", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: [convertToThreadData(latestThread)],
+        threads: [latestThread],
       })
     );
 
@@ -496,7 +492,7 @@ describe("WebSocket events", () => {
 
 describe("useThreadsSuspense", () => {
   test("should fetch threads", async () => {
-    const threads = [dummyThreadDataPlain()];
+    const threads = [dummyThreadData()];
 
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
@@ -527,7 +523,7 @@ describe("useThreadsSuspense", () => {
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        threads: threads.map(convertToThreadData),
+        threads,
       })
     );
 

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -286,8 +286,10 @@ describe("useThreads", () => {
 
     unmount();
   });
+});
 
-  test("should refresh thread after getting a COMMENT_CREATED event", async () => {
+describe("WebSocket events", () => {
+  test("COMMENT_CREATED event should refresh thread", async () => {
     const newThread = dummyThreadDataPlain();
 
     server.use(
@@ -344,7 +346,7 @@ describe("useThreads", () => {
     unmount();
   });
 
-  test("should delete thread if getThread return 404 after getting a COMMENT_DELETED event", async () => {
+  test("COMMENT_DELETED event should delete thread if getThread return 404", async () => {
     const newThread = dummyThreadDataPlain();
 
     server.use(

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -481,7 +481,7 @@ export function selectedThreads<TThreadMetadata extends BaseMetadata>(
  * @param threadB The second thread to compare.
  * @returns 1 if threadA is newer, -1 if threadB is newer, or 0 if they are the same age or can't be compared.
  */
-function compareThreads<TThreadMetadata extends BaseMetadata>(
+export function compareThreads<TThreadMetadata extends BaseMetadata>(
   thread1: ThreadData<TThreadMetadata>,
   thread2: ThreadData<TThreadMetadata>
 ): number {

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -346,6 +346,15 @@ export function applyOptimisticUpdates<TThreadMetadata extends BaseMetadata>(
               : comment
           ),
         };
+
+        if (
+          !result[thread.id].comments.some(
+            (comment) => comment.deletedAt === undefined
+          )
+        ) {
+          delete result[thread.id];
+        }
+
         break;
       }
       case "add-reaction": {
@@ -481,8 +490,8 @@ function compareThreads<TThreadMetadata extends BaseMetadata>(
     return thread1.updatedAt > thread2.updatedAt
       ? 1
       : thread1.updatedAt < thread2.updatedAt
-      ? -1
-      : 0;
+        ? -1
+        : 0;
   } else if (thread1.updatedAt || thread2.updatedAt) {
     return thread1.updatedAt ? 1 : -1;
   }

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -161,6 +161,20 @@ export function createClientStore<TThreadMetadata extends BaseMetadata>() {
   return {
     ...store,
 
+    deleteThread(threadId: string) {
+      store.set((state) => {
+        return {
+          ...state,
+          threads: deleteKeyImmutable(state.threads, threadId),
+          inboxNotifications: Object.fromEntries(
+            Object.entries(state.inboxNotifications).filter(
+              ([_id, notification]) => notification.threadId !== threadId
+            )
+          ),
+        };
+      });
+    },
+
     updateThreadsAndNotifications(
       threads: Record<string, ThreadData<TThreadMetadata> | undefined>,
       inboxNotifications: Record<
@@ -195,6 +209,18 @@ export function createClientStore<TThreadMetadata extends BaseMetadata>() {
       }));
     },
   };
+}
+
+function deleteKeyImmutable<TKey extends string | number | symbol, TValue>(
+  record: Record<TKey, TValue>,
+  key: TKey
+) {
+  if (record.hasOwnProperty(key)) {
+    const { [key]: _toDelete, ...rest } = record;
+    return rest;
+  }
+
+  return record;
 }
 
 export function upsertComment<TThreadMetadata extends BaseMetadata>(
@@ -443,8 +469,8 @@ function compareThreads<TThreadMetadata extends BaseMetadata>(
     return thread1.updatedAt > thread2.updatedAt
       ? 1
       : thread1.updatedAt < thread2.updatedAt
-        ? -1
-        : 0;
+      ? -1
+      : 0;
   } else if (thread1.updatedAt || thread2.updatedAt) {
     return thread1.updatedAt ? 1 : -1;
   }

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -457,12 +457,15 @@ export function applyOptimisticUpdates<TThreadMetadata extends BaseMetadata>(
 }
 
 export function selectedThreads<TThreadMetadata extends BaseMetadata>(
+  roomId: string,
   state: State<TThreadMetadata>,
   options: UseThreadsOptions<TThreadMetadata>
 ) {
   const result = applyOptimisticUpdates(state);
 
   return Object.values(result).filter((thread) => {
+    if (thread.roomId !== roomId) return false;
+
     const query = options.query;
     if (!query) return true;
 

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -227,7 +227,7 @@ function deleteKeyImmutable<TKey extends string | number | symbol, TValue>(
   record: Record<TKey, TValue>,
   key: TKey
 ) {
-  if (record.hasOwnProperty(key)) {
+  if (Object.prototype.hasOwnProperty.call(record, key)) {
     const { [key]: _toDelete, ...rest } = record;
     return rest;
   }

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -114,32 +114,48 @@ export function createClientStore<TThreadMetadata extends BaseMetadata>() {
 
   function mergeThreads(
     existingThreads: Record<string, ThreadData<TThreadMetadata>>,
-    newThreads: ThreadData<TThreadMetadata>[]
-  ) {
+    newThreads: Record<string, ThreadData<TThreadMetadata> | undefined>
+  ): Record<string, ThreadData<TThreadMetadata>> {
     // TODO: Do not replace existing thread if it has been updated more recently than the incoming thread
-    return {
+    const threads = Object.values({
       ...existingThreads,
-      ...Object.fromEntries(newThreads.map((thread) => [thread.id, thread])),
-    };
+      ...newThreads,
+    }).filter(
+      (thread) => thread !== undefined
+    ) as ThreadData<TThreadMetadata>[];
+
+    return Object.fromEntries(threads.map((thread) => [thread.id, thread]));
   }
 
   function mergeNotifications(
     existingInboxNotifications: Record<string, PartialInboxNotificationData>,
-    newInboxNotifications: PartialInboxNotificationData[]
+    newInboxNotifications: Record<
+      string,
+      PartialInboxNotificationData | undefined
+    >
   ) {
     // TODO: Do not replace existing inboxNotifications if it has been updated more recently than the incoming inbox notifications
-    return {
+    const inboxNotifications = Object.values({
       ...existingInboxNotifications,
-      ...Object.fromEntries(newInboxNotifications.map((ibn) => [ibn.id, ibn])),
-    };
+      ...newInboxNotifications,
+    }).filter(
+      (notification) => notification !== undefined
+    ) as PartialInboxNotificationData[];
+
+    return Object.fromEntries(
+      inboxNotifications.map((notification) => [notification.id, notification])
+    );
   }
 
   return {
     ...store,
 
     updateThreadsAndNotifications(
-      threads: ThreadData<TThreadMetadata>[],
-      inboxNotifications: PartialInboxNotificationData[],
+      threads: Record<string, ThreadData<TThreadMetadata> | undefined>,
+      inboxNotifications: Record<
+        string,
+        PartialInboxNotificationData | undefined
+      >,
       queryKey?: string
     ) {
       store.set((state) => ({

--- a/packages/liveblocks-react/src/comments/store.ts
+++ b/packages/liveblocks-react/src/comments/store.ts
@@ -116,13 +116,15 @@ export function createClientStore<TThreadMetadata extends BaseMetadata>() {
     existingThreads: Record<string, ThreadData<TThreadMetadata>>,
     newThreads: Record<string, ThreadData<TThreadMetadata> | undefined>
   ): Record<string, ThreadData<TThreadMetadata>> {
+    const updatedThreads = { ...existingThreads };
+
     Object.entries(newThreads).forEach(([id, thread]) => {
       if (thread === undefined) {
-        delete existingThreads[id];
+        delete updatedThreads[id];
         return;
       }
 
-      const existingThread = existingThreads[id];
+      const existingThread = updatedThreads[id];
 
       // If the thread already exists, we need to compare the two threads to determine which one is newer.
       if (existingThread) {
@@ -130,10 +132,10 @@ export function createClientStore<TThreadMetadata extends BaseMetadata>() {
         // If the existing thread is newer than the new thread, we do not update the existing thread.
         if (result === 1) return;
       }
-      existingThreads[id] = thread;
+      updatedThreads[id] = thread;
     });
 
-    return existingThreads;
+    return updatedThreads;
   }
 
   function mergeNotifications(

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -389,28 +389,10 @@ export function createRoomContext<
             // If the thread doesn't exist in the local cache, we do not update it with the server data as an optimistic update could have deleted the thread locally.
             if (!existingThread) break;
 
-            store.updateThreadsAndNotifications(
-              {
-                [thread.id]: thread,
-              },
-              {
-                ...(inboxNotification && {
-                  [inboxNotification.id]: inboxNotification,
-                }),
-              }
-            );
+            store.updateThreadAndNotification(thread, inboxNotification);
             break;
           case ServerMsgCode.COMMENT_CREATED:
-            store.updateThreadsAndNotifications(
-              {
-                [thread.id]: thread,
-              },
-              {
-                ...(inboxNotification && {
-                  [inboxNotification.id]: inboxNotification,
-                }),
-              }
-            );
+            store.updateThreadAndNotification(thread, inboxNotification);
             break;
           default:
             break;

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -399,10 +399,9 @@ export function createRoomContext<
         }
       }
 
-      const unsub = room.events.comments.subscribe(handleCommentEvent);
-      return () => {
-        unsub();
-      };
+      return room.events.comments.subscribe(
+        (message) => void handleCommentEvent(message)
+      );
     }, [room]);
 
     React.useEffect(() => {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -368,25 +368,13 @@ export function createRoomContext<
     );
 
     React.useEffect(() => {
-      function handleThreadDelete(threadId: string) {
-        const notifications = Object.values(
-          store.get().inboxNotifications
-        ).filter((notification) => notification.threadId === threadId);
-        store.updateThreadsAndNotifications(
-          {
-            [threadId]: undefined,
-          },
-          Object.fromEntries(notifications.map((n) => [n.id, undefined]))
-        );
-      }
-
       async function handleCommentEvent(message: CommentsEventServerMsg) {
         // TODO: Error handling
         const info = await room.getThread({ threadId: message.threadId });
 
         // If no thread info was returned (i.e., 404), we remove the thread and relevant inbox notifications from local cache.
         if (!info) {
-          handleThreadDelete(message.threadId);
+          store.deleteThread(message.threadId);
           return;
         }
         const { thread, inboxNotification } = info;

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1140,7 +1140,7 @@ export function createRoomContext<
         }
 
         return {
-          threads: selectedThreads(state, options),
+          threads: selectedThreads(room.id, state, options),
           isLoading: false,
         };
       }
@@ -1174,7 +1174,7 @@ export function createRoomContext<
       store.get,
       (state) => {
         return {
-          threads: selectedThreads(state, options),
+          threads: selectedThreads(room.id, state, options),
           isLoading: false,
         };
       }


### PR DESCRIPTION
- [x] Implement `getThread` method that calls the `GET :threadId` API endpoint to retrieve thread with the specified id and associated notifications.
- [x] Handle comment websocket event messages.
- [x] Compare threads using `updatedAt` property before merging new threads into existing ones in cache.
- [x] Add tests to validate the aforementioned features.