### PR TITLE
Fix error handling inside inbox notification api implementation inside room

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1,5 +1,8 @@
 import type { AuthManager, AuthValue } from "./auth-manager";
-import { getAuthBearerHeaderFromAuthValue } from "./client";
+import {
+  getAuthBearerHeaderFromAuthValue,
+  NotificationsApiError,
+} from "./client";
 import type {
   Delegates,
   LegacyConnectionStatus,
@@ -2832,7 +2835,7 @@ export function createRoom<
     fetchClientApi
   );
 
-  async function fetchJson<T>(
+  async function fetchInboxNotificationJson<T>(
     endpoint: string,
     options?: RequestInit
   ): Promise<T> {
@@ -2846,16 +2849,24 @@ export function createRoom<
 
     if (!response.ok) {
       if (response.status >= 400 && response.status < 600) {
-        let errorMessage = "";
+        let error: NotificationsApiError;
+
         try {
           const errorBody = (await response.json()) as { message: string };
-          errorMessage = errorBody.message;
-        } catch (error) {
-          errorMessage = response.statusText;
+
+          error = new NotificationsApiError(
+            errorBody.message,
+            response.status,
+            errorBody
+          );
+        } catch {
+          error = new NotificationsApiError(
+            response.statusText,
+            response.status
+          );
         }
-        throw new Error(
-          `Request failed with status ${response.status}: ${errorMessage}`
-        );
+
+        throw error;
       }
     }
 
@@ -2871,19 +2882,24 @@ export function createRoom<
   }
 
   function getRoomNotificationSettings(): Promise<RoomNotificationSettings> {
-    return fetchJson<RoomNotificationSettings>("/notification-settings");
+    return fetchInboxNotificationJson<RoomNotificationSettings>(
+      "/notification-settings"
+    );
   }
 
   function updateRoomNotificationSettings(
     settings: Partial<RoomNotificationSettings>
   ): Promise<RoomNotificationSettings> {
-    return fetchJson<RoomNotificationSettings>("/notification-settings", {
-      method: "POST",
-      body: JSON.stringify(settings),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    return fetchInboxNotificationJson<RoomNotificationSettings>(
+      "/notification-settings",
+      {
+        method: "POST",
+        body: JSON.stringify(settings),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
   }
 
   return Object.defineProperty(

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2835,7 +2835,7 @@ export function createRoom<
     fetchClientApi
   );
 
-  async function fetchInboxNotificationJson<T>(
+  async function fetchNotificationsJson<T>(
     endpoint: string,
     options?: RequestInit
   ): Promise<T> {
@@ -2882,7 +2882,7 @@ export function createRoom<
   }
 
   function getRoomNotificationSettings(): Promise<RoomNotificationSettings> {
-    return fetchInboxNotificationJson<RoomNotificationSettings>(
+    return fetchNotificationsJson<RoomNotificationSettings>(
       "/notification-settings"
     );
   }
@@ -2890,7 +2890,7 @@ export function createRoom<
   function updateRoomNotificationSettings(
     settings: Partial<RoomNotificationSettings>
   ): Promise<RoomNotificationSettings> {
-    return fetchInboxNotificationJson<RoomNotificationSettings>(
+    return fetchNotificationsJson<RoomNotificationSettings>(
       "/notification-settings",
       {
         method: "POST",

--- a/packages/liveblocks-react/src/__tests__/_restMocks.ts
+++ b/packages/liveblocks-react/src/__tests__/_restMocks.ts
@@ -119,3 +119,16 @@ export function mockGetRoomNotificationSettings(
     resolver
   );
 }
+
+export function mockUpdateRoomNotificationSettings(
+  resolver: ResponseResolver<
+    RestRequest<never, never>,
+    RestContext,
+    RoomNotificationSettings
+  >
+) {
+  return rest.post(
+    "https://api.liveblocks.io/v2/c/rooms/room-id/notification-settings",
+    resolver
+  );
+}

--- a/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
@@ -154,11 +154,11 @@ describe("useRoomNotificationSettings", () => {
     });
 
     await waitFor(() => {
-      // The readAt field should have been updated in the inbox notification cache
+      // Notification settings should be reverted to the original value ("all") after the error response from the server
       expect(result.current[0]).toEqual({
         isLoading: false,
         settings: {
-          threads: "none",
+          threads: "all",
         },
       });
     });

--- a/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
@@ -2,14 +2,17 @@ import "@testing-library/jest-dom";
 
 import type { BaseMetadata, JsonObject } from "@liveblocks/core";
 import { createClient } from "@liveblocks/core";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
 
 import { createLiveblocksContext } from "../liveblocks";
 import { createRoomContext } from "../room";
 import MockWebSocket from "./_MockWebSocket";
-import { mockGetRoomNotificationSettings } from "./_restMocks";
+import {
+  mockGetRoomNotificationSettings,
+  mockUpdateRoomNotificationSettings,
+} from "./_restMocks";
 
 const server = setupServer();
 
@@ -95,6 +98,76 @@ describe("useRoomNotificationSettings", () => {
 
     unmount();
   });
+
+  test.failing(
+    "should update room notification settings optimistically and revert the updates if error response from server",
+    async () => {
+      server.use(
+        mockGetRoomNotificationSettings(async (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              threads: "all",
+            })
+          );
+        }),
+        mockUpdateRoomNotificationSettings((_req, res, ctx) =>
+          res(ctx.status(500))
+        )
+      );
+
+      const {
+        roomCtx: { RoomProvider, useRoomNotificationSettings },
+      } = createRoomContextForTest();
+
+      const { result, unmount } = renderHook(
+        () => useRoomNotificationSettings(),
+        {
+          wrapper: ({ children }) => (
+            <RoomProvider id="room-id" initialPresence={{}}>
+              {children}
+            </RoomProvider>
+          ),
+        }
+      );
+
+      expect(result.current[0]).toEqual({ isLoading: true });
+
+      await waitFor(() =>
+        expect(result.current[0]).toEqual({
+          isLoading: false,
+          settings: {
+            threads: "all",
+          },
+        })
+      );
+
+      const updateRoomNotificationSettings = result.current[1];
+      // Update the room notification settings to none
+      await act(() => {
+        updateRoomNotificationSettings({ threads: "none" });
+      });
+
+      // Notification settings should be updated optimistically
+      expect(result.current[0]).toEqual({
+        isLoading: false,
+        settings: {
+          threads: "none",
+        },
+      });
+
+      await waitFor(() => {
+        // The readAt field should have been updated in the inbox notification cache
+        expect(result.current[0]).toEqual({
+          isLoading: false,
+          settings: {
+            threads: "none",
+          },
+        });
+      });
+
+      unmount();
+    }
+  );
 });
 
 describe("useRoomNotificationSettings suspense", () => {


### PR DESCRIPTION
Fixes https://github.com/liveblocks/liveblocks.io/issues/1955

`onMutationFailure` method throws the error if the error isn't an instance of `CommentsApiError` or `NotificationsApiError`, and the notification related room methods threw `Error` object instead of `NotificationsApiError`, so this wasn't being handled correctly.

```tsx
function onMutationFailure(
  innerError: Error,
  optimisticUpdateId: string,
  createPublicError: (error: Error) => CommentsError<TThreadMetadata>
) {
  store.set((state) => ({
    ...state,
    optimisticUpdates: state.optimisticUpdates.filter(
      (update) => update.id !== optimisticUpdateId
    ),
  }));

  if (innerError instanceof CommentsApiError) {
    const error = handleApiError(innerError);
    commentsErrorEventSource.notify(createPublicError(error));
    return;
  }

  if (innerError instanceof NotificationsApiError) {
    handleApiError(innerError);
    // TODO: Create public error and notify via notificationsErrorEventSource?
    return;
  }

  throw innerError;
}
```