### PR TITLE
Fix typo in user color array variable at `/docs/rooms/authentication/access-token-permissions/nextjs` page

### DIFF
--- a/docs/pages/rooms/authentication/access-token-permissions/nextjs.mdx
+++ b/docs/pages/rooms/authentication/access-token-permissions/nextjs.mdx
@@ -163,7 +163,7 @@ start building your own security logic in Next.js’ `/app` directory.
             userInfo: {
               name: user.name,
               avatar: user.avatarUrl,
-              colors: users.colorArray,
+              colors: user.colorArray,
             }
           }
         );


### PR DESCRIPTION
### Issue
Currently, there is an error in the code when attempting to access the `colorArray` property from the `users` object. This results in unexpected behavior and may cause the application to malfunction.

### Proposed Changes
To resolve this issue, I propose modifying the `colors` field in the `prepareSession` function call to correctly access the `colorArray` property from the `user` object.

### Details
In the original code:

```ts
// Get the current user from your database
const user = __getUserFromDB__(request);

// Start an auth session inside your endpoint
const session = liveblocks.prepareSession(
  user.id,
  {
    userInfo: {
      name: user.name,
      avatar: user.avatarUrl,
      colors: users.colorArray,
    }
  }
);
```

`users` seems to be a typo or a mistaken reference, as the user object is already retrieved from the database and assigned to the variable `user`. To fix this, I suggest replacing `users` with `user` to access the `colorArray` property of the current user.

Proposed modification:

```ts
// Get the current user from your database
const user = __getUserFromDB__(request);

// Start an auth session inside your endpoint
const session = liveblocks.prepareSession(
  user.id,
  {
    userInfo: {
      name: user.name,
      avatar: user.avatarUrl,
      colors: user.colorArray,
    }
  }
);
```

You can find more information about the `prepareSession` function and its usage in the Liveblocks documentation, specifically at the following URL:

[Liveblocks Authentication Access Token Permissions - Next.js](https://liveblocks.io/docs/rooms/authentication/access-token-permissions/nextjs)

### Testing
I have tested this change locally and confirmed that it resolves the error and provides the expected behavior. Additionally, I've ensured that it does not introduce any new issues or regressions.