### PR TITLE
Updated limits page for comments

### DIFF
--- a/docs/pages/platform/limits.mdx
+++ b/docs/pages/platform/limits.mdx
@@ -17,6 +17,7 @@ meta:
 | Average connections per MAU          | Up to <Limits.FreeAvgConnectionsPerMau />     | Up to <Limits.ProAvgConnectionsPerMau />     | Custom     |
 | Maximum storage size per room        | Up to <Limits.FreeMaxStorageSizePerRoom /> MB | Up to <Limits.ProMaxStorageSizePerRoom /> MB | Custom     |
 | Simultaneous connections per room    | Up to <Limits.FreeMaxConnectionsPerRoom />    | Up to <Limits.ProMaxConnectionsPerRoom />    | Custom     |
+| Comments created per month           | <Limits.FreeMaxCommentsCreatedPerMonth />     | <Limits.FreeMaxCommentsCreatedPerMonth />    | Custom     |
 | Team members per account             | <Limits.FreeTeamMembersPerAccount />          | <Limits.ProTeamMembersPerAccount />          | Custom     |
 
 ### Monthly active users
@@ -28,6 +29,11 @@ Learn more about how monthly active users are calculated for each plan on our
 
 Learn more about handling simultaneous room connection limits in our guide about
 [joining rooms at maximum capacity](/docs/guides/what-happens-when-a-user-joins-a-room-at-maximum-capacity).
+
+### Unlimited comments
+
+If <Limits.FreeMaxCommentsCreatedPerMonth /> comments created per month isn’t enough for you, you can add 
+unlimited comments to the Pro plan for $199/month. You can also [contact us](/contact) to have unlimited comments on the enterprise plan.
 
 ## Other limits
 


### PR DESCRIPTION
Included comments limits information to the limits page in the docs. This can only be merged when the corresponding PR in the `liveblocks.io` repo is merged.