### PR TITLE
Inbox notifications types

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -184,7 +184,7 @@ export type { Immutable } from "./types/Immutable";
 export type {
   InboxNotificationData,
   InboxNotificationDataPlain,
-  ThreadInboxNotificationData,
+  InboxNotificationThreadData,
 } from "./types/InboxNotificationData";
 export type {
   IWebSocket,

--- a/packages/liveblocks-core/src/types/InboxNotificationData.ts
+++ b/packages/liveblocks-core/src/types/InboxNotificationData.ts
@@ -1,6 +1,6 @@
 import type { DateToString } from "./DateToString";
 
-export type ThreadInboxNotificationData = {
+export type InboxNotificationThreadData = {
   kind: "thread";
   id: string;
   threadId: string;
@@ -8,6 +8,6 @@ export type ThreadInboxNotificationData = {
   readAt: Date | null;
 };
 
-export type InboxNotificationData = ThreadInboxNotificationData;
+export type InboxNotificationData = InboxNotificationThreadData;
 
 export type InboxNotificationDataPlain = DateToString<InboxNotificationData>;

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -10,6 +10,8 @@ import type {
   CommentDataPlain,
   CommentUserReaction,
   CommentUserReactionPlain,
+  InboxNotificationData,
+  InboxNotificationDataPlain,
   IUserInfo,
   Json,
   JsonObject,
@@ -117,22 +119,6 @@ export type Schema = {
 };
 
 type SchemaPlain = DateToString<Schema>;
-
-type InboxNotificationResponse = {
-  readAt: string | null;
-  notifiedAt: string;
-  id: string;
-  threadId: string;
-  kind: "thread";
-};
-
-export type InboxNotification = {
-  readAt: Date | null;
-  notifiedAt: Date;
-  id: string;
-  threadId: string;
-  kind: "thread";
-};
 
 /**
  * Interact with the Liveblocks API from your Node.js backend.
@@ -1225,7 +1211,7 @@ export class Liveblocks {
   public async getInboxNotification(params: {
     userId: string;
     inboxNotificationId: string;
-  }): Promise<InboxNotification> {
+  }): Promise<InboxNotificationData> {
     const { userId, inboxNotificationId } = params;
 
     const res = await this.get(
@@ -1236,7 +1222,7 @@ export class Liveblocks {
       throw new LiveblocksError(res.status, text);
     }
 
-    const data = (await res.json()) as InboxNotificationResponse;
+    const data = (await res.json()) as InboxNotificationDataPlain;
 
     return {
       ...data,

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -4,8 +4,8 @@ import type {
   BaseMetadata,
   CommentData,
   InboxNotificationData,
+  InboxNotificationThreadData,
   ThreadData,
-  ThreadInboxNotificationData,
 } from "@liveblocks/core";
 import {
   assertNever,
@@ -32,7 +32,7 @@ import { User } from "./internal/User";
 
 const THREAD_INBOX_NOTIFICATION_MAX_COMMENTS = 3;
 
-type ThreadInboxNotificationCommentsContents = {
+type InboxNotificationThreadCommentsContents = {
   type: "comments";
   unread: boolean;
   comments: CommentData[];
@@ -40,7 +40,7 @@ type ThreadInboxNotificationCommentsContents = {
   date: Date;
 };
 
-type ThreadInboxNotificationMentionContents = {
+type InboxNotificationThreadMentionContents = {
   type: "mention";
   unread: boolean;
   comments: CommentData[];
@@ -48,9 +48,9 @@ type ThreadInboxNotificationMentionContents = {
   date: Date;
 };
 
-type ThreadInboxNotificationContents =
-  | ThreadInboxNotificationCommentsContents
-  | ThreadInboxNotificationMentionContents;
+type InboxNotificationThreadContents =
+  | InboxNotificationThreadCommentsContents
+  | InboxNotificationThreadMentionContents;
 
 export interface InboxNotificationProps
   extends ComponentPropsWithoutRef<"div"> {
@@ -219,11 +219,11 @@ function getUserIdsFromComments(comments: CommentData[]) {
   return Array.from(new Set(comments.map((comment) => comment.userId)));
 }
 
-function generateThreadInboxNotificationContents(
-  inboxNotification: ThreadInboxNotificationData,
+function generateInboxNotificationThreadContents(
+  inboxNotification: InboxNotificationThreadData,
   thread: ThreadData<BaseMetadata>,
   userId: string
-): ThreadInboxNotificationContents {
+): InboxNotificationThreadContents {
   const unreadComments = thread.comments.filter((comment) => {
     if (!comment.body) {
       return false;
@@ -280,7 +280,7 @@ function generateThreadInboxNotificationContents(
   };
 }
 
-const ThreadInboxNotification = forwardRef<
+const InboxNotificationThread = forwardRef<
   HTMLDivElement,
   InboxNotificationProps
 >(({ inboxNotification, ...props }, forwardedRef) => {
@@ -291,7 +291,7 @@ const ThreadInboxNotification = forwardRef<
 
   // [comments-unread] TODO: How do we get the current user ID?
   const { unread, date, aside, title, content } = useMemo(() => {
-    const contents = generateThreadInboxNotificationContents(
+    const contents = generateInboxNotificationThreadContents(
       inboxNotification,
       thread,
       "[comments-unread] TODO: get current user's ID"
@@ -374,7 +374,7 @@ const ThreadInboxNotification = forwardRef<
           "Unexpected thread inbox notification type"
         );
     }
-  }, [inboxNotification]);
+  }, [inboxNotification, thread]);
 
   return (
     <InboxNotificationLayout
@@ -407,7 +407,7 @@ export const InboxNotification = forwardRef<
   switch (inboxNotification.kind) {
     case "thread":
       return (
-        <ThreadInboxNotification
+        <InboxNotificationThread
           inboxNotification={inboxNotification}
           {...props}
           ref={forwardedRef}


### PR DESCRIPTION
This PR removes duplicated types for notifications in the Node client and renames all `ThreadInboxNotification` prefixed variables to be prefixed by `InboxNotificationThread` (it's more logical in this order and also more consistent, for example with the previous order an override for the title of an inbox notification showing a mention would be named `THREAD_INBOX_NOTIFICATION_MENTION`, which feels like the inbox notification is a sub-part of a thread instead of the opposite, it can now be `INBOX_NOTIFICATION_THREAD_MENTION`).