### PR TITLE
Add transitional errors for `resolveUsers` and `resolveMentionSuggestions`

### DIFF
--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -21,6 +21,9 @@ import type {
   CommentReaction,
   CommentsEventServerMsg,
   EnterOptions,
+  OptionalPromise,
+  ResolveMentionSuggestionsArgs,
+  ResolveUsersArgs,
   RoomEventMessage,
   RoomNotificationSettings,
   ThreadData,
@@ -192,6 +195,26 @@ export function useRoomContextBundle() {
   return bundle;
 }
 
+type Options<TUserMeta extends BaseUserMeta> = {
+  /**
+   * @deprecated - Define 'resolveUsers' in 'createClient' from '@liveblocks/client' instead.
+   *
+   * A function that returns user info from user IDs.
+   */
+  resolveUsers?: (
+    args: ResolveUsersArgs
+  ) => OptionalPromise<(TUserMeta["info"] | undefined)[] | undefined>;
+
+  /**
+   * @deprecated - Define 'resolveMentionSuggestions' in 'createClient' from '@liveblocks/client' instead.
+   *
+   * A function that returns a list of user IDs matching a string.
+   */
+  resolveMentionSuggestions?: (
+    args: ResolveMentionSuggestionsArgs
+  ) => OptionalPromise<string[]>;
+};
+
 export function createRoomContext<
   TPresence extends JsonObject,
   TStorage extends LsonObject = LsonObject,
@@ -199,7 +222,8 @@ export function createRoomContext<
   TRoomEvent extends Json = never,
   TThreadMetadata extends BaseMetadata = never,
 >(
-  client: Client
+  client: Client,
+  options?: Options<TUserMeta>
 ): RoomContextBundle<
   TPresence,
   TStorage,
@@ -209,6 +233,20 @@ export function createRoomContext<
 > {
   type TRoom = Room<TPresence, TStorage, TUserMeta, TRoomEvent>;
   type TRoomLeavePair = { room: TRoom; leave: () => void };
+
+  // Deprecated option
+  if (options?.resolveUsers) {
+    throw new Error(
+      "The 'resolveUsers' option has moved to 'createClient' from '@liveblocks/client'."
+    );
+  }
+
+  // Deprecated option
+  if (options?.resolveMentionSuggestions) {
+    throw new Error(
+      "The 'resolveMentionSuggestions' option has moved to 'createClient' from '@liveblocks/client'."
+    );
+  }
 
   const RoomContext = React.createContext<TRoom | null>(null);
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -197,7 +197,8 @@ export function useRoomContextBundle() {
 
 type Options<TUserMeta extends BaseUserMeta> = {
   /**
-   * @deprecated - Define 'resolveUsers' in 'createClient' from '@liveblocks/client' instead.
+   * @deprecated Define 'resolveUsers' in 'createClient' from '@liveblocks/client' instead.
+   * Please refer to our Upgrade Guide to learn more, see https://liveblocks.io/docs/platform/upgrading/1.10.
    *
    * A function that returns user info from user IDs.
    */
@@ -206,7 +207,8 @@ type Options<TUserMeta extends BaseUserMeta> = {
   ) => OptionalPromise<(TUserMeta["info"] | undefined)[] | undefined>;
 
   /**
-   * @deprecated - Define 'resolveMentionSuggestions' in 'createClient' from '@liveblocks/client' instead.
+   * @deprecated Define 'resolveMentionSuggestions' in 'createClient' from '@liveblocks/client' instead.
+   * Please refer to our Upgrade Guide to learn more, see https://liveblocks.io/docs/platform/upgrading/1.10.
    *
    * A function that returns a list of user IDs matching a string.
    */
@@ -237,14 +239,14 @@ export function createRoomContext<
   // Deprecated option
   if (options?.resolveUsers) {
     throw new Error(
-      "The 'resolveUsers' option has moved to 'createClient' from '@liveblocks/client'."
+      "The 'resolveUsers' option has moved to 'createClient' from '@liveblocks/client'. Please refer to our Upgrade Guide to learn more, see https://liveblocks.io/docs/platform/upgrading/1.10."
     );
   }
 
   // Deprecated option
   if (options?.resolveMentionSuggestions) {
     throw new Error(
-      "The 'resolveMentionSuggestions' option has moved to 'createClient' from '@liveblocks/client'."
+      "The 'resolveMentionSuggestions' option has moved to 'createClient' from '@liveblocks/client'. Please refer to our Upgrade Guide to learn more, see https://liveblocks.io/docs/platform/upgrading/1.10."
     );
   }
 


### PR DESCRIPTION
This PR attempts to make the `resolveUsers`/`resolveMentionSuggestions` breaking change slightly easier to understand for users who upgrade without necessarily seeing the upgrade guide.