### PR TITLE
fix: docs linking to localhost instead of proper relative URLS

### DIFF
--- a/guides/pages/getting-prosemirror-state-on-the-server.mdx
+++ b/guides/pages/getting-prosemirror-state-on-the-server.mdx
@@ -45,4 +45,4 @@ export async function POST() {
 ```
 
 If you’d like to edit your document, make sure to read
-[how to use your `Y.Doc` on the server](http://localhost:3001/docs/guides/how-to-use-your-ydoc-on-the-server).
+[how to use your `Y.Doc` on the server](/docs/guides/how-to-use-your-ydoc-on-the-server).

--- a/guides/pages/getting-tiptap-state-on-the-server.mdx
+++ b/guides/pages/getting-tiptap-state-on-the-server.mdx
@@ -46,4 +46,4 @@ export async function POST() {
 ```
 
 If you’d like to edit your document, make sure to read
-[how to use your `Y.Doc` on the server](http://localhost:3001/docs/guides/how-to-use-your-ydoc-on-the-server).
+[how to use your `Y.Doc` on the server](/docs/guides/how-to-use-your-ydoc-on-the-server).


### PR DESCRIPTION
### Fixing a bug (docs)

- Broken links in docs:
  - Go to [https://liveblocks.io/docs/guides/getting-tiptap-state-on-the-server](https://liveblocks.io/docs/guides/getting-tiptap-state-on-the-server)
  - Link to "how to use your Y.Doc on the server" points to http://localhost:3001

#### Related issue(s)

- Sorry, just glanced over any issues, wasn't sure if this was already in pipeline to be fixed :)
