### PR TITLE
Support “@“ in mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This release introduces Notifications (and unread indicators) for Comments.
 
 - Add new default components: `InboxNotification` and `InboxNotificationList`.
 - Add unread indicators to the default `Thread` component.
+- Support "@" in mentions. (e.g. `@user@email.com` is now a valid mention and
+  will trigger `resolveMentionSuggestions` with `"user@email.com"`)
 
 ### `@liveblocks/node`
 

--- a/packages/liveblocks-react-comments/src/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-comments/src/slate/plugins/mentions.ts
@@ -28,26 +28,25 @@ export function getMentionDraftAtSelection(
     return;
   }
 
-  const match = getMatchRange(editor, selection, [MENTION_CHARACTER]);
+  // Match the word at the current selection by walking back until
+  // a terminator is found (whitespace, special characters like "!", etc)
+  const match = getMatchRange(editor, selection);
 
   if (!match) {
     return;
   }
 
-  const mentionCharacter = getCharacterBefore(editor, match);
+  const matchText = SlateEditor.string(editor, match);
 
-  // Check if the match is preceded by the mention character
-  if (!mentionCharacter || mentionCharacter.text !== MENTION_CHARACTER) {
+  // Check if the match starts with the mention character
+  if (!matchText.startsWith(MENTION_CHARACTER)) {
     return;
   }
 
   return {
-    range: SlateEditor.range(
-      editor,
-      mentionCharacter.range,
-      SlateRange.end(match)
-    ),
-    text: SlateEditor.string(editor, match),
+    range: match,
+    // Exclude the mention character from the text
+    text: matchText.substring(1),
   };
 }
 

--- a/packages/liveblocks-react-comments/src/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-comments/src/slate/plugins/mentions.ts
@@ -28,8 +28,8 @@ export function getMentionDraftAtSelection(
     return;
   }
 
-  // Match the word at the current selection by walking back until
-  // a terminator is found (whitespace, special characters like "!", etc)
+  // Match the word at the current selection by walking back
+  // until a whitespace character is found
   const match = getMatchRange(editor, selection);
 
   if (!match) {


### PR DESCRIPTION
This PR adds support for “@“ in mentions. Currently, typing “@“ in a mention results in a new mention starting.

The current logic is to walk back until an “@“ is found, the new logic is to walk back until a whitespace character is found instead, and after that, check if the range that was found starts with an “@“.

We’re already adding whitespace characters (if necessary) when inserting “@“ via the mention button so those scenarios are handled by the new logic automatically. 

Fixes https://github.com/liveblocks/liveblocks.io/issues/1965.

https://github.com/liveblocks/liveblocks/assets/6959425/84a8255e-afbd-4b57-a907-a67fc83bd9de