### PR TITLE
Fix race condition that could leave zombie websockets open indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+### `@liveblocks/client`
+
+- Fix race condition in client that could leave zombie websockets open
+  indefinitely in a small edge case (thanks for reporting, @dev-badace)
+
 ### `@liveblocks/react`
 
 - Fix type definitions of `useOthersListener` hook

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -585,6 +585,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
       //
       async (ctx) => {
         let capturedPrematureEvent: IWebSocketEvent | null = null;
+        let unconfirmedSocket: IWebSocketInstance | null = null;
 
         const connect$ = new Promise<[IWebSocketInstance, () => void]>(
           (resolve, rej) => {
@@ -594,6 +595,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
             }
 
             const socket = delegates.createSocket(ctx.authValue as T);
+            unconfirmedSocket = socket;
 
             function reject(event: IWebSocketEvent) {
               capturedPrematureEvent = event;
@@ -709,6 +711,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
             }
           )
           .catch((e) => {
+            teardownSocket(unconfirmedSocket);
             throw e;
           });
       },

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -683,33 +683,34 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
           connect$,
           SOCKET_CONNECT_TIMEOUT,
           "Timed out during websocket connection"
-        ).then(
-          //
-          // Part 3:
-          // By now, our "open" event has fired, and the promise has been
-          // resolved. Two possible scenarios:
-          //
-          // 1. The happy path. Most likely.
-          // 2. Uh-oh. A premature close/error event has been observed. Let's
-          //    reject the promise after all.
-          //
-          // Any close/error event that will get scheduled after this point
-          // onwards, will be caught in the OK state, and dealt with
-          // accordingly.
-          //
-          ([socket, unsub]) => {
-            unsub();
-
-            if (capturedPrematureEvent) {
-              throw capturedPrematureEvent;
-            }
-
-            return socket;
-          }
         )
-        .catch((e) => {
-          throw e;
-        });
+          .then(
+            //
+            // Part 3:
+            // By now, our "open" event has fired, and the promise has been
+            // resolved. Two possible scenarios:
+            //
+            // 1. The happy path. Most likely.
+            // 2. Uh-oh. A premature close/error event has been observed. Let's
+            //    reject the promise after all.
+            //
+            // Any close/error event that will get scheduled after this point
+            // onwards, will be caught in the OK state, and dealt with
+            // accordingly.
+            //
+            ([socket, unsub]) => {
+              unsub();
+
+              if (capturedPrematureEvent) {
+                throw capturedPrematureEvent;
+              }
+
+              return socket;
+            }
+          )
+          .catch((e) => {
+            throw e;
+          });
       },
 
       // Only transition to OK state after a successfully opened WebSocket connection

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -706,7 +706,10 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
 
             return socket;
           }
-        );
+        )
+        .catch((e) => {
+          throw e;
+        });
       },
 
       // Only transition to OK state after a successfully opened WebSocket connection

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -362,31 +362,37 @@ export class FSM<
 
   public onEnterAsync<T>(
     nameOrPattern: TState | Wildcard<TState>,
-    promiseFn: (context: Readonly<TContext>) => Promise<T>,
+    promiseFn: (context: Readonly<TContext>, signal: AbortSignal) => Promise<T>,
     onOK: Target<TContext, AsyncOKEvent<T>, TState>,
     onError: Target<TContext, AsyncErrorEvent, TState>
   ): this {
     return this.onEnter(nameOrPattern, () => {
-      let cancelled = false;
+      const abortController = new AbortController();
+      const signal = abortController.signal;
 
-      void promiseFn(this.currentContext.current).then(
+      let done = false;
+      void promiseFn(this.currentContext.current, signal).then(
         // On OK
         (data: T) => {
-          if (!cancelled) {
+          if (!signal.aborted) {
+            done = true;
             this.transition({ type: "ASYNC_OK", data }, onOK);
           }
         },
 
         // On Error
         (reason: unknown) => {
-          if (!cancelled) {
+          if (!signal.aborted) {
+            done = true;
             this.transition({ type: "ASYNC_ERROR", reason }, onError);
           }
         }
       );
 
       return () => {
-        cancelled = true;
+        if (!done) {
+          abortController.abort();
+        }
       };
     });
   }


### PR DESCRIPTION
Fixes #1459.

This PR fixes a race condition in the client that could leave zombie websockets open indefinitely in a small edge case. If this bug manifests, one client would hold multiple connections to the same room, making it appear as if multiple users were connected to the room, and taking up valuable seats in the room. (This incorrect state would only exist temporarily, since the lack of heartbeat would kill those zombie sockets a bit later anyway.)

Can you confirm this fixes the issue, @dev-bahttps://github.com/liveblocks/liveblocks/pull/1463dace?

Thanks so much for reporting and providing these amazingly clear replication steps, @dev-badace! 😍 This made the bug obvious and the fix easy.
