### PR TITLE
Fix reactions in `CommentDataPlain` type

### DIFF
--- a/packages/liveblocks-core/src/types/CommentData.ts
+++ b/packages/liveblocks-core/src/types/CommentData.ts
@@ -30,7 +30,7 @@ export type CommentDataPlain = Omit<
   DateToString<CommentData>,
   "reactions" | "body"
 > & {
-  reactions: DateToString<CommentReaction[]>;
+  reactions: DateToString<CommentReaction>[];
 } & (
     | { body: CommentBody; deletedAt?: never }
     | { body?: never; deletedAt: string }


### PR DESCRIPTION
This PR fixes reactions in `CommentDataPlain` type, they weren't typed as `string`.