### PR TITLE
Fix bug where client backoff would not be exponential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.10.1 (Unpublished)
 
+### `@liveblocks/client`
+
+- Fix bug where the client’s backoff delay would not be respected correctly in a
+  small edge case
+
 ### `@liveblocks/react-comments`
 
 - Fix date localization in `InboxNotification`.

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -245,7 +245,7 @@ export class LiveblocksError extends Error {
 
 function nextBackoffDelay(
   currentDelay: number,
-  delays: readonly number[] = BACKOFF_DELAYS
+  delays: readonly number[]
 ): number {
   return (
     delays.find((delay) => delay > currentDelay) ?? delays[delays.length - 1]
@@ -253,7 +253,9 @@ function nextBackoffDelay(
 }
 
 function increaseBackoffDelay(context: Patchable<Context>) {
-  context.patch({ backoffDelay: nextBackoffDelay(context.backoffDelay) });
+  context.patch({
+    backoffDelay: nextBackoffDelay(context.backoffDelay, BACKOFF_DELAYS),
+  });
 }
 
 function increaseBackoffDelayAggressively(context: Patchable<Context>) {

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -502,7 +502,6 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
         target: "@connecting.busy",
         effect: assign({
           authValue: okEvent.data,
-          backoffDelay: RESET_DELAY,
         }),
       }),
 


### PR DESCRIPTION
This PR fixes a client connection issue in an edge case that could lead to the exponential backoff not being respected and thus can lead to hammering our servers.

### When can it happen?
It's not common. It would only happen if we'd have infrastructure issues accepting WebSocket connections.

The bug happens if this combination of conditions apply:
1. Our authorization endpoint is working fine
2. Our server connections are being rejected with an unexpected error (e.g. an unhandled exception in our socket endpoint)

### How does it happen?
When the server refuses a connection attempt with an `UNEXPECTED_CONDITION ` close code (see condition (2)), the machine transitions from `@connecting.busy` back to `@auth.backoff` (while increasing the backoff delay), but then `@auth.busy` succeeds (see condition (1)), it resets the backoff delay again, and transitions to `@connecting.busy`. Rinse, repeat.

This effectively keeps hitting our server's authentication endpoint and a socket connection attempt in an infinite loop every 250ms, instead of using an exponential back off.

### The quick fix (= this PR)
This PR fixes it in the simplest way possible, by no longer resetting the delay after successful auth. Instead, the delay is only reset after a successful *connection* attempt. This fix should not have any adverse effects, as far as I can tell.

### A more robust solution (future work)
This fix should suffice, but there are still too many states to think about to my liking. How and when the backoff delay is set, is still hard to manage, even with our state machine, because multiple states use the same backoff delay value, and it's modified in a couple places.

Splitting this into two different backoff delay values (one for `@auth.backoff` and one for `@connection.backoff` states) could work, but would add yet another state variable, which arguably increases instead of decreases complexity, and is undesirable.

To solve this more elegantly, I'm thinking about adding the concept of "rate limiting" right into the FSM itself, on a per-state basis. This way, instead of managing the backoff delays manually in the machine context, we'd have a way to express that a state should not execute again in the next X milliseconds.

Benefits would include:
- It would express our intent much more directly
- I'd be easy to unit test at the FSM level
- We could drop the `backoffDelay` state variable (and all mutations of that value) entirely
- It's easier to reason about its correctness
- What happens in other states/transitions cannot impact correct behavior
