### PR TITLE
Remove mentions of Discord beta channels from documentation

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -213,9 +213,8 @@ using a value of at least a few minutes, to avoid unnecessary disconnections.
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 
@@ -257,9 +256,8 @@ const client = createClient({
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 
@@ -305,9 +303,8 @@ you might need to call your backend for example. In that case, providing it via
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-react-comments.mdx
+++ b/docs/pages/api-reference/liveblocks-react-comments.mdx
@@ -13,9 +13,8 @@ components to build a commenting experience. Read our
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1169,9 +1169,8 @@ the dependency arrays of your `useMutation` calls:
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 
@@ -1300,10 +1299,9 @@ removeReaction({ threadId: "th_xxx", commentId: "cm_xxx", emoji: "👍" });
 
 <Banner title="Public beta">
 
-Notifications is currently part of Comments, which is in beta. If you have any
-questions or feedback, please reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+Comments is currently in beta. If you have any questions or feedback, please
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-yjs.mdx
+++ b/docs/pages/api-reference/liveblocks-yjs.mdx
@@ -13,9 +13,8 @@ Read our [getting started](/docs/get-started) guides to learn more.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/nextjs-comments.mdx
+++ b/docs/pages/get-started/nextjs-comments.mdx
@@ -16,9 +16,8 @@ components from
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/react-comments.mdx
+++ b/docs/pages/get-started/react-comments.mdx
@@ -16,9 +16,8 @@ from
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-blocknote-react.mdx
+++ b/docs/pages/get-started/yjs-blocknote-react.mdx
@@ -14,9 +14,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-codemirror-javascript.mdx
+++ b/docs/pages/get-started/yjs-codemirror-javascript.mdx
@@ -14,9 +14,8 @@ collaboration to your JavaScript application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-codemirror-react.mdx
+++ b/docs/pages/get-started/yjs-codemirror-react.mdx
@@ -13,9 +13,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-codemirror-svelte.mdx
+++ b/docs/pages/get-started/yjs-codemirror-svelte.mdx
@@ -14,9 +14,8 @@ collaboration to your Svelte application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-codemirror-vuejs.mdx
+++ b/docs/pages/get-started/yjs-codemirror-vuejs.mdx
@@ -14,9 +14,8 @@ collaboration to your Vue.js application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-lexical-react.mdx
+++ b/docs/pages/get-started/yjs-lexical-react.mdx
@@ -14,9 +14,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-monaco-javascript.mdx
+++ b/docs/pages/get-started/yjs-monaco-javascript.mdx
@@ -14,9 +14,8 @@ collaboration to your JavaScript application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -14,9 +14,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-monaco-svelte.mdx
+++ b/docs/pages/get-started/yjs-monaco-svelte.mdx
@@ -13,9 +13,8 @@ collaboration to your Svelte application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-monaco-vuejs.mdx
+++ b/docs/pages/get-started/yjs-monaco-vuejs.mdx
@@ -13,9 +13,8 @@ collaboration to your Vue.js application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-quill-javascript.mdx
+++ b/docs/pages/get-started/yjs-quill-javascript.mdx
@@ -14,9 +14,8 @@ collaboration to your JavaScript application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-quill-react.mdx
+++ b/docs/pages/get-started/yjs-quill-react.mdx
@@ -14,9 +14,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-quill-svelte.mdx
+++ b/docs/pages/get-started/yjs-quill-svelte.mdx
@@ -13,9 +13,8 @@ collaboration to your Svelte application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-quill-vuejs.mdx
+++ b/docs/pages/get-started/yjs-quill-vuejs.mdx
@@ -13,9 +13,8 @@ collaboration to your Vue.js application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-slate-react.mdx
+++ b/docs/pages/get-started/yjs-slate-react.mdx
@@ -14,9 +14,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-tiptap-javascript.mdx
+++ b/docs/pages/get-started/yjs-tiptap-javascript.mdx
@@ -14,9 +14,8 @@ collaboration to your JavaScript application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-tiptap-react.mdx
+++ b/docs/pages/get-started/yjs-tiptap-react.mdx
@@ -14,9 +14,8 @@ collaboration to your React application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-tiptap-svelte.mdx
+++ b/docs/pages/get-started/yjs-tiptap-svelte.mdx
@@ -13,9 +13,8 @@ collaboration to your Svelte application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/get-started/yjs-tiptap-vuejs.mdx
+++ b/docs/pages/get-started/yjs-tiptap-vuejs.mdx
@@ -13,9 +13,8 @@ collaboration to your Vue.js application using the APIs from the
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/docs/pages/products/comments.mdx
+++ b/docs/pages/products/comments.mdx
@@ -16,9 +16,8 @@ annotations, video annotations, and more.
 <Banner title="Public beta">
 
 Comments is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#comments-beta](https://discord.com/channels/913109211746009108/1126614905160749097).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks.mdx
@@ -23,9 +23,8 @@ CodeMirror, Yjs, Next.js, and Liveblocks.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
@@ -22,9 +22,8 @@ Yjs, Next.js, and Liveblocks.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
@@ -23,9 +23,8 @@ Yjs, Next.js, and Liveblocks.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks.mdx
@@ -22,9 +22,8 @@ Yjs, Next.js, and Liveblocks.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
@@ -22,9 +22,8 @@ Yjs, Next.js, and Liveblocks.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
@@ -22,9 +22,8 @@ Yjs, Next.js, and Liveblocks.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-synchronize-your-liveblocks-yjs-document-data-to-a-planetscale-mysql-database.mdx
+++ b/guides/pages/how-to-synchronize-your-liveblocks-yjs-document-data-to-a-planetscale-mysql-database.mdx
@@ -16,9 +16,8 @@ it changes, and store it in your database.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-synchronize-your-liveblocks-yjs-document-data-to-a-supabase-postgres-database.mdx
+++ b/guides/pages/how-to-synchronize-your-liveblocks-yjs-document-data-to-a-supabase-postgres-database.mdx
@@ -16,9 +16,8 @@ it changes, and store it in your database.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 

--- a/guides/pages/how-to-synchronize-your-liveblocks-yjs-document-data-to-a-vercel-postgres-database.mdx
+++ b/guides/pages/how-to-synchronize-your-liveblocks-yjs-document-data-to-a-vercel-postgres-database.mdx
@@ -16,9 +16,8 @@ it changes, and store it in your database.
 <Banner title="Public beta">
 
 Yjs support is currently in beta. If you have any questions or feedback, please
-reach out to us via the dedicated Discord channel,
-[#yjs-beta](https://discord.com/channels/913109211746009108/1123560088997728328).
-We’d love to hear from you.
+join us on our [Discord server](https://liveblocks.io/discord). We’d love to
+hear from you.
 
 </Banner>
 


### PR DESCRIPTION
For comments and Yjs I replaced all mentions of the beta channel, in fabvor of the Discord server
