### PR TITLE
Add ROOM_ID_UPDATED enum to WebsocketCloseCodes

### DIFF
--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -75,6 +75,8 @@ export enum WebsocketCloseCodes {
   MAX_NUMBER_OF_MESSAGES_PER_DAY_PER_APP = 4004,
   /** Room is full, disconnect */
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS_PER_ROOM = 4005,
+  /** The room's roomId was updated, disconnect */
+  ROOM_ID_UPDATED = 4006,
   /** The server kicked the connection from the room. */
   KICKED = 4100,
   /** The auth token is expired, reauthorize to get a fresh one. In spirit akin to HTTP 401 */

--- a/packages/liveblocks-core/src/types/IWebSocket.ts
+++ b/packages/liveblocks-core/src/types/IWebSocket.ts
@@ -75,7 +75,7 @@ export enum WebsocketCloseCodes {
   MAX_NUMBER_OF_MESSAGES_PER_DAY_PER_APP = 4004,
   /** Room is full, disconnect */
   MAX_NUMBER_OF_CONCURRENT_CONNECTIONS_PER_ROOM = 4005,
-  /** The room's roomId was updated, disconnect */
+  /** The room's ID was updated, disconnect */
   ROOM_ID_UPDATED = 4006,
   /** The server kicked the connection from the room. */
   KICKED = 4100,


### PR DESCRIPTION
### Description

Part of multiple PRs to setup roomId update.

This PR adds the ROOM_ID_UPDATED error code, it will emitted when the room's ID is updated, all users will be kicked from the room and will received the updated room ID along with this error code.