### PR TITLE
Handle invalid response for `getRooms` method

### DIFF
--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -347,6 +347,11 @@ export class Liveblocks {
 
     const res = await this.get(path, queryParams);
 
+    if (!res.ok) {
+      const text = await res.text();
+      throw new LiveblocksError(res.status, text);
+    }
+
     const data = (await res.json()) as {
       nextPage: string | null;
       data: RoomInfoPlain[];


### PR DESCRIPTION
We missed adding error response handler to the `getRooms` method. This PR updates the method to add that handling logic.