### PR TITLE
Upgrade to MSW 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8928,14 +8928,6 @@
         "@types/jest": "*"
       }
     },
-    "node_modules/@types/through": {
-      "version": "0.0.30",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "license": "MIT"
@@ -24137,7 +24129,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
-        "msw": "^0.36.4",
+        "msw": "^2.0.12",
         "zustand": "^4.1.3"
       },
       "peerDependencies": {
@@ -24145,88 +24137,42 @@
       }
     },
     "packages/liveblocks-zustand/node_modules/@mswjs/cookies": {
-      "version": "0.1.6",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/liveblocks-zustand/node_modules/@mswjs/interceptors": {
-      "version": "0.12.7",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.2",
-        "debug": "^4.3.2",
-        "headers-utils": "^3.0.2",
-        "outvariant": "^1.2.0",
-        "strict-event-emitter": "^0.2.0"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/@types/inquirer": {
-      "version": "8.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^7.2.0"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/graphql": {
-      "version": "15.8.0",
-      "dev": true,
-      "license": "MIT",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
       "engines": {
-        "node": ">= 10.x"
+        "node": ">=18"
       }
     },
-    "packages/liveblocks-zustand/node_modules/headers-utils": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
+    "packages/liveblocks-zustand/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
-    "packages/liveblocks-zustand/node_modules/msw": {
-      "version": "0.36.4",
+    "packages/liveblocks-zustand/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.6",
-        "@mswjs/interceptors": "^0.12.7",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/inquirer": "^8.1.3",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.5.1",
-        "headers-utils": "^3.0.2",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.1",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
-        "yargs": "^17.3.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -24238,12 +24184,73 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "packages/liveblocks-zustand/node_modules/type-fest": {
-      "version": "1.4.0",
+    "packages/liveblocks-zustand/node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
+    },
+    "packages/liveblocks-zustand/node_modules/msw": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.4.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x <= 5.3.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/liveblocks-zustand/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
+    },
+    "packages/liveblocks-zustand/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -26917,84 +26924,91 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^5.16.5",
-        "msw": "^0.36.4",
+        "msw": "^2.0.12",
         "zustand": "^4.1.3"
       },
       "dependencies": {
         "@mswjs/cookies": {
-          "version": "0.1.6",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
-        },
-        "@mswjs/interceptors": {
-          "version": "0.12.7",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@xmldom/xmldom": "^0.7.2",
-            "debug": "^4.3.2",
-            "headers-utils": "^3.0.2",
-            "outvariant": "^1.2.0",
-            "strict-event-emitter": "^0.2.0"
-          }
-        },
-        "@types/inquirer": {
-          "version": "8.1.3",
-          "dev": true,
-          "requires": {
-            "@types/through": "*",
-            "rxjs": "^7.2.0"
-          }
-        },
-        "graphql": {
-          "version": "15.8.0",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
           "dev": true
         },
-        "headers-utils": {
-          "version": "3.0.2",
+        "@mswjs/interceptors": {
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
+          "dev": true,
+          "requires": {
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/logger": "^0.3.0",
+            "@open-draft/until": "^2.0.0",
+            "is-node-process": "^1.2.0",
+            "outvariant": "^1.2.1",
+            "strict-event-emitter": "^0.5.1"
+          }
+        },
+        "@open-draft/until": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "headers-polyfill": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
           "dev": true
         },
         "msw": {
-          "version": "0.36.4",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
           "dev": true,
           "requires": {
-            "@mswjs/cookies": "^0.1.6",
-            "@mswjs/interceptors": "^0.12.7",
-            "@open-draft/until": "^1.0.3",
+            "@bundled-es-modules/cookie": "^2.0.0",
+            "@bundled-es-modules/js-levenshtein": "^2.0.1",
+            "@bundled-es-modules/statuses": "^1.0.1",
+            "@mswjs/cookies": "^1.1.0",
+            "@mswjs/interceptors": "^0.25.13",
+            "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.4.1",
-            "@types/inquirer": "^8.1.3",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "4.1.1",
+            "@types/js-levenshtein": "^1.1.1",
+            "@types/statuses": "^2.0.1",
+            "chalk": "^4.1.2",
             "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.5.1",
-            "headers-utils": "^3.0.2",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "^4.0.1",
             "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
+            "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.1",
+            "outvariant": "^1.4.0",
             "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.0",
-            "type-fest": "^1.2.2",
-            "yargs": "^17.3.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.1",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
+            "strict-event-emitter": "^0.5.0",
+            "type-fest": "^2.19.0",
+            "yargs": "^17.3.1"
           }
         },
+        "strict-event-emitter": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+          "dev": true
+        },
         "type-fest": {
-          "version": "1.4.0",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -31012,13 +31026,6 @@
       "dev": true,
       "requires": {
         "@types/jest": "*"
-      }
-    },
-    "@types/through": {
-      "version": "0.0.30",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2196,31 +2196,29 @@
       ]
     },
     "node_modules/@mswjs/cookies": {
-      "version": "0.2.2",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.15.3",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.5",
-        "debug": "^4.3.3",
-        "headers-polyfill": "^3.0.4",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.0"
+        "strict-event-emitter": "^0.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@next/env": {
@@ -2469,9 +2467,10 @@
       }
     },
     "node_modules/@open-draft/until": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@parcel/bundler-default": {
       "version": "2.9.3",
@@ -8902,14 +8901,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
     },
-    "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "license": "MIT"
@@ -9247,14 +9238,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.7.9",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -10520,14 +10503,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/copy-anything": {
@@ -13735,9 +13710,10 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -16607,46 +16583,58 @@
       }
     },
     "node_modules/msw": {
-      "version": "0.39.2",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.2.0",
-        "@mswjs/interceptors": "^0.15.1",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^16.3.0",
-        "headers-polyfill": "^3.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
       "bin": {
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x <= 5.3.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16659,11 +16647,12 @@
       }
     },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "1.4.0",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19841,11 +19830,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.5.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -20294,12 +20278,10 @@
       }
     },
     "node_modules/strict-event-emitter": {
-      "version": "0.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0"
-      }
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -23179,7 +23161,7 @@
         "@liveblocks/jest-config": "*",
         "@types/ws": "^8.5.3",
         "dotenv": "^16.0.3",
-        "msw": "^0.39.1",
+        "msw": "^2.0.12",
         "ws": "^8.5.0"
       }
     },
@@ -23195,125 +23177,6 @@
         "eslint-plugin-rulesdir": "^0.2.1",
         "msw": "^2.0.12",
         "ws": "^8.5.0"
-      }
-    },
-    "packages/liveblocks-core/node_modules/@mswjs/cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-core/node_modules/@mswjs/interceptors": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-core/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
-    },
-    "packages/liveblocks-core/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-core/node_modules/headers-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-      "dev": true
-    },
-    "packages/liveblocks-core/node_modules/msw": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.3.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-core/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "packages/liveblocks-core/node_modules/type-fest": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/liveblocks-devtools": {
@@ -23373,131 +23236,11 @@
         "svix": "^0.75.0"
       }
     },
-    "packages/liveblocks-node/node_modules/@mswjs/cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-node/node_modules/@mswjs/interceptors": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-node/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
-    },
     "packages/liveblocks-node/node_modules/@types/node": {
       "version": "20.7.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
       "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
       "dev": true
-    },
-    "packages/liveblocks-node/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-node/node_modules/headers-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-      "dev": true
-    },
-    "packages/liveblocks-node/node_modules/msw": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.3.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-node/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "packages/liveblocks-node/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
@@ -23602,38 +23345,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "packages/liveblocks-react-comments/node_modules/@mswjs/cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/@mswjs/interceptors": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
-    },
     "packages/liveblocks-react-comments/node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.1",
       "license": "MIT",
@@ -23667,82 +23378,6 @@
         }
       }
     },
-    "packages/liveblocks-react-comments/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/headers-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-      "dev": true
-    },
-    "packages/liveblocks-react-comments/node_modules/msw": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.3.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
     "packages/liveblocks-react-comments/node_modules/stylelint-config-recommended": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
@@ -23770,120 +23405,6 @@
         "stylelint": "^15.10.0"
       }
     },
-    "packages/liveblocks-react-comments/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/liveblocks-react/node_modules/@mswjs/cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-react/node_modules/@mswjs/interceptors": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-react/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
-    },
-    "packages/liveblocks-react/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-react/node_modules/headers-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-      "dev": true
-    },
-    "packages/liveblocks-react/node_modules/msw": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.3.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "packages/liveblocks-react/node_modules/nanoid": {
       "version": "3.3.6",
       "funding": [
@@ -23897,23 +23418,6 @@
       },
       "engines": {
         "node": "^14 || ^16 || >=18"
-      }
-    },
-    "packages/liveblocks-react/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "packages/liveblocks-react/node_modules/type-fest": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/liveblocks-redux": {
@@ -23934,126 +23438,6 @@
       },
       "peerDependencies": {
         "redux": "^4"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/@mswjs/cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/@mswjs/interceptors": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
-    },
-    "packages/liveblocks-redux/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/headers-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-      "dev": true
-    },
-    "packages/liveblocks-redux/node_modules/msw": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.3.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-redux/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "packages/liveblocks-redux/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/liveblocks-yjs": {
@@ -24091,126 +23475,6 @@
       },
       "peerDependencies": {
         "zustand": "^4.1.3"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/@mswjs/cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/@mswjs/interceptors": {
-      "version": "0.25.13",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
-    },
-    "packages/liveblocks-zustand/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/headers-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-      "dev": true
-    },
-    "packages/liveblocks-zustand/node_modules/msw": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
-        "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
-        "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.3.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
-    },
-    "packages/liveblocks-zustand/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "schema-lang/codemirror-language": {
@@ -25935,7 +25199,7 @@
         "@liveblocks/jest-config": "*",
         "@types/ws": "^8.5.3",
         "dotenv": "^16.0.3",
-        "msw": "^0.39.1",
+        "msw": "^2.0.12",
         "ws": "^8.5.0"
       }
     },
@@ -25962,89 +25226,6 @@
         "eslint-plugin-rulesdir": "^0.2.1",
         "msw": "^2.0.12",
         "ws": "^8.5.0"
-      },
-      "dependencies": {
-        "@mswjs/cookies": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-          "dev": true
-        },
-        "@mswjs/interceptors": {
-          "version": "0.25.13",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-          "dev": true,
-          "requires": {
-            "@open-draft/deferred-promise": "^2.2.0",
-            "@open-draft/logger": "^0.3.0",
-            "@open-draft/until": "^2.0.0",
-            "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.5.1"
-          }
-        },
-        "@open-draft/until": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "headers-polyfill": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-          "dev": true
-        },
-        "msw": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-          "dev": true,
-          "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
-            "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.1.0",
-            "@mswjs/interceptors": "^0.25.13",
-            "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "dev": true
-        }
       }
     },
     "@liveblocks/devtools": {
@@ -26156,93 +25337,10 @@
         "svix": "^0.75.0"
       },
       "dependencies": {
-        "@mswjs/cookies": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-          "dev": true
-        },
-        "@mswjs/interceptors": {
-          "version": "0.25.13",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-          "dev": true,
-          "requires": {
-            "@open-draft/deferred-promise": "^2.2.0",
-            "@open-draft/logger": "^0.3.0",
-            "@open-draft/until": "^2.0.0",
-            "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.5.1"
-          }
-        },
-        "@open-draft/until": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-          "dev": true
-        },
         "@types/node": {
           "version": "20.7.1",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
           "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "headers-polyfill": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-          "dev": true
-        },
-        "msw": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-          "dev": true,
-          "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
-            "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.1.0",
-            "@mswjs/interceptors": "^0.25.13",
-            "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -26263,89 +25361,8 @@
         "use-sync-external-store": "^1.2.0"
       },
       "dependencies": {
-        "@mswjs/cookies": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-          "dev": true
-        },
-        "@mswjs/interceptors": {
-          "version": "0.25.13",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-          "dev": true,
-          "requires": {
-            "@open-draft/deferred-promise": "^2.2.0",
-            "@open-draft/logger": "^0.3.0",
-            "@open-draft/until": "^2.0.0",
-            "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.5.1"
-          }
-        },
-        "@open-draft/until": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "headers-polyfill": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-          "dev": true
-        },
-        "msw": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-          "dev": true,
-          "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
-            "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.1.0",
-            "@mswjs/interceptors": "^0.25.13",
-            "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
         "nanoid": {
           "version": "3.3.6"
-        },
-        "strict-event-emitter": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "dev": true
         }
       }
     },
@@ -26415,32 +25432,6 @@
             "@floating-ui/dom": "^1.5.1"
           }
         },
-        "@mswjs/cookies": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-          "dev": true
-        },
-        "@mswjs/interceptors": {
-          "version": "0.25.13",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-          "dev": true,
-          "requires": {
-            "@open-draft/deferred-promise": "^2.2.0",
-            "@open-draft/logger": "^0.3.0",
-            "@open-draft/until": "^2.0.0",
-            "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.5.1"
-          }
-        },
-        "@open-draft/until": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-          "dev": true
-        },
         "@radix-ui/react-compose-refs": {
           "version": "1.0.1",
           "requires": {
@@ -26453,57 +25444,6 @@
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-compose-refs": "1.0.1"
           }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "headers-polyfill": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-          "dev": true
-        },
-        "msw": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-          "dev": true,
-          "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
-            "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.1.0",
-            "@mswjs/interceptors": "^0.25.13",
-            "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-          "dev": true
         },
         "stylelint-config-recommended": {
           "version": "13.0.0",
@@ -26520,12 +25460,6 @@
           "requires": {
             "stylelint-config-recommended": "^13.0.0"
           }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
         }
       }
     },
@@ -26540,91 +25474,6 @@
         "@testing-library/jest-dom": "^5.16.5",
         "msw": "^2.0.12",
         "redux": "^4.1.2"
-      },
-      "dependencies": {
-        "@mswjs/cookies": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-          "dev": true
-        },
-        "@mswjs/interceptors": {
-          "version": "0.25.13",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-          "dev": true,
-          "requires": {
-            "@open-draft/deferred-promise": "^2.2.0",
-            "@open-draft/logger": "^0.3.0",
-            "@open-draft/until": "^2.0.0",
-            "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.5.1"
-          }
-        },
-        "@open-draft/until": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "headers-polyfill": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-          "dev": true
-        },
-        "msw": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-          "dev": true,
-          "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
-            "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.1.0",
-            "@mswjs/interceptors": "^0.25.13",
-            "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
-        }
       }
     },
     "@liveblocks/schema": {
@@ -26881,91 +25730,6 @@
         "@testing-library/jest-dom": "^5.16.5",
         "msw": "^2.0.12",
         "zustand": "^4.1.3"
-      },
-      "dependencies": {
-        "@mswjs/cookies": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
-          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
-          "dev": true
-        },
-        "@mswjs/interceptors": {
-          "version": "0.25.13",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
-          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
-          "dev": true,
-          "requires": {
-            "@open-draft/deferred-promise": "^2.2.0",
-            "@open-draft/logger": "^0.3.0",
-            "@open-draft/until": "^2.0.0",
-            "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.5.1"
-          }
-        },
-        "@open-draft/until": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "headers-polyfill": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
-          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
-          "dev": true
-        },
-        "msw": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
-          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
-          "dev": true,
-          "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
-            "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.1.0",
-            "@mswjs/interceptors": "^0.25.13",
-            "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
-        }
       }
     },
     "@ljharb/through": {
@@ -27056,23 +25820,23 @@
       "optional": true
     },
     "@mswjs/cookies": {
-      "version": "0.2.2",
-      "dev": true,
-      "requires": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+      "dev": true
     },
     "@mswjs/interceptors": {
-      "version": "0.15.3",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
       "requires": {
-        "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.5",
-        "debug": "^4.3.3",
-        "headers-polyfill": "^3.0.4",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.0"
+        "strict-event-emitter": "^0.5.1"
       }
     },
     "@next/env": {
@@ -27192,7 +25956,9 @@
       }
     },
     "@open-draft/until": {
-      "version": "1.0.3",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "@parcel/bundler-default": {
@@ -30960,13 +29726,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
     },
-    "@types/set-cookie-parser": {
-      "version": "2.4.2",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "2.0.1"
     },
@@ -31204,10 +29963,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
-    },
-    "@xmldom/xmldom": {
-      "version": "0.7.9",
-      "dev": true
     },
     "abab": {
       "version": "2.0.6"
@@ -32036,10 +30791,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cookie": {
-      "version": "0.4.2",
-      "dev": true
     },
     "copy-anything": {
       "version": "2.0.6",
@@ -34201,7 +32952,9 @@
       }
     },
     "headers-polyfill": {
-      "version": "3.1.2",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
       "dev": true
     },
     "hoist-non-react-statics": {
@@ -36001,32 +34754,38 @@
       }
     },
     "msw": {
-      "version": "0.39.2",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
       "requires": {
-        "@mswjs/cookies": "^0.2.0",
-        "@mswjs/interceptors": "^0.15.1",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^16.3.0",
-        "headers-polyfill": "^3.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
+        "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
       "dependencies": {
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -36034,7 +34793,9 @@
           }
         },
         "type-fest": {
-          "version": "1.4.0",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -38018,10 +36779,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "set-cookie-parser": {
-      "version": "2.5.1",
-      "dev": true
-    },
     "set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -38337,11 +37094,10 @@
       }
     },
     "strict-event-emitter": {
-      "version": "0.2.7",
-      "dev": true,
-      "requires": {
-        "events": "^3.3.0"
-      }
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8764,31 +8764,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
-    "node_modules/@types/inquirer": {
-      "version": "7.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^6.4.0"
-      }
-    },
-    "node_modules/@types/inquirer/node_modules/rxjs": {
-      "version": "6.6.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@types/inquirer/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@types/is-hotkey": {
       "version": "0.1.7",
       "license": "MIT"
@@ -13785,11 +13760,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/headers-utils": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
@@ -17027,11 +16997,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
-    "node_modules/node-match-path": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-3.0.0.tgz",
@@ -17043,22 +17008,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
-      "license": "MIT"
-    },
-    "node_modules/node-request-interceptor": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "debug": "^4.3.0",
-        "headers-utils": "^1.2.0",
-        "strict-event-emitter": "^0.1.0"
-      }
-    },
-    "node_modules/node-request-interceptor/node_modules/strict-event-emitter": {
-      "version": "0.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/noop-logger": {
@@ -23655,7 +23604,7 @@
         "emojibase": "^15.0.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^2.0.12",
         "postcss": "^8.4.31",
         "postcss-advanced-variables": "^3.0.1",
         "postcss-combine-duplicated-selectors": "^10.0.3",
@@ -23705,13 +23654,36 @@
       }
     },
     "packages/liveblocks-react-comments/node_modules/@mswjs/cookies": {
-      "version": "0.1.7",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
+      "engines": {
+        "node": ">=18"
       }
+    },
+    "packages/liveblocks-react-comments/node_modules/@mswjs/interceptors": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/liveblocks-react-comments/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "packages/liveblocks-react-comments/node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.1",
@@ -23748,8 +23720,9 @@
     },
     "packages/liveblocks-react-comments/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -23761,91 +23734,65 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "packages/liveblocks-react-comments/node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/graphql": {
-      "version": "15.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/inquirer": {
-      "version": "7.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+    "packages/liveblocks-react-comments/node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "packages/liveblocks-react-comments/node_modules/msw": {
-      "version": "0.27.2",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.1.4",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.0",
-        "@types/inquirer": "^7.3.1",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "^4.1.0",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.4.0",
-        "headers-utils": "^1.2.0",
-        "inquirer": "^7.3.3",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.1",
-        "node-match-path": "^0.6.1",
-        "node-request-interceptor": "^0.6.3",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.1.0",
-        "yargs": "^16.2.0"
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
       },
       "bin": {
         "msw": "cli/index.js"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/rxjs": {
-      "version": "6.6.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
       },
       "engines": {
-        "npm": ">=2.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x <= 5.3.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "packages/liveblocks-react-comments/node_modules/strict-event-emitter": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "packages/liveblocks-react-comments/node_modules/stylelint-config-recommended": {
       "version": "13.0.0",
@@ -23874,34 +23821,16 @@
         "stylelint": "^15.10.0"
       }
     },
-    "packages/liveblocks-react-comments/node_modules/tslib": {
-      "version": "1.14.1",
+    "packages/liveblocks-react-comments/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
-      "license": "0BSD"
-    },
-    "packages/liveblocks-react-comments/node_modules/yargs": {
-      "version": "16.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+      "engines": {
+        "node": ">=12.20"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/liveblocks-react-comments/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/liveblocks-react/node_modules/@mswjs/cookies": {
@@ -26465,7 +26394,7 @@
         "emojibase": "^15.0.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^2.0.12",
         "postcss": "^8.4.31",
         "postcss-advanced-variables": "^3.0.1",
         "postcss-combine-duplicated-selectors": "^10.0.3",
@@ -26510,12 +26439,30 @@
           }
         },
         "@mswjs/cookies": {
-          "version": "0.1.7",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+          "dev": true
+        },
+        "@mswjs/interceptors": {
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
           "dev": true,
           "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/logger": "^0.3.0",
+            "@open-draft/until": "^2.0.0",
+            "is-node-process": "^1.2.0",
+            "outvariant": "^1.2.1",
+            "strict-event-emitter": "^0.5.1"
           }
+        },
+        "@open-draft/until": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+          "dev": true
         },
         "@radix-ui/react-compose-refs": {
           "version": "1.0.1",
@@ -26532,77 +26479,53 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
         },
-        "cliui": {
-          "version": "7.0.4",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "graphql": {
-          "version": "15.8.0",
+        "headers-polyfill": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
           "dev": true
         },
-        "inquirer": {
-          "version": "7.3.3",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^3.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.19",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.4.0",
-            "rxjs": "^6.6.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
-          }
-        },
         "msw": {
-          "version": "0.27.2",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
           "dev": true,
           "requires": {
-            "@mswjs/cookies": "^0.1.4",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.0",
-            "@types/inquirer": "^7.3.1",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "^4.1.0",
+            "@bundled-es-modules/cookie": "^2.0.0",
+            "@bundled-es-modules/js-levenshtein": "^2.0.1",
+            "@bundled-es-modules/statuses": "^1.0.1",
+            "@mswjs/cookies": "^1.1.0",
+            "@mswjs/interceptors": "^0.25.13",
+            "@open-draft/until": "^2.1.0",
+            "@types/cookie": "^0.4.1",
+            "@types/js-levenshtein": "^1.1.1",
+            "@types/statuses": "^2.0.1",
+            "chalk": "^4.1.2",
             "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.4.0",
-            "headers-utils": "^1.2.0",
-            "inquirer": "^7.3.3",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "^4.0.1",
+            "inquirer": "^8.2.0",
+            "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.1",
-            "node-match-path": "^0.6.1",
-            "node-request-interceptor": "^0.6.3",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.1.0",
-            "yargs": "^16.2.0"
-          }
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
+            "outvariant": "^1.4.0",
+            "path-to-regexp": "^6.2.0",
+            "strict-event-emitter": "^0.5.0",
+            "type-fest": "^2.19.0",
+            "yargs": "^17.3.1"
           }
         },
         "strict-event-emitter": {
-          "version": "0.1.0",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
           "dev": true
         },
         "stylelint-config-recommended": {
@@ -26621,25 +26544,10 @@
             "stylelint-config-recommended": "^13.0.0"
           }
         },
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -30938,27 +30846,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
-    "@types/inquirer": {
-      "version": "7.3.3",
-      "dev": true,
-      "requires": {
-        "@types/through": "*",
-        "rxjs": "^6.4.0"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "6.6.7",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
     "@types/is-hotkey": {
       "version": "0.1.7"
     },
@@ -34343,10 +34230,6 @@
       "version": "3.1.2",
       "dev": true
     },
-    "headers-utils": {
-      "version": "1.2.5",
-      "dev": true
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "requires": {
@@ -36384,10 +36267,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
-    "node-match-path": {
-      "version": "0.6.3",
-      "dev": true
-    },
     "node-object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-3.0.0.tgz",
@@ -36395,22 +36274,6 @@
     },
     "node-releases": {
       "version": "2.0.13"
-    },
-    "node-request-interceptor": {
-      "version": "0.6.3",
-      "dev": true,
-      "requires": {
-        "@open-draft/until": "^1.0.3",
-        "debug": "^4.3.0",
-        "headers-utils": "^1.2.0",
-        "strict-event-emitter": "^0.1.0"
-      },
-      "dependencies": {
-        "strict-event-emitter": {
-          "version": "0.1.0",
-          "dev": true
-        }
-      }
     },
     "noop-logger": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23980,7 +23980,7 @@
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
         "@testing-library/jest-dom": "^5.16.5",
-        "msw": "^0.36.4",
+        "msw": "^2.0.12",
         "redux": "^4.1.2"
       },
       "peerDependencies": {
@@ -23988,88 +23988,42 @@
       }
     },
     "packages/liveblocks-redux/node_modules/@mswjs/cookies": {
-      "version": "0.1.7",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/liveblocks-redux/node_modules/@mswjs/interceptors": {
-      "version": "0.12.7",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.2",
-        "debug": "^4.3.2",
-        "headers-utils": "^3.0.2",
-        "outvariant": "^1.2.0",
-        "strict-event-emitter": "^0.2.0"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/@types/inquirer": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^7.2.0"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/graphql": {
-      "version": "15.8.0",
-      "dev": true,
-      "license": "MIT",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
       "engines": {
-        "node": ">= 10.x"
+        "node": ">=18"
       }
     },
-    "packages/liveblocks-redux/node_modules/headers-utils": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
+    "packages/liveblocks-redux/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
-    "packages/liveblocks-redux/node_modules/msw": {
-      "version": "0.36.8",
+    "packages/liveblocks-redux/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.7",
-        "@mswjs/interceptors": "^0.12.7",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/inquirer": "^8.1.3",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.5.1",
-        "headers-utils": "^3.0.2",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
-        "yargs": "^17.3.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -24081,12 +24035,73 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "packages/liveblocks-redux/node_modules/msw/node_modules/type-fest": {
-      "version": "1.4.0",
+    "packages/liveblocks-redux/node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
+    },
+    "packages/liveblocks-redux/node_modules/msw": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.4.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.2.0",
+        "js-levenshtein": "^1.1.6",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.0",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x <= 5.3.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/liveblocks-redux/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
+    },
+    "packages/liveblocks-redux/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -26561,85 +26576,92 @@
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
         "@testing-library/jest-dom": "^5.16.5",
-        "msw": "^0.36.4",
+        "msw": "^2.0.12",
         "redux": "^4.1.2"
       },
       "dependencies": {
         "@mswjs/cookies": {
-          "version": "0.1.7",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
-        },
-        "@mswjs/interceptors": {
-          "version": "0.12.7",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@xmldom/xmldom": "^0.7.2",
-            "debug": "^4.3.2",
-            "headers-utils": "^3.0.2",
-            "outvariant": "^1.2.0",
-            "strict-event-emitter": "^0.2.0"
-          }
-        },
-        "@types/inquirer": {
-          "version": "8.2.0",
-          "dev": true,
-          "requires": {
-            "@types/through": "*",
-            "rxjs": "^7.2.0"
-          }
-        },
-        "graphql": {
-          "version": "15.8.0",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
           "dev": true
         },
-        "headers-utils": {
-          "version": "3.0.2",
+        "@mswjs/interceptors": {
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
+          "dev": true,
+          "requires": {
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/logger": "^0.3.0",
+            "@open-draft/until": "^2.0.0",
+            "is-node-process": "^1.2.0",
+            "outvariant": "^1.2.1",
+            "strict-event-emitter": "^0.5.1"
+          }
+        },
+        "@open-draft/until": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "headers-polyfill": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
           "dev": true
         },
         "msw": {
-          "version": "0.36.8",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
           "dev": true,
           "requires": {
-            "@mswjs/cookies": "^0.1.7",
-            "@mswjs/interceptors": "^0.12.7",
-            "@open-draft/until": "^1.0.3",
+            "@bundled-es-modules/cookie": "^2.0.0",
+            "@bundled-es-modules/js-levenshtein": "^2.0.1",
+            "@bundled-es-modules/statuses": "^1.0.1",
+            "@mswjs/cookies": "^1.1.0",
+            "@mswjs/interceptors": "^0.25.13",
+            "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.4.1",
-            "@types/inquirer": "^8.1.3",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "4.1.1",
+            "@types/js-levenshtein": "^1.1.1",
+            "@types/statuses": "^2.0.1",
+            "chalk": "^4.1.2",
             "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.5.1",
-            "headers-utils": "^3.0.2",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "^4.0.1",
             "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
+            "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
+            "outvariant": "^1.4.0",
             "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.0",
-            "type-fest": "^1.2.2",
-            "yargs": "^17.3.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.1",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "type-fest": {
-              "version": "1.4.0",
-              "dev": true
-            }
+            "strict-event-emitter": "^0.5.0",
+            "type-fest": "^2.19.0",
+            "yargs": "^17.3.1"
           }
+        },
+        "strict-event-emitter": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13121,19 +13121,6 @@
         "node": ">= 14.17"
       }
     },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "4.2.0",
       "dev": true,
@@ -16893,25 +16880,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
       "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
     },
     "node_modules/node-emoji": {
       "version": "2.1.3",
@@ -22683,15 +22651,6 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/webextension-polyfill": {
       "version": "0.10.0",
       "dev": true,
@@ -23410,23 +23369,23 @@
         "@liveblocks/jest-config": "*",
         "@types/node": "^20.7.1",
         "@types/node-fetch": "^2.6.6",
-        "msw": "^2.0.2",
+        "msw": "^2.0.12",
         "svix": "^0.75.0"
       }
     },
     "packages/liveblocks-node/node_modules/@mswjs/cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
-      "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "packages/liveblocks-node/node_modules/@mswjs/interceptors": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.7.tgz",
-      "integrity": "sha512-U7iFYs/qU/5jfz1VDpoYz3xqX9nzhsBXw7q923dv6GiGTy+m2ZLhD33L80R/shHOW/YWjeH6k16GbIHGw+bAng==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -23475,30 +23434,28 @@
       "dev": true
     },
     "packages/liveblocks-node/node_modules/msw": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.2.tgz",
-      "integrity": "sha512-loyQnNUDY1x05R/t2naVdtNhP+tfyf+ckEwtvRUuoK9JnDeoh3/ZN3Fu2ZtvO/iJ3IwwuLizWwWaxBxS3sDQUw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/js-levenshtein": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.0.0",
-        "@mswjs/interceptors": "^0.25.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
         "@types/statuses": "^2.0.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "formdata-node": "4.4.1",
         "graphql": "^16.8.1",
         "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
         "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
         "strict-event-emitter": "^0.5.0",
@@ -23516,7 +23473,7 @@
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.2.x"
+        "typescript": ">= 4.7.x <= 5.3.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -26194,21 +26151,21 @@
         "@types/node": "^20.7.1",
         "@types/node-fetch": "^2.6.6",
         "fast-sha256": "^1.3.0",
-        "msw": "^2.0.2",
+        "msw": "^2.0.12",
         "node-fetch": "^2.6.1",
         "svix": "^0.75.0"
       },
       "dependencies": {
         "@mswjs/cookies": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
-          "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
           "dev": true
         },
         "@mswjs/interceptors": {
-          "version": "0.25.7",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.7.tgz",
-          "integrity": "sha512-U7iFYs/qU/5jfz1VDpoYz3xqX9nzhsBXw7q923dv6GiGTy+m2ZLhD33L80R/shHOW/YWjeH6k16GbIHGw+bAng==",
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
           "dev": true,
           "requires": {
             "@open-draft/deferred-promise": "^2.2.0",
@@ -26248,29 +26205,27 @@
           "dev": true
         },
         "msw": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.2.tgz",
-          "integrity": "sha512-loyQnNUDY1x05R/t2naVdtNhP+tfyf+ckEwtvRUuoK9JnDeoh3/ZN3Fu2ZtvO/iJ3IwwuLizWwWaxBxS3sDQUw==",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
           "dev": true,
           "requires": {
             "@bundled-es-modules/cookie": "^2.0.0",
             "@bundled-es-modules/js-levenshtein": "^2.0.1",
             "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.0.0",
-            "@mswjs/interceptors": "^0.25.1",
+            "@mswjs/cookies": "^1.1.0",
+            "@mswjs/interceptors": "^0.25.13",
             "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.4.1",
             "@types/js-levenshtein": "^1.1.1",
             "@types/statuses": "^2.0.1",
             "chalk": "^4.1.2",
             "chokidar": "^3.4.2",
-            "formdata-node": "4.4.1",
             "graphql": "^16.8.1",
             "headers-polyfill": "^4.0.1",
             "inquirer": "^8.2.0",
             "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
             "outvariant": "^1.4.0",
             "path-to-regexp": "^6.2.0",
             "strict-event-emitter": "^0.5.0",
@@ -33860,16 +33815,6 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw=="
     },
-    "formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      }
-    },
     "fraction.js": {
       "version": "4.2.0",
       "dev": true
@@ -36238,12 +36183,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
       "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
     },
     "node-emoji": {
       "version": "2.1.3",
@@ -39814,12 +39753,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
-    },
-    "web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true
     },
     "webextension-polyfill": {
       "version": "0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8714,14 +8714,6 @@
         "@types/d3-selection": "*"
       }
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/degit": {
       "version": "2.8.3",
       "dev": true,
@@ -8859,11 +8851,6 @@
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/ms": {
-      "version": "0.7.31",
       "dev": true,
       "license": "MIT"
     },
@@ -9301,12 +9288,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)",
-      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -22761,30 +22742,6 @@
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
     },
-    "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
-    "node_modules/web-encoding/node_modules/util": {
-      "version": "0.12.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -23336,32 +23293,47 @@
         "@types/ws": "^8.5.3",
         "dotenv": "^16.0.3",
         "eslint-plugin-rulesdir": "^0.2.1",
-        "msw": "^0.47.4",
+        "msw": "^2.0.12",
         "ws": "^8.5.0"
       }
     },
-    "packages/liveblocks-core/node_modules/@mswjs/interceptors": {
-      "version": "0.17.5",
+    "packages/liveblocks-core/node_modules/@mswjs/cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.7.5",
-        "debug": "^4.3.3",
-        "headers-polyfill": "^3.1.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
-      },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "packages/liveblocks-core/node_modules/chalk": {
-      "version": "4.1.1",
+    "packages/liveblocks-core/node_modules/@mswjs/interceptors": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/liveblocks-core/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
+    },
+    "packages/liveblocks-core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -23373,30 +23345,38 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "packages/liveblocks-core/node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
+    },
     "packages/liveblocks-core/node_modules/msw": {
-      "version": "0.47.4",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.0",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "outvariant": "^1.3.0",
+        "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.6",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -23404,20 +23384,26 @@
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.2.x <= 4.8.x"
+        "typescript": ">= 4.7.x <= 5.3.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
       }
+    },
+    "packages/liveblocks-core/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "packages/liveblocks-core/node_modules/type-fest": {
       "version": "2.19.0",
@@ -26066,57 +26052,86 @@
         "@types/ws": "^8.5.3",
         "dotenv": "^16.0.3",
         "eslint-plugin-rulesdir": "^0.2.1",
-        "msw": "^0.47.4",
+        "msw": "^2.0.12",
         "ws": "^8.5.0"
       },
       "dependencies": {
+        "@mswjs/cookies": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+          "dev": true
+        },
         "@mswjs/interceptors": {
-          "version": "0.17.5",
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
           "dev": true,
           "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@types/debug": "^4.1.7",
-            "@xmldom/xmldom": "^0.7.5",
-            "debug": "^4.3.3",
-            "headers-polyfill": "^3.1.0",
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/logger": "^0.3.0",
+            "@open-draft/until": "^2.0.0",
+            "is-node-process": "^1.2.0",
             "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.2.4",
-            "web-encoding": "^1.1.5"
+            "strict-event-emitter": "^0.5.1"
           }
         },
+        "@open-draft/until": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+          "dev": true
+        },
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
         },
+        "headers-polyfill": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+          "dev": true
+        },
         "msw": {
-          "version": "0.47.4",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
           "dev": true,
           "requires": {
-            "@mswjs/cookies": "^0.2.2",
-            "@mswjs/interceptors": "^0.17.5",
-            "@open-draft/until": "^1.0.3",
+            "@bundled-es-modules/cookie": "^2.0.0",
+            "@bundled-es-modules/js-levenshtein": "^2.0.1",
+            "@bundled-es-modules/statuses": "^1.0.1",
+            "@mswjs/cookies": "^1.1.0",
+            "@mswjs/interceptors": "^0.25.13",
+            "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.4.1",
             "@types/js-levenshtein": "^1.1.1",
-            "chalk": "4.1.1",
+            "@types/statuses": "^2.0.1",
+            "chalk": "^4.1.2",
             "chokidar": "^3.4.2",
-            "cookie": "^0.4.2",
-            "graphql": "^15.0.0 || ^16.0.0",
-            "headers-polyfill": "^3.1.0",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "^4.0.1",
             "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
+            "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
-            "outvariant": "^1.3.0",
+            "outvariant": "^1.4.0",
             "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.6",
+            "strict-event-emitter": "^0.5.0",
             "type-fest": "^2.19.0",
             "yargs": "^17.3.1"
           }
+        },
+        "strict-event-emitter": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+          "dev": true
         },
         "type-fest": {
           "version": "2.19.0",
@@ -30877,13 +30892,6 @@
         "@types/d3-selection": "*"
       }
     },
-    "@types/debug": {
-      "version": "4.1.7",
-      "dev": true,
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/degit": {
       "version": "2.8.3",
       "dev": true
@@ -31007,10 +31015,6 @@
     },
     "@types/minimist": {
       "version": "1.2.2",
-      "dev": true
-    },
-    "@types/ms": {
-      "version": "0.7.31",
       "dev": true
     },
     "@types/node": {
@@ -31333,11 +31337,6 @@
     "@xmldom/xmldom": {
       "version": "0.7.9",
       "dev": true
-    },
-    "@zxing/text-encoding": {
-      "version": "0.9.0",
-      "dev": true,
-      "optional": true
     },
     "abab": {
       "version": "2.0.6"
@@ -39923,28 +39922,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
-    },
-    "web-encoding": {
-      "version": "1.1.5",
-      "dev": true,
-      "requires": {
-        "@zxing/text-encoding": "0.9.0",
-        "util": "^0.12.3"
-      },
-      "dependencies": {
-        "util": {
-          "version": "0.12.4",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
     },
     "web-streams-polyfill": {
       "version": "4.0.0-beta.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23632,7 +23632,7 @@
         "@testing-library/react": "^13.1.1",
         "@types/use-sync-external-store": "^0.0.3",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "1.2.3"
+        "msw": "^2.0.12"
       },
       "peerDependencies": {
         "react": "^16.14.0 || ^17 || ^18"
@@ -23918,36 +23918,43 @@
         "node": ">=10"
       }
     },
-    "packages/liveblocks-react/node_modules/@mswjs/interceptors": {
-      "version": "0.17.9",
+    "packages/liveblocks-react/node_modules/@mswjs/cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/liveblocks-react/node_modules/@mswjs/interceptors": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
+      "dev": true,
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "^3.1.0",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
+        "strict-event-emitter": "^0.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "packages/liveblocks-react/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
+    "packages/liveblocks-react/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "packages/liveblocks-react/node_modules/chalk": {
-      "version": "4.1.1",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -23959,29 +23966,38 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "packages/liveblocks-react/node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
+    },
     "packages/liveblocks-react/node_modules/msw": {
-      "version": "1.2.3",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+      "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
         "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.4.3",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -23989,25 +24005,20 @@
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.1.x"
+        "typescript": ">= 4.7.x <= 5.3.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
       }
-    },
-    "packages/liveblocks-react/node_modules/msw/node_modules/strict-event-emitter": {
-      "version": "0.4.6",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/liveblocks-react/node_modules/nanoid": {
       "version": "3.3.6",
@@ -24023,6 +24034,12 @@
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
+    },
+    "packages/liveblocks-react/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "packages/liveblocks-react/node_modules/type-fest": {
       "version": "2.19.0",
@@ -26320,70 +26337,90 @@
         "@testing-library/react": "^13.1.1",
         "@types/use-sync-external-store": "^0.0.3",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "1.2.3",
+        "msw": "^2.0.12",
         "nanoid": "^3",
         "use-sync-external-store": "^1.2.0"
       },
       "dependencies": {
+        "@mswjs/cookies": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+          "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+          "dev": true
+        },
         "@mswjs/interceptors": {
-          "version": "0.17.9",
+          "version": "0.25.13",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+          "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
           "dev": true,
           "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@types/debug": "^4.1.7",
-            "@xmldom/xmldom": "^0.8.3",
-            "debug": "^4.3.3",
-            "headers-polyfill": "^3.1.0",
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/logger": "^0.3.0",
+            "@open-draft/until": "^2.0.0",
+            "is-node-process": "^1.2.0",
             "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.2.4",
-            "web-encoding": "^1.1.5"
+            "strict-event-emitter": "^0.5.1"
           }
         },
-        "@xmldom/xmldom": {
-          "version": "0.8.10",
+        "@open-draft/until": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
         },
+        "headers-polyfill": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+          "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+          "dev": true
+        },
         "msw": {
-          "version": "1.2.3",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.12.tgz",
+          "integrity": "sha512-TN9HuRDRf8dA2tmIhc7xpX45A37zBMcjBBem490lBK+zz/eyveGoQZQTARAIiEHld6rz9bpzl1GSuxmy1mG87A==",
           "dev": true,
           "requires": {
-            "@mswjs/cookies": "^0.2.2",
-            "@mswjs/interceptors": "^0.17.5",
-            "@open-draft/until": "^1.0.3",
+            "@bundled-es-modules/cookie": "^2.0.0",
+            "@bundled-es-modules/js-levenshtein": "^2.0.1",
+            "@bundled-es-modules/statuses": "^1.0.1",
+            "@mswjs/cookies": "^1.1.0",
+            "@mswjs/interceptors": "^0.25.13",
+            "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.4.1",
             "@types/js-levenshtein": "^1.1.1",
-            "chalk": "4.1.1",
+            "@types/statuses": "^2.0.1",
+            "chalk": "^4.1.2",
             "chokidar": "^3.4.2",
-            "cookie": "^0.4.2",
-            "graphql": "^15.0.0 || ^16.0.0",
-            "headers-polyfill": "^3.1.2",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "^4.0.1",
             "inquirer": "^8.2.0",
             "is-node-process": "^1.2.0",
             "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
             "outvariant": "^1.4.0",
             "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.4.3",
+            "strict-event-emitter": "^0.5.0",
             "type-fest": "^2.19.0",
             "yargs": "^17.3.1"
-          },
-          "dependencies": {
-            "strict-event-emitter": {
-              "version": "0.4.6",
-              "dev": true
-            }
           }
         },
         "nanoid": {
           "version": "3.3.6"
+        },
+        "strict-event-emitter": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+          "dev": true
         },
         "type-fest": {
           "version": "2.19.0",

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -40,7 +40,7 @@
     "@liveblocks/jest-config": "*",
     "@types/ws": "^8.5.3",
     "dotenv": "^16.0.3",
-    "msw": "^0.39.1",
+    "msw": "^2.0.12",
     "ws": "^8.5.0"
   },
   "sideEffects": false,

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -51,7 +51,7 @@
     "@types/ws": "^8.5.3",
     "dotenv": "^16.0.3",
     "eslint-plugin-rulesdir": "^0.2.1",
-    "msw": "^0.47.4",
+    "msw": "^2.0.12",
     "ws": "^8.5.0"
   },
   "repository": {

--- a/packages/liveblocks-core/src/__tests__/auth-manager.test.ts
+++ b/packages/liveblocks-core/src/__tests__/auth-manager.test.ts
@@ -1,4 +1,4 @@
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
 import { createAuthManager } from "../auth-manager";
@@ -46,34 +46,34 @@ describe("auth-manager - secret auth", () => {
     "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NjQ1NjY0MTAsImV4cCI6MTY2NDU3MDAxMCwicGlkIjoiNjA1YTRmZDMxYTM2ZDVlYTdhMmUwOGYxIiwidWlkIjoidXNlcjEiLCJrIjoiaWQifQ.MhjHg2udkBivX7cW8Q1jmgc4DOZ1YnMoUnP61O32JLVJlIsc0zmHWA__DItsO3vBbRS8doG98cOzSE2qQ-5rKoX2l19k5Mr7gk6M75u1kOAzppV_3YQAGeZ8PfsUUPUBGOF5O6msLnha-HcAywvBuoUmcqP0CF_xhBBx0CLbFeuaWVJqndPKe8LJk9EYcB29HEwFaIzrOSarU1iLxRhsa8FCB910GTDcaApaUTPM9ZRadmf33ypSn3c6by0BWI54vx4O2p-hFsmJ71R38ifRRVq3ETXn78ftwbu1pp6hMTqyYn5YLlnZPPM-JAck_OsarGvE9cxg_Z3Y8bMTOlA5E";
 
   const server = setupServer(
-    rest.post("/mocked-api/legacy-auth", (_req, res, ctx) => {
-      return res(
-        ctx.json({ token: legacyTokens[requestCount++ % legacyTokens.length] })
-      );
+    http.post("/mocked-api/legacy-auth", () => {
+      return HttpResponse.json({
+        token: legacyTokens[requestCount++ % legacyTokens.length],
+      });
     }),
-    rest.post("/mocked-api/legacy-auth-that-caches", (_req, res, ctx) => {
+    http.post("/mocked-api/legacy-auth-that-caches", () => {
       requestCount++;
-      return res(ctx.json({ token: legacyTokens[0] }));
+      return HttpResponse.json({ token: legacyTokens[0] });
     }),
-    rest.post("/mocked-api/access-auth", (_req, res, ctx) => {
+    http.post("/mocked-api/access-auth", () => {
       requestCount++;
-      return res(ctx.json({ token: accessToken }));
+      return HttpResponse.json({ token: accessToken });
     }),
-    rest.post("/mocked-api/id-auth", (_req, res, ctx) => {
+    http.post("/mocked-api/id-auth", () => {
       requestCount++;
-      return res(ctx.json({ token: idToken }));
+      return HttpResponse.json({ token: idToken });
     }),
-    rest.post("/mocked-api/403", (_req, res, ctx) => {
-      return res(ctx.status(403));
+    http.post("/mocked-api/403", () => {
+      return new HttpResponse(null, { status: 403 });
     }),
-    rest.post("/mocked-api/401-with-details", (_req, res, ctx) => {
-      return res(ctx.status(401), ctx.text("wrong key type"));
+    http.post("/mocked-api/401-with-details", () => {
+      return HttpResponse.text("wrong key type", { status: 401 });
     }),
-    rest.post("/mocked-api/not-json", (_req, res, ctx) => {
-      return res(ctx.status(202), ctx.text("this is not json"));
+    http.post("/mocked-api/not-json", () => {
+      return HttpResponse.text("this is not json", { status: 202 });
     }),
-    rest.post("/mocked-api/missing-token", (_req, res, ctx) => {
-      return res(ctx.status(202), ctx.json({}));
+    http.post("/mocked-api/missing-token", () => {
+      return HttpResponse.json({}, { status: 202 });
     })
   );
 

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -43,7 +43,7 @@
     "@liveblocks/jest-config": "*",
     "@types/node": "^20.7.1",
     "@types/node-fetch": "^2.6.6",
-    "msw": "^2.0.2",
+    "msw": "^2.0.12",
     "svix": "^0.75.0"
   },
   "bugs": {

--- a/packages/liveblocks-react-comments/package.json
+++ b/packages/liveblocks-react-comments/package.json
@@ -77,7 +77,7 @@
     "emojibase": "^15.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "msw": "^0.27.1",
+    "msw": "^2.0.12",
     "postcss": "^8.4.31",
     "postcss-advanced-variables": "^3.0.1",
     "postcss-combine-duplicated-selectors": "^10.0.3",

--- a/packages/liveblocks-react-comments/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react-comments/src/__tests__/index.test.tsx
@@ -6,7 +6,7 @@ import type {
   ThreadData,
 } from "@liveblocks/core";
 import { ServerMsgCode } from "@liveblocks/core";
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import React from "react";
 
@@ -112,13 +112,11 @@ class MockWebSocket {
 window.WebSocket = MockWebSocket as any;
 
 const server = setupServer(
-  rest.post("/api/auth", (_, res, ctx) => {
-    return res(
-      ctx.json({
-        token:
-          "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-HHtmvzOi8LdEnpxgxGjxefdu6m4a-fJj6LwoYCGi1rlLDHH9aOHFwYVrBBBVwoeIDSHoAonkPaae9AWM6igJhNt9-ihgEH6sF-qgFiPxHNXdg",
-      })
-    );
+  http.post("/api/auth", () => {
+    return HttpResponse.json({
+      token:
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-HHtmvzOi8LdEnpxgxGjxefdu6m4a-fJj6LwoYCGi1rlLDHH9aOHFwYVrBBBVwoeIDSHoAonkPaae9AWM6igJhNt9-ihgEH6sF-qgFiPxHNXdg",
+    });
   })
 );
 

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -49,7 +49,7 @@
     "@testing-library/react": "^13.1.1",
     "@types/use-sync-external-store": "^0.0.3",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "msw": "1.2.3"
+    "msw": "^2.0.12"
   },
   "sideEffects": false,
   "bugs": {

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { createClient, shallow } from "@liveblocks/client";
 import type { ThreadData } from "@liveblocks/core";
 import { ClientMsgCode, CrdtType, ServerMsgCode } from "@liveblocks/core";
 import { render } from "@testing-library/react";
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import * as React from "react";
 
@@ -26,19 +26,17 @@ const exampleToken =
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-";
 let requestCount = 0;
 const server = setupServer(
-  rest.post("/api/auth", (_, res, ctx) => {
-    return res(
-      ctx.json({
-        token:
-          // Append a unique counter in the (unchecked) signature part of the
-          // JWT token at the end, to make each subsequent request return
-          // a unique value
-          `${exampleToken}${requestCount++}`,
-      })
-    );
+  http.post("/api/auth", () => {
+    return HttpResponse.json({
+      token:
+        // Append a unique counter in the (unchecked) signature part of the
+        // JWT token at the end, to make each subsequent request return
+        // a unique value
+        `${exampleToken}${requestCount++}`,
+    });
   }),
-  rest.post("/api/auth-fail", (_, res, ctx) => {
-    return res(ctx.status(400));
+  http.post("/api/auth-fail", () => {
+    return new HttpResponse(null, { status: 400 });
   })
 );
 
@@ -446,7 +444,7 @@ describe("useThreads", () => {
     ];
 
     server.use(
-      rest.post(
+      http.post(
         "https://api.liveblocks.io/v2/c/rooms/room/threads/search",
         (_, res, ctx) => {
           return res(

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1,8 +1,7 @@
 import type { ThreadData } from "@liveblocks/core";
 import { createClient } from "@liveblocks/core";
 import { render, renderHook, screen, waitFor } from "@testing-library/react";
-import type { ResponseComposition, RestContext, RestRequest } from "msw";
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
 
@@ -34,7 +33,7 @@ const threads: ThreadData[] = [
 const fetchThreadsMock = jest.fn();
 
 const server = setupServer(
-  rest.post(
+  http.post(
     "https://api.liveblocks.io/v2/c/rooms/room-id/threads/search",
     fetchThreadsMock
   )
@@ -44,15 +43,11 @@ beforeAll(() => server.listen());
 
 beforeEach(() => {
   fetchThreadsMock.mockReset();
-  fetchThreadsMock.mockImplementation(
-    (_: RestRequest, res: ResponseComposition, ctx: RestContext) => {
-      return res(
-        ctx.json({
-          data: threads,
-        })
-      );
-    }
-  );
+  fetchThreadsMock.mockImplementation(() => {
+    return HttpResponse.json({
+      data: threads,
+    });
+  });
   jest.useFakeTimers();
   MockWebSocket.instances = [];
 });

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -43,7 +43,7 @@
     "@liveblocks/jest-config": "*",
     "@reduxjs/toolkit": "^1.7.2",
     "@testing-library/jest-dom": "^5.16.5",
-    "msw": "^0.36.4",
+    "msw": "^2.0.12",
     "redux": "^4.1.2"
   },
   "sideEffects": false,

--- a/packages/liveblocks-redux/src/__tests__/index.test.ts
+++ b/packages/liveblocks-redux/src/__tests__/index.test.ts
@@ -10,7 +10,7 @@ import type {
 import { ClientMsgCode, OpCode, ServerMsgCode } from "@liveblocks/core";
 import type { Reducer } from "@reduxjs/toolkit";
 import { configureStore } from "@reduxjs/toolkit";
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
 import type { Mapping, WithLiveblocks } from "..";
@@ -27,16 +27,14 @@ window.WebSocket = MockWebSocket as any;
 const { enterRoom, leaveRoom } = actions;
 
 const server = setupServer(
-  rest.post("/api/auth", (_req, res, ctx) => {
-    return res(
-      ctx.json({
-        token:
-          "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-HHtmvzOi8LdEnpxgxGjxefdu6m4a-fJj6LwoYCGi1rlLDHH9aOHFwYVrBBBVwoeIDSHoAonkPaae9AWM6igJhNt9-ihgEH6sF-qgFiPxHNXdg",
-      })
-    );
+  http.post("/api/auth", () => {
+    return HttpResponse.json({
+      token:
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-HHtmvzOi8LdEnpxgxGjxefdu6m4a-fJj6LwoYCGi1rlLDHH9aOHFwYVrBBBVwoeIDSHoAonkPaae9AWM6igJhNt9-ihgEH6sF-qgFiPxHNXdg",
+    });
   }),
-  rest.post("/api/auth-fail", (_req, res, ctx) => {
-    return res(ctx.status(400));
+  http.post("/api/auth-fail", () => {
+    return new HttpResponse(null, { status: 400 });
   })
 );
 

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -43,7 +43,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@testing-library/jest-dom": "^5.16.5",
-    "msw": "^0.36.4",
+    "msw": "^2.0.12",
     "zustand": "^4.1.3"
   },
   "sideEffects": false,

--- a/packages/liveblocks-zustand/src/__tests__/index.test.ts
+++ b/packages/liveblocks-zustand/src/__tests__/index.test.ts
@@ -13,7 +13,7 @@ import type {
   UpdatePresenceServerMsg,
 } from "@liveblocks/core";
 import { ClientMsgCode, OpCode, ServerMsgCode } from "@liveblocks/core";
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import type { StateCreator } from "zustand";
 import create from "zustand";
@@ -27,16 +27,14 @@ window.WebSocket = MockWebSocket as any;
 const INVALID_CONFIG_ERROR = /Invalid @liveblocks\/zustand middleware config/;
 
 const server = setupServer(
-  rest.post("/api/auth", (_req, res, ctx) => {
-    return res(
-      ctx.json({
-        token:
-          "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-HHtmvzOi8LdEnpxgxGjxefdu6m4a-fJj6LwoYCGi1rlLDHH9aOHFwYVrBBBVwoeIDSHoAonkPaae9AWM6igJhNt9-ihgEH6sF-qgFiPxHNXdg",
-      })
-    );
+  http.post("/api/auth", () => {
+    return HttpResponse.json({
+      token:
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2OTAwMzMzMjgsImV4cCI6MTY5MDAzMzMzMywiayI6InNlYy1sZWdhY3kiLCJyb29tSWQiOiJlTFB3dU9tTXVUWEN6Q0dSaTVucm4iLCJhcHBJZCI6IjYyNDFjYjk1ZWQ2ODdkNWRlNWFhYTEzMiIsImFjdG9yIjoxLCJzY29wZXMiOlsicm9vbTp3cml0ZSJdLCJpZCI6InVzZXItMyIsIm1heENvbm5lY3Rpb25zUGVyUm9vbSI6MjB9.QoRc9dJJp-C1LzmQ-S_scHfFsAZ7dBcqep0bUZNyWxEWz_VeBHBBNdJpNs7b7RYRFDBi7RxkywKJlO-gNE8h3wkhebgLQVeSgI3YfTJo7J8Jzj38TzH85ZIbybaiGcxda_sYn3VohDtUHA1k67ns08Q2orJBNr30Gc88jJmc1He_7bLStsDP4M2F1NRMuFuqLULWHnPeEM7jMvLZYkbu3SBeCH4TQGyweu7qAXvP-HHtmvzOi8LdEnpxgxGjxefdu6m4a-fJj6LwoYCGi1rlLDHH9aOHFwYVrBBBVwoeIDSHoAonkPaae9AWM6igJhNt9-ihgEH6sF-qgFiPxHNXdg",
+    });
   }),
-  rest.post("/api/auth-fail", (_req, res, ctx) => {
-    return res(ctx.status(400));
+  http.post("/api/auth-fail", () => {
+    return new HttpResponse(null, { status: 400 });
   })
 );
 


### PR DESCRIPTION
## For Maintainers

### Description

This updates the `msw` package across the entire Liveblocks monorepo to be of the latest version ([2.0.12](https://github.com/mswjs/msw/releases/tag/v2.0.12) at the moment). 

#### How to test it

- Existing tests should pass. 

#### Related issue(s)

Not related to any issues. 
