### PR TITLE
Remove explicit `undefined` from partial metadata types

### DIFF
--- a/packages/liveblocks-core/src/types/PartialNullable.ts
+++ b/packages/liveblocks-core/src/types/PartialNullable.ts
@@ -1,3 +1,3 @@
 export type PartialNullable<T> = {
-  [P in keyof T]?: T[P] | null | undefined;
+  [P in keyof T]?: T[P] | null;
 };


### PR DESCRIPTION
**Context:** https://liveblocks.slack.com/archives/C04TFCME5MF/p1710249036364819?thread_ts=1710156229.250929&cid=C04TFCME5MF

In places where users can edit or set thread metadata, we currently allow `undefined` values even though they will be stripped during serialization and won't do anything. Ideally, we would allow partial updates **but** prevent explicit `undefined` values to avoid misunderstandings. That's what I wanted to do with this PR but turns out that we can't control this from our end: making a property optional will always make TS accept explicit `undefined` values.

Since TypeScript 4.4, [that behavior can be changed](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#exact-optional-property-types) but only from the user's side. So to allow this setting to work as expected for users that have it enabled, this PR removes the explicit `undefined` we added to optional values ourselves (I'm not 100% sure why we had it in the first place).

---

It might be hard to review this snippet in isolation, `PartialNullable` is only used for thread metadata at the moment.

![](https://github.com/liveblocks/liveblocks/assets/6959425/3264a117-c4f5-4235-aed6-860ee6b3f58c)