### PR TITLE
Don't return anything in Next auth endpoint handlers

### DIFF
--- a/examples/nextjs-form/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-form/pages/api/liveblocks-auth.ts
@@ -23,5 +23,5 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   session.allow(req.body.room, session.FULL_ACCESS);
 
   const { status, body } = await session.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }

--- a/examples/nextjs-live-avatars-advanced/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-live-avatars-advanced/pages/api/liveblocks-auth.ts
@@ -24,7 +24,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   session.allow(req.body.room, session.FULL_ACCESS);
 
   const { status, body } = await session.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }
 
 const NAMES = [

--- a/examples/nextjs-live-avatars/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-live-avatars/pages/api/liveblocks-auth.ts
@@ -23,7 +23,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   session.allow(req.body.room, session.FULL_ACCESS);
 
   const { status, body } = await session.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }
 
 const NAMES = [

--- a/examples/nextjs-live-cursors-advanced/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-live-cursors-advanced/pages/api/liveblocks-auth.ts
@@ -26,7 +26,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   session.allow(req.body.room, session.FULL_ACCESS);
 
   const { status, body } = await session.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }
 
 const NAMES = [

--- a/examples/nextjs-nextauth-google-avatars/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-nextauth-google-avatars/pages/api/liveblocks-auth.ts
@@ -33,5 +33,5 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   liveblocksSession.allow(req.body.room, liveblocksSession.FULL_ACCESS);
 
   const { status, body } = await liveblocksSession.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }

--- a/examples/nextjs-spreadsheet-advanced/src/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-spreadsheet-advanced/src/pages/api/liveblocks-auth.ts
@@ -28,5 +28,5 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   session.allow(req.body.room, session.FULL_ACCESS);
 
   const { status, body } = await session.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }

--- a/examples/nextjs-whiteboard-advanced/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-whiteboard-advanced/pages/api/liveblocks-auth.ts
@@ -19,5 +19,5 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   session.allow(req.body.room, session.FULL_ACCESS);
 
   const { status, body } = await session.authorize();
-  return res.status(status).end(body);
+  res.status(status).end(body);
 }


### PR DESCRIPTION
This fixes these warnings printed to the console:

![Screen Shot 2024-02-23 at 16 36 57@2x](https://github.com/liveblocks/liveblocks/assets/83844/b4823e17-70b9-4dae-8846-ca13e6ba2fd3)
