### PR TITLE
Change `Comment` background color in some scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add actions to `InboxNotification` with a single action for now: marking as
   read.
 - Improve actions hover behavior in `Comment`/`Thread`.
+- Change `Comment` background color when it’s linked to or being edited.
 
 ### `@liveblocks/node`
 

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -20,6 +20,7 @@ import type {
 import React, {
   forwardRef,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -378,6 +379,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
     const markThreadAsRead = useMarkThreadAsRead();
     const $ = useOverrides(overrides);
     const [isEditing, setEditing] = useState(false);
+    const [isTarget, setTarget] = useState(false);
     const [isMoreActionOpen, setMoreActionOpen] = useState(false);
     const [isReactionActionOpen, setReactionActionOpen] = useState(false);
 
@@ -476,6 +478,18 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
       ]
     );
 
+    useEffect(() => {
+      const isWindowDefined = typeof window !== "undefined";
+      if (!isWindowDefined) return;
+
+      const hash = window.location.hash;
+      const commentId = hash.slice(1);
+
+      if (commentId === comment.id) {
+        setTarget(true);
+      }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
     if (!showDeleted && !comment.body) {
       return null;
     }
@@ -494,6 +508,8 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
           )}
           data-deleted={!comment.body ? "" : undefined}
           data-editing={isEditing ? "" : undefined}
+          // In some cases, `:target` doesn't work as expected so we also define it manually.
+          data-target={isTarget ? "" : undefined}
           dir={$.dir}
           {...props}
           ref={mergedRefs}

--- a/packages/liveblocks-react-comments/src/styles/index.css
+++ b/packages/liveblocks-react-comments/src/styles/index.css
@@ -795,6 +795,10 @@
   &:where(:target) {
     --lb-dynamic-background: var(--lb-background-accent-faint);
   }
+
+  &:where([data-editing]) {
+    --lb-dynamic-background: var(--lb-background-foreground-faint);
+  }
 }
 
 .lb-comment-header {

--- a/packages/liveblocks-react-comments/src/styles/index.css
+++ b/packages/liveblocks-react-comments/src/styles/index.css
@@ -773,6 +773,7 @@
   background: var(--lb-dynamic-background);
   color: var(--lb-foreground);
   font-weight: 400;
+  scroll-margin: var(--lb-spacing);
 
   @media (hover: hover) {
     &:where(.lb-comment\:show-actions-hover) {

--- a/packages/liveblocks-react-comments/src/styles/index.css
+++ b/packages/liveblocks-react-comments/src/styles/index.css
@@ -791,6 +791,10 @@
       }
     }
   }
+
+  &:where(:target) {
+    --lb-dynamic-background: var(--lb-background-accent-faint);
+  }
 }
 
 .lb-comment-header {

--- a/packages/liveblocks-react-comments/src/styles/index.css
+++ b/packages/liveblocks-react-comments/src/styles/index.css
@@ -793,7 +793,7 @@
     }
   }
 
-  &:where(:target) {
+  &:where(:target, [data-target]) {
     --lb-dynamic-background: var(--lb-background-accent-faint);
   }
 


### PR DESCRIPTION
This PR leverages the recent improvements we did to our color tokens setup for Notifications to improve some Comments scenarios:
- Change background to faint accent when a `Comment` is being linked to
- Change background to faint grey when a `Comment` is being edited

![linked](https://github.com/liveblocks/liveblocks/assets/6959425/760bce04-285a-410a-91b6-24cf04ee9c94)
![edited](https://github.com/liveblocks/liveblocks/assets/6959425/b4d3e25f-c88b-4499-a207-d05b5ae7e88b)

I also added a default `scroll-margin` value to avoid scrolling **exactly** to linked comments, users can override this default easily if they want to.