### PR TITLE
Fix mention suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
-# v1.9.4
+# v1.9.5
 
 ### `@liveblocks/react-comments`
+
+- Fix mention suggestions not appearing.
+
+# v1.9.4
+
+### `@liveblocks/react`
 
 - Fix polling on `useThreads` hook.
 
 # v1.9.3
 
-### `@liveblocks/react-comments`
+### `@liveblocks/react`
 
 - Fix a bug that prevented comments from being used across multiple rooms.
 

--- a/packages/liveblocks-react-comments/src/utils/Portal.tsx
+++ b/packages/liveblocks-react-comments/src/utils/Portal.tsx
@@ -16,13 +16,13 @@ interface PortalProps extends ComponentPropsWithSlot<"div"> {
 }
 
 const Portal = forwardRef<HTMLDivElement, PortalProps>(
-  ({ container, asChild, ...props }, forwardedRef) => {
+  ({ container = document?.body, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
 
     return container
       ? createPortal(
           <Component data-liveblocks-portal="" {...props} ref={forwardedRef} />,
-          container ?? document?.body
+          container
         )
       : null;
   }


### PR DESCRIPTION
Our `Portal` component didn't fallback to `document.body` as expected when not passing a container.