### PR TITLE
Add rooms URLs to `resolveRoomsInfo`

### DIFF
--- a/packages/liveblocks-core/src/types/RoomInfo.ts
+++ b/packages/liveblocks-core/src/types/RoomInfo.ts
@@ -3,4 +3,9 @@ export type RoomInfo = {
    * The name of the room.
    */
   name?: string;
+
+  /**
+   * The URL of the room.
+   */
+  url?: string;
 };


### PR DESCRIPTION
This PR adds support for providing URLs for room IDs in `resolveRoomsInfo` (which currently only asks for room names), and then uses that in `<InboxNotification />` to allow making notifications clickable without having to call your back-end in React-land to generate an `href` value.

IMO, this should be considered the default path, but if you can use `inboxNotification.roomId` to generate URLs and don't need the resolver, setting `href` on `<InboxNotification />` will always take priority and you can just ignore the resolver.