### PR TITLE
Add error retrying logic to `useThreads` and `useThreadsSuspense`

### DIFF
--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -4,6 +4,7 @@ import type { BaseMetadata, JsonObject } from "@liveblocks/core";
 import { createClient, kInternal, ServerMsgCode } from "@liveblocks/core";
 import {
   act,
+  fireEvent,
   render,
   renderHook,
   screen,
@@ -14,6 +15,7 @@ import { rest } from "msw";
 import { setupServer } from "msw/node";
 import type { ReactNode } from "react";
 import React, { Suspense } from "react";
+import type { FallbackProps } from "react-error-boundary";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { createLiveblocksContext } from "../liveblocks";
@@ -1733,6 +1735,94 @@ describe("useThreadsSuspense", () => {
         screen.getByText("There was an error while getting threads.")
       ).toBeInTheDocument();
     });
+
+    unmount();
+  });
+});
+
+describe("useThreadsSuspense: error", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers(); // Restores the real timers
+  });
+
+  test("should retry with exponential backoff on error and clear error boundary", async () => {
+    let getThreadsReqCount = 0;
+    server.use(
+      mockGetThreads((_req, res, ctx) => {
+        getThreadsReqCount++;
+
+        if (getThreadsReqCount === 1) {
+          // Mock an error response from the server
+          return res(ctx.status(500));
+        } else {
+          // Mock a successful response from the server for the subsequent fetches
+          return res(
+            ctx.json({
+              data: [],
+              inboxNotifications: [],
+              deletedThreads: [],
+              deletedInboxNotifications: [],
+              meta: {
+                requestedAt: new Date().toISOString(),
+              },
+            })
+          );
+        }
+      })
+    );
+
+    const {
+      roomCtx: {
+        RoomProvider,
+        suspense: { useThreads },
+      },
+    } = createRoomContextForTest();
+
+    function Fallback({ resetErrorBoundary }: FallbackProps) {
+      return (
+        <div>
+          <p>There was an error while getting threads.</p>
+          <button onClick={resetErrorBoundary}>Retry</button>
+        </div>
+      );
+    }
+
+    const { result, unmount } = renderHook(() => useThreads(), {
+      wrapper: ({ children }) => (
+        <RoomProvider id="room-id" initialPresence={{}}>
+          <ErrorBoundary FallbackComponent={Fallback}>
+            <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+          </ErrorBoundary>
+        </RoomProvider>
+      ),
+    });
+
+    expect(result.current).toEqual(null);
+
+    // A new fetch request for the threads should have been made after the initial render
+    await waitFor(() => expect(getThreadsReqCount).toBe(1));
+    // Check if the error boundary's fallback UI is displayed
+    expect(
+      screen.getByText("There was an error while getting threads.")
+    ).toBeInTheDocument();
+
+    // The first retry should be made after ERROR_RETRY_INTERVAL * 2^0
+    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL);
+    // A new fetch request for the threads should have been made after the first retry
+    await waitFor(() => expect(getThreadsReqCount).toBe(2));
+
+    // Simulate clicking the retry button
+    fireEvent.click(screen.getByText("Retry"));
+
+    // The error boundary's fallback UI should be cleared
+    expect(
+      screen.queryByText("There was an error while getting threads.")
+    ).not.toBeInTheDocument();
 
     unmount();
   });

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -19,13 +19,7 @@ import type { FallbackProps } from "react-error-boundary";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { createLiveblocksContext } from "../liveblocks";
-import {
-  createRoomContext,
-  ERROR_RETRY_INTERVAL,
-  generateQueryKey,
-  MAX_ERROR_RETRY_COUNT,
-  POLLING_INTERVAL,
-} from "../room";
+import { createRoomContext, generateQueryKey, POLLING_INTERVAL } from "../room";
 import { dummyInboxNoficationData, dummyThreadData } from "./_dummies";
 import MockWebSocket, { websocketSimulator } from "./_MockWebSocket";
 import {
@@ -1114,21 +1108,21 @@ describe("useThreads: error", () => {
       error: expect.any(Error),
     });
 
-    // The first retry should be made after ERROR_RETRY_INTERVAL * 2^0
-    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL);
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
     // A new fetch request for the threads should have been made after the first retry
     await waitFor(() => expect(getThreadsReqCount).toBe(2));
 
-    // The second retry should be made after ERROR_RETRY_INTERVAL * 2^1
-    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL * Math.pow(2, 1));
+    // The second retry should be made after 5000ms * 2^1
+    jest.advanceTimersByTime(5000 * Math.pow(2, 1));
     await waitFor(() => expect(getThreadsReqCount).toBe(3));
 
-    // The third retry should be made after ERROR_RETRY_INTERVAL * 2^2
-    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL * Math.pow(2, 2));
+    // The third retry should be made after 5000ms * 2^2
+    jest.advanceTimersByTime(5000 * Math.pow(2, 2));
     await waitFor(() => expect(getThreadsReqCount).toBe(4));
 
-    // The fourth retry should be made after ERROR_RETRY_INTERVAL * 2^3
-    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL * Math.pow(2, 3));
+    // The fourth retry should be made after 5000ms * 2^3
+    jest.advanceTimersByTime(5000 * Math.pow(2, 3));
     await waitFor(() => expect(getThreadsReqCount).toBe(5));
 
     // and so on...
@@ -1170,22 +1164,20 @@ describe("useThreads: error", () => {
       error: expect.any(Error),
     });
 
-    // Simulate retries up to MAX_RETRY_COUNT
-    for (let i = 0; i < MAX_ERROR_RETRY_COUNT; i++) {
-      const interval = ERROR_RETRY_INTERVAL * Math.pow(2, i);
+    // Simulate retries up to maximum retry count (currently set to 5)
+    for (let i = 0; i < 5; i++) {
+      const interval = 5000 * Math.pow(2, i); // 5000ms is the currently set error retry interval
       jest.advanceTimersByTime(interval);
       await waitFor(() => expect(getThreadsReqCount).toBe(i + 2));
     }
 
-    expect(getThreadsReqCount).toBe(MAX_ERROR_RETRY_COUNT + 1); // initial request + MAX_ERROR_RETRY_COUNT retries
+    expect(getThreadsReqCount).toBe(1 + 5); // initial request + 5 retries
 
     // No more retries should be made after the maximum number of retries
-    await jest.advanceTimersByTimeAsync(
-      ERROR_RETRY_INTERVAL * Math.pow(2, MAX_ERROR_RETRY_COUNT)
-    );
+    await jest.advanceTimersByTimeAsync(5 * Math.pow(2, 5));
 
     // The number of requests should not have increased after the maximum number of retries
-    expect(getThreadsReqCount).toBe(MAX_ERROR_RETRY_COUNT + 1);
+    expect(getThreadsReqCount).toBe(5 + 1);
 
     unmount();
   });
@@ -1240,8 +1232,8 @@ describe("useThreads: error", () => {
       error: expect.any(Error),
     });
 
-    // The first retry should be made after ERROR_RETRY_INTERVAL * 2^0
-    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL);
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
     // A new fetch request for the threads should have been made after the first retry
     await waitFor(() => expect(getThreadsReqCount).toBe(2));
 
@@ -1251,7 +1243,7 @@ describe("useThreads: error", () => {
     });
 
     // No more retries should be made after successful retry
-    await jest.advanceTimersByTimeAsync(ERROR_RETRY_INTERVAL * Math.pow(2, 1));
+    await jest.advanceTimersByTimeAsync(5000 * Math.pow(2, 1));
     expect(getThreadsReqCount).toBe(2);
 
     unmount();
@@ -1811,8 +1803,8 @@ describe("useThreadsSuspense: error", () => {
       screen.getByText("There was an error while getting threads.")
     ).toBeInTheDocument();
 
-    // The first retry should be made after ERROR_RETRY_INTERVAL * 2^0
-    jest.advanceTimersByTime(ERROR_RETRY_INTERVAL);
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
     // A new fetch request for the threads should have been made after the first retry
     await waitFor(() => expect(getThreadsReqCount).toBe(2));
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1026,9 +1026,7 @@ export function createRoomContext<
         room.id
       );
 
-      const subscribers = subscribersByQuery.get(notificationSettingsQuery);
-      // If there are subscribers for the notification settings query, we retrieve the notification settings for the room
-      if (subscribers !== undefined && subscribers > 0) {
+      if (requestsByQuery.has(notificationSettingsQuery)) {
         requests.push(
           room[kInternal].notifications
             .getRoomNotificationSettings()

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1128,14 +1128,14 @@ export function createRoomContext<
     // If a request was already made for the query, we do not make another request and return the existing promise of the request
     if (existingRequest !== undefined) return existingRequest;
 
-    store.setQueryState(queryKey, {
-      isLoading: true,
-    });
-
     const request = room[kInternal].comments.getThreads(options);
 
     // Store the promise of the request for the query so that we do not make another request for the same query
     requestsByQuery.set(queryKey, request);
+
+    store.setQueryState(queryKey, {
+      isLoading: true,
+    });
 
     try {
       const result = await request;
@@ -2034,14 +2034,16 @@ export function createRoomContext<
     // If a request was already made for the notifications query, we do not make another request and return the existing promise
     if (existingRequest !== undefined) return existingRequest;
 
-    const promise = room[kInternal].notifications.getRoomNotificationSettings();
+    const request = room[kInternal].notifications.getRoomNotificationSettings();
+
+    requestsByQuery.set(queryKey, request);
 
     store.setQueryState(queryKey, {
       isLoading: true,
     });
 
     try {
-      const settings = await promise;
+      const settings = await request;
       store.updateRoomInboxNotificationSettings(room.id, settings, queryKey);
     } catch (err) {
       // TODO: Implement error retry mechanism


### PR DESCRIPTION
This PR adds error retrying logic to `useThreads` and `useThreadsSuspense`. If an error is encountered while fetching threads/notifications inside `useThreads`(and `useThreadsSuspense`), attempt to fetch is done again in 5 seconds. If the retry attempt fails, we retry again in 10 seconds, 20 seconds, 40 seconds, and so on until we've retried for the maximum number of times (which is set to 8).

- [x] Retry on error while fetching threads/notifications inside `useThreads`.
- [x] Test retrying on error for `useThreads`.
- [x] Test retrying on error for `useThreadsSuspense`.

Next steps (in separate PRs): 
- Retry on error while fetching notification settings inside `useRoomNotificationSettings`
- Retry on error while fetching notification settings inside `useInboxNotifications`