### PR TITLE
Get base URL from `LIVEBLOCKS_BASE_URL` envvar if not explicitly defined

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -289,7 +289,7 @@ export type ClientOptions<TUserMeta extends BaseUserMeta = BaseUserMeta> = {
 //     | ((room: string) => Promise<{ token: string }>);
 //
 
-function getBaseUrl(baseUrl: string | undefined) {
+function getBaseUrl(baseUrl?: string | undefined): string {
   baseUrl ||=
     process.env.LIVEBLOCKS_BASE_URL ||
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -293,6 +293,7 @@ function getBaseUrl(baseUrl?: string | undefined): string {
   baseUrl ||=
     process.env.LIVEBLOCKS_BASE_URL ||
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||
+    process.env.VITE_LIVEBLOCKS_BASE_URL ||
     undefined;
   if (
     typeof baseUrl === "string" &&

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -289,15 +289,16 @@ export type ClientOptions<TUserMeta extends BaseUserMeta = BaseUserMeta> = {
 //     | ((room: string) => Promise<{ token: string }>);
 //
 
-function getBaseUrlFromClientOptions(clientOptions: ClientOptions) {
-  if ("liveblocksServer" in clientOptions) {
-    throw new Error("Client option no longer supported");
-  }
+function getBaseUrl(baseUrl: string | undefined) {
+  baseUrl ||=
+    process.env.LIVEBLOCKS_BASE_URL ||
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||
+    undefined;
   if (
-    typeof clientOptions.baseUrl === "string" &&
-    clientOptions.baseUrl.startsWith("http") // Must be http or https URL
+    typeof baseUrl === "string" &&
+    baseUrl.startsWith("http") // Must be http or https URL
   ) {
-    return clientOptions.baseUrl;
+    return baseUrl;
   } else {
     return DEFAULT_BASE_URL;
   }
@@ -349,7 +350,7 @@ export function createClient<TUserMeta extends BaseUserMeta = BaseUserMeta>(
   const backgroundKeepAliveTimeout = getBackgroundKeepAliveTimeout(
     clientOptions.backgroundKeepAliveTimeout
   );
-  const baseUrl = getBaseUrlFromClientOptions(clientOptions);
+  const baseUrl = getBaseUrl(clientOptions.baseUrl);
 
   const authManager = createAuthManager(options);
 

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -8,7 +8,9 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
 import { Liveblocks, LiveblocksError } from "../client";
-import { DEFAULT_BASE_URL } from "../utils";
+import { getBaseUrl } from "../utils";
+
+const DEFAULT_BASE_URL = getBaseUrl();
 
 describe("client", () => {
   const room = {

--- a/packages/liveblocks-node/src/authorize.ts
+++ b/packages/liveblocks-node/src/authorize.ts
@@ -1,7 +1,7 @@
 import {
   assertNonEmpty,
-  DEFAULT_BASE_URL,
   fetchPolyfill,
+  getBaseUrl,
   normalizeStatusCode,
   urljoin,
 } from "./utils";
@@ -120,7 +120,7 @@ export async function authorize(
     url = buildLiveblocksAuthorizeEndpoint(options, room);
 
     const fetch = await fetchPolyfill();
-    const resp = await fetch(buildLiveblocksAuthorizeEndpoint(options, room), {
+    const resp = await fetch(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${secret}`,
@@ -153,5 +153,5 @@ function buildLiveblocksAuthorizeEndpoint(
   roomId: string
 ): string {
   const path = `/v2/rooms/${encodeURIComponent(roomId)}/authorize`;
-  return urljoin(options.baseUrl || DEFAULT_BASE_URL, path);
+  return urljoin(getBaseUrl(options.baseUrl), path);
 }

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -31,12 +31,12 @@ import {
   assertNonEmpty,
   assertSecretKey,
   fetchPolyfill,
+  getBaseUrl,
   normalizeStatusCode,
   type QueryParams,
   url,
   urljoin,
   type URLSafeString,
-  getBaseUrl,
 } from "./utils";
 
 export type LiveblocksOptions = {

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -30,13 +30,13 @@ import { Session } from "./Session";
 import {
   assertNonEmpty,
   assertSecretKey,
-  DEFAULT_BASE_URL,
   fetchPolyfill,
   normalizeStatusCode,
   type QueryParams,
   url,
   urljoin,
   type URLSafeString,
+  getBaseUrl,
 } from "./utils";
 
 export type LiveblocksOptions = {
@@ -138,7 +138,7 @@ export class Liveblocks {
     const secret = options_.secret;
     assertSecretKey(secret, "secret");
     this._secret = secret;
-    this._baseUrl = new URL(options.baseUrl ?? DEFAULT_BASE_URL);
+    this._baseUrl = new URL(getBaseUrl(options.baseUrl));
   }
 
   /** @internal */

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -1,6 +1,21 @@
 import type { Brand } from "@liveblocks/core";
 
-export const DEFAULT_BASE_URL = "https://api.liveblocks.io";
+const DEFAULT_BASE_URL = "https://api.liveblocks.io";
+
+export function getBaseUrl(baseUrl: string | undefined) {
+  baseUrl ||=
+    process.env.LIVEBLOCKS_BASE_URL ||
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||
+    undefined;
+  if (
+    typeof baseUrl === "string" &&
+    baseUrl.startsWith("http") // Must be http or https URL
+  ) {
+    return baseUrl;
+  } else {
+    return DEFAULT_BASE_URL;
+  }
+}
 
 export async function fetchPolyfill(): Promise<typeof fetch> {
   return typeof globalThis.fetch !== "undefined"

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -6,6 +6,7 @@ export function getBaseUrl(baseUrl?: string | undefined): string {
   baseUrl ||=
     process.env.LIVEBLOCKS_BASE_URL ||
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||
+    process.env.VITE_LIVEBLOCKS_BASE_URL ||
     undefined;
   if (
     typeof baseUrl === "string" &&

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -2,7 +2,7 @@ import type { Brand } from "@liveblocks/core";
 
 const DEFAULT_BASE_URL = "https://api.liveblocks.io";
 
-export function getBaseUrl(baseUrl?: string | undefined) {
+export function getBaseUrl(baseUrl?: string | undefined): string {
   baseUrl ||=
     process.env.LIVEBLOCKS_BASE_URL ||
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -2,7 +2,7 @@ import type { Brand } from "@liveblocks/core";
 
 const DEFAULT_BASE_URL = "https://api.liveblocks.io";
 
-export function getBaseUrl(baseUrl: string | undefined) {
+export function getBaseUrl(baseUrl?: string | undefined) {
   baseUrl ||=
     process.env.LIVEBLOCKS_BASE_URL ||
     process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||


### PR DESCRIPTION
This will make it much easier to test Liveblocks against a locally running backend, i.e. by running an example instead of:

```bash
$ turbo run dev
```

…and instead just run the following command without making any config/code changes:

```bash
$ env NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://127.0.0.1:3333 turbo run dev
```

Because this requires both the frontend (in `createClient()`) and the backend (in `new Liveblocks()`) to read the same base URL value, I've stayed pragmatic and allowed it to read the `NEXT_PUBLIC_` value (and `VITE_`) here, since in a Next.js setup it will otherwise not be visible to the frontend for obvious reasons.

For non-Next.js projects, it will also be read from `LIVEBLOCKS_BASE_URL` too.
