### PR TITLE
Temporary change of permission logic for access token for notifications

### DIFF
--- a/packages/liveblocks-node/src/Session.ts
+++ b/packages/liveblocks-node/src/Session.ts
@@ -183,10 +183,9 @@ export class Session {
   public async authorize(): Promise<AuthResponse> {
     this.seal();
     if (!this.hasPermissions()) {
-      return {
-        status: 403,
-        body: "Forbidden",
-      };
+      console.warn(
+        "Access tokens without any permission will not be supported soon, you should use wildcards when the client requests a token for resources outside a room. See https://liveblocks.io/docs/errors/liveblocks-client/access-tokens-not-enough-permissions"
+      );
     }
 
     try {


### PR DESCRIPTION
### Description
In this PR, we change the liveblocks-node `authorize` method to allow access token with no permission.
The client's auth manager accepts access tokens with no permissions for requests without roomId.
