### PR TITLE
Export `EmojiPicker` primitive and update Emojibase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.10.3 (Unpublished)
+# v1.10.3
 
 ### `@liveblocks/react-comments`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### `@liveblocks/react-comments`
 
+- Add support for Emoji v15.1 in emoji picker, along two additional locales:
+  Bengali (`bn`) and Hindi (`hi`).
 - Fix bug where the `showRoomName` prop on `InboxNotification.Thread` wasn’t
   applied to notifications about mentions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11766,9 +11766,9 @@
       "license": "MIT"
     },
     "node_modules/emojibase": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-15.0.0.tgz",
-      "integrity": "sha512-bvSIs98sHaVnyKPmW+obRjo49MFx0g+rhfSz6mTePAagEZSlDPosq0b6AcSJa5gt48z3VP2ooXclyBs8vIkpGA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-15.3.0.tgz",
+      "integrity": "sha512-lFdQb14hoznwDh1xDoOFzkPdeeexmbuJdhUUjDaJZf/+jK+6Z3HkI5hWOemWfEdaMxtTujc1vNRx9DKtdtiOXA==",
       "dev": true,
       "funding": {
         "type": "ko-fi",
@@ -23758,7 +23758,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.1.1",
         "@types/use-sync-external-store": "^0.0.3",
-        "emojibase": "^15.0.0",
+        "emojibase": "^15.3.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "msw": "^0.27.1",
@@ -26718,7 +26718,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.1.1",
         "@types/use-sync-external-store": "^0.0.3",
-        "emojibase": "^15.0.0",
+        "emojibase": "^15.3.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "msw": "^0.27.1",
@@ -33279,9 +33279,9 @@
       "version": "8.0.0"
     },
     "emojibase": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-15.0.0.tgz",
-      "integrity": "sha512-bvSIs98sHaVnyKPmW+obRjo49MFx0g+rhfSz6mTePAagEZSlDPosq0b6AcSJa5gt48z3VP2ooXclyBs8vIkpGA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-15.3.0.tgz",
+      "integrity": "sha512-lFdQb14hoznwDh1xDoOFzkPdeeexmbuJdhUUjDaJZf/+jK+6Z3HkI5hWOemWfEdaMxtTujc1vNRx9DKtdtiOXA==",
       "dev": true
     },
     "emojilib": {

--- a/packages/liveblocks-react-comments/package.json
+++ b/packages/liveblocks-react-comments/package.json
@@ -74,7 +74,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.1.1",
     "@types/use-sync-external-store": "^0.0.3",
-    "emojibase": "^15.0.0",
+    "emojibase": "^15.3.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "msw": "^0.27.1",

--- a/packages/liveblocks-react-comments/src/primitives/EmojiPicker/index.tsx
+++ b/packages/liveblocks-react-comments/src/primitives/EmojiPicker/index.tsx
@@ -47,6 +47,22 @@ const EMOJIPICKER_ROOT_NAME = "EmojiPickerRoot";
 const EMOJIPICKER_CONTENT_NAME = "EmojiPickerContent";
 const EMOJIPICKER_SEARCH_NAME = "EmojiPickerSearch";
 
+/**
+ * @private
+ * The EmojiPicker primitive is undocumented for now and subject to change,
+ * use at your own risk. If you have any feedback on it, please let us know!
+ * See how we use it in the default components to learn how to use it:
+ * https://github.com/liveblocks/liveblocks/blob/main/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx.
+ *
+ * Surrounds the emoji picker, it handles emoji data and coordinates
+ * `EmojiPicker.Search` and `EmojiPicker.Content`.
+ *
+ * @example
+ * <EmojiPicker.Root>
+ *   <EmojiPicker.Search />
+ *   <EmojiPicker.Content />
+ * </EmojiPicker.Root>
+ */
 function EmojiPickerRoot({
   columns = DEFAULT_COLUMNS,
   locale = DEFAULT_LOCALE,
@@ -270,6 +286,19 @@ function EmojiPickerRoot({
   );
 }
 
+/**
+ * @private
+ * The EmojiPicker primitive is undocumented for now and subject to change,
+ * use at your own risk. If you have any feedback on it, please let us know!
+ * See how we use it in the default components to learn how to use it:
+ * https://github.com/liveblocks/liveblocks/blob/main/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx.
+ *
+ * The search input of the emoji picker. It also affects the focus and selection
+ * within `EmojiPicker.Content`.
+ *
+ * @example
+ * <EmojiPicker.Search />
+ */
 const EmojiPickerSearch = forwardRef<HTMLInputElement, EmojiPickerSearchProps>(
   ({ asChild, value, defaultValue, onChange, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "input";
@@ -382,6 +411,29 @@ const VirtuosoTopList = forwardRef<HTMLDivElement, TopItemListProps>(
   }
 );
 
+/**
+ * @private
+ * The EmojiPicker primitive is undocumented for now and subject to change,
+ * use at your own risk. If you have any feedback on it, please let us know!
+ * See how we use it in the default components to learn how to use it:
+ * https://github.com/liveblocks/liveblocks/blob/main/packages/liveblocks-react-comments/src/components/internal/EmojiPicker.tsx.
+ *
+ * The main content of the emoji picker, either displaying the emoji grid or various
+ * alternative states (loading, empty, and error).
+ *
+ * @example
+ * <EmojiPicker.Content
+ *  components={{
+ *    Loading: EmojiPickerLoading,
+ *    Empty: EmojiPickerEmpty,
+ *    Error: EmojiPickerError,
+ *    CategoryHeader: EmojiPickerCategoryHeader,
+ *    Grid: EmojiPickerGrid,
+ *    Row: EmojiPickerRow,
+ *    Emoji: EmojiPickerEmoji,
+ *  }}
+ * />
+ */
 const EmojiPickerContent = forwardRef<HTMLDivElement, EmojiPickerContentProps>(
   ({ components, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";

--- a/packages/liveblocks-react-comments/src/primitives/EmojiPicker/utils.ts
+++ b/packages/liveblocks-react-comments/src/primitives/EmojiPicker/utils.ts
@@ -15,13 +15,14 @@ import type {
   EmojiPickerRow,
 } from "./types";
 
-const EMOJIBASE_VERSION = "15.0.0";
+const EMOJIBASE_VERSION = "15.3.0";
 const EMOJIBASE_CDN_URL = `https://cdn.jsdelivr.net/npm/emojibase-data@${EMOJIBASE_VERSION}`;
 const EMOJIBASE_EMOJIS_URL = (locale: EmojibaseLocale) =>
   `${EMOJIBASE_CDN_URL}/${locale}/data.json`;
 const EMOJIBASE_MESSAGES_URL = (locale: EmojibaseLocale) =>
   `${EMOJIBASE_CDN_URL}/${locale}/messages.json`;
 const EMOJIBASE_LOCALES: EmojibaseLocale[] = [
+  "bn",
   "da",
   "de",
   "en",
@@ -31,6 +32,7 @@ const EMOJIBASE_LOCALES: EmojibaseLocale[] = [
   "et",
   "fi",
   "fr",
+  "hi",
   "hu",
   "it",
   "ja",

--- a/packages/liveblocks-react-comments/src/primitives/index.ts
+++ b/packages/liveblocks-react-comments/src/primitives/index.ts
@@ -24,5 +24,19 @@ export type {
   ComposerSuggestionsListItemProps,
   ComposerSuggestionsListProps,
 } from "./Composer/types";
+export * as EmojiPicker from "./EmojiPicker";
+export type {
+  EmojiPickerContentCategoryHeaderProps,
+  EmojiPickerContentComponents,
+  EmojiPickerContentEmojiProps,
+  EmojiPickerContentEmptyProps,
+  EmojiPickerContentErrorProps,
+  EmojiPickerContentGridProps,
+  EmojiPickerContentLoadingProps,
+  EmojiPickerContentProps,
+  EmojiPickerContentRowProps,
+  EmojiPickerRootProps,
+  EmojiPickerSearchProps,
+} from "./EmojiPicker/types";
 export type { TimestampProps } from "./Timestamp";
 export { Timestamp } from "./Timestamp";


### PR DESCRIPTION
This PR makes the `EmojiPicker` primitive public (undocumented for now) and updates Emojibase (the emoji database we use as our source of truth).

**Context:**
If you use primitives to build your own `Thread`/`Comment` components, one big missing piece is the emoji picker. We've built our own but kept it private and reserved it for the default components. This choice was made based on the primitive's complexity, but if we never have people trying it we'll never know what works and what doesn't.