### PR TITLE
Make the E2E tests a bit more robust

### DIFF
--- a/e2e/next-sandbox/pages/auth/acc-token.tsx
+++ b/e2e/next-sandbox/pages/auth/acc-token.tsx
@@ -1,12 +1,12 @@
-import { createClient } from "@liveblocks/client";
 import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
 
 import { getRoomFromUrl } from "../../utils";
+import { createLiveblocksClient } from "../../utils/createClient";
 
-const client = createClient({
+const client = createLiveblocksClient({
   authEndpoint: "/api/auth/access-token",
 
   // @ts-expect-error - Hidden setting

--- a/e2e/next-sandbox/pages/auth/acc-token.tsx
+++ b/e2e/next-sandbox/pages/auth/acc-token.tsx
@@ -1,4 +1,3 @@
-import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
@@ -8,12 +7,6 @@ import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient({
   authEndpoint: "/api/auth/access-token",
-
-  // @ts-expect-error - Hidden setting
-  baseUrl: nn(
-    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
-    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
-  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/id-token.tsx
+++ b/e2e/next-sandbox/pages/auth/id-token.tsx
@@ -1,4 +1,3 @@
-import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
@@ -8,12 +7,6 @@ import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient({
   authEndpoint: "/api/auth/id-token",
-
-  // @ts-expect-error - Hidden setting
-  baseUrl: nn(
-    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
-    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
-  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/id-token.tsx
+++ b/e2e/next-sandbox/pages/auth/id-token.tsx
@@ -1,12 +1,12 @@
-import { createClient } from "@liveblocks/client";
 import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
 
 import { getRoomFromUrl } from "../../utils";
+import { createLiveblocksClient } from "../../utils/createClient";
 
-const client = createClient({
+const client = createLiveblocksClient({
   authEndpoint: "/api/auth/id-token",
 
   // @ts-expect-error - Hidden setting

--- a/e2e/next-sandbox/pages/auth/pubkey.tsx
+++ b/e2e/next-sandbox/pages/auth/pubkey.tsx
@@ -11,12 +11,6 @@ const client = createLiveblocksClient({
     process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY,
     "Please specify NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY env var"
   ),
-
-  // @ts-expect-error - Hidden setting
-  baseUrl: nn(
-    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
-    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
-  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/pubkey.tsx
+++ b/e2e/next-sandbox/pages/auth/pubkey.tsx
@@ -1,12 +1,12 @@
-import { createClient } from "@liveblocks/client";
 import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
 
 import { getRoomFromUrl } from "../../utils";
+import { createLiveblocksClient } from "../../utils/createClient";
 
-const client = createClient({
+const client = createLiveblocksClient({
   publicApiKey: nn(
     process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY,
     "Please specify NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY env var"

--- a/e2e/next-sandbox/pages/auth/secret-legacy.tsx
+++ b/e2e/next-sandbox/pages/auth/secret-legacy.tsx
@@ -1,4 +1,3 @@
-import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
@@ -8,12 +7,6 @@ import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient({
   authEndpoint: "/api/auth/legacy-token",
-
-  // @ts-expect-error - Hidden setting
-  baseUrl: nn(
-    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
-    "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
-  ),
 });
 
 const { RoomProvider, useMyPresence, useSelf, useOthers, useStatus } =

--- a/e2e/next-sandbox/pages/auth/secret-legacy.tsx
+++ b/e2e/next-sandbox/pages/auth/secret-legacy.tsx
@@ -1,12 +1,12 @@
-import { createClient } from "@liveblocks/client";
 import { nn } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import Link from "next/link";
 import React from "react";
 
 import { getRoomFromUrl } from "../../utils";
+import { createLiveblocksClient } from "../../utils/createClient";
 
-const client = createClient({
+const client = createLiveblocksClient({
   authEndpoint: "/api/auth/legacy-token",
 
   // @ts-expect-error - Hidden setting

--- a/e2e/next-sandbox/pages/batching.tsx
+++ b/e2e/next-sandbox/pages/batching.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import { getRoomFromUrl, Row, styles, useRenderCount } from "../utils";
 import Button from "../utils/Button";
-import createLiveblocksClient from "../utils/createClient";
+import { createLiveblocksClient } from "../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/comments/index.tsx
+++ b/e2e/next-sandbox/pages/comments/index.tsx
@@ -4,7 +4,7 @@ import { useRef } from "react";
 
 import { getRoomFromUrl, Row } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/comments/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/comments/with-suspense.tsx
@@ -4,7 +4,7 @@ import { useRef } from "react";
 
 import { getRoomFromUrl, Row } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/multi.tsx
+++ b/e2e/next-sandbox/pages/multi.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import { getRoomFromUrl, Row, styles, useRenderCount } from "../utils";
 import Button from "../utils/Button";
-import createLiveblocksClient from "../utils/createClient";
+import { createLiveblocksClient } from "../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/offline.tsx
+++ b/e2e/next-sandbox/pages/offline.tsx
@@ -13,7 +13,7 @@ import {
   useRenderCount,
 } from "../utils";
 import Button from "../utils/Button";
-import createLiveblocksClient from "../utils/createClient";
+import { createLiveblocksClient } from "../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/presence/index.tsx
+++ b/e2e/next-sandbox/pages/presence/index.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import { getRoomFromUrl, Row, styles, useRenderCount } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/presence/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/presence/with-suspense.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import { getRoomFromUrl, Row, styles, useRenderCount } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/storage/list-with-suspense.tsx
+++ b/e2e/next-sandbox/pages/storage/list-with-suspense.tsx
@@ -12,7 +12,7 @@ import {
   useRenderCount,
 } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/storage/list.tsx
+++ b/e2e/next-sandbox/pages/storage/list.tsx
@@ -12,7 +12,7 @@ import {
   useRenderCount,
 } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/storage/map.tsx
+++ b/e2e/next-sandbox/pages/storage/map.tsx
@@ -10,7 +10,7 @@ import {
   useRenderCount,
 } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/storage/object.tsx
+++ b/e2e/next-sandbox/pages/storage/object.tsx
@@ -11,7 +11,7 @@ import {
   useRenderCount,
 } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/ydoc/subdoc.tsx
+++ b/e2e/next-sandbox/pages/ydoc/subdoc.tsx
@@ -6,7 +6,7 @@ import * as Y from "yjs";
 
 import { getRoomFromUrl, Row, styles, useRenderCount } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/ydoc/text.tsx
+++ b/e2e/next-sandbox/pages/ydoc/text.tsx
@@ -5,7 +5,7 @@ import * as Y from "yjs";
 
 import { getRoomFromUrl, Row, styles, useRenderCount } from "../../utils";
 import Button from "../../utils/Button";
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/pages/zustand.tsx
+++ b/e2e/next-sandbox/pages/zustand.tsx
@@ -12,7 +12,7 @@ import {
   useRenderCount,
 } from "../utils";
 import Button from "../utils/Button";
-import createLiveblocksClient from "../utils/createClient";
+import { createLiveblocksClient } from "../utils/createClient";
 
 const client = createLiveblocksClient();
 

--- a/e2e/next-sandbox/test/batching.test.ts
+++ b/e2e/next-sandbox/test/batching.test.ts
@@ -7,6 +7,7 @@ import {
   preparePages,
   waitForJson,
   waitUntilEqualOnAllPages,
+  waitUntilFlushed,
 } from "./utils";
 
 test.describe.configure({ mode: "parallel" });
@@ -31,9 +32,11 @@ test.describe("Storage - Batching", () => {
 
     await page1.click("#clear");
     await expectJson(page1, "#numItems", 0);
+    await waitUntilFlushed();
 
     await page1.click("#update-storage-presence-batch");
     await expectJson(page1, "#numItems", 1);
+    await waitUntilFlushed();
 
     await waitUntilEqualOnAllPages(pages, "#items");
 
@@ -41,6 +44,7 @@ test.describe("Storage - Batching", () => {
     await expectJson(page2, "#theirPresence", { count: 1 });
 
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
   });
 

--- a/e2e/next-sandbox/test/offline.test.ts
+++ b/e2e/next-sandbox/test/offline.test.ts
@@ -7,9 +7,9 @@ import {
   nanoSleep,
   pickFrom,
   preparePages,
-  sleep,
   waitForJson,
   waitUntilEqualOnAllPages,
+  waitUntilFlushed,
 } from "./utils";
 
 test.describe.configure({ mode: "parallel" });
@@ -106,6 +106,7 @@ test.describe("Offline", () => {
     await waitForJson(pages, "#socketStatus", "connected");
 
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
 
     // Page 1 loses network connectivity
@@ -209,15 +210,22 @@ test.describe("Offline", () => {
   test("forced disconnect (via invalid message)", async () => {
     const [page1, page2] = pages;
     await waitForJson(pages, "#socketStatus", "connected");
+
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
     await waitForJson(pages, "#numOthers", 1);
 
     await page1.click("#push");
+    await waitUntilFlushed();
+    await waitForJson(pages, "#numItems", 1);
+
     await page1.click("#send-invalid-data");
-    await sleep(300); // give the server a few millis to disconnect
+    await waitUntilFlushed();
+
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitForJson(page1, "#socketStatus", "disconnected");
 
     // Client A will see the local push, but client B will never receive it
@@ -231,14 +239,22 @@ test.describe("Offline", () => {
   test("forced disconnect (via not allowed)", async () => {
     const [page1, page2] = pages;
     await waitForJson(pages, "#socketStatus", "connected");
+
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
     await waitForJson(pages, "#numOthers", 1);
 
     await page1.click("#push");
+    await waitUntilFlushed();
+    await waitForJson(pages, "#numItems", 1);
+
     await page1.click("#close-with-not-allowed");
+    await waitUntilFlushed();
+
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitForJson(page1, "#socketStatus", "disconnected");
 
     // Client A will see the local push, but client B will never receive it
@@ -252,14 +268,22 @@ test.describe("Offline", () => {
   test("forced disconnect (via room full)", async () => {
     const [page1, page2] = pages;
     await waitForJson(pages, "#socketStatus", "connected");
+
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
     await waitForJson(pages, "#numOthers", 1);
 
     await page1.click("#push");
+    await waitUntilFlushed();
+    await waitForJson(pages, "#numItems", 1);
+
     await page1.click("#close-with-room-full");
+    await waitUntilFlushed();
+
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitForJson(page1, "#socketStatus", "disconnected");
 
     // Client A will see the local push, but client B will never receive it
@@ -273,14 +297,22 @@ test.describe("Offline", () => {
   test("forced disconnect (via explicit ask to not retry)", async () => {
     const [page1, page2] = pages;
     await waitForJson(pages, "#socketStatus", "connected");
+
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
     await waitForJson(pages, "#numOthers", 1);
 
     await page1.click("#push");
+    await waitUntilFlushed();
+    await waitForJson(pages, "#numItems", 1);
+
     await page1.click("#close-with-dont-retry");
+    await waitUntilFlushed();
+
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitForJson(page1, "#socketStatus", "disconnected");
 
     // Client A will see the local push, but client B will never receive it

--- a/e2e/next-sandbox/test/redux.test.ts
+++ b/e2e/next-sandbox/test/redux.test.ts
@@ -9,6 +9,7 @@ import {
   preparePages,
   waitForJson,
   waitUntilEqualOnAllPages,
+  waitUntilFlushed,
 } from "./utils";
 
 test.describe.configure({ mode: "parallel" });
@@ -33,20 +34,25 @@ test.describe("Redux", () => {
     await waitForJson(pages, "#socketStatus", "connected");
 
     await page1.click("#clear");
+    await waitUntilFlushed();
     await expectJson(page1, "#numItems", 0);
     await waitForJson(pages, "#numOthers", 1);
 
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 3);
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
     await waitForJson(page2, "#theirPresence", { counter: 0 });
   });
@@ -65,18 +71,22 @@ test.describe("Redux", () => {
     await page1.click("#set-name");
     await page1.click("#inc-counter");
     await page1.click("#inc-counter");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#push");
     await page1.click("#set-name");
     await page1.click("#inc-counter");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 3);
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
     await waitForJson(page2, "#theirPresence", { counter: 3, name: "Vincent" });
   });

--- a/e2e/next-sandbox/test/utils.ts
+++ b/e2e/next-sandbox/test/utils.ts
@@ -4,6 +4,7 @@ import { chromium, expect } from "@playwright/test";
 import _ from "lodash";
 
 import { randomInt } from "../utils";
+import { DEFAULT_THROTTLE } from "../utils/createClient";
 
 export type IDSelector = `#${string}`;
 
@@ -171,6 +172,13 @@ export async function waitForTextContains(
       })
     )
   );
+}
+
+export async function waitUntilFlushed() {
+  // This isn't a fancy implementation. It just waits for <default throttle>
+  // millis, so by the time the test continues, the messages have been sent to
+  // the server ¯\_(ツ)_/¯
+  await sleep(DEFAULT_THROTTLE);
 }
 
 export async function expectJson(

--- a/e2e/next-sandbox/test/zustand.test.ts
+++ b/e2e/next-sandbox/test/zustand.test.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { test } from "@playwright/test";
 
-import type { IDSelector } from "./utils";
+import { IDSelector, waitUntilFlushed } from "./utils";
 import {
   expectJson,
   genRoomId,
@@ -38,19 +38,23 @@ test.describe("Zustand", () => {
 
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
 
     await page1.click("#push");
     await page1.click("#push");
     await page1.click("#push");
+    await waitUntilFlushed();
     await waitUntilEqualOnAllPages(pages, "#items");
     await expectJson(page2, "#numItems", 7);
 
     await page1.click("#clear");
+    await waitUntilFlushed();
     await waitForJson(pages, "#numItems", 0);
   });
 

--- a/e2e/next-sandbox/utils/createClient.ts
+++ b/e2e/next-sandbox/utils/createClient.ts
@@ -4,7 +4,11 @@ import { nn } from "@liveblocks/core";
 
 export const DEFAULT_THROTTLE = 100;
 
-export function createLiveblocksClient(options: Partial<ClientOptions> = {}) {
+export function createLiveblocksClient(
+  options: Omit<Partial<ClientOptions>, "publicApiKey"> & {
+    publicApiKey?: string;
+  } = {}
+) {
   const defaultAuthEndpoint = "/api/auth/access-token";
 
   if (

--- a/e2e/next-sandbox/utils/createClient.ts
+++ b/e2e/next-sandbox/utils/createClient.ts
@@ -6,7 +6,7 @@ const DEFAULT_E2E_OPTIONS = {
   authEndpoint: "/api/auth/access-token",
 };
 
-export const DEFAULT_THROTTLE = 100;
+export const DEFAULT_THROTTLE = 16;
 
 /**
  * Like your regular createClient(), but will override the base URL, and use

--- a/e2e/next-sandbox/utils/createClient.ts
+++ b/e2e/next-sandbox/utils/createClient.ts
@@ -1,15 +1,34 @@
-import { createClient } from "@liveblocks/client";
+import type { ClientOptions } from "@liveblocks/client";
+import { createClient as realCreateClient } from "@liveblocks/client";
 import { nn } from "@liveblocks/core";
 
-export default function createLiveblocksClient() {
-  return createClient({
-    authEndpoint: "/api/auth/access-token",
+export const DEFAULT_THROTTLE = 100;
+
+export function createLiveblocksClient(options: Partial<ClientOptions> = {}) {
+  const defaultAuthEndpoint = "/api/auth/access-token";
+
+  if (
+    options.publicApiKey === undefined &&
+    options.authEndpoint === undefined
+  ) {
+    options = {
+      ...options,
+      publicApiKey: undefined,
+      authEndpoint: defaultAuthEndpoint,
+    };
+  }
+
+  return realCreateClient({
+    throttle: DEFAULT_THROTTLE,
 
     // @ts-expect-error - Hidden settings
     baseUrl: nn(
       process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
       "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
     ),
+
     enableDebugLogging: true,
+
+    ...options,
   });
 }

--- a/e2e/next-sandbox/utils/createClient.ts
+++ b/e2e/next-sandbox/utils/createClient.ts
@@ -2,37 +2,29 @@ import type { ClientOptions } from "@liveblocks/client";
 import { createClient as realCreateClient } from "@liveblocks/client";
 import { nn } from "@liveblocks/core";
 
+const DEFAULT_E2E_OPTIONS = {
+  authEndpoint: "/api/auth/access-token",
+};
+
 export const DEFAULT_THROTTLE = 100;
 
+/**
+ * Like your regular createClient(), but will override the base URL, and use
+ * a faster-than-normal throttle.
+ */
 export function createLiveblocksClient(
-  options: Omit<Partial<ClientOptions>, "publicApiKey"> & {
-    publicApiKey?: string;
-  } = {}
+  options: ClientOptions = DEFAULT_E2E_OPTIONS
 ) {
-  const defaultAuthEndpoint = "/api/auth/access-token";
-
-  if (
-    options.publicApiKey === undefined &&
-    options.authEndpoint === undefined
-  ) {
-    options = {
-      ...options,
-      publicApiKey: undefined,
-      authEndpoint: defaultAuthEndpoint,
-    };
-  }
+  options.throttle ??= DEFAULT_THROTTLE;
 
   return realCreateClient({
-    throttle: DEFAULT_THROTTLE,
+    ...options,
 
     // @ts-expect-error - Hidden settings
+    enableDebugLogging: true,
     baseUrl: nn(
       process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
       "Please specify NEXT_PUBLIC_LIVEBLOCKS_BASE_URL env var"
     ),
-
-    enableDebugLogging: true,
-
-    ...options,
   });
 }

--- a/e2e/next-sandbox/utils/for-redux/store.ts
+++ b/e2e/next-sandbox/utils/for-redux/store.ts
@@ -2,7 +2,7 @@ import { liveblocksEnhancer, type WithLiveblocks } from "@liveblocks/redux";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { configureStore, createSlice } from "@reduxjs/toolkit";
 
-import createLiveblocksClient from "../../utils/createClient";
+import { createLiveblocksClient } from "../../utils/createClient";
 
 export const client = createLiveblocksClient();
 

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -9,6 +9,7 @@ export type {
   BaseUserMeta,
   BroadcastOptions,
   Client,
+  ClientOptions,
   CommentBody,
   CommentBodyBlockElement,
   CommentBodyElement,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -16,7 +16,7 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
  * https://join.team/liveblocks ;)
  */
 
-export type { Client, EnterOptions } from "./client";
+export type { Client, ClientOptions, EnterOptions } from "./client";
 export { createClient } from "./client";
 export type { BaseAuthResult, Delegates, LiveblocksError } from "./connection";
 export type {

--- a/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
+++ b/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
@@ -17,22 +17,27 @@ enum WebSocketErrorCodes {
 }
 
 export default class MockWebSocket {
-  readyState: number;
-  static instances: MockWebSocket[] = [];
+  public readyState: number;
 
-  isMock = true;
+  private static nextActor = 0;
+  public static readonly instances: MockWebSocket[] = [];
 
-  callbacks = {
+  public readonly isMock = true;
+
+  // Registered event listeners
+  public readonly callbacks = {
     open: [] as Array<(event?: WebSocketEventMap["open"]) => void>,
     close: [] as Array<(event?: WebSocketEventMap["close"]) => void>,
     error: [] as Array<(event?: WebSocketEventMap["error"]) => void>,
     message: [] as Array<(event?: WebSocketEventMap["message"]) => void>,
   };
 
-  sentMessages: string[] = [];
+  public readonly sentMessages: string[] = [];
 
   constructor(public url: string) {
-    const actor = MockWebSocket.instances.push(this) - 1;
+    MockWebSocket.instances.push(this);
+    const actor = MockWebSocket.nextActor++;
+
     this.readyState = 0 /* CONNECTING */;
 
     // Fake the server accepting the new connection
@@ -54,6 +59,11 @@ export default class MockWebSocket {
         msgCb({ data: JSON.stringify(msg) } as MessageEvent);
       }
     }, 0);
+  }
+
+  public static reset() {
+    MockWebSocket.instances.length = 0;
+    MockWebSocket.nextActor = 0;
   }
 
   addEventListener(event: "open", callback: (event: Event) => void): void;

--- a/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
+++ b/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
@@ -113,8 +113,8 @@ export async function waitForSocketToBeConnected() {
   await waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
 
   const socket = MockWebSocket.instances[0];
-  expect(socket.callbacks.open.length).toBe(1); // Got open callback
-  expect(socket.callbacks.message.length).toBe(1); // Got ROOM_STATE message callback
+  expect(socket.callbacks.open).toEqual([expect.any(Function)]); // Got open callback
+  expect(socket.callbacks.message).toEqual([expect.any(Function)]); // Got ROOM_STATE message callback
 
   // Give open callback (scheduled for next tick) a chance to finish before returning
   await wait(0);

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -44,10 +44,10 @@ const server = setupServer(
 
 beforeAll(() => server.listen());
 afterEach(() => {
-  MockWebSocket.instances = [];
+  MockWebSocket.reset();
 });
 beforeEach(() => {
-  MockWebSocket.instances = [];
+  MockWebSocket.reset();
 });
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/packages/liveblocks-react/src/__tests__/polling.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/polling.test.tsx
@@ -17,12 +17,12 @@ const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 beforeEach(() => {
-  MockWebSocket.instances = [];
+  MockWebSocket.reset();
   jest.useFakeTimers();
 });
 
 afterEach(() => {
-  MockWebSocket.instances = [];
+  MockWebSocket.reset();
   jest.useRealTimers();
   server.resetHandlers();
 });

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -19,14 +19,14 @@ const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 beforeEach(() => {
-  MockWebSocket.instances = [];
+  MockWebSocket.reset();
   jest.useFakeTimers();
   // Initial state is online (by default) and visible
   mockVisibility.mockReturnValue("visible");
 });
 
 afterEach(() => {
-  MockWebSocket.instances = [];
+  MockWebSocket.reset();
   jest.useRealTimers();
   server.resetHandlers();
 });


### PR DESCRIPTION
This PR:

- Uses a single `createClient()` helper for all pages, which sets the base URL and configures a lower throttle time.
- Uses `waitUntilFlushed()` helper which you can click after pressing buttons in the UI, to ensure that enough time has passed to flush the ops over the network, before asserting. Oftentimes, the assertions are already waiting, but this makes it more explicit and also silghtly more robust when it comes to edge cases.
- Lowers the default throttle time for our client to 16ms.

I've updated a handful of tests by adding in those `await waitUntilFlushed()` calls, but there are more tests that would benefit from this. The best way to find which ones is by setting the default throttle time to 1000 milliseconds, which increases the change of those tests failing.
