### PR TITLE
add modifyStorage api to Node

### DIFF
--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -87,7 +87,6 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     return [root, parentToChildren];
   }
 
-  /** @internal */
   static _fromItems<O extends LsonObject>(
     items: IdTuple<SerializedCrdt>[],
     pool: ManagedPool

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -48,6 +48,7 @@ export {
   convertToCommentUserReaction,
   convertToThreadData,
 } from "./convert-plain-data";
+export type { ManagedPool } from "./crdts/AbstractCrdt";
 export { cloneLson, isLiveNode } from "./crdts/liveblocks-helpers";
 export { LiveList } from "./crdts/LiveList";
 export { LiveMap } from "./crdts/LiveMap";


### PR DESCRIPTION
- Adds a new modifyDocumentStorage method to node client

Requires backend modification 

Use it like this:
```
import { Liveblocks } from "@liveblocks/node";

const liveblocks = new Liveblocks({ secret:  "sk_dev_.....",});

await liveblocks.modifyStorageDocument("roomId", (root) => {
  const obj = root.get("someObject");
  obj.set("99", 12345);
});

```

Root will be a fully hydrated LiveObject.

With types:

```
type MyRoomStorage =  {
    someObject: LiveObject<{
      [key: string]: number | LiveObject<{ a: number }>;
    }>
}
await liveblocks.modifyStorageDocument<MyRoomStorage>("roomId", (root) => {
  const obj = root.get("someObject");
  obj.set("99", 12345);
});
```