### PR TITLE
Unmerge thread from inbox notification data

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -27,8 +27,8 @@ import type { CacheStore } from "./store";
 import { createClientStore } from "./store";
 import type { BaseMetadata } from "./types/BaseMetadata";
 import type {
-  PartialInboxNotificationData,
-  PartialInboxNotificationDataPlain,
+  InboxNotificationData,
+  InboxNotificationDataPlain,
 } from "./types/InboxNotificationData";
 import type { OptionalPromise } from "./types/OptionalPromise";
 import type { ThreadData, ThreadDataPlain } from "./types/ThreadData";
@@ -102,7 +102,7 @@ type InboxNotificationsApi<TThreadMetadata extends BaseMetadata = never> = {
    * @private
    */
   getInboxNotifications(): Promise<{
-    inboxNotifications: PartialInboxNotificationData[];
+    inboxNotifications: InboxNotificationData[];
     threads: ThreadData<TThreadMetadata>[];
   }>;
 
@@ -655,7 +655,7 @@ function createInboxNotificationsApi(
     const json = await fetchJson<{
       // [comments-unread] TODO: How do we type ThreadMetadata?
       threads: ThreadDataPlain[];
-      inboxNotifications: PartialInboxNotificationDataPlain[];
+      inboxNotifications: InboxNotificationDataPlain[];
     }>(`/inbox-notifications?${queryParams.toString()}`);
 
     return {

--- a/packages/liveblocks-core/src/convert-plain-data.ts
+++ b/packages/liveblocks-core/src/convert-plain-data.ts
@@ -5,8 +5,8 @@ import type {
   CommentUserReactionPlain,
 } from "./types/CommentReaction";
 import type {
-  PartialInboxNotificationData,
-  PartialInboxNotificationDataPlain,
+  InboxNotificationData,
+  InboxNotificationDataPlain,
 } from "./types/InboxNotificationData";
 import type { ThreadData, ThreadDataPlain } from "./types/ThreadData";
 
@@ -89,8 +89,8 @@ export function convertToCommentUserReaction(
  * @returns The rich partial inbox notification data object that can be used by the client.
  */
 export function convertToPartialInboxNotificationData(
-  data: PartialInboxNotificationDataPlain
-): PartialInboxNotificationData {
+  data: InboxNotificationDataPlain
+): InboxNotificationData {
   const notifiedAt = new Date(data.notifiedAt);
   const readAt = data.readAt ? new Date(data.readAt) : null;
 

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -183,9 +183,7 @@ export type {
 export type { Immutable } from "./types/Immutable";
 export type {
   InboxNotificationData,
-  PartialInboxNotificationData,
-  PartialInboxNotificationDataPlain,
-  PartialThreadInboxNotificationData,
+  InboxNotificationDataPlain,
   ThreadInboxNotificationData,
 } from "./types/InboxNotificationData";
 export type {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -68,8 +68,8 @@ import type {
 } from "./types/CommentReaction";
 import type * as DevTools from "./types/DevToolsTreeNode";
 import type {
-  PartialInboxNotificationData,
-  PartialInboxNotificationDataPlain,
+  InboxNotificationData,
+  InboxNotificationDataPlain,
 } from "./types/InboxNotificationData";
 import type {
   IWebSocket,
@@ -491,7 +491,7 @@ type CommentsApi<TThreadMetadata extends BaseMetadata = never> = {
    */
   getThreads(options?: GetThreadsOptions<TThreadMetadata>): Promise<{
     threads: ThreadData<TThreadMetadata>[];
-    inboxNotifications: PartialInboxNotificationData[];
+    inboxNotifications: InboxNotificationData[];
   }>;
 
   /**
@@ -500,7 +500,7 @@ type CommentsApi<TThreadMetadata extends BaseMetadata = never> = {
   getThread(options: { threadId: string }): Promise<
     | {
         thread: ThreadData<TThreadMetadata>;
-        inboxNotification?: PartialInboxNotificationData;
+        inboxNotification?: InboxNotificationData;
       }
     | undefined
   >;
@@ -1134,7 +1134,7 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     if (response.ok) {
       const json = await (response.json() as Promise<{
         data: ThreadDataPlain<TThreadMetadata>[];
-        inboxNotifications: PartialInboxNotificationDataPlain[];
+        inboxNotifications: InboxNotificationDataPlain[];
       }>);
 
       return {
@@ -1156,7 +1156,7 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
     if (response.ok) {
       const json = await (response.json() as Promise<
         ThreadDataPlain<TThreadMetadata> & {
-          inboxNotification?: PartialInboxNotificationDataPlain;
+          inboxNotification?: InboxNotificationDataPlain;
         }
       >);
       const inboxNotification = json.inboxNotification

--- a/packages/liveblocks-core/src/store.ts
+++ b/packages/liveblocks-core/src/store.ts
@@ -4,7 +4,7 @@ import type { Resolve } from "./lib/Resolve";
 import type { BaseMetadata } from "./types/BaseMetadata";
 import type { CommentBody } from "./types/CommentBody";
 import type { CommentData, CommentReaction } from "./types/CommentData";
-import type { PartialInboxNotificationData } from "./types/InboxNotificationData";
+import type { InboxNotificationData } from "./types/InboxNotificationData";
 import type { ThreadData } from "./types/ThreadData";
 
 type PartialNullable<T> = {
@@ -106,7 +106,7 @@ export type CacheState<TThreadMetadata extends BaseMetadata> = {
   /**
    * Inbox notifications by ID.
    */
-  inboxNotifications: Record<string, PartialInboxNotificationData>;
+  inboxNotifications: Record<string, InboxNotificationData>;
 };
 
 export interface CacheStore<TThreadMetadata extends BaseMetadata>
@@ -114,11 +114,11 @@ export interface CacheStore<TThreadMetadata extends BaseMetadata>
   deleteThread(threadId: string): void;
   updateThreadAndNotification(
     thread: ThreadData<TThreadMetadata>,
-    inboxNotification?: PartialInboxNotificationData
+    inboxNotification?: InboxNotificationData
   ): void;
   updateThreadsAndNotifications(
     threads: ThreadData<TThreadMetadata>[],
-    inboxNotifications: PartialInboxNotificationData[],
+    inboxNotifications: InboxNotificationData[],
     queryKey?: string
   ): void;
   pushOptimisticUpdate(
@@ -163,8 +163,8 @@ export function createClientStore<
   }
 
   function mergeNotifications(
-    existingInboxNotifications: Record<string, PartialInboxNotificationData>,
-    newInboxNotifications: Record<string, PartialInboxNotificationData>
+    existingInboxNotifications: Record<string, InboxNotificationData>,
+    newInboxNotifications: Record<string, InboxNotificationData>
   ) {
     // TODO: Do not replace existing inboxNotifications if it has been updated more recently than the incoming inbox notifications
     const inboxNotifications = Object.values({
@@ -196,7 +196,7 @@ export function createClientStore<
 
     updateThreadAndNotification(
       thread: ThreadData<TThreadMetadata>,
-      inboxNotification?: PartialInboxNotificationData
+      inboxNotification?: InboxNotificationData
     ) {
       store.set((state) => {
         const existingThread = state.threads[thread.id];
@@ -221,7 +221,7 @@ export function createClientStore<
 
     updateThreadsAndNotifications(
       threads: ThreadData<TThreadMetadata>[],
-      inboxNotifications: PartialInboxNotificationData[],
+      inboxNotifications: InboxNotificationData[],
       queryKey?: string
     ) {
       store.set((state) => ({

--- a/packages/liveblocks-core/src/types/InboxNotificationData.ts
+++ b/packages/liveblocks-core/src/types/InboxNotificationData.ts
@@ -1,8 +1,6 @@
-import type { BaseMetadata } from "./BaseMetadata";
 import type { DateToString } from "./DateToString";
-import type { ThreadData } from "./ThreadData";
 
-export type PartialThreadInboxNotificationData = {
+export type ThreadInboxNotificationData = {
   kind: "thread";
   id: string;
   threadId: string;
@@ -10,17 +8,6 @@ export type PartialThreadInboxNotificationData = {
   readAt: Date | null;
 };
 
-export type PartialInboxNotificationData = PartialThreadInboxNotificationData;
+export type InboxNotificationData = ThreadInboxNotificationData;
 
-export type PartialInboxNotificationDataPlain =
-  DateToString<PartialInboxNotificationData>;
-
-export type ThreadInboxNotificationData<
-  TThreadMetadata extends BaseMetadata = never,
-> = PartialThreadInboxNotificationData & {
-  thread: ThreadData<TThreadMetadata>;
-};
-
-export type InboxNotificationData<
-  TThreadMetadata extends BaseMetadata = never,
-> = ThreadInboxNotificationData<TThreadMetadata>;
+export type InboxNotificationDataPlain = DateToString<InboxNotificationData>;

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import type {
+  BaseMetadata,
   CommentData,
   InboxNotificationData,
+  ThreadData,
   ThreadInboxNotificationData,
 } from "@liveblocks/core";
 import { assertNever, getMentionedIdsFromCommentBody } from "@liveblocks/core";
+import { useLiveblocksContextBundle } from "@liveblocks/react";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type {
   ComponentProps,
@@ -210,9 +213,10 @@ function getUserIdsFromComments(comments: CommentData[]) {
 
 function generateThreadInboxNotificationContents(
   inboxNotification: ThreadInboxNotificationData,
+  thread: ThreadData<BaseMetadata>,
   userId: string
 ): ThreadInboxNotificationContents {
-  const unreadComments = inboxNotification.thread.comments.filter((comment) => {
+  const unreadComments = thread.comments.filter((comment) => {
     if (!comment.body) {
       return false;
     }
@@ -225,7 +229,7 @@ function generateThreadInboxNotificationContents(
 
   // If the thread is read, show the last comments.
   if (unreadComments.length === 0) {
-    const lastComments = inboxNotification.thread.comments
+    const lastComments = thread.comments
       .filter((comment) => comment.body)
       .slice(-THREAD_INBOX_NOTIFICATION_MAX_COMMENTS);
 
@@ -272,10 +276,15 @@ const ThreadInboxNotification = forwardRef<
   HTMLDivElement,
   InboxNotificationProps
 >(({ inboxNotification, ...props }, forwardedRef) => {
+  const { useThreadFromCache } = useLiveblocksContextBundle();
+
+  const thread = useThreadFromCache(inboxNotification.threadId);
+
   // [comments-unread] TODO: How do we get the current user ID?
   const { unread, date, aside, title, content } = useMemo(() => {
     const contents = generateThreadInboxNotificationContents(
       inboxNotification,
+      thread,
       "[comments-unread] TODO: get current user's ID"
     );
 

--- a/packages/liveblocks-react/src/__tests__/_restMocks.ts
+++ b/packages/liveblocks-react/src/__tests__/_restMocks.ts
@@ -1,6 +1,6 @@
 import type {
   CommentData,
-  PartialInboxNotificationData,
+  InboxNotificationData,
   ThreadData,
 } from "@liveblocks/core";
 import type { ResponseResolver, RestContext, RestRequest } from "msw";
@@ -12,7 +12,7 @@ export function mockGetThreads(
     RestContext,
     {
       data: ThreadData<any>[];
-      inboxNotifications: any[];
+      inboxNotifications: InboxNotificationData[];
     }
   >
 ) {
@@ -28,7 +28,7 @@ export function mockGetThread(
     RestRequest<never, never>,
     RestContext,
     ThreadData<any> & {
-      inboxNotification?: PartialInboxNotificationData;
+      inboxNotification?: InboxNotificationData;
     }
   >
 ) {
@@ -70,6 +70,22 @@ export function mockMarkInboxNotificationsAsRead(
 ) {
   return rest.post(
     "https://api.liveblocks.io/v2/c/inbox-notifications/read",
+    resolver
+  );
+}
+
+export function mockGetInboxNotifications(
+  resolver: ResponseResolver<
+    RestRequest<never, never>,
+    RestContext,
+    {
+      threads: ThreadData<any>[];
+      inboxNotifications: InboxNotificationData[];
+    }
+  >
+) {
+  return rest.get(
+    "https://api.liveblocks.io/v2/c/inbox-notifications",
     resolver
   );
 }

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -127,27 +127,23 @@ export type InboxNotificationsStateLoading = {
   loadMore: () => void;
 };
 
-export type InboxNotificationsStateResolved<
-  TThreadMetadata extends BaseMetadata,
-> = {
+export type InboxNotificationsStateResolved = {
   isLoading: false;
-  inboxNotifications: InboxNotificationData<TThreadMetadata>[];
+  inboxNotifications: InboxNotificationData[];
   error?: Error;
   loadMore: () => void;
 };
 
-export type InboxNotificationsStateSuccess<
-  TThreadMetadata extends BaseMetadata,
-> = {
+export type InboxNotificationsStateSuccess = {
   isLoading: false;
-  inboxNotifications: InboxNotificationData<TThreadMetadata>[];
+  inboxNotifications: InboxNotificationData[];
   error?: never;
   loadMore: () => void;
 };
 
-export type InboxNotificationsState<TThreadMetadata extends BaseMetadata> =
+export type InboxNotificationsState =
   | InboxNotificationsStateLoading
-  | InboxNotificationsStateResolved<TThreadMetadata>;
+  | InboxNotificationsStateResolved;
 
 export type RoomNotificationSettingsStateLoading = {
   isLoading: true;
@@ -1104,10 +1100,7 @@ type LiveblocksContextBundleShared = {
   useMarkAllInboxNotificationsAsRead(): () => void;
 };
 
-export type LiveblocksContextBundle<
-  TUserMeta extends BaseUserMeta,
-  TThreadMetadata extends BaseMetadata,
-> = Resolve<
+export type LiveblocksContextBundle<TUserMeta extends BaseUserMeta> = Resolve<
   LiveblocksContextBundleShared & {
     /**
      * @beta
@@ -1117,7 +1110,7 @@ export type LiveblocksContextBundle<
      * @example
      * const { inboxNotifications, error, isLoading, loadMore } = useInboxNotifications();
      */
-    useInboxNotifications(): InboxNotificationsState<TThreadMetadata>;
+    useInboxNotifications(): InboxNotificationsState;
 
     /**
      * @beta
@@ -1139,6 +1132,16 @@ export type LiveblocksContextBundle<
      */
     useUser(userId: string): UserState<TUserMeta["info"]>;
 
+    /**
+     * @internal
+     *
+     * Returns thread from cache.
+     *
+     * @example
+     * const thread = useThreadFromCache("th_xxx");
+     */
+    useThreadFromCache(threadId: string): ThreadData<BaseMetadata>;
+
     suspense: Resolve<
       LiveblocksContextBundleShared & {
         /**
@@ -1149,7 +1152,7 @@ export type LiveblocksContextBundle<
          * @example
          * const { inboxNotifications, error, isLoading, loadMore } = useInboxNotifications();
          */
-        useInboxNotifications(): InboxNotificationsStateSuccess<TThreadMetadata>;
+        useInboxNotifications(): InboxNotificationsStateSuccess;
 
         /**
          * @beta


### PR DESCRIPTION
- Unmerge `ThreadData` from `InboxNotificationData`
- Introduce internal hook: `useThreadFromCache`
- Delete  `PartialInboxNotificationData`, `PartialInboxNotificationDataPlain`,  `PartialThreadInboxNotificationData`