### PR TITLE
Fetch updates since last requested time when room mounts + Set up one poller per room

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -104,7 +104,6 @@ type PrivateClientApi<TUserMeta extends BaseUserMeta> = {
   cacheStore: CacheStore<BaseMetadata>;
   usersStore: BatchStore<TUserMeta["info"] | undefined, [string]>;
   roomsInfoStore: BatchStore<RoomInfo | undefined, [string]>;
-  getRoomIds: () => string[];
 };
 
 export type InboxNotificationsApi<
@@ -623,9 +622,6 @@ export function createClient<TUserMeta extends BaseUserMeta = BaseUserMeta>(
         cacheStore,
         usersStore,
         roomsInfoStore,
-        getRoomIds() {
-          return Array.from(roomsById.keys());
-        },
       },
     },
     kInternal,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -850,11 +850,6 @@ type PrivateRoomApi = {
     explicitClose(event: IWebSocketCloseEvent): void;
     rawSend(data: string): void;
   };
-
-  // Used to store metadata related to comments
-  comments: {
-    lastRequestedAt: Date | null; // Stores the timestamp when threads and notifications were last requested for the room
-  };
 };
 
 // The maximum message size on websockets is 1MB. We'll set the threshold
@@ -936,10 +931,6 @@ type RoomState<
 
   readonly undoStack: HistoryOp<TPresence>[][];
   readonly redoStack: HistoryOp<TPresence>[][];
-
-  readonly comments: {
-    lastRequestedAt: Date | null;
-  };
 
   /**
    * When history is paused, all operations will get queued up here. When
@@ -1493,10 +1484,6 @@ export function createRoom<
     opClock: 0,
     nodes: new Map<string, LiveNode>(),
     root: undefined,
-
-    comments: {
-      lastRequestedAt: null,
-    },
 
     undoStack: [],
     redoStack: [],
@@ -2935,15 +2922,6 @@ export function createRoom<
           // These exist only for our E2E testing app
           explicitClose: (event) => managedSocket._privateSendMachineEvent({ type: "EXPLICIT_SOCKET_CLOSE", event }),
           rawSend: (data) => managedSocket.send(data),
-        },
-
-        comments: {
-          get lastRequestedAt() {
-            return context.comments.lastRequestedAt;
-          },
-          set lastRequestedAt(value: Date | null) {
-            context.comments.lastRequestedAt = value;
-          },
         },
       },
 

--- a/packages/liveblocks-react/src/__tests__/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/_dummies.ts
@@ -27,7 +27,7 @@ export function dummyThreadData<
     roomId: "room-id",
     createdAt: now,
     metadata: {}, // TODO Fix type
-    updatedAt: undefined,
+    updatedAt: now,
     comments: [comment],
   } as ThreadData<TThreadMetadata>;
 }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1042,17 +1042,6 @@ export function createRoomContext<
     }
 
     requestCache.subscribers--;
-
-    let totalSubscribers = 0;
-    for (const requestCache of requestsCache.values()) {
-      totalSubscribers += requestCache.subscribers;
-    }
-
-    // If there are no more subscribers for the room, we stop the poller
-    if (totalSubscribers <= 0) {
-      const poller = getPoller(roomId);
-      poller.stop();
-    }
   }
 
   async function getThreadsAndInboxNotifications(


### PR DESCRIPTION
This PR aims to fix https://github.com/liveblocks/liveblocks.io/issues/1939 by making the following changes:

- [x] When a `RoomProvider` remounts after being unmounted, we want to retrieve updates since the last time we requested them. We can do so by utilizing the `lastRequestedAt` timestamp, which represents the timestamp when threads and notification updates were last requested. 

Some other improvements that this PR introduces:
- [x] Each room now has their own poller that fetches any thread/notification updates every 5 minutes.