### PR TITLE
Comments/Notifications overrides

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -688,7 +688,7 @@ import { CommentsConfig } from "@liveblocks/react-comments";
 export function App() {
   return (
     <CommentsConfig
-      overrides={{ locale: "fr", UNKNOWN_USER: "Anonyme" /* ... */ }}
+      overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme" /* ... */ }}
     >
       {/* ... */}
     </CommentsConfig>

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -688,7 +688,7 @@ import { CommentsConfig } from "@liveblocks/react-comments";
 export function App() {
   return (
     <CommentsConfig
-      overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme" /* ... */ }}
+      overrides={{ locale: "fr", UNKNOWN_USER: "Anonyme" /* ... */ }}
     >
       {/* ... */}
     </CommentsConfig>

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -188,7 +188,6 @@ const CommentReaction = forwardRef<HTMLButtonElement, CommentReactionProps>(
       () => (
         <span>
           {$.COMMENT_REACTION_LIST(
-            reaction.emoji,
             <List
               values={reaction.users.map((users, index) => (
                 <User
@@ -201,6 +200,7 @@ const CommentReaction = forwardRef<HTMLButtonElement, CommentReactionProps>(
               formatRemaining={$.LIST_REMAINING_USERS}
               truncate={REACTIONS_TRUNCATE}
             />,
+            reaction.emoji,
             reaction.users.length
           )}
         </span>

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -187,7 +187,7 @@ const CommentReaction = forwardRef<HTMLButtonElement, CommentReactionProps>(
     const tooltipContent = useMemo(
       () => (
         <span>
-          {$.COMMENT_REACTION_TOOLTIP(
+          {$.COMMENT_REACTION_LIST(
             reaction.emoji,
             <List
               values={reaction.users.map((users, index) => (
@@ -198,7 +198,7 @@ const CommentReaction = forwardRef<HTMLButtonElement, CommentReactionProps>(
                   replaceSelf
                 />
               ))}
-              formatRemaining={$.COMMENT_REACTION_REMAINING}
+              formatRemaining={$.LIST_REMAINING_USERS}
               truncate={REACTIONS_TRUNCATE}
             />,
             reaction.users.length

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -133,6 +133,7 @@ export interface CommentProps extends ComponentPropsWithoutRef<"div"> {
 interface CommentReactionProps extends ComponentPropsWithoutRef<"button"> {
   comment: CommentData;
   reaction: CommentReactionData;
+  overrides?: Partial<CommentOverrides>;
 }
 
 export function CommentMention({
@@ -174,7 +175,7 @@ export function CommentLink({
 }
 
 const CommentReaction = forwardRef<HTMLButtonElement, CommentReactionProps>(
-  ({ comment, reaction, className, ...props }, forwardedRef) => {
+  ({ comment, reaction, overrides, className, ...props }, forwardedRef) => {
     const { useAddReaction, useRemoveReaction, useSelf } =
       useRoomContextBundle();
     const self = useSelf();
@@ -183,7 +184,7 @@ const CommentReaction = forwardRef<HTMLButtonElement, CommentReactionProps>(
     const isActive = useMemo(() => {
       return reaction.users.some((users) => users.id === self?.id);
     }, [reaction, self?.id]);
-    const $ = useOverrides();
+    const $ = useOverrides(overrides);
     const tooltipContent = useMemo(
       () => (
         <span>
@@ -595,6 +596,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
                         key={reaction.emoji}
                         comment={comment}
                         reaction={reaction}
+                        overrides={overrides}
                       />
                     ))}
                     <EmojiPicker onEmojiSelect={handleReactionSelect}>

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -76,6 +76,7 @@ interface InboxNotificationLayoutProps
   date: Date | string | number;
   unread?: boolean;
   interactive?: boolean;
+  overrides?: Partial<InboxNotificationOverrides>;
 }
 
 type InboxNotificationAvatarProps = AvatarProps;
@@ -83,6 +84,7 @@ type InboxNotificationAvatarProps = AvatarProps;
 interface InboxNotificationCommentProps extends ComponentProps<"div"> {
   comment: CommentData;
   showHeader?: boolean;
+  overrides?: Partial<CommentOverrides>;
 }
 
 const InboxNotificationLayout = forwardRef<
@@ -97,12 +99,13 @@ const InboxNotificationLayout = forwardRef<
       date,
       unread,
       interactive = true,
+      overrides,
       className,
       ...props
     },
     forwardedRef
   ) => {
-    const $ = useOverrides();
+    const $ = useOverrides(overrides);
 
     return (
       <TooltipProvider>
@@ -156,10 +159,11 @@ function InboxNotificationAvatar({
 function InboxNotificationComment({
   comment,
   showHeader = true,
+  overrides,
   className,
   ...props
 }: InboxNotificationCommentProps) {
-  const $ = useOverrides();
+  const $ = useOverrides(overrides);
 
   return (
     <div
@@ -337,6 +341,7 @@ const ThreadInboxNotification = forwardRef<
                 key={comment.id}
                 comment={comment}
                 showHeader={contents.comments.length > 1}
+                overrides={overrides}
               />
             ))}
           </div>
@@ -386,7 +391,7 @@ const ThreadInboxNotification = forwardRef<
           "Unexpected thread inbox notification type"
         );
     }
-  }, [$, inboxNotification, thread]);
+  }, [$, inboxNotification, overrides, thread]);
 
   return (
     <InboxNotificationLayout
@@ -394,6 +399,7 @@ const ThreadInboxNotification = forwardRef<
       title={title}
       date={date}
       unread={unread}
+      overrides={overrides}
       {...props}
       ref={forwardedRef}
     >

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -284,6 +284,7 @@ const ThreadInboxNotification = forwardRef<
   HTMLDivElement,
   InboxNotificationProps
 >(({ inboxNotification, ...props }, forwardedRef) => {
+  const $ = useOverrides();
   const {
     [kInternal]: { useThreadFromCache },
   } = useLiveblocksContextBundle();
@@ -310,7 +311,7 @@ const ThreadInboxNotification = forwardRef<
               values={reversedUserIds.map((userId, index) => (
                 <User key={userId} userId={userId} capitalize={index === 0} />
               ))}
-              // formatRemaining={$.COMMENT_REACTION_REMAINING}
+              formatRemaining={$.LIST_REMAINING_USERS}
               truncate={THREAD_INBOX_NOTIFICATION_MAX_COMMENTS - 1}
             />{" "}
             commented on <span>Document</span>
@@ -374,7 +375,7 @@ const ThreadInboxNotification = forwardRef<
           "Unexpected thread inbox notification type"
         );
     }
-  }, [inboxNotification]);
+  }, [$.LIST_REMAINING_USERS, inboxNotification, thread]);
 
   return (
     <InboxNotificationLayout

--- a/packages/liveblocks-react-comments/src/components/Thread.tsx
+++ b/packages/liveblocks-react-comments/src/components/Thread.tsx
@@ -280,10 +280,13 @@ export const Thread = forwardRef(
               return index === firstUnreadCommentIndex &&
                 firstUnreadCommentIndex !== firstCommentIndex ? (
                 <Fragment key={comment.id}>
-                  <div className="lb-thread-unread-indicator">
+                  <div
+                    className="lb-thread-unread-indicator"
+                    aria-label={$.THREAD_UNREAD_INDICATOR_DESCRIPTION}
+                  >
                     <span className="lb-thread-unread-indicator-label">
                       <ArrowDownIcon className="lb-thread-unread-indicator-label-icon" />
-                      New
+                      {$.THREAD_UNREAD_INDICATOR}
                     </span>
                   </div>
                   {children}

--- a/packages/liveblocks-react-comments/src/components/internal/User.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/User.tsx
@@ -29,13 +29,13 @@ export function User({
   // const resolvedUserName = useMemo(() => {
   //   const name =
   //     replaceSelf && self?.id === userId
-  //       ? $.SELF
-  //       : user?.name ?? $.UNKNOWN_USER;
+  //       ? $.USER_SELF
+  //       : user?.name ?? $.USER_UNKNOWN;
 
   //   return shouldCapitalize ? capitalize(name) : name;
   // }, [
-  //   $.SELF,
-  //   $.UNKNOWN_USER,
+  //   $.USER_SELF,
+  //   $.USER_UNKNOWN,
   //   shouldCapitalize,
   //   replaceSelf,
   //   self?.id,
@@ -47,10 +47,10 @@ export function User({
   const { user, isLoading } = useUser(userId);
   const $ = useOverrides();
   const resolvedUserName = useMemo(() => {
-    const name = user?.name ?? $.UNKNOWN_USER;
+    const name = user?.name ?? $.USER_UNKNOWN;
 
     return shouldCapitalize ? capitalize(name) : name;
-  }, [$.UNKNOWN_USER, shouldCapitalize, user?.name]);
+  }, [$.USER_UNKNOWN, shouldCapitalize, user?.name]);
 
   return (
     <span

--- a/packages/liveblocks-react-comments/src/config.tsx
+++ b/packages/liveblocks-react-comments/src/config.tsx
@@ -14,7 +14,7 @@ type CommentsConfigProps = PropsWithChildren<{
  * Set configuration options for all Comments components.
  *
  * @example
- * <CommentsConfig overrides={{ locale: "fr", UNKNOWN_USER: "Anonyme", ... }}>
+ * <CommentsConfig overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme", ... }}>
  *   <App />
  * </CommentsConfig>
  */

--- a/packages/liveblocks-react-comments/src/overrides.tsx
+++ b/packages/liveblocks-react-comments/src/overrides.tsx
@@ -14,9 +14,10 @@ export interface LocalizationOverrides {
 }
 
 export interface GlobalOverrides {
-  SELF: string;
-  UNKNOWN_USER: string;
+  USER_SELF: string;
+  USER_UNKNOWN: string;
   LIST_REMAINING: (count: number) => string;
+  LIST_REMAINING_USERS: (count: number) => string;
   EMOJI_PICKER_SEARCH_PLACEHOLDER: string;
   EMOJI_PICKER_EMPTY: ReactNode;
   EMOJI_PICKER_ERROR: (error: Error) => ReactNode;
@@ -32,8 +33,7 @@ export interface CommentOverrides {
   COMMENT_EDIT_COMPOSER_SAVE: string;
   COMMENT_DELETE: string;
   COMMENT_ADD_REACTION: string;
-  COMMENT_REACTION_REMAINING: (others: number) => string;
-  COMMENT_REACTION_TOOLTIP: (
+  COMMENT_REACTION_LIST: (
     emoji: string,
     list: ReactNode,
     count: number
@@ -68,9 +68,10 @@ type OverridesProviderProps = PropsWithChildren<{
 export const defaultOverrides: Overrides = {
   locale: "en",
   dir: "ltr",
-  SELF: "you",
-  UNKNOWN_USER: "Anonymous",
+  USER_SELF: "you",
+  USER_UNKNOWN: "Anonymous",
   LIST_REMAINING: (count) => `${count} more`,
+  LIST_REMAINING_USERS: (others) => `${others} ${pluralize(others, "other")}`,
   EMOJI_PICKER_SEARCH_PLACEHOLDER: "Search…",
   EMOJI_PICKER_EMPTY: "No emoji found.",
   EMOJI_PICKER_ERROR: () =>
@@ -88,13 +89,11 @@ export const defaultOverrides: Overrides = {
   COMMENT_EDIT_COMPOSER_SAVE: "Save",
   COMMENT_DELETE: "Delete comment",
   COMMENT_ADD_REACTION: "Add reaction",
-  COMMENT_REACTION_TOOLTIP: (emoji, list) => (
+  COMMENT_REACTION_LIST: (emoji, list) => (
     <>
       {list} reacted with <Emoji emoji={emoji} />
     </>
   ),
-  COMMENT_REACTION_REMAINING: (others) =>
-    `${others} ${pluralize(others, "other")}`,
   COMMENT_REACTION_DESCRIPTION: (emoji, count) =>
     `${count} ${pluralize(count, "reaction")}, react with ${emoji}`,
   THREAD_RESOLVE: "Resolve thread",

--- a/packages/liveblocks-react-comments/src/overrides.tsx
+++ b/packages/liveblocks-react-comments/src/overrides.tsx
@@ -18,6 +18,7 @@ export interface GlobalOverrides {
   USER_UNKNOWN: string;
   LIST_REMAINING: (count: number) => string;
   LIST_REMAINING_USERS: (count: number) => string;
+  LIST_REMAINING_COMMENTS: (count: number) => string;
   EMOJI_PICKER_SEARCH_PLACEHOLDER: string;
   EMOJI_PICKER_EMPTY: ReactNode;
   EMOJI_PICKER_ERROR: (error: Error) => ReactNode;
@@ -34,8 +35,8 @@ export interface CommentOverrides {
   COMMENT_DELETE: string;
   COMMENT_ADD_REACTION: string;
   COMMENT_REACTION_LIST: (
-    emoji: string,
     list: ReactNode,
+    emoji: string,
     count: number
   ) => ReactNode;
   COMMENT_REACTION_DESCRIPTION: (emoji: string, count: number) => string;
@@ -55,11 +56,26 @@ export interface ThreadOverrides {
   THREAD_COMPOSER_SEND: string;
 }
 
+export interface InboxNotificationOverrides {
+  INBOX_NOTIFICATION_MORE: string;
+  INBOX_NOTIFICATION_MARK_AS_READ: string;
+  INBOX_NOTIFICATION_THREAD_COMMENTS_LIST: (
+    list: ReactNode,
+    room: ReactNode,
+    count: number
+  ) => ReactNode;
+  INBOX_NOTIFICATION_THREAD_MENTION: (
+    user: ReactNode,
+    room: ReactNode
+  ) => ReactNode;
+}
+
 export type Overrides = LocalizationOverrides &
   GlobalOverrides &
   ComposerOverrides &
   CommentOverrides &
-  ThreadOverrides;
+  ThreadOverrides &
+  InboxNotificationOverrides;
 
 type OverridesProviderProps = PropsWithChildren<{
   overrides?: Partial<Overrides>;
@@ -71,7 +87,9 @@ export const defaultOverrides: Overrides = {
   USER_SELF: "you",
   USER_UNKNOWN: "Anonymous",
   LIST_REMAINING: (count) => `${count} more`,
-  LIST_REMAINING_USERS: (others) => `${others} ${pluralize(others, "other")}`,
+  LIST_REMAINING_USERS: (count) => `${count} ${pluralize(count, "other")}`,
+  LIST_REMAINING_COMMENTS: (count) =>
+    `${count} more ${pluralize(count, "comment")}`,
   EMOJI_PICKER_SEARCH_PLACEHOLDER: "Search…",
   EMOJI_PICKER_EMPTY: "No emoji found.",
   EMOJI_PICKER_ERROR: () =>
@@ -89,7 +107,7 @@ export const defaultOverrides: Overrides = {
   COMMENT_EDIT_COMPOSER_SAVE: "Save",
   COMMENT_DELETE: "Delete comment",
   COMMENT_ADD_REACTION: "Add reaction",
-  COMMENT_REACTION_LIST: (emoji, list) => (
+  COMMENT_REACTION_LIST: (list, emoji) => (
     <>
       {list} reacted with <Emoji emoji={emoji} />
     </>
@@ -100,6 +118,21 @@ export const defaultOverrides: Overrides = {
   THREAD_UNRESOLVE: "Re-open thread",
   THREAD_COMPOSER_PLACEHOLDER: "Reply to thread…",
   THREAD_COMPOSER_SEND: "Reply",
+  INBOX_NOTIFICATION_MORE: "More",
+  INBOX_NOTIFICATION_MARK_AS_READ: "Mark as read",
+  INBOX_NOTIFICATION_THREAD_COMMENTS_LIST: (
+    list: ReactNode,
+    room: ReactNode
+  ) => (
+    <>
+      {list} commented on {room}
+    </>
+  ),
+  INBOX_NOTIFICATION_THREAD_MENTION: (user: ReactNode, room: ReactNode) => (
+    <>
+      {user} mentioned you in {room}
+    </>
+  ),
 };
 
 export const OverridesContext = createContext<Overrides | undefined>(undefined);

--- a/packages/liveblocks-react-comments/src/overrides.tsx
+++ b/packages/liveblocks-react-comments/src/overrides.tsx
@@ -52,6 +52,8 @@ export interface ComposerOverrides {
 export interface ThreadOverrides {
   THREAD_RESOLVE: string;
   THREAD_UNRESOLVE: string;
+  THREAD_UNREAD_INDICATOR: string;
+  THREAD_UNREAD_INDICATOR_DESCRIPTION: string;
   THREAD_COMPOSER_PLACEHOLDER: string;
   THREAD_COMPOSER_SEND: string;
 }
@@ -116,6 +118,8 @@ export const defaultOverrides: Overrides = {
     `${count} ${pluralize(count, "reaction")}, react with ${emoji}`,
   THREAD_RESOLVE: "Resolve thread",
   THREAD_UNRESOLVE: "Re-open thread",
+  THREAD_UNREAD_INDICATOR: "New",
+  THREAD_UNREAD_INDICATOR_DESCRIPTION: "All comments below are unread",
   THREAD_COMPOSER_PLACEHOLDER: "Reply to thread…",
   THREAD_COMPOSER_SEND: "Reply",
   INBOX_NOTIFICATION_MORE: "More",


### PR DESCRIPTION
This PR tweaks existing overrides and adds new ones for Notifications.

### Breaking changes

- `SELF` is renamed to `USER_SELF`
- `UNKNOWN_USER` is renamed to `USER_UNKNOWN`
- `COMMENT_REACTION_REMAINING` doesn't exist anymore, use the global `LIST_REMAINING_USERS` instead
- `COMMENT_REACTION_TOOLTIP` is renamed to `COMMENT_REACTION_LIST`, and its arguments are now ordered as `list`, `emoji`, and `count`