### PR TITLE
Tiny test tweak

### DIFF
--- a/packages/liveblocks-core/src/__tests__/auth-manager.test.ts
+++ b/packages/liveblocks-core/src/__tests__/auth-manager.test.ts
@@ -374,7 +374,7 @@ describe("auth-manager - secret auth", () => {
     await expect(
       authManager.getAuthValue("room:read", "room1")
     ).rejects.toThrow(
-      'Expected a JSON response when doing a POST request on "/mocked-api/not-json". SyntaxError: Unexpected token h in JSON at position 1'
+      'Expected a JSON response when doing a POST request on "/mocked-api/not-json". SyntaxError: Unexpected token'
     );
   });
 


### PR DESCRIPTION
Slightly change error message assertion here, so other runtimes (and other versions of node where this error message is slightly different) will also pass this test.
