### PR TITLE
Add new WebSocket close codes

### DIFF
--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -55,6 +55,8 @@ export interface IWebSocket {
  *
  */
 export enum WebsocketCloseCodes {
+  /** Normal close of connection, the connection fulfilled its purpose. */
+  CLOSE_NORMAL = 1000,
   /** Unexpected error happened with the network/infra level. In spirit akin to HTTP 503 */
   CLOSE_ABNORMAL = 1006,
   /** Unexpected error happened. In spirit akin to HTTP 500 */

--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -48,6 +48,7 @@ export interface IWebSocket {
 /**
  * The following ranges will be respected by the client:
  *
+ *   10xx: client will reauthorize (just like 41xx)
  *   40xx: client will disconnect
  *   41xx: client will reauthorize
  *   42xx: client will retry without reauthorizing (currently not used)
@@ -72,6 +73,8 @@ export enum WebsocketCloseCodes {
   MAX_NUMBER_OF_MESSAGES_PER_DAY_PER_APP = 4004,
   /** Room is full, disconnect */
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS_PER_ROOM = 4005,
+  /** The server kicked the connection from the room. */
+  KICKED = 4100,
   /** The auth token is expired, reauthorize to get a fresh one. In spirit akin to HTTP 401 */
   TOKEN_EXPIRED = 4109,
   /** Disconnect immediately */


### PR DESCRIPTION
This PR adds a new WebSocket close code to the list of options. The server will currently, in a couple of places, close the connection without specifying a code or reason explicitly. As a result, this will default to sending a 1000 close code (without a clear reason). The client will handle this by reauthorizing when attempting to reconnect. Therefore, we can safely replace these implicit 1000 error codes sent by the server to be 4100, which falls in the 41xx range, which follows the exact same behavior as the implicit 10xx range.

Related to https://github.com/liveblocks/liveblocks-cloudflare/pull/691.