### PR TITLE
Fix UI bug in Monaco example

### DIFF
--- a/examples/nextjs-yjs-monaco/src/components/Cursors.tsx
+++ b/examples/nextjs-yjs-monaco/src/components/Cursors.tsx
@@ -43,7 +43,7 @@ export function Cursors({ yProvider }: Props) {
         cursorStyles += `
           .yRemoteSelection-${clientId}, 
           .yRemoteSelectionHead-${clientId}  {
-            --user-color: ${client.user.color};
+            --user-color: ${client.user.color || "orangered"};
           }
           
           .yRemoteSelectionHead-${clientId}::after {


### PR DESCRIPTION
Tiny UI fix in our Monaco example. I set up a local test and ran into this weird UI rendering issue:

![Screen Shot 2024-02-22 at 23 42 56@2x](https://github.com/liveblocks/liveblocks/assets/83844/670ba92d-9b3c-4239-9dda-37065c7cd437)

Turns out I just wasn't setting the `color` property in the `user.info` correctly in my local test. By falling back to a default color, at least the UI won't look broken if it's ever missing:

![Screen Shot 2024-02-22 at 23 44 31@2x](https://github.com/liveblocks/liveblocks/assets/83844/0a031337-74bf-4519-9d46-6269988b8987)
