### PR TITLE
Retry on error when fetching room notification settings and inbox notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fix date localization in `InboxNotification`.
 - Add vendor prefixes to more CSS properties within the default styles.
 
+### `@liveblocks/react`
+
+- Implemented error retrying for `useThreads`, `useRoomNotificationSettings`,
+  and `useInboxNotifications` to handle initial fetching failures.
+
 # v1.10.0
 
 This release introduces Notifications (and unread indicators) for Comments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### `@liveblocks/react`
 
-- Implemented error retrying for `useThreads`, `useRoomNotificationSettings`,
-  and `useInboxNotifications` to handle initial fetching failures.
+- Added error retrying to `useThreads`, `useRoomNotificationSettings`, and
+  `useInboxNotifications` during initial fetching.
 
 # v1.10.0
 

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@testing-library/react";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 import {
   createLiveblocksContext,
@@ -20,7 +21,6 @@ import { dummyInboxNoficationData, dummyThreadData } from "./_dummies";
 import MockWebSocket from "./_MockWebSocket";
 import { mockGetInboxNotifications } from "./_restMocks";
 import { generateFakeJwt } from "./_utils";
-import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 const server = setupServer();
 

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -1,7 +1,13 @@
 import "@testing-library/jest-dom";
 
 import { createClient, kInternal } from "@liveblocks/core";
-import { render, renderHook, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
 
@@ -14,6 +20,7 @@ import { dummyInboxNoficationData, dummyThreadData } from "./_dummies";
 import MockWebSocket from "./_MockWebSocket";
 import { mockGetInboxNotifications } from "./_restMocks";
 import { generateFakeJwt } from "./_utils";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 const server = setupServer();
 
@@ -309,6 +316,183 @@ describe("useInboxNotifications", () => {
   });
 });
 
+describe("useInboxNotifications: error", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers(); // Restores the real timers
+  });
+
+  test("should retry with exponential backoff on error", async () => {
+    let getInboxNotificationsReqCount = 0;
+    server.use(
+      mockGetInboxNotifications(async (_req, res, ctx) => {
+        getInboxNotificationsReqCount++;
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      liveblocksCtx: { LiveblocksProvider, useInboxNotifications },
+    } = createLiveblocksContextForTest();
+
+    const { result, unmount } = renderHook(() => useInboxNotifications(), {
+      wrapper: ({ children }) => (
+        <LiveblocksProvider>{children}</LiveblocksProvider>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      isLoading: true,
+    });
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        isLoading: false,
+        error: expect.any(Error),
+      })
+    );
+
+    // Unmount so polling doesn't interfere with the test
+    unmount();
+
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
+    // A new fetch request for the inbox notifications should have been made after the first retry
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(2));
+
+    // The second retry should be made after 5000ms * 2^1
+    jest.advanceTimersByTime(5000 * Math.pow(2, 1));
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(3));
+
+    // The third retry should be made after 5000ms * 2^2
+    jest.advanceTimersByTime(5000 * Math.pow(2, 2));
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(4));
+
+    // The fourth retry should be made after 5000ms * 2^3
+    jest.advanceTimersByTime(5000 * Math.pow(2, 3));
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(5));
+
+    // and so on...
+  });
+
+  test("should retry with exponential backoff with a maximum retry limit", async () => {
+    let getInboxNotificationsReqCount = 0;
+    server.use(
+      mockGetInboxNotifications(async (_req, res, ctx) => {
+        getInboxNotificationsReqCount++;
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      liveblocksCtx: { LiveblocksProvider, useInboxNotifications },
+    } = createLiveblocksContextForTest();
+
+    const { result, unmount } = renderHook(() => useInboxNotifications(), {
+      wrapper: ({ children }) => (
+        <LiveblocksProvider>{children}</LiveblocksProvider>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      isLoading: true,
+    });
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        isLoading: false,
+        error: expect.any(Error),
+      })
+    );
+
+    // Unmount so polling doesn't interfere with the test
+    unmount();
+
+    // Simulate retries up to maximum retry count (currently set to 5)
+    for (let i = 0; i < 5; i++) {
+      const interval = 5000 * Math.pow(2, i); // 5000ms is the currently set error retry interval
+
+      jest.advanceTimersByTime(interval);
+
+      await waitFor(() => expect(getInboxNotificationsReqCount).toBe(i + 2));
+    }
+
+    expect(getInboxNotificationsReqCount).toBe(1 + 5); // initial request + 5 retries
+
+    // No more retries should be made after the maximum number of retries
+    await jest.advanceTimersByTimeAsync(5 * Math.pow(2, 5));
+
+    // The number of requests should not have increased after the maximum number of retries
+    expect(getInboxNotificationsReqCount).toBe(1 + 5);
+  });
+
+  test("should retry with exponential backoff with a maximum retry limit", async () => {
+    let getInboxNotificationsReqCount = 0;
+    server.use(
+      mockGetInboxNotifications(async (_req, res, ctx) => {
+        getInboxNotificationsReqCount++;
+        if (getInboxNotificationsReqCount === 1) {
+          return res(ctx.status(500));
+        } else {
+          return res(
+            ctx.json({
+              threads: [],
+              inboxNotifications: [],
+              deletedThreads: [],
+              deletedInboxNotifications: [],
+              meta: {
+                requestedAt: new Date().toISOString(),
+              },
+            })
+          );
+        }
+      })
+    );
+
+    const {
+      liveblocksCtx: { LiveblocksProvider, useInboxNotifications },
+    } = createLiveblocksContextForTest();
+
+    const { result, unmount } = renderHook(() => useInboxNotifications(), {
+      wrapper: ({ children }) => (
+        <LiveblocksProvider>{children}</LiveblocksProvider>
+      ),
+    });
+
+    expect(result.current).toEqual({
+      isLoading: true,
+    });
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        isLoading: false,
+        error: expect.any(Error),
+      })
+    );
+
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
+    // A new fetch request for inbox notifications should have been made after the first retry
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(2));
+
+    expect(result.current).toEqual({
+      inboxNotifications: [],
+      isLoading: false,
+    });
+
+    // No more retries should be made after successful retry
+    await jest.advanceTimersByTimeAsync(5000 * Math.pow(2, 1));
+    expect(getInboxNotificationsReqCount).toBe(2);
+
+    // Unmount so polling doesn't interfere with the test
+    unmount();
+  });
+});
+
 describe("useInboxNotifications - Suspense", () => {
   test("should be referentially stable after rerendering", async () => {
     const threads = [dummyThreadData()];
@@ -431,6 +615,152 @@ describe("useInboxNotifications: polling", () => {
     jest.advanceTimersByTime(POLLING_INTERVAL);
     // Wait for the second polling to occur
     await waitFor(() => expect(getInboxNotificationsReqCount).toBe(3));
+
+    unmount();
+  });
+});
+
+describe("useThreadsSuspense: error", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers(); // Restores the real timers
+  });
+
+  test("should trigger error boundary if initial fetch throws an error", async () => {
+    server.use(
+      mockGetInboxNotifications((_req, res, ctx) => {
+        // Mock an error response from the server for the initial fetch
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      liveblocksCtx: {
+        suspense: { LiveblocksProvider, useInboxNotifications },
+      },
+    } = createLiveblocksContextForTest();
+
+    function Fallback({ resetErrorBoundary }: FallbackProps) {
+      return (
+        <div>
+          <p>There was an error while getting inbox notifications.</p>
+          <button onClick={resetErrorBoundary}>Retry</button>
+        </div>
+      );
+    }
+
+    const { result, unmount } = renderHook(() => useInboxNotifications(), {
+      wrapper: ({ children }) => (
+        <LiveblocksProvider>
+          <ErrorBoundary FallbackComponent={Fallback}>
+            <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+          </ErrorBoundary>
+        </LiveblocksProvider>
+      ),
+    });
+
+    expect(result.current).toEqual(null);
+
+    await waitFor(() =>
+      // Check if the error boundary's fallback UI is displayed
+      expect(
+        screen.getByText(
+          "There was an error while getting inbox notifications."
+        )
+      ).toBeInTheDocument()
+    );
+
+    unmount();
+  });
+
+  test("should retry with exponential backoff on error and clear error boundary", async () => {
+    const threads = [dummyThreadData()];
+    const inboxNotification = dummyInboxNoficationData();
+    inboxNotification.threadId = threads[0].id;
+    const inboxNotifications = [inboxNotification];
+
+    let getInboxNotificationsReqCount = 0;
+    server.use(
+      mockGetInboxNotifications((_req, res, ctx) => {
+        getInboxNotificationsReqCount++;
+
+        if (getInboxNotificationsReqCount === 1) {
+          // Mock an error response from the server
+          return res(ctx.status(500));
+        } else {
+          // Mock a successful response from the server for the subsequent fetches
+          return res(
+            ctx.json({
+              threads,
+              inboxNotifications,
+              deletedThreads: [],
+              deletedInboxNotifications: [],
+              meta: {
+                requestedAt: new Date().toISOString(),
+              },
+            })
+          );
+        }
+      })
+    );
+
+    const {
+      liveblocksCtx: {
+        suspense: { LiveblocksProvider, useInboxNotifications },
+      },
+    } = createLiveblocksContextForTest();
+
+    function Fallback({ resetErrorBoundary }: FallbackProps) {
+      return (
+        <div>
+          <p>There was an error while getting inbox notifications.</p>
+          <button onClick={resetErrorBoundary}>Retry</button>
+        </div>
+      );
+    }
+
+    const { result, unmount } = renderHook(() => useInboxNotifications(), {
+      wrapper: ({ children }) => (
+        <LiveblocksProvider>
+          <ErrorBoundary FallbackComponent={Fallback}>
+            <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+          </ErrorBoundary>
+        </LiveblocksProvider>
+      ),
+    });
+
+    expect(result.current).toEqual(null);
+
+    // A new fetch request for the threads should have been made after the initial render
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(1));
+    // Check if the error boundary's fallback UI is displayed
+    expect(
+      screen.getByText("There was an error while getting inbox notifications.")
+    ).toBeInTheDocument();
+
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
+    // A new fetch request for the threads should have been made after the first retry
+    await waitFor(() => expect(getInboxNotificationsReqCount).toBe(2));
+
+    // Simulate clicking the retry button
+    fireEvent.click(screen.getByText("Retry"));
+
+    // The error boundary's fallback UI should be cleared
+    expect(
+      screen.queryByText(
+        "There was an error while getting inbox notifications."
+      )
+    ).not.toBeInTheDocument();
+
+    expect(result.current).toEqual({
+      isLoading: false,
+      inboxNotifications,
+    });
 
     unmount();
   });

--- a/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
@@ -2,9 +2,16 @@ import "@testing-library/jest-dom";
 
 import type { BaseMetadata, JsonObject } from "@liveblocks/core";
 import { createClient } from "@liveblocks/core";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
 import { createLiveblocksContext } from "../liveblocks";
 import { createRoomContext } from "../room";
@@ -167,6 +174,230 @@ describe("useRoomNotificationSettings", () => {
   });
 });
 
+describe("useRoomNotificationSettings: error", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers(); // Restores the real timers
+  });
+
+  test("should include an error object in the returned value if initial fetch throws an error", async () => {
+    server.use(
+      mockGetRoomNotificationSettings((_req, res, ctx) => {
+        // Mock an error response from the server for the initial fetch
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      roomCtx: { RoomProvider, useRoomNotificationSettings },
+    } = createRoomContextForTest();
+
+    const { result, unmount } = renderHook(
+      () => useRoomNotificationSettings(),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current[0]).toEqual({ isLoading: true });
+
+    await waitFor(() =>
+      expect(result.current[0]).toEqual({
+        isLoading: false,
+        error: expect.any(Error),
+      })
+    );
+
+    unmount();
+  });
+
+  test("should retry with exponential backoff on error", async () => {
+    let getRoomNotificationSettingsReqCount = 0;
+
+    server.use(
+      mockGetRoomNotificationSettings((_req, res, ctx) => {
+        getRoomNotificationSettingsReqCount++;
+        // Mock an error response from the server
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      roomCtx: { RoomProvider, useRoomNotificationSettings },
+    } = createRoomContextForTest();
+
+    const { result, unmount } = renderHook(
+      () => useRoomNotificationSettings(),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current[0]).toEqual({ isLoading: true });
+
+    // A new fetch request for the threads should have been made after the initial render
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
+
+    expect(result.current[0]).toEqual({
+      isLoading: false,
+      error: expect.any(Error),
+    });
+
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
+    // A new fetch request for the threads should have been made after the first retry
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(2));
+
+    // The second retry should be made after 5000ms * 2^1
+    jest.advanceTimersByTime(5000 * Math.pow(2, 1));
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(3));
+
+    // The third retry should be made after 5000ms * 2^2
+    jest.advanceTimersByTime(5000 * Math.pow(2, 2));
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(4));
+
+    // The fourth retry should be made after 5000ms * 2^3
+    jest.advanceTimersByTime(5000 * Math.pow(2, 3));
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(5));
+
+    // and so on...
+
+    unmount();
+  });
+
+  test("should retry with exponential backoff with a maximum retry limit", async () => {
+    let getRoomNotificationSettingsReqCount = 0;
+
+    server.use(
+      mockGetRoomNotificationSettings((_req, res, ctx) => {
+        getRoomNotificationSettingsReqCount++;
+        // Mock an error response from the server
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      roomCtx: { RoomProvider, useRoomNotificationSettings },
+    } = createRoomContextForTest();
+
+    const { result, unmount } = renderHook(
+      () => useRoomNotificationSettings(),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current[0]).toEqual({ isLoading: true });
+
+    // A new fetch request for the threads should have been made after the initial render
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
+
+    expect(result.current[0]).toEqual({
+      isLoading: false,
+      error: expect.any(Error),
+    });
+
+    // Simulate retries up to maximum retry count (currently set to 5)
+    for (let i = 0; i < 5; i++) {
+      const interval = 5000 * Math.pow(2, i); // 5000ms is the currently set error retry interval
+      jest.advanceTimersByTime(interval);
+      await waitFor(() =>
+        expect(getRoomNotificationSettingsReqCount).toBe(i + 2)
+      );
+    }
+
+    expect(getRoomNotificationSettingsReqCount).toBe(1 + 5); // initial request + 5 retries
+
+    // No more retries should be made after the maximum number of retries
+    await jest.advanceTimersByTimeAsync(5 * Math.pow(2, 5));
+
+    // The number of requests should not have increased after the maximum number of retries
+    expect(getRoomNotificationSettingsReqCount).toBe(5 + 1);
+
+    unmount();
+  });
+
+  test("should clear error state after a successful error retry", async () => {
+    let getRoomNotificationSettingsReqCount = 0;
+
+    server.use(
+      mockGetRoomNotificationSettings((_req, res, ctx) => {
+        getRoomNotificationSettingsReqCount++;
+        if (getRoomNotificationSettingsReqCount === 1) {
+          // Mock an error response from the server for the initial fetch
+          return res(ctx.status(500));
+        } else {
+          // Mock a successful response from the server for the subsequent fetches
+          return res(
+            ctx.json({
+              threads: "all",
+            })
+          );
+        }
+      })
+    );
+
+    const {
+      roomCtx: { RoomProvider, useRoomNotificationSettings },
+    } = createRoomContextForTest();
+
+    const { result, unmount } = renderHook(
+      () => useRoomNotificationSettings(),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current[0]).toEqual({ isLoading: true });
+
+    // A new fetch request for the threads should have been made after the initial render
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
+
+    expect(result.current[0]).toEqual({
+      isLoading: false,
+      error: expect.any(Error),
+    });
+
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
+    // A new fetch request for the threads should have been made after the first retry
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(2));
+
+    expect(result.current[0]).toEqual({
+      settings: {
+        threads: "all",
+      },
+      isLoading: false,
+    });
+
+    // No more retries should be made after successful retry
+    await jest.advanceTimersByTimeAsync(5000 * Math.pow(2, 1));
+    expect(getRoomNotificationSettingsReqCount).toBe(2);
+
+    unmount();
+  });
+});
+
 describe("useRoomNotificationSettings suspense", () => {
   test("should be referentially stable", async () => {
     server.use(
@@ -210,6 +441,152 @@ describe("useRoomNotificationSettings suspense", () => {
     rerender();
 
     expect(result.current).toBe(oldResult);
+
+    unmount();
+  });
+});
+
+describe("useRoomNotificationSettingsSuspense: error", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers(); // Restores the real timers
+  });
+
+  test("should trigger error boundary if initial fetch throws an error", async () => {
+    server.use(
+      mockGetRoomNotificationSettings((_req, res, ctx) => {
+        // Mock an error response from the server for the initial fetch
+        return res(ctx.status(500));
+      })
+    );
+
+    const {
+      roomCtx: {
+        suspense: { RoomProvider, useRoomNotificationSettings },
+      },
+    } = createRoomContextForTest();
+
+    function Fallback({ resetErrorBoundary }: FallbackProps) {
+      return (
+        <div>
+          <p>There was an error while getting room notification settings.</p>
+          <button onClick={resetErrorBoundary}>Retry</button>
+        </div>
+      );
+    }
+
+    const { result, unmount } = renderHook(
+      () => useRoomNotificationSettings(),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            <ErrorBoundary FallbackComponent={Fallback}>
+              <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+            </ErrorBoundary>
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current).toEqual(null);
+
+    await waitFor(() =>
+      // Check if the error boundary's fallback UI is displayed
+      expect(
+        screen.getByText(
+          "There was an error while getting room notification settings."
+        )
+      ).toBeInTheDocument()
+    );
+
+    unmount();
+  });
+
+  test("should retry with exponential backoff on error and clear error boundary", async () => {
+    let getRoomNotificationSettingsReqCount = 0;
+    server.use(
+      mockGetRoomNotificationSettings((_req, res, ctx) => {
+        getRoomNotificationSettingsReqCount++;
+
+        if (getRoomNotificationSettingsReqCount === 1) {
+          // Mock an error response from the server
+          return res(ctx.status(500));
+        } else {
+          // Mock a successful response from the server for the subsequent fetches
+          return res(
+            ctx.json({
+              threads: "all",
+            })
+          );
+        }
+      })
+    );
+
+    const {
+      roomCtx: {
+        RoomProvider,
+        suspense: { useRoomNotificationSettings },
+      },
+    } = createRoomContextForTest();
+
+    function Fallback({ resetErrorBoundary }: FallbackProps) {
+      return (
+        <div>
+          <p>There was an error while getting room notification settings.</p>
+          <button onClick={resetErrorBoundary}>Retry</button>
+        </div>
+      );
+    }
+
+    const { result, unmount } = renderHook(
+      () => useRoomNotificationSettings(),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            <ErrorBoundary FallbackComponent={Fallback}>
+              <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+            </ErrorBoundary>
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current).toEqual(null);
+
+    // A new fetch request for the threads should have been made after the initial render
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
+    // Check if the error boundary's fallback UI is displayed
+    expect(
+      screen.getByText(
+        "There was an error while getting room notification settings."
+      )
+    ).toBeInTheDocument();
+
+    // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
+    jest.advanceTimersByTime(5000);
+    // A new fetch request for the threads should have been made after the first retry
+    await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(2));
+
+    // Simulate clicking the retry button
+    fireEvent.click(screen.getByText("Retry"));
+
+    // The error boundary's fallback UI should be cleared
+    expect(
+      screen.queryByText(
+        "There was an error while getting room notification settings."
+      )
+    ).not.toBeInTheDocument();
+
+    expect(result.current[0]).toEqual({
+      isLoading: false,
+      settings: {
+        threads: "all",
+      },
+    });
 
     unmount();
   });

--- a/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
@@ -247,7 +247,7 @@ describe("useRoomNotificationSettings: error", () => {
 
     expect(result.current[0]).toEqual({ isLoading: true });
 
-    // A new fetch request for the threads should have been made after the initial render
+    // A new fetch request for the room notification settings should have been made after the initial render
     await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
 
     expect(result.current[0]).toEqual({
@@ -257,7 +257,7 @@ describe("useRoomNotificationSettings: error", () => {
 
     // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
     jest.advanceTimersByTime(5000);
-    // A new fetch request for the threads should have been made after the first retry
+    // A new fetch request for the room notification settings should have been made after the first retry
     await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(2));
 
     // The second retry should be made after 5000ms * 2^1
@@ -305,7 +305,7 @@ describe("useRoomNotificationSettings: error", () => {
 
     expect(result.current[0]).toEqual({ isLoading: true });
 
-    // A new fetch request for the threads should have been made after the initial render
+    // A new fetch request for the room notification settings should have been made after the initial render
     await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
 
     expect(result.current[0]).toEqual({
@@ -370,7 +370,7 @@ describe("useRoomNotificationSettings: error", () => {
 
     expect(result.current[0]).toEqual({ isLoading: true });
 
-    // A new fetch request for the threads should have been made after the initial render
+    // A new fetch request for the room notification settings should have been made after the initial render
     await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(1));
 
     expect(result.current[0]).toEqual({
@@ -380,7 +380,7 @@ describe("useRoomNotificationSettings: error", () => {
 
     // The first retry should be made after 5000ms * 2^0 (5000ms is the currently set error retry interval)
     jest.advanceTimersByTime(5000);
-    // A new fetch request for the threads should have been made after the first retry
+    // A new fetch request for the room notification settings should have been made after the first retry
     await waitFor(() => expect(getRoomNotificationSettingsReqCount).toBe(2));
 
     expect(result.current[0]).toEqual({

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1398,7 +1398,7 @@ describe("useThreads: polling", () => {
     unmount();
   });
 
-  test("should not poll if useThreads or useRoomNotificationSettings isn't used", async () => {
+  test("should not poll if useThreads isn't used", async () => {
     let hasCalledGetThreads = false;
 
     const threads = [dummyThreadData()];

--- a/packages/liveblocks-react/src/lib/retry-error.ts
+++ b/packages/liveblocks-react/src/lib/retry-error.ts
@@ -1,0 +1,18 @@
+const MAX_ERROR_RETRY_COUNT = 5;
+
+const ERROR_RETRY_INTERVAL = 5000; // 5 seconds
+
+/**
+ * Retries an action using the exponential backoff algorithm
+ * @param action The action to retry
+ * @param retryCount The number of times the action has been retried
+ */
+export function retryError(action: () => void, retryCount: number) {
+  if (retryCount >= MAX_ERROR_RETRY_COUNT) return;
+
+  const timeout = Math.pow(2, retryCount) * ERROR_RETRY_INTERVAL;
+
+  setTimeout(() => {
+    void action();
+  }, timeout);
+}

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -245,6 +245,10 @@ export function createLiveblocksContext<
       throw fetchInboxNotifications();
     }
 
+    if (query.error !== undefined) {
+      throw query.error;
+    }
+
     React.useEffect(() => {
       incrementInboxNotificationsSubscribers();
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -25,6 +25,7 @@ import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 
 import { selectedInboxNotifications } from "./comments/lib/selected-inbox-notifications";
+import { retryError } from "./lib/retry-error";
 import { createSharedContext } from "./shared";
 import type {
   InboxNotificationsState,
@@ -90,6 +91,7 @@ export function createLiveblocksContext<
   const poller = makePoller(refreshThreadsAndNotifications);
 
   function refreshThreadsAndNotifications() {
+    console.log("Refreshing threads and notifications");
     return notifications.getInboxNotifications({ since: lastRequestedAt }).then(
       (result) => {
         lastRequestedAt = result.meta.requestedAt;
@@ -129,8 +131,10 @@ export function createLiveblocksContext<
     }
   }
 
-  async function fetchInboxNotifications() {
-    if (fetchInboxNotificationsRequest) {
+  async function fetchInboxNotifications(
+    { retryCount }: { retryCount: number } = { retryCount: 0 }
+  ) {
+    if (fetchInboxNotificationsRequest !== null) {
       return fetchInboxNotificationsRequest;
     }
 
@@ -163,8 +167,18 @@ export function createLiveblocksContext<
       ) {
         lastRequestedAt = result.meta.requestedAt;
       }
+
+      poller.start(POLLING_INTERVAL);
     } catch (er) {
-      // TODO: Implement error retry mechanism
+      fetchInboxNotificationsRequest = null;
+
+      // Retry the action using the exponential backoff algorithm
+      retryError(() => {
+        void fetchInboxNotifications({
+          retryCount: retryCount + 1,
+        });
+      }, retryCount);
+
       store.setQueryState(INBOX_NOTIFICATIONS_QUERY, {
         isLoading: false,
         error: er as Error,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -91,7 +91,6 @@ export function createLiveblocksContext<
   const poller = makePoller(refreshThreadsAndNotifications);
 
   function refreshThreadsAndNotifications() {
-    console.log("Refreshing threads and notifications");
     return notifications.getInboxNotifications({ since: lastRequestedAt }).then(
       (result) => {
         lastRequestedAt = result.meta.requestedAt;

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -67,6 +67,7 @@ import { createCommentId, createThreadId } from "./comments/lib/createIds";
 import { selectNotificationSettings } from "./comments/lib/select-notification-settings";
 import { selectedInboxNotifications } from "./comments/lib/selected-inbox-notifications";
 import { selectedThreads } from "./comments/lib/selected-threads";
+import { retryError } from "./lib/retry-error";
 import { useInitial } from "./lib/use-initial";
 import { useLatest } from "./lib/use-latest";
 import { useRerender } from "./lib/use-rerender";
@@ -123,10 +124,6 @@ function useSyncExternalStore<Snapshot>(
 const STABLE_EMPTY_LIST = Object.freeze([]);
 
 export const POLLING_INTERVAL = 5 * 60 * 1000; // 5 minutes
-
-export const ERROR_RETRY_INTERVAL = 5000; // 5 seconds
-
-export const MAX_ERROR_RETRY_COUNT = 5;
 
 const MENTION_SUGGESTIONS_DEBOUNCE = 500;
 
@@ -1070,21 +1067,6 @@ export function createRoomContext<
     if (totalSubscribers <= 0) {
       poller.stop();
     }
-  }
-
-  /**
-   * Retries an action using the exponential backoff algorithm
-   * @param action The action to retry
-   * @param retryCount The number of times the action has been retried
-   */
-  function retryError(action: () => void, retryCount: number) {
-    if (retryCount >= MAX_ERROR_RETRY_COUNT) return;
-
-    const timeout = Math.pow(2, retryCount) * ERROR_RETRY_INTERVAL;
-
-    setTimeout(() => {
-      void action();
-    }, timeout);
   }
 
   async function getThreadsAndInboxNotifications(


### PR DESCRIPTION
### `useRoomNotificationSettings`

- [x] Retry fetching room notification settings on error
- [x] Test retry on error logic
- [x] Exclude fetching room notifications settings from polling

### `useInboxNotifications`

- [x] Retry fetching inbox notifications on error
- [x] Clear error if polling inbox notifications returns a successful response
- [x] Test retry on error logic