### PR TITLE
Remove unnecessary query params for `getThreads` node method

### DIFF
--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -874,9 +874,7 @@ export class Liveblocks {
   }): Promise<{ data: ThreadData[] }> {
     const { roomId } = params;
 
-    const res = await this.get(url`/v2/rooms/${roomId}/threads`, {
-      "metadata.resolved": "false",
-    });
+    const res = await this.get(url`/v2/rooms/${roomId}/threads`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);


### PR DESCRIPTION
We missed to remove an unnecessary query parameter for `getThreads` method under `@liveblocks/node`. Note that the presence of this query parameter doesn't affect the API response because the backend endpoint doesn't look at the query parameter. But, it is still a good idea to remove this query parameter from the method to remove any confusion.