### PR TITLE
Fix bug: calling `.clone()` after creating new `LiveObject` could sometimes throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
+# v1.10.2 (unreleased)
+
+### `@liveblocks/client`
+
+- Fix bug where calling `.clone()` immediately after creating a new `LiveObject`
+  could throw an error
+
 # v1.10.1
 
 ### `@liveblocks/client`
 
 - Fix bug where the client’s backoff delay would not be respected correctly in a
   small edge case.
-- Fix bug where calling `.clone()` immediately after creating a new `LiveObject`
-  could throw an error
 
 ### `@liveblocks/react-comments`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix bug where the client’s backoff delay would not be respected correctly in a
   small edge case.
+- Fix bug where calling `.clone()` immediately after creating a new `LiveObject`
+  could throw an error
 
 ### `@liveblocks/react-comments`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.10.2 (unreleased)
+# v1.10.2
 
 ### `@liveblocks/client`
 

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -2,7 +2,7 @@ import type { LiveNode, Lson, LsonObject } from "../crdts/Lson";
 import { nn } from "../lib/assert";
 import type { JsonObject } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
-import { deepClone } from "../lib/utils";
+import { compactObject, deepClone } from "../lib/utils";
 import type {
   CreateObjectOp,
   CreateOp,
@@ -105,16 +105,15 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
 
     this._propToLastUpdate = new Map<string, string>();
 
-    for (const key in obj) {
-      const value = obj[key];
-      if (value === undefined) {
-        continue;
-      } else if (isLiveNode(value)) {
+    const o = compactObject(obj);
+    for (const key of Object.keys(o)) {
+      const value = o[key];
+      if (isLiveNode(value)) {
         value._setParentLink(this, key);
       }
     }
 
-    this._map = new Map(Object.entries(obj)) as Map<string, Lson>;
+    this._map = new Map(Object.entries(o));
   }
 
   /** @internal */

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -2,6 +2,7 @@ import type { LiveNode, Lson, LsonObject } from "../crdts/Lson";
 import { nn } from "../lib/assert";
 import type { JsonObject } from "../lib/Json";
 import { nanoid } from "../lib/nanoid";
+import type { RemoveUndefinedValues } from "../lib/utils";
 import { compactObject, deepClone } from "../lib/utils";
 import type {
   CreateObjectOp,
@@ -105,7 +106,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
 
     this._propToLastUpdate = new Map<string, string>();
 
-    const o = compactObject(obj);
+    const o: RemoveUndefinedValues<LsonObject> = compactObject(obj);
     for (const key of Object.keys(o)) {
       const value = o[key];
       if (isLiveNode(value)) {

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -141,7 +141,7 @@ export function compact<T>(items: readonly T[]): NonNullable<T>[] {
   );
 }
 
-type RemoveUndefinedValues<T> = {
+export type RemoveUndefinedValues<T> = {
   [K in keyof T]-?: Exclude<T[K], undefined>;
 };
 

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -141,11 +141,17 @@ export function compact<T>(items: readonly T[]): NonNullable<T>[] {
   );
 }
 
+type RemoveUndefinedValues<T> = {
+  [K in keyof T]-?: Exclude<T[K], undefined>;
+};
+
 /**
  * Returns a new object instance where all explictly-undefined values are
  * removed.
  */
-export function compactObject<O extends Record<string, unknown>>(obj: O): O {
+export function compactObject<O extends Record<string, unknown>>(
+  obj: O
+): RemoveUndefinedValues<O> {
   const newObj = { ...obj };
   Object.keys(obj).forEach((k) => {
     const key = k as keyof O;
@@ -153,7 +159,7 @@ export function compactObject<O extends Record<string, unknown>>(obj: O): O {
       delete newObj[key];
     }
   });
-  return newObj;
+  return newObj as RemoveUndefinedValues<O>;
 }
 
 /**


### PR DESCRIPTION
The bug is fixed by skipping over explicitly-`undefined` values when initializing `LiveObject`.