### PR TITLE
Fix localized `Timestamp` in `InboxNotification`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.10.1
+
+### `@liveblocks/react-comments`
+
+- Fix date localization in `InboxNotification`.
+
 # v1.10.0
 
 This release introduces Notifications (and unread indicators) for Comments.

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -170,6 +170,7 @@ const InboxNotificationLayout = forwardRef<
               <div className="lb-inbox-notification-details">
                 <span className="lb-inbox-notification-details-labels">
                   <Timestamp
+                    locale={$.locale}
                     date={date}
                     className="lb-inbox-notification-date"
                   />


### PR DESCRIPTION
This PR fixes https://github.com/liveblocks/liveblocks.io/issues/1974.

The `Timestamp` instance in `InboxNotification` wasn't inheriting the locale as it should (it's set to `"en"` by default to fit with the English default localization).