### PR TITLE
remove clientID/actorId hack

### DIFF
--- a/packages/liveblocks-yjs/src/__tests__/awareness.test.ts
+++ b/packages/liveblocks-yjs/src/__tests__/awareness.test.ts
@@ -85,7 +85,7 @@ describe("presence", () => {
     });
     yProvider.awareness.setLocalState({ test: "local state" });
     expect(updatesCalled).toBe(1);
-    expect(update?.added[0]).toBe(yProvider.awareness.clientID);
+    expect(update?.added[0]).toBe(yProvider.awareness.doc.clientID);
     leave();
   });
 

--- a/packages/liveblocks-yjs/src/index.ts
+++ b/packages/liveblocks-yjs/src/index.ts
@@ -56,10 +56,6 @@ export default class LiveblocksProvider<
       fetchDoc: this.fetchDoc,
     });
     // if we have a connectionId already during construction, use that
-    const connectionId = this.room.getSelf()?.connectionId;
-    if (connectionId) {
-      this.rootDoc.clientID = connectionId;
-    }
     this.awareness = new Awareness(this.rootDoc, this.room);
 
     this.unsubscribers.push(
@@ -164,15 +160,6 @@ export default class LiveblocksProvider<
   };
 
   private syncDoc = () => {
-    /**
-     * If the connection changes, set the new id, this is used by awareness.
-     * yjs' only requirement for clientID is that it's truly unique and a number.
-     * Liveblock's connectionID satisfies those constraints
-     *  */
-    this.rootDoc.clientID =
-      this.room.getSelf()?.connectionId || this.rootDoc.clientID;
-    this.awareness.clientID = this.rootDoc.clientID; // tell our awareness provider the new ID
-
     this.rootDocHandler.syncDoc();
     for (const [_, handler] of this.subdocHandlers) {
       handler.syncDoc();


### PR DESCRIPTION
This fixes a bug where the first user in a room would not have their yjs awareness (cursors normally) reflected in other rooms.

Previously we set clientID to connectionID to avoid having to map between those values. It turns out this was not very reliable. This PR undoes that and adds clientID to presence and then maps to it. 