### PR TITLE
Update `useSyncExternalStore` import

### DIFF
--- a/packages/liveblocks-react/src/comments/CommentsRoom.tsx
+++ b/packages/liveblocks-react/src/comments/CommentsRoom.tsx
@@ -23,9 +23,9 @@ import React, {
   useEffect,
   useMemo,
 } from "react";
-import { useSyncExternalStore } from "use-sync-external-store/shim";
 import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 
+import { useSyncExternalStore } from "../factory";
 import {
   AddReactionError,
   type CommentsError,

--- a/packages/liveblocks-react/src/factory.tsx
+++ b/packages/liveblocks-react/src/factory.tsx
@@ -81,7 +81,7 @@ Why? Please see https://liveblocks.io/docs/platform/troubleshooting#stale-props-
 const superfluous_unstable_batchedUpdates =
   "You don’t need to pass unstable_batchedUpdates to RoomProvider anymore, since you’re on React 18+ already.";
 
-function useSyncExternalStore<Snapshot>(
+export function useSyncExternalStore<Snapshot>(
   s: (onStoreChange: () => void) => () => void,
   gs: () => Snapshot,
   gss: undefined | null | (() => Snapshot)


### PR DESCRIPTION
Some of our examples were failing to build due to the way `useSyncExternalStore` was imported. This PR updates the import so that it is consistent across both `room.tsx` and `factory.tsx`. Thanks for catching this @CTNicholas 

https://github.com/liveblocks/liveblocks/pull/1390#issuecomment-1883119154