### PR TITLE
Fix regression in Vite builds (introduced in 1.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.10.4 (Unpublished)
+# v1.10.4
 
 - Fix bundling issue in Vite projects, where `process is not defined` could
   happen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.10.4 (Unpublished)
+
+- Fix bundling issue in Vite projects, where `process is not defined` could
+  happen
+
 # v1.10.3
 
 ### `@liveblocks/react-comments`

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -290,11 +290,6 @@ export type ClientOptions<TUserMeta extends BaseUserMeta = BaseUserMeta> = {
 //
 
 function getBaseUrl(baseUrl?: string | undefined): string {
-  baseUrl ||=
-    process.env.LIVEBLOCKS_BASE_URL ||
-    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ||
-    process.env.VITE_LIVEBLOCKS_BASE_URL ||
-    undefined;
   if (
     typeof baseUrl === "string" &&
     baseUrl.startsWith("http") // Must be http or https URL


### PR DESCRIPTION
This removes the use of `process.env.WHATEVER` expressions (except `proces.env.NODE_ENV` specifically).

The reason is that Vite does not seem to rewrite any of these in the final bundle, leaving those `process.env.WHATEVER` expressions in the final bundle. Other frameworks/bundlers do rewrite these expressions to `undefined`, which is what the expected behavior was here.

It's still fine to use `process.env.NODE_ENV`, as that specific expression _is_ still recognized by Vite (as well as all other bundlers).

Fixes #1523 and #1524.
