### PR TITLE
Fix `showRoomName` prop in mentions notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.10.3 (Unpublished)
+
+### `@liveblocks/react-comments`
+
+- Fix bug where the `showRoomName` prop on `InboxNotification.Thread` wasn’t
+  applied to notifications about mentions.
+
 # v1.10.2
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -435,7 +435,7 @@ const InboxNotificationThread = forwardRef<
             const aside = <InboxNotificationAvatar userId={mentionUserId} />;
             const title = $.INBOX_NOTIFICATION_THREAD_MENTION(
               <User key={mentionUserId} userId={mentionUserId} capitalize />,
-              <Room roomId={thread.roomId} />
+              showRoomName ? <Room roomId={thread.roomId} /> : undefined
             );
             const content = (
               <div className="lb-inbox-notification-comments">


### PR DESCRIPTION
This PR fixes the bug where the `showRoomName` prop on `InboxNotification.Thread` wasn’t applied to notifications about mentions.