### PR TITLE
Fix thread metadata not being updated correctly after reading server response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fix bug where the `showRoomName` prop on `InboxNotification.Thread` wasn’t
   applied to notifications about mentions.
 
+### `@liveblocks/react`
+
+- Fix bug where removing metadata via `useEditThreadMetadata` would result in a
+  brief flash of the old metadata after the metadata was removed optimistically.
+
 # v1.10.2
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
@@ -136,7 +136,11 @@ describe("useEditThreadMetadata", () => {
           { threadId: initialThread.id },
           async (_, res, ctx) => {
             hasCalledEditThreadMetadata = true;
-            return res(ctx.json({}));
+            return res(
+              ctx.json({
+                color: "yellow",
+              })
+            );
           }
         )
       );

--- a/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
@@ -111,89 +111,86 @@ describe("useEditThreadMetadata", () => {
     unmount();
   });
 
-  test.failing(
-    "should remove thread metadata optimistically and update it with the server response",
-    async () => {
-      const initialThread = dummyThreadData();
-      initialThread.metadata = { color: "blue", resolved: true };
-      let hasCalledEditThreadMetadata = false;
+  test("should remove thread metadata optimistically and update it with the server response", async () => {
+    const initialThread = dummyThreadData();
+    initialThread.metadata = { color: "blue", resolved: true };
+    let hasCalledEditThreadMetadata = false;
 
-      server.use(
-        mockGetThreads((_req, res, ctx) => {
+    server.use(
+      mockGetThreads((_req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: [initialThread],
+            inboxNotifications: [],
+            deletedThreads: [],
+            deletedInboxNotifications: [],
+            meta: {
+              requestedAt: new Date().toISOString(),
+            },
+          })
+        );
+      }),
+      mockEditThreadMetadata(
+        { threadId: initialThread.id },
+        async (_, res, ctx) => {
+          hasCalledEditThreadMetadata = true;
           return res(
             ctx.json({
-              data: [initialThread],
-              inboxNotifications: [],
-              deletedThreads: [],
-              deletedInboxNotifications: [],
-              meta: {
-                requestedAt: new Date().toISOString(),
-              },
+              color: "yellow",
             })
           );
-        }),
-        mockEditThreadMetadata(
-          { threadId: initialThread.id },
-          async (_, res, ctx) => {
-            hasCalledEditThreadMetadata = true;
-            return res(
-              ctx.json({
-                color: "yellow",
-              })
-            );
-          }
-        )
-      );
-
-      const { RoomProvider, useThreads, useEditThreadMetadata } =
-        createRoomContextForTest();
-
-      const { result, unmount } = renderHook(
-        () => ({
-          threads: useThreads().threads,
-          editThreadMetadata: useEditThreadMetadata(),
-        }),
-        {
-          wrapper: ({ children }) => (
-            <RoomProvider id="room-id" initialPresence={{}}>
-              {children}
-            </RoomProvider>
-          ),
         }
-      );
+      )
+    );
 
-      expect(result.current.threads).toBeUndefined();
+    const { RoomProvider, useThreads, useEditThreadMetadata } =
+      createRoomContextForTest();
 
-      await waitFor(() =>
-        expect(result.current.threads).toEqual([initialThread])
-      );
+    const { result, unmount } = renderHook(
+      () => ({
+        threads: useThreads().threads,
+        editThreadMetadata: useEditThreadMetadata(),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
 
-      await act(() =>
-        result.current.editThreadMetadata({
-          threadId: initialThread.id,
-          metadata: {
-            color: "yellow",
-            resolved: null,
-          },
-        })
-      );
+    expect(result.current.threads).toBeUndefined();
 
-      expect(result.current.threads).toBeDefined();
+    await waitFor(() =>
+      expect(result.current.threads).toEqual([initialThread])
+    );
+
+    await act(() =>
+      result.current.editThreadMetadata({
+        threadId: initialThread.id,
+        metadata: {
+          color: "yellow",
+          resolved: null,
+        },
+      })
+    );
+
+    expect(result.current.threads).toBeDefined();
+    expect(result.current.threads![0].metadata).toEqual({
+      resolved: null,
+      color: "yellow",
+    });
+
+    // Thread updatedAt is not updated by the server response so exceptionally,
+    // we need to check if mock has been called
+    await waitFor(() => expect(hasCalledEditThreadMetadata).toEqual(true));
+
+    await waitFor(() => {
       expect(result.current.threads![0].metadata).toEqual({
-        resolved: null,
         color: "yellow",
       });
-
-      // Thread updatedAt is not updated by the server response so exceptionally,
-      // we need to check if mock has been called
-      await waitFor(() => expect(hasCalledEditThreadMetadata).toEqual(true));
-
-      await waitFor(() => {
-        expect(result.current.threads![0].metadata).toEqual({
-          color: "yellow",
-        });
-      });
-      unmount();
-    }
-  );
+    });
+    unmount();
+  });
 });

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1374,7 +1374,7 @@ export function createRoomContext<
         room[kInternal].comments
           .editThreadMetadata({ metadata, threadId })
           .then(
-            (metadata: TThreadMetadata) => {
+            (metadata) => {
               store.set((state) => {
                 const existingThread = state.threads[threadId];
                 const updatedOptimisticUpdates = state.optimisticUpdates.filter(
@@ -1413,10 +1413,9 @@ export function createRoomContext<
                     ...state.threads,
                     [threadId]: {
                       ...existingThread,
-                      metadata: {
-                        ...existingThread.metadata,
-                        ...metadata,
-                      },
+                      metadata: metadata as [TThreadMetadata] extends [never]
+                        ? Record<string, never>
+                        : TThreadMetadata,
                     },
                   },
                   optimisticUpdates: updatedOptimisticUpdates,


### PR DESCRIPTION
Fixes https://github.com/liveblocks/liveblocks/issues/1521

See failing test that verifies the bug: https://github.com/liveblocks/liveblocks/blob/a2d9cc0433640c58a63eaa60ae1e43efeb828eca/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx#L114-L198