### PR TITLE
Remove shared context provider

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -3,7 +3,7 @@ import { createAuthManager } from "./auth-manager";
 import { isIdle } from "./connection";
 import { DEFAULT_BASE_URL } from "./constants";
 import {
-  convertToPartialInboxNotificationData,
+  convertToInboxNotificationData,
   convertToThreadData,
 } from "./convert-plain-data";
 import type { LsonObject } from "./crdts/Lson";
@@ -661,7 +661,7 @@ function createInboxNotificationsApi(
     return {
       threads: json.threads.map((thread) => convertToThreadData(thread)),
       inboxNotifications: json.inboxNotifications.map((notification) =>
-        convertToPartialInboxNotificationData(notification)
+        convertToInboxNotificationData(notification)
       ),
     };
   }

--- a/packages/liveblocks-core/src/convert-plain-data.ts
+++ b/packages/liveblocks-core/src/convert-plain-data.ts
@@ -83,12 +83,12 @@ export function convertToCommentUserReaction(
 }
 
 /**
- * Converts a plain partial inbox notification data object (usually returned by the API) to a partial inbox notification data object that can be used by the client.
+ * Converts a plain inbox notification data object (usually returned by the API) to an inbox notification data object that can be used by the client.
  * This is necessary because the plain data object stores dates as ISO strings, but the client expects them as Date objects.
- * @param data The plain partial inbox notification data object (usually returned by the API)
- * @returns The rich partial inbox notification data object that can be used by the client.
+ * @param data The plain inbox notification data object (usually returned by the API)
+ * @returns The rich inbox notification data object that can be used by the client.
  */
-export function convertToPartialInboxNotificationData(
+export function convertToInboxNotificationData(
   data: InboxNotificationDataPlain
 ): InboxNotificationData {
   const notifiedAt = new Date(data.notifiedAt);

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -577,9 +577,8 @@ export type Room<
   /**
    * @private
    *
-   * Private methods to directly control the underlying state machine for this
-   * room. Used in the core internals and for unit testing, but as a user of
-   * Liveblocks, NEVER USE ANY OF THESE METHODS DIRECTLY, because bad things
+   * Private methods and variables used in the core internals, but as a user
+   * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
    * will probably happen if you do.
    */
   readonly [kInternal]: PrivateRoomApi;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -10,7 +10,7 @@ import { ManagedSocket, newToLegacyStatus, StopRetrying } from "./connection";
 import {
   convertToCommentData,
   convertToCommentUserReaction,
-  convertToPartialInboxNotificationData,
+  convertToInboxNotificationData,
   convertToThreadData,
 } from "./convert-plain-data";
 import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
@@ -1139,7 +1139,7 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
       return {
         threads: json.data.map((thread) => convertToThreadData(thread)),
         inboxNotifications: json.inboxNotifications.map((notification) =>
-          convertToPartialInboxNotificationData(notification)
+          convertToInboxNotificationData(notification)
         ),
       };
     } else if (response.status === 404) {
@@ -1159,7 +1159,7 @@ function createCommentsApi<TThreadMetadata extends BaseMetadata>(
         }
       >);
       const inboxNotification = json.inboxNotification
-        ? convertToPartialInboxNotificationData(json.inboxNotification)
+        ? convertToInboxNotificationData(json.inboxNotification)
         : undefined;
 
       return {

--- a/packages/liveblocks-react-comments/src/components/Composer.tsx
+++ b/packages/liveblocks-react-comments/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { BaseMetadata } from "@liveblocks/core";
+import { type BaseMetadata, kInternal } from "@liveblocks/core";
 import { useRoomContextBundle } from "@liveblocks/react";
 import type {
   ComponentPropsWithoutRef,
@@ -288,7 +288,9 @@ const ComposerWithContext = forwardRef<
     },
     forwardedRef
   ) => {
-    const { hasResolveMentionSuggestions } = useRoomContextBundle();
+    const {
+      [kInternal]: { hasResolveMentionSuggestions },
+    } = useRoomContextBundle();
     const { isEmpty } = useComposer();
     const $ = useOverrides(overrides);
     const [isEmojiPickerOpen, setEmojiPickerOpen] = useState(false);

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -7,7 +7,11 @@ import type {
   ThreadData,
   ThreadInboxNotificationData,
 } from "@liveblocks/core";
-import { assertNever, getMentionedIdsFromCommentBody } from "@liveblocks/core";
+import {
+  assertNever,
+  getMentionedIdsFromCommentBody,
+  kInternal,
+} from "@liveblocks/core";
 import { useLiveblocksContextBundle } from "@liveblocks/react";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type {
@@ -280,8 +284,9 @@ const ThreadInboxNotification = forwardRef<
   HTMLDivElement,
   InboxNotificationProps
 >(({ inboxNotification, ...props }, forwardedRef) => {
-  const { useThreadFromCache } = useLiveblocksContextBundle();
-
+  const {
+    [kInternal]: { useThreadFromCache },
+  } = useLiveblocksContextBundle();
   const thread = useThreadFromCache(inboxNotification.threadId);
 
   // [comments-unread] TODO: How do we get the current user ID?

--- a/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/Composer/index.tsx
@@ -13,7 +13,7 @@ import {
   size,
   useFloating,
 } from "@floating-ui/react-dom";
-import type { CommentBody } from "@liveblocks/core";
+import { type CommentBody, kInternal } from "@liveblocks/core";
 import { useRoomContextBundle } from "@liveblocks/react";
 import { Slot } from "@radix-ui/react-slot";
 import type {
@@ -621,7 +621,10 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
     },
     forwardedRef
   ) => {
-    const { useMentionSuggestions, useSelf } = useRoomContextBundle();
+    const {
+      [kInternal]: { useMentionSuggestions },
+      useSelf,
+    } = useRoomContextBundle();
     const self = useSelf();
     const isDisabled = useMemo(
       () => disabled || !self?.canComment,

--- a/packages/liveblocks-react/src/__tests__/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/_dummies.ts
@@ -1,7 +1,7 @@
 import type {
   BaseMetadata,
   CommentData,
-  PartialInboxNotificationData,
+  InboxNotificationData,
   ThreadData,
 } from "@liveblocks/core";
 
@@ -53,7 +53,7 @@ export function dummyCommentData(): CommentData {
   };
 }
 
-export function dummyInboxNoficationData(): PartialInboxNotificationData {
+export function dummyInboxNoficationData(): InboxNotificationData {
   const id = createInboxNotificationId();
   const threadId = createThreadId();
   const now = new Date();

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -10,7 +10,6 @@ export {
   useLiveblocksContextBundle,
 } from "./liveblocks";
 export { createRoomContext, useRoomContextBundle } from "./room";
-// [comments-unread] TODO: We need to access `useSharedContextBundle` within the `@liveblocks/react-comments` default components but how do make this more hidden?
 export { useSharedContextBundle } from "./shared";
 export type { MutationContext } from "./types";
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -4,12 +4,12 @@ import type {
   Client,
   ThreadData,
 } from "@liveblocks/client";
-import {
-  PartialInboxNotificationData,
-  type InboxNotificationData,
+import type {
   CacheStore,
-  kInternal,
+  InboxNotificationData,
+  PartialInboxNotificationData,
 } from "@liveblocks/core";
+import { kInternal } from "@liveblocks/core";
 import type { PropsWithChildren } from "react";
 import React, {
   createContext,
@@ -17,6 +17,7 @@ import React, {
   useContext,
   useEffect,
 } from "react";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 
 import { createSharedContext } from "./shared";
 import type {
@@ -24,9 +25,8 @@ import type {
   InboxNotificationsStateSuccess,
   LiveblocksContextBundle,
 } from "./types";
-import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 
-const ContextBundle = createContext<LiveblocksContextBundle<
+export const ContextBundle = createContext<LiveblocksContextBundle<
   BaseUserMeta,
   BaseMetadata
 > | null>(null);
@@ -51,7 +51,6 @@ export function createLiveblocksContext<
   client: Client<TUserMeta>
 ): LiveblocksContextBundle<TUserMeta, TThreadMetadata> {
   const {
-    SharedProvider,
     useUser,
     suspense: { useUser: useUserSuspense },
   } = createSharedContext<TUserMeta>(client);
@@ -61,18 +60,16 @@ export function createLiveblocksContext<
 
   function LiveblocksProvider(props: PropsWithChildren) {
     return (
-      <SharedProvider>
-        <ContextBundle.Provider
-          value={
-            bundle as unknown as LiveblocksContextBundle<
-              BaseUserMeta,
-              BaseMetadata
-            >
-          }
-        >
-          {props.children}
-        </ContextBundle.Provider>
-      </SharedProvider>
+      <ContextBundle.Provider
+        value={
+          bundle as unknown as LiveblocksContextBundle<
+            BaseUserMeta,
+            BaseMetadata
+          >
+        }
+      >
+        {props.children}
+      </ContextBundle.Provider>
     );
   }
 
@@ -97,7 +94,7 @@ export function createLiveblocksContext<
 
     try {
       const { inboxNotifications, threads } =
-        await fetchInboxNotificationsRequest!;
+        await fetchInboxNotificationsRequest;
 
       store.updateThreadsAndNotifications(
         threads,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -168,7 +168,7 @@ function makeMutationContext<
   };
 }
 
-const ContextBundle = React.createContext<InternalRoomContextBundle<
+export const ContextBundle = React.createContext<InternalRoomContextBundle<
   JsonObject,
   LsonObject,
   BaseUserMeta,
@@ -213,7 +213,6 @@ export function createRoomContext<
     makeEventSource<CommentsError<TThreadMetadata>>();
 
   const {
-    SharedProvider,
     useUser,
     suspense: { useUser: useUserSuspense },
   } = createSharedContext<TUserMeta>(client);
@@ -385,23 +384,21 @@ export function createRoomContext<
     }, [roomId, frozenProps, stableEnterRoom]);
 
     return (
-      <SharedProvider>
-        <RoomContext.Provider value={room}>
-          <ContextBundle.Provider
-            value={
-              internalBundle as unknown as InternalRoomContextBundle<
-                JsonObject,
-                LsonObject,
-                BaseUserMeta,
-                never,
-                BaseMetadata
-              >
-            }
-          >
-            {props.children}
-          </ContextBundle.Provider>
-        </RoomContext.Provider>
-      </SharedProvider>
+      <RoomContext.Provider value={room}>
+        <ContextBundle.Provider
+          value={
+            internalBundle as unknown as InternalRoomContextBundle<
+              JsonObject,
+              LsonObject,
+              BaseUserMeta,
+              never,
+              BaseMetadata
+            >
+          }
+        >
+          {props.children}
+        </ContextBundle.Provider>
+      </RoomContext.Provider>
     );
   }
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -68,7 +68,6 @@ import type {
   DeleteCommentOptions,
   EditCommentOptions,
   EditThreadMetadataOptions,
-  InternalRoomContextBundle,
   MutationContext,
   OmitFirstArg,
   RoomContextBundle,
@@ -168,7 +167,7 @@ function makeMutationContext<
   };
 }
 
-export const ContextBundle = React.createContext<InternalRoomContextBundle<
+export const ContextBundle = React.createContext<RoomContextBundle<
   JsonObject,
   LsonObject,
   BaseUserMeta,
@@ -387,7 +386,7 @@ export function createRoomContext<
       <RoomContext.Provider value={room}>
         <ContextBundle.Provider
           value={
-            internalBundle as unknown as InternalRoomContextBundle<
+            bundle as unknown as RoomContextBundle<
               JsonObject,
               LsonObject,
               BaseUserMeta,
@@ -1923,21 +1922,16 @@ export function createRoomContext<
       useRoomNotificationSettings: useRoomNotificationSettingsSuspense,
       useUpdateRoomNotificationSettings,
     },
+
+    [kInternal]: {
+      hasResolveMentionSuggestions: resolveMentionSuggestions !== undefined,
+      useMentionSuggestions,
+    },
   };
 
-  const internalBundle: InternalRoomContextBundle<
-    TPresence,
-    TStorage,
-    TUserMeta,
-    TRoomEvent,
-    TThreadMetadata
-  > = {
-    ...bundle,
-    hasResolveMentionSuggestions: resolveMentionSuggestions !== undefined,
-    useMentionSuggestions,
-  };
-
-  return bundle;
+  return Object.defineProperty(bundle, kInternal, {
+    enumerable: false,
+  });
 }
 
 function getCurrentUserId(

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -19,6 +19,7 @@ import type {
   CommentData,
   GetThreadsOptions,
   InboxNotificationData,
+  kInternal,
   Resolve,
   RoomEventMessage,
   RoomInitializers,
@@ -738,6 +739,18 @@ type RoomContextBundleCommon<
   useThreadUnreadSince(threadId: string): Date | null;
 };
 
+/**
+ * @private
+ *
+ * Private methods and variables used in the core internals, but as a user
+ * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
+ * will probably happen if you do.
+ */
+type PrivateRoomContextApi = {
+  hasResolveMentionSuggestions: boolean;
+  useMentionSuggestions(search?: string): string[] | undefined;
+};
+
 export type RoomContextBundle<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
@@ -1060,26 +1073,16 @@ export type RoomContextBundle<
           }
       >;
     }
->;
-
-export type InternalRoomContextBundle<
-  TPresence extends JsonObject,
-  TStorage extends LsonObject,
-  TUserMeta extends BaseUserMeta,
-  TRoomEvent extends Json,
-  TThreadMetadata extends BaseMetadata,
-> = Resolve<
-  RoomContextBundle<
-    TPresence,
-    TStorage,
-    TUserMeta,
-    TRoomEvent,
-    TThreadMetadata
-  > & {
-    hasResolveMentionSuggestions: boolean;
-    useMentionSuggestions(search?: string): string[] | undefined;
-  }
->;
+> & {
+  /**
+   * @private
+   *
+   * Private methods and variables used in the core internals, but as a user
+   * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
+   * will probably happen if you do.
+   */
+  readonly [kInternal]: PrivateRoomContextApi;
+};
 
 /**
  * Properties that are the same in LiveblocksContext and LiveblocksContext["suspense"].

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -238,7 +238,34 @@ export type MutationContext<
   ) => void;
 };
 
-type RoomContextBundleShared<
+export type SharedContextBundle<TUserMeta extends BaseUserMeta> = {
+  /**
+   * @beta
+   *
+   * Returns user info from a given user ID.
+   *
+   * @example
+   * const { user, error, isLoading } = useUser("user-id");
+   */
+  useUser(userId: string): UserState<TUserMeta["info"]>;
+
+  suspense: {
+    /**
+     * @beta
+     *
+     * Returns user info from a given user ID.
+     *
+     * @example
+     * const { user } = useUser("user-id");
+     */
+    useUser(userId: string): UserStateSuccess<TUserMeta["info"]>;
+  };
+};
+
+/**
+ * Properties that are the same in RoomContext and RoomContext["suspense"].
+ */
+type RoomContextBundleCommon<
   TPresence extends JsonObject,
   TStorage extends LsonObject,
   TUserMeta extends BaseUserMeta,
@@ -718,339 +745,321 @@ export type RoomContextBundle<
   TRoomEvent extends Json,
   TThreadMetadata extends BaseMetadata,
 > = Resolve<
-  RoomContextBundleShared<
+  RoomContextBundleCommon<
     TPresence,
     TStorage,
     TUserMeta,
     TRoomEvent,
     TThreadMetadata
-  > & {
-    /**
-     * Extract arbitrary data from the Liveblocks Storage state, using an
-     * arbitrary selector function.
-     *
-     * The selector function will get re-evaluated any time something changes in
-     * Storage. The value returned by your selector function will also be the
-     * value returned by the hook.
-     *
-     * The `root` value that gets passed to your selector function is
-     * a immutable/readonly version of your Liveblocks storage root.
-     *
-     * The component that uses this hook will automatically re-render if the
-     * returned value changes.
-     *
-     * By default `useStorage()` uses strict `===` to check for equality. Take
-     * extra care when returning a computed object or list, for example when you
-     * return the result of a .map() or .filter() call from the selector. In
-     * those cases, you'll probably want to use a `shallow` comparison check.
-     */
-    useStorage<T>(
-      selector: (root: ToImmutable<TStorage>) => T,
-      isEqual?: (prev: T | null, curr: T | null) => boolean
-    ): T | null;
+  > &
+    Omit<SharedContextBundle<TUserMeta>, "suspense"> & {
+      /**
+       * Extract arbitrary data from the Liveblocks Storage state, using an
+       * arbitrary selector function.
+       *
+       * The selector function will get re-evaluated any time something changes in
+       * Storage. The value returned by your selector function will also be the
+       * value returned by the hook.
+       *
+       * The `root` value that gets passed to your selector function is
+       * a immutable/readonly version of your Liveblocks storage root.
+       *
+       * The component that uses this hook will automatically re-render if the
+       * returned value changes.
+       *
+       * By default `useStorage()` uses strict `===` to check for equality. Take
+       * extra care when returning a computed object or list, for example when you
+       * return the result of a .map() or .filter() call from the selector. In
+       * those cases, you'll probably want to use a `shallow` comparison check.
+       */
+      useStorage<T>(
+        selector: (root: ToImmutable<TStorage>) => T,
+        isEqual?: (prev: T | null, curr: T | null) => boolean
+      ): T | null;
 
-    /**
-     * Gets the current user once it is connected to the room.
-     *
-     * @example
-     * const me = useSelf();
-     * const { x, y } = me.presence.cursor;
-     */
-    useSelf(): User<TPresence, TUserMeta> | null;
+      /**
+       * Gets the current user once it is connected to the room.
+       *
+       * @example
+       * const me = useSelf();
+       * const { x, y } = me.presence.cursor;
+       */
+      useSelf(): User<TPresence, TUserMeta> | null;
 
-    /**
-     * Extract arbitrary data based on the current user.
-     *
-     * The selector function will get re-evaluated any time your presence data
-     * changes.
-     *
-     * The component that uses this hook will automatically re-render if your
-     * selector function returns a different value from its previous run.
-     *
-     * By default `useSelf()` uses strict `===` to check for equality. Take extra
-     * care when returning a computed object or list, for example when you return
-     * the result of a .map() or .filter() call from the selector. In those
-     * cases, you'll probably want to use a `shallow` comparison check.
-     *
-     * Will return `null` while Liveblocks isn't connected to a room yet.
-     *
-     * @example
-     * const cursor = useSelf(me => me.presence.cursor);
-     * if (cursor !== null) {
-     *   const { x, y } = cursor;
-     * }
-     *
-     */
-    useSelf<T>(
-      selector: (me: User<TPresence, TUserMeta>) => T,
-      isEqual?: (prev: T, curr: T) => boolean
-    ): T | null;
+      /**
+       * Extract arbitrary data based on the current user.
+       *
+       * The selector function will get re-evaluated any time your presence data
+       * changes.
+       *
+       * The component that uses this hook will automatically re-render if your
+       * selector function returns a different value from its previous run.
+       *
+       * By default `useSelf()` uses strict `===` to check for equality. Take extra
+       * care when returning a computed object or list, for example when you return
+       * the result of a .map() or .filter() call from the selector. In those
+       * cases, you'll probably want to use a `shallow` comparison check.
+       *
+       * Will return `null` while Liveblocks isn't connected to a room yet.
+       *
+       * @example
+       * const cursor = useSelf(me => me.presence.cursor);
+       * if (cursor !== null) {
+       *   const { x, y } = cursor;
+       * }
+       *
+       */
+      useSelf<T>(
+        selector: (me: User<TPresence, TUserMeta>) => T,
+        isEqual?: (prev: T, curr: T) => boolean
+      ): T | null;
 
-    /**
-     * @beta
-     *
-     * Returns the threads within the current room.
-     *
-     * @example
-     * const { threads, error, isLoading } = useThreads();
-     */
-    useThreads(
-      options?: UseThreadsOptions<TThreadMetadata>
-    ): ThreadsState<TThreadMetadata>;
+      /**
+       * @beta
+       *
+       * Returns the threads within the current room.
+       *
+       * @example
+       * const { threads, error, isLoading } = useThreads();
+       */
+      useThreads(
+        options?: UseThreadsOptions<TThreadMetadata>
+      ): ThreadsState<TThreadMetadata>;
 
-    /**
-     * @beta
-     *
-     * Returns user info from a given user ID.
-     *
-     * @example
-     * const { user, error, isLoading } = useUser("user-id");
-     */
-    useUser(userId: string): UserState<TUserMeta["info"]>;
+      /**
+       * @beta
+       *
+       * Returns the user's notification settings for the current room
+       * and a function to update them.
+       *
+       * @example
+       * const [{ settings }, updateSettings] = useRoomNotificationSettings();
+       */
+      useRoomNotificationSettings(): [
+        RoomNotificationSettingsState,
+        (settings: Partial<RoomNotificationSettings>) => void,
+      ];
 
-    /**
-     * @beta
-     *
-     * Returns the user's notification settings for the current room
-     * and a function to update them.
-     *
-     * @example
-     * const [{ settings }, updateSettings] = useRoomNotificationSettings();
-     */
-    useRoomNotificationSettings(): [
-      RoomNotificationSettingsState,
-      (settings: Partial<RoomNotificationSettings>) => void,
-    ];
+      //
+      // Legacy hooks
+      //
 
-    //
-    // Legacy hooks
-    //
+      /**
+       * Returns the LiveList associated with the provided key. The hook triggers
+       * a re-render if the LiveList is updated, however it does not triggers
+       * a re-render if a nested CRDT is updated.
+       *
+       * @param key The top-level storage key associated with the LiveList
+       * @returns null while storage is still loading, otherwise, returns the LiveList instance at the storage key
+       *
+       * @example
+       * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
+       * const animals = useStorage((root) => root.animals);                    // ✅ Do this instead
+       *
+       * @deprecated We no longer recommend using `useList`. Prefer `useStorage`
+       * for reading and `useMutation` for writing.
+       */
+      useList<TKey extends Extract<keyof TStorage, string>>(
+        key: TKey
+      ): TStorage[TKey] | null;
 
-    /**
-     * Returns the LiveList associated with the provided key. The hook triggers
-     * a re-render if the LiveList is updated, however it does not triggers
-     * a re-render if a nested CRDT is updated.
-     *
-     * @param key The top-level storage key associated with the LiveList
-     * @returns null while storage is still loading, otherwise, returns the LiveList instance at the storage key
-     *
-     * @example
-     * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
-     * const animals = useStorage((root) => root.animals);                    // ✅ Do this instead
-     *
-     * @deprecated We no longer recommend using `useList`. Prefer `useStorage`
-     * for reading and `useMutation` for writing.
-     */
-    useList<TKey extends Extract<keyof TStorage, string>>(
-      key: TKey
-    ): TStorage[TKey] | null;
+      /**
+       * Returns the LiveMap associated with the provided key. If the LiveMap
+       * does not exist, a new empty LiveMap will be created. The hook triggers
+       * a re-render if the LiveMap is updated, however it does not triggers
+       * a re-render if a nested CRDT is updated.
+       *
+       * @param key The top-level storage key associated with the LiveMap
+       * @returns null while storage is still loading, otherwise, returns the LiveMap instance at the storage key
+       *
+       * @example
+       * const shapesById = useMap("shapes");                   // ❌ No longer recommended
+       * const shapesById = useStorage((root) => root.shapes);  // ✅ Do this instead
+       *
+       * @deprecated We no longer recommend using `useMap`. Prefer `useStorage`
+       * for reading and `useMutation` for writing.
+       */
+      useMap<TKey extends Extract<keyof TStorage, string>>(
+        key: TKey
+      ): TStorage[TKey] | null;
 
-    /**
-     * Returns the LiveMap associated with the provided key. If the LiveMap
-     * does not exist, a new empty LiveMap will be created. The hook triggers
-     * a re-render if the LiveMap is updated, however it does not triggers
-     * a re-render if a nested CRDT is updated.
-     *
-     * @param key The top-level storage key associated with the LiveMap
-     * @returns null while storage is still loading, otherwise, returns the LiveMap instance at the storage key
-     *
-     * @example
-     * const shapesById = useMap("shapes");                   // ❌ No longer recommended
-     * const shapesById = useStorage((root) => root.shapes);  // ✅ Do this instead
-     *
-     * @deprecated We no longer recommend using `useMap`. Prefer `useStorage`
-     * for reading and `useMutation` for writing.
-     */
-    useMap<TKey extends Extract<keyof TStorage, string>>(
-      key: TKey
-    ): TStorage[TKey] | null;
+      /**
+       * Returns the LiveObject associated with the provided key.
+       * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
+       *
+       * @param key The top-level storage key associated with the LiveObject
+       * @returns null while storage is still loading, otherwise, returns the LiveObject instance at the storage key
+       *
+       * @example
+       * const object = useObject("obj");                // ❌ No longer recommended
+       * const object = useStorage((root) => root.obj);  // ✅ Do this instead
+       *
+       * @deprecated We no longer recommend using `useObject`. Prefer `useStorage`
+       * for reading and `useMutation` for writing.
+       */
+      useObject<TKey extends Extract<keyof TStorage, string>>(
+        key: TKey
+      ): TStorage[TKey] | null;
 
-    /**
-     * Returns the LiveObject associated with the provided key.
-     * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
-     *
-     * @param key The top-level storage key associated with the LiveObject
-     * @returns null while storage is still loading, otherwise, returns the LiveObject instance at the storage key
-     *
-     * @example
-     * const object = useObject("obj");                // ❌ No longer recommended
-     * const object = useStorage((root) => root.obj);  // ✅ Do this instead
-     *
-     * @deprecated We no longer recommend using `useObject`. Prefer `useStorage`
-     * for reading and `useMutation` for writing.
-     */
-    useObject<TKey extends Extract<keyof TStorage, string>>(
-      key: TKey
-    ): TStorage[TKey] | null;
+      suspense: Resolve<
+        RoomContextBundleCommon<
+          TPresence,
+          TStorage,
+          TUserMeta,
+          TRoomEvent,
+          TThreadMetadata
+        > &
+          SharedContextBundle<TUserMeta>["suspense"] & {
+            /**
+             * Extract arbitrary data from the Liveblocks Storage state, using an
+             * arbitrary selector function.
+             *
+             * The selector function will get re-evaluated any time something changes in
+             * Storage. The value returned by your selector function will also be the
+             * value returned by the hook.
+             *
+             * The `root` value that gets passed to your selector function is
+             * a immutable/readonly version of your Liveblocks storage root.
+             *
+             * The component that uses this hook will automatically re-render if the
+             * returned value changes.
+             *
+             * By default `useStorage()` uses strict `===` to check for equality. Take
+             * extra care when returning a computed object or list, for example when you
+             * return the result of a .map() or .filter() call from the selector. In
+             * those cases, you'll probably want to use a `shallow` comparison check.
+             */
+            useStorage<T>(
+              selector: (root: ToImmutable<TStorage>) => T,
+              isEqual?: (prev: T, curr: T) => boolean
+            ): T;
 
-    suspense: Resolve<
-      RoomContextBundleShared<
-        TPresence,
-        TStorage,
-        TUserMeta,
-        TRoomEvent,
-        TThreadMetadata
-      > & {
-        /**
-         * Extract arbitrary data from the Liveblocks Storage state, using an
-         * arbitrary selector function.
-         *
-         * The selector function will get re-evaluated any time something changes in
-         * Storage. The value returned by your selector function will also be the
-         * value returned by the hook.
-         *
-         * The `root` value that gets passed to your selector function is
-         * a immutable/readonly version of your Liveblocks storage root.
-         *
-         * The component that uses this hook will automatically re-render if the
-         * returned value changes.
-         *
-         * By default `useStorage()` uses strict `===` to check for equality. Take
-         * extra care when returning a computed object or list, for example when you
-         * return the result of a .map() or .filter() call from the selector. In
-         * those cases, you'll probably want to use a `shallow` comparison check.
-         */
-        useStorage<T>(
-          selector: (root: ToImmutable<TStorage>) => T,
-          isEqual?: (prev: T, curr: T) => boolean
-        ): T;
+            /**
+             * Gets the current user once it is connected to the room.
+             *
+             * @example
+             * const me = useSelf();
+             * const { x, y } = me.presence.cursor;
+             */
+            useSelf(): User<TPresence, TUserMeta>;
 
-        /**
-         * Gets the current user once it is connected to the room.
-         *
-         * @example
-         * const me = useSelf();
-         * const { x, y } = me.presence.cursor;
-         */
-        useSelf(): User<TPresence, TUserMeta>;
+            /**
+             * Extract arbitrary data based on the current user.
+             *
+             * The selector function will get re-evaluated any time your presence data
+             * changes.
+             *
+             * The component that uses this hook will automatically re-render if your
+             * selector function returns a different value from its previous run.
+             *
+             * By default `useSelf()` uses strict `===` to check for equality. Take extra
+             * care when returning a computed object or list, for example when you return
+             * the result of a .map() or .filter() call from the selector. In those
+             * cases, you'll probably want to use a `shallow` comparison check.
+             *
+             * Will return `null` while Liveblocks isn't connected to a room yet.
+             *
+             * @example
+             * const cursor = useSelf(me => me.presence.cursor);
+             * if (cursor !== null) {
+             *   const { x, y } = cursor;
+             * }
+             *
+             */
+            useSelf<T>(
+              selector: (me: User<TPresence, TUserMeta>) => T,
+              isEqual?: (prev: T, curr: T) => boolean
+            ): T;
 
-        /**
-         * Extract arbitrary data based on the current user.
-         *
-         * The selector function will get re-evaluated any time your presence data
-         * changes.
-         *
-         * The component that uses this hook will automatically re-render if your
-         * selector function returns a different value from its previous run.
-         *
-         * By default `useSelf()` uses strict `===` to check for equality. Take extra
-         * care when returning a computed object or list, for example when you return
-         * the result of a .map() or .filter() call from the selector. In those
-         * cases, you'll probably want to use a `shallow` comparison check.
-         *
-         * Will return `null` while Liveblocks isn't connected to a room yet.
-         *
-         * @example
-         * const cursor = useSelf(me => me.presence.cursor);
-         * if (cursor !== null) {
-         *   const { x, y } = cursor;
-         * }
-         *
-         */
-        useSelf<T>(
-          selector: (me: User<TPresence, TUserMeta>) => T,
-          isEqual?: (prev: T, curr: T) => boolean
-        ): T;
+            /**
+             * @beta
+             *
+             * Returns the threads within the current room.
+             *
+             * @example
+             * const { threads } = useThreads();
+             */
+            useThreads(
+              options?: UseThreadsOptions<TThreadMetadata>
+            ): ThreadsStateSuccess<TThreadMetadata>;
 
-        /**
-         * @beta
-         *
-         * Returns the threads within the current room.
-         *
-         * @example
-         * const { threads } = useThreads();
-         */
-        useThreads(
-          options?: UseThreadsOptions<TThreadMetadata>
-        ): ThreadsStateSuccess<TThreadMetadata>;
+            /**
+             * @beta
+             *
+             * Returns the user's notification settings for the current room
+             * and a function to update them.
+             *
+             * @example
+             * const [{ settings }, updateSettings] = useRoomNotificationSettings();
+             */
+            useRoomNotificationSettings(): [
+              RoomNotificationSettingsStateSuccess,
+              (settings: Partial<RoomNotificationSettings>) => void,
+            ];
 
-        /**
-         * @beta
-         *
-         * Returns user info from a given user ID.
-         *
-         * @example
-         * const { user } = useUser("user-id");
-         */
-        useUser(userId: string): UserStateSuccess<TUserMeta["info"]>;
+            //
+            // Legacy hooks
+            //
 
-        /**
-         * @beta
-         *
-         * Returns the user's notification settings for the current room
-         * and a function to update them.
-         *
-         * @example
-         * const [{ settings }, updateSettings] = useRoomNotificationSettings();
-         */
-        useRoomNotificationSettings(): [
-          RoomNotificationSettingsStateSuccess,
-          (settings: Partial<RoomNotificationSettings>) => void,
-        ];
+            /**
+             * Returns the LiveList associated with the provided key. The hook triggers
+             * a re-render if the LiveList is updated, however it does not triggers
+             * a re-render if a nested CRDT is updated.
+             *
+             * @param key The top-level storage key associated with the LiveList
+             * @returns Returns the LiveList instance at the storage key
+             *
+             * @example
+             * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
+             * const animals = useStorage((root) => root.animals);                    // ✅ Do this instead
+             *
+             * @deprecated We no longer recommend using `useList`. Prefer `useStorage`
+             * for reading and `useMutation` for writing.
+             */
+            useList<TKey extends Extract<keyof TStorage, string>>(
+              key: TKey
+            ): TStorage[TKey];
 
-        //
-        // Legacy hooks
-        //
+            /**
+             * Returns the LiveMap associated with the provided key. If the LiveMap
+             * does not exist, a new empty LiveMap will be created. The hook triggers
+             * a re-render if the LiveMap is updated, however it does not triggers
+             * a re-render if a nested CRDT is updated.
+             *
+             * @param key The top-level storage key associated with the LiveMap
+             * @returns Returns the LiveMap instance at the storage key
+             *
+             * @example
+             * const shapesById = useMap("shapes");                   // ❌ No longer recommended
+             * const shapesById = useStorage((root) => root.shapes);  // ✅ Do this instead
+             *
+             * @deprecated We no longer recommend using `useMap`. Prefer `useStorage`
+             * for reading and `useMutation` for writing.
+             */
+            useMap<TKey extends Extract<keyof TStorage, string>>(
+              key: TKey
+            ): TStorage[TKey];
 
-        /**
-         * Returns the LiveList associated with the provided key. The hook triggers
-         * a re-render if the LiveList is updated, however it does not triggers
-         * a re-render if a nested CRDT is updated.
-         *
-         * @param key The top-level storage key associated with the LiveList
-         * @returns Returns the LiveList instance at the storage key
-         *
-         * @example
-         * const animals = useList("animals");  // e.g. [] or ["🦁", "🐍", "🦍"]  // ❌ No longer recommended
-         * const animals = useStorage((root) => root.animals);                    // ✅ Do this instead
-         *
-         * @deprecated We no longer recommend using `useList`. Prefer `useStorage`
-         * for reading and `useMutation` for writing.
-         */
-        useList<TKey extends Extract<keyof TStorage, string>>(
-          key: TKey
-        ): TStorage[TKey];
-
-        /**
-         * Returns the LiveMap associated with the provided key. If the LiveMap
-         * does not exist, a new empty LiveMap will be created. The hook triggers
-         * a re-render if the LiveMap is updated, however it does not triggers
-         * a re-render if a nested CRDT is updated.
-         *
-         * @param key The top-level storage key associated with the LiveMap
-         * @returns Returns the LiveMap instance at the storage key
-         *
-         * @example
-         * const shapesById = useMap("shapes");                   // ❌ No longer recommended
-         * const shapesById = useStorage((root) => root.shapes);  // ✅ Do this instead
-         *
-         * @deprecated We no longer recommend using `useMap`. Prefer `useStorage`
-         * for reading and `useMutation` for writing.
-         */
-        useMap<TKey extends Extract<keyof TStorage, string>>(
-          key: TKey
-        ): TStorage[TKey];
-
-        /**
-         * Returns the LiveObject associated with the provided key.
-         * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
-         *
-         * @param key The top-level storage key associated with the LiveObject
-         * @returns Returns the LiveObject instance at the storage key
-         *
-         * @example
-         * const object = useObject("obj");                // ❌ No longer recommended
-         * const object = useStorage((root) => root.obj);  // ✅ Do this instead
-         *
-         * @deprecated We no longer recommend using `useObject`. Prefer `useStorage`
-         * for reading and `useMutation` for writing.
-         */
-        useObject<TKey extends Extract<keyof TStorage, string>>(
-          key: TKey
-        ): TStorage[TKey];
-      }
-    >;
-  }
+            /**
+             * Returns the LiveObject associated with the provided key.
+             * The hook triggers a re-render if the LiveObject is updated, however it does not triggers a re-render if a nested CRDT is updated.
+             *
+             * @param key The top-level storage key associated with the LiveObject
+             * @returns Returns the LiveObject instance at the storage key
+             *
+             * @example
+             * const object = useObject("obj");                // ❌ No longer recommended
+             * const object = useStorage((root) => root.obj);  // ✅ Do this instead
+             *
+             * @deprecated We no longer recommend using `useObject`. Prefer `useStorage`
+             * for reading and `useMutation` for writing.
+             */
+            useObject<TKey extends Extract<keyof TStorage, string>>(
+              key: TKey
+            ): TStorage[TKey];
+          }
+      >;
+    }
 >;
 
 export type InternalRoomContextBundle<
@@ -1072,7 +1081,10 @@ export type InternalRoomContextBundle<
   }
 >;
 
-type LiveblocksContextBundleShared = {
+/**
+ * Properties that are the same in LiveblocksContext and LiveblocksContext["suspense"].
+ */
+type LiveblocksContextBundleCommon = {
   /**
    * @beta
    *
@@ -1108,91 +1120,51 @@ export type LiveblocksContextBundle<
   TUserMeta extends BaseUserMeta,
   TThreadMetadata extends BaseMetadata,
 > = Resolve<
-  LiveblocksContextBundleShared & {
-    /**
-     * @beta
-     *
-     * Returns the inbox notifications for the current user.
-     *
-     * @example
-     * const { inboxNotifications, error, isLoading, loadMore } = useInboxNotifications();
-     */
-    useInboxNotifications(): InboxNotificationsState<TThreadMetadata>;
+  LiveblocksContextBundleCommon &
+    Omit<SharedContextBundle<TUserMeta>, "suspense"> & {
+      /**
+       * @beta
+       *
+       * Returns the inbox notifications for the current user.
+       *
+       * @example
+       * const { inboxNotifications, error, isLoading, loadMore } = useInboxNotifications();
+       */
+      useInboxNotifications(): InboxNotificationsState<TThreadMetadata>;
 
-    /**
-     * @beta
-     *
-     * Returns the number of unread inbox notifications for the current user.
-     *
-     * @example
-     * const unreadCount = useUnreadInboxNotificationsCount();
-     */
-    useUnreadInboxNotificationsCount(): number | null;
+      /**
+       * @beta
+       *
+       * Returns the number of unread inbox notifications for the current user.
+       *
+       * @example
+       * const unreadCount = useUnreadInboxNotificationsCount();
+       */
+      useUnreadInboxNotificationsCount(): number | null;
 
-    /**
-     * @beta
-     *
-     * Returns user info from a given user ID.
-     *
-     * @example
-     * const { user, error, isLoading } = useUser("user-id");
-     */
-    useUser(userId: string): UserState<TUserMeta["info"]>;
+      suspense: Resolve<
+        LiveblocksContextBundleCommon &
+          SharedContextBundle<TUserMeta>["suspense"] & {
+            /**
+             * @beta
+             *
+             * Returns the inbox notifications for the current user.
+             *
+             * @example
+             * const { inboxNotifications, error, isLoading, loadMore } = useInboxNotifications();
+             */
+            useInboxNotifications(): InboxNotificationsStateSuccess<TThreadMetadata>;
 
-    suspense: Resolve<
-      LiveblocksContextBundleShared & {
-        /**
-         * @beta
-         *
-         * Returns the inbox notifications for the current user.
-         *
-         * @example
-         * const { inboxNotifications, error, isLoading, loadMore } = useInboxNotifications();
-         */
-        useInboxNotifications(): InboxNotificationsStateSuccess<TThreadMetadata>;
-
-        /**
-         * @beta
-         *
-         * Returns the number of unread inbox notifications for the current user.
-         *
-         * @example
-         * const unreadCount = useUnreadInboxNotificationsCount();
-         */
-        useUnreadInboxNotificationsCount(): number;
-
-        /**
-         * @beta
-         *
-         * Returns user info from a given user ID.
-         *
-         * @example
-         * const { user } = useUser("user-id");
-         */
-        useUser(userId: string): UserStateSuccess<TUserMeta["info"]>;
-      }
-    >;
-  }
->;
-
-/**
- * @private
- */
-type SharedContextBundleShared = {
-  SharedProvider(props: PropsWithChildren): JSX.Element;
-};
-
-/**
- * @private
- */
-export type SharedContextBundle<TUserMeta extends BaseUserMeta> = Resolve<
-  SharedContextBundleShared & {
-    useUser(userId: string): UserState<TUserMeta["info"]>;
-
-    suspense: Resolve<
-      SharedContextBundleShared & {
-        useUser(userId: string): UserStateSuccess<TUserMeta["info"]>;
-      }
-    >;
-  }
+            /**
+             * @beta
+             *
+             * Returns the number of unread inbox notifications for the current user.
+             *
+             * @example
+             * const unreadCount = useUnreadInboxNotificationsCount();
+             */
+            useUnreadInboxNotificationsCount(): number;
+          }
+      >;
+    }
 >;


### PR DESCRIPTION
This PR simplifies the shared context (only containing `useUser` for now) to not be an actual context (which means no extra provider).
This PR also leverages `kInternal` to improve how we attach/hide internal hooks/values on `RoomContext`/`LiveblocksContext`.