### PR TITLE
`create-liveblocks-app`: Update `liveblocks.config` to 1.10

### DIFF
--- a/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
+++ b/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
@@ -27,8 +27,9 @@ function createClient({ framework, comments }: InitQuestions) {
   const options = comments
     ? `{
   // publicApiKey: "",
-  // authEndpoint: "/api/auth",
+  // authEndpoint: "/api/liveblocks-auth",
   // throttle: 100,
+  ${resolvers()}
 }`
     : `{}`;
   return `${
@@ -97,7 +98,11 @@ export type ThreadMetadata = {
 `;
 }
 
-function reactExports({ framework, suspense, typescript }: InitQuestions) {
+function reactRoomContextExports({
+  framework,
+  suspense,
+  typescript,
+}: InitQuestions) {
   if (framework !== "react") {
     if (typescript) {
       return `export type TypedRoom = Room<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>;`;
@@ -149,24 +154,23 @@ function reactLiveblocksContextExports({
 } = `;
   } else {
     start = `export const {
-  ${allHooks()} 
+  ${liveblocksContextHooks()} 
 } = `;
   }
 
   let end;
 
   if (typescript) {
-    end = `createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(client, ${reactExportsOptions()});`;
+    end = `createLiveblocksContext<UserMeta, ThreadMetadata>(client);`;
   } else {
-    end = `createRoomContext(client, ${reactExportsOptions()});`;
+    end = `createLiveblocksContext(client);`;
   }
 
   return start + end;
 }
 
-function reactExportsOptions() {
-  return `{
-  async resolveUsers({ userIds }) {
+function resolvers() {
+  return `async resolveUsers({ userIds }) {
     // Used only for Comments. Return a list of user information retrieved
     // from \`userIds\`. This info is used in comments, mentions etc.
     
@@ -179,7 +183,7 @@ function reactExportsOptions() {
     
     return [];
   },
-  async resolveMentionSuggestions({ text, roomId }) {
+  async resolveMentionSuggestions({ text }) {
     // Used only for Comments. Return a list of userIds that match \`text\`.
     // These userIds are used to create a mention list when typing in the
     // composer. 
@@ -187,22 +191,25 @@ function reactExportsOptions() {
     // For example when you type "@jo", \`text\` will be \`"jo"\`, and 
     // you should to return an array with John and Joanna's userIds:
     // ["john@example.com", "joanna@example.com"]
+
+    // const users = await getUsers({ search: text });
+    // return users.map((user) => user.id);
+
+    return [];
+  },
+  async resolveRoomsInfo({ roomIds }) {
+    // Used only for Comments. Return a list of room information retrieved
+    // from \`roomIds\`.
     
-    // const userIds = await __fetchAllUserIdsFromDB__(roomId);
-    //
-    // Return all userIds if no \`text\`
-    // if (!text) {
-    //   return userIds;
-    // }
-    //
-    // Otherwise, filter userIds for the search \`text\` and return
-    // return userIds.filter((userId) => 
-    //   userId.toLowerCase().includes(text.toLowerCase())  
-    // );
+    // const roomsData = await __fetchRoomsFromDB__(roomIds);
+    // 
+    // return roomsData.map((roomData) => ({
+    //   name: roomData.name,
+    // }));
     
     return [];
   },
-}`;
+  `;
 }
 
 function roomContextHooks() {

--- a/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
+++ b/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
@@ -221,6 +221,7 @@ function roomContextHooks() {
   useSelf,
   useOthers,
   useOthersMapped,
+  useOthersListener,
   useOthersConnectionIds,
   useOther,
   useBroadcastEvent,

--- a/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
+++ b/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
@@ -113,13 +113,15 @@ function reactRoomContextExports({
   let start;
 
   if (suspense) {
-    start = `export const {
+    start = `// Room-level hooks, use inside \`RoomProvider\`
+export const {
   suspense: {
     ${indentString(roomContextHooks())}
   }
 } = `;
   } else {
-    start = `export const {
+    start = `// Room-level hooks, use inside \`RoomProvider\`
+export const {
   ${roomContextHooks()} 
 } = `;
   }
@@ -149,13 +151,15 @@ function reactLiveblocksContextExports({
   let start;
 
   if (suspense) {
-    start = `export const {
+    start = `// Project-level hooks, use inside \`LiveblocksProvider\`
+export const {
   suspense: {
     ${indentString(liveblocksContextHooks())}
   }
 } = `;
   } else {
-    start = `export const {
+    start = `// Project-level hooks, use inside \`LiveblocksProvider\`
+export const {
   ${liveblocksContextHooks()} 
 } = `;
   }
@@ -241,7 +245,6 @@ function roomContextHooks() {
   useStatus,
   useLostConnectionListener,
   useThreads,
-  useUser,
   useCreateThread,
   useEditThreadMetadata,
   useCreateComment,
@@ -252,16 +255,23 @@ function roomContextHooks() {
   useThreadSubscription,
   useMarkThreadAsRead,
   useRoomNotificationSettings,
-  useUpdateRoomNotificationSettings,`;
+  useUpdateRoomNotificationSettings,
+
+  // These hooks can be exported from either context
+  // useUser,
+  // useRoomInfo`;
 }
 
 function liveblocksContextHooks() {
   return `LiveblocksProvider,
-  useRoomInfo,
   useMarkInboxNotificationAsRead,
   useMarkAllInboxNotificationsAsRead,
   useInboxNotifications,
-  useUnreadInboxNotificationsCount,`;
+  useUnreadInboxNotificationsCount,
+
+  // These hooks can be exported from either context
+  useUser,
+  useRoomInfo,`;
 }
 
 function indentString(str: string) {

--- a/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
+++ b/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
@@ -13,7 +13,7 @@ ${reactLiveblocksContextExports(args)}
 function imports({ framework, typescript }: InitQuestions) {
   if (framework === "react") {
     return `import { createClient } from "@liveblocks/client";
-import { createRoomContext } from "@liveblocks/react";`;
+import { createRoomContext, createLiveblocksContext } from "@liveblocks/react";`;
   }
 
   if (typescript) {
@@ -105,7 +105,7 @@ function reactRoomContextExports({
 }: InitQuestions) {
   if (framework !== "react") {
     if (typescript) {
-      return `export type TypedRoom = Room<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>;`;
+      return `export type TypedRoom = Room<Presence, Storage, UserMeta, RoomEvent>;`;
     }
     return "";
   }
@@ -127,9 +127,11 @@ function reactRoomContextExports({
   let end;
 
   if (typescript) {
-    end = `createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(client);`;
+    end = `createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(client);
+`;
   } else {
-    end = `createRoomContext(client);`;
+    end = `createRoomContext(client);
+`;
   }
 
   return start + end;
@@ -208,8 +210,7 @@ function resolvers() {
     // }));
     
     return [];
-  },
-  `;
+  },`;
 }
 
 function roomContextHooks() {

--- a/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
+++ b/packages/create-liveblocks-app/bin/templates/init/config-generation.ts
@@ -5,7 +5,8 @@ export function configGeneration(args: InitQuestions) {
   
 ${createClient(args)}
 ${typeDefinitions(args)}
-${reactExports(args)}
+${reactRoomContextExports(args)}
+${reactLiveblocksContextExports(args)}
 `;
 }
 
@@ -109,7 +110,41 @@ function reactExports({ framework, suspense, typescript }: InitQuestions) {
   if (suspense) {
     start = `export const {
   suspense: {
-    ${indentString(allHooks())}
+    ${indentString(roomContextHooks())}
+  }
+} = `;
+  } else {
+    start = `export const {
+  ${roomContextHooks()} 
+} = `;
+  }
+
+  let end;
+
+  if (typescript) {
+    end = `createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(client);`;
+  } else {
+    end = `createRoomContext(client);`;
+  }
+
+  return start + end;
+}
+
+function reactLiveblocksContextExports({
+  framework,
+  suspense,
+  typescript,
+}: InitQuestions) {
+  if (framework !== "react") {
+    return "";
+  }
+
+  let start;
+
+  if (suspense) {
+    start = `export const {
+  suspense: {
+    ${indentString(liveblocksContextHooks())}
   }
 } = `;
   } else {
@@ -170,7 +205,7 @@ function reactExportsOptions() {
 }`;
 }
 
-function allHooks() {
+function roomContextHooks() {
   return `RoomProvider,
   useRoom,
   useMyPresence,
@@ -204,7 +239,20 @@ function allHooks() {
   useEditComment,
   useDeleteComment,
   useAddReaction,
-  useRemoveReaction,`;
+  useRemoveReaction,
+  useThreadSubscription,
+  useMarkThreadAsRead,
+  useRoomNotificationSettings,
+  useUpdateRoomNotificationSettings,`;
+}
+
+function liveblocksContextHooks() {
+  return `LiveblocksProvider,
+  useRoomInfo,
+  useMarkInboxNotificationAsRead,
+  useMarkAllInboxNotificationsAsRead,
+  useInboxNotifications,
+  useUnreadInboxNotificationsCount,`;
 }
 
 function indentString(str: string) {


### PR DESCRIPTION
This PR updates the `liveblocks.config.{js,ts}` file to use the 1.10 configuration options. This includes the following changes:

1. Move resolver options from `createRoomContext` to `createClient`.
2. Add the `resolveRoomsInfo({ roomIds })` option to the list of resolvers.
3. Add `createLiveblocksContext` along with the exported hooks for both suspense and non-suspense options.
4. Export `useThreadSubscription`, `useMarkThreadAsRead`, `useRoomNotificationSettings`, `useUpdateRoomNotificationSettings` hooks from `createRoomContext`.