### PR TITLE
Add more vendor prefixes to default styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# v1.10.1
+# v1.10.1 (Unpublished)
 
 ### `@liveblocks/react-comments`
 
 - Fix date localization in `InboxNotification`.
+- Add vendor prefixes to more CSS properties within the default styles.
 
 # v1.10.0
 

--- a/packages/liveblocks-react-comments/plugins/rollup/styles.ts
+++ b/packages/liveblocks-react-comments/plugins/rollup/styles.ts
@@ -46,7 +46,7 @@ export function styles({ files }: Options): Plugin {
         require("postcss-nesting"),
         require("postcss-combine-duplicated-selectors"),
         require("postcss-sort-media-queries"),
-        require("postcss-lightningcss"),
+        require("postcss-lightningcss")({ browsers: ">= 1%" }),
         require("postcss-reporter")({
           clearReportedMessages: true,
           plugins: ["stylelint"],

--- a/packages/liveblocks-react-comments/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react-comments/src/__tests__/index.test.tsx
@@ -124,10 +124,10 @@ const server = setupServer(
 
 beforeAll(() => server.listen());
 afterEach(() => {
-  MockWebSocket.reset();
+  MockWebSocket.instances = [];
 });
 beforeEach(() => {
-  MockWebSocket.reset();
+  MockWebSocket.instances = [];
 });
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());


### PR DESCRIPTION
This PR fixes https://github.com/liveblocks/liveblocks.io/issues/1975. We were already correctly handling inline elements like mentions but this highlighted a deeper issue:

The issue was not happening in the examples, but it was in the Starter Kit. The reason is that the styles we ship are not fully auto-prefixed when being compiled, so if your setup didn't run them through an auto-prefixer (like the Starter Kit, but unlike the examples), you could be missing some important vendor prefixes (like the one that started this issue: `box-decoration-break` is still only available as `-webkit-box-decoration-break` in the latest Chrome version for example). This PR now makes [our CSS compiler](https://lightningcss.dev/) auto-prefix the files we ship with a pretty balanced target: browsers with at least 1% usage.