### PR TITLE
Retrieve threads/notifications updates since last requested at when room remounts

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -810,9 +810,7 @@ type PrivateRoomApi = {
     rawSend(data: string): void;
   };
 
-  comments: CommentsApi & {
-    lastRequestedAt: Date | null; // Stores the timestamp when threads and notifications were last requested for the room
-  };
+  comments: CommentsApi;
 
   notifications: {
     getRoomNotificationSettings(): Promise<RoomNotificationSettings>;
@@ -901,10 +899,6 @@ type RoomState<
 
   readonly undoStack: HistoryOp<TPresence>[][];
   readonly redoStack: HistoryOp<TPresence>[][];
-
-  readonly comments: {
-    lastRequestedAt: Date | null;
-  };
 
   /**
    * When history is paused, all operations will get queued up here. When
@@ -1462,10 +1456,6 @@ export function createRoom<
     opClock: 0,
     nodes: new Map<string, LiveNode>(),
     root: undefined,
-
-    comments: {
-      lastRequestedAt: null,
-    },
 
     undoStack: [],
     redoStack: [],
@@ -2907,12 +2897,6 @@ export function createRoom<
 
         comments: {
           ...commentsApi,
-          get lastRequestedAt() {
-            return context.comments.lastRequestedAt;
-          },
-          set lastRequestedAt(value: Date | null) {
-            context.comments.lastRequestedAt = value;
-          },
         },
 
         notifications: {

--- a/packages/liveblocks-react/src/__tests__/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/_dummies.ts
@@ -27,7 +27,7 @@ export function dummyThreadData<
     roomId: "room-id",
     createdAt: now,
     metadata: {}, // TODO Fix type
-    updatedAt: undefined,
+    updatedAt: now,
     comments: [comment],
   } as ThreadData<TThreadMetadata>;
 }

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -899,19 +899,39 @@ describe("useThreads", () => {
     unmount();
   });
 
-  // TODO: This test fails because of the way we handle request cache after room is unmounted
-  test.skip("should refetch threads if room has been mounted after being unmounted", async () => {
-    const threads = [dummyThreadData()];
-    let getThreadsReqCount = 0;
+  test("should update threads if room has been mounted after being unmounted", async () => {
+    let threads = [dummyThreadData(), dummyThreadData()];
+    const originalThreads = [...threads];
 
     server.use(
-      mockGetThreads(async (_req, res, ctx) => {
-        getThreadsReqCount++;
+      mockGetThreads(async (req, res, ctx) => {
+        const url = new URL(req.url);
+        const since = url.searchParams.get("since");
+
+        if (since) {
+          const updatedThreads = threads.filter((thread) => {
+            if (thread.updatedAt === undefined) return false;
+            return new Date(thread.updatedAt) >= new Date(since);
+          });
+
+          return res(
+            ctx.json({
+              data: updatedThreads,
+              deletedThreads: [],
+              inboxNotifications: [],
+              deletedInboxNotifications: [],
+              meta: {
+                requestedAt: new Date().toISOString(),
+              },
+            })
+          );
+        }
+
         return res(
           ctx.json({
             data: threads,
-            inboxNotifications: [],
             deletedThreads: [],
+            inboxNotifications: [],
             deletedInboxNotifications: [],
             meta: {
               requestedAt: new Date().toISOString(),
@@ -925,32 +945,53 @@ describe("useThreads", () => {
       roomCtx: { RoomProvider, useThreads },
     } = createRoomContextForTest();
 
-    const Room = () => {
-      return (
+    const firstRenderResult = renderHook(() => useThreads(), {
+      wrapper: ({ children }) => (
         <RoomProvider id="room-id" initialPresence={{}}>
-          <Threads />
+          {children}
         </RoomProvider>
-      );
-    };
+      ),
+    });
 
-    const Threads = () => {
-      useThreads();
-      return null;
-    };
+    expect(firstRenderResult.result.current).toEqual({ isLoading: true });
 
-    const { unmount } = render(<Room />);
+    // Threads should be displayed after the server responds with the threads
+    await waitFor(() =>
+      expect(firstRenderResult.result.current).toEqual({
+        isLoading: false,
+        threads,
+      })
+    );
 
-    // A new fetch request for the threads should have been made
-    await waitFor(() => expect(getThreadsReqCount).toBe(1));
+    firstRenderResult.unmount();
 
-    unmount();
+    // Add a new thread to the threads array to simulate a new thread being added to the room
+    threads = [...originalThreads, dummyThreadData()];
 
-    // Render the RoomProvider again and verify a new fetch request is initiated
-    const result = render(<Room />);
+    // Render the RoomProvider again and verify the threads are updated
+    const secondRenderResult = renderHook(() => useThreads(), {
+      wrapper: ({ children }) => (
+        <RoomProvider id="room-id" initialPresence={{}}>
+          {children}
+        </RoomProvider>
+      ),
+    });
 
-    await waitFor(() => expect(getThreadsReqCount).toBe(2));
+    // Threads (outdated ones) should be displayed instantly because we already fetched them previously
+    expect(secondRenderResult.result.current).toEqual({
+      isLoading: false,
+      threads: originalThreads,
+    });
 
-    result.unmount();
+    // The updated threads should be displayed after the server responds with the updated threads (either due to a fetch request to get all threads or just the updated threads)
+    await waitFor(() => {
+      expect(secondRenderResult.result.current).toEqual({
+        isLoading: false,
+        threads,
+      });
+    });
+
+    secondRenderResult.unmount();
   });
 
   test("should not refetch threads if room has been mounted after being unmounted if another RoomProvider for the same id is still mounted", async () => {
@@ -1009,13 +1050,13 @@ describe("useThreads", () => {
     if (room === null) return;
 
     // Mock the getThreads method so we can verify it wasn't called
-    room.getThreads = jest.fn();
+    room[kInternal].comments.getThreads = jest.fn();
 
     // Rerender the first RoomProvider and verify a new fetch request wasn't initiated
     rerender(<FirstRoom />);
 
     // A new fetch request for the threads should not have been made
-    expect(room.getThreads).not.toHaveBeenCalled();
+    expect(room[kInternal].comments.getThreads).not.toHaveBeenCalled();
 
     unmountFirstRoom();
     unmountSecondRoom();

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -410,6 +410,11 @@ export function createRoomContext<
     }, [room]);
 
     React.useEffect(() => {
+      // Retrieve threads that have been updated/deleted since the last time the room requested threads updates
+      void getThreadsUpdates(room.id);
+    }, [room.id]);
+
+    React.useEffect(() => {
       const pair = stableEnterRoom(roomId, frozenProps);
 
       setRoomLeavePair(pair);
@@ -443,9 +448,7 @@ export function createRoomContext<
             >
           }
         >
-          <CommentsRoomProvider room={room}>
-            {props.children}
-          </CommentsRoomProvider>
+          {props.children}
         </ContextBundle.Provider>
       </RoomContext.Provider>
     );
@@ -1208,20 +1211,6 @@ export function createRoomContext<
       isFetchingThreadsUpdates = false;
       // TODO: Implement error handling
     }
-  }
-
-  function CommentsRoomProvider({
-    room,
-    children,
-  }: React.PropsWithChildren<{
-    room: Room<JsonObject, LsonObject, BaseUserMeta, Json>;
-  }>) {
-    React.useEffect(() => {
-      // Retrieve threads that have been updated/deleted since the last time the room requested threads updates
-      void getThreadsUpdates(room.id);
-    }, [room.id]);
-
-    return <>{children}</>;
   }
 
   function useThreads(


### PR DESCRIPTION
This PR aims to fix https://github.com/liveblocks/liveblocks.io/issues/1939 by making the following changes:

- [x] When a `RoomProvider` remounts after being unmounted, we want to retrieve updates since the last time we requested them. We can do so by utilizing the `lastRequestedAt` timestamp, which represents the timestamp when threads and notification updates were last requested. 