### PR TITLE
Yjs subdocument guide and reference

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -737,9 +737,8 @@ await liveblocks.deleteStorageDocument("my-room-id");
 
 #### Liveblocks.getYjsDocument [#get-rooms-roomId-ydoc]
 
-Returns a JSON representation of a room’s Yjs document. To return a subdocument
-instead of the main document, pass its `guid`. Throws an error if the room isn’t
-found. This is a wrapper around the
+Returns a JSON representation of a room’s Yjs document. Throws an error if the
+room isn’t found. This is a wrapper around the
 [Get Yjs Document API](/docs/api-reference/rest-api-endpoints#get-rooms-roomId-ydoc)
 and returns the same response.
 
@@ -754,9 +753,6 @@ A number of options are available.
 
 ```ts
 const yjsDocument = await liveblocks.getYjsDocument("my-room-id", {
-  // Optional, return a subdocument instead. guid is its unique identifier
-  guid: "c4a755...",
-
   // Optional, if true, `yText` values will return formatting
   formatting: true,
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -737,8 +737,9 @@ await liveblocks.deleteStorageDocument("my-room-id");
 
 #### Liveblocks.getYjsDocument [#get-rooms-roomId-ydoc]
 
-Returns a JSON representation of a room’s Yjs document. Throws an error if the
-room isn’t found. This is a wrapper around the
+Returns a JSON representation of a room’s Yjs document. To return a subdocument
+instead of the main document, pass its `guid`. Throws an error if the room isn’t
+found. This is a wrapper around the
 [Get Yjs Document API](/docs/api-reference/rest-api-endpoints#get-rooms-roomId-ydoc)
 and returns the same response.
 
@@ -753,6 +754,9 @@ A number of options are available.
 
 ```ts
 const yjsDocument = await liveblocks.getYjsDocument("my-room-id", {
+  // Optional, return a subdocument instead. guid is its unique identifier
+  guid: "c4a755...",
+
   // Optional, if true, `yText` values will return formatting
   formatting: true,
 
@@ -794,6 +798,15 @@ const update = Y.encodeStateAsUpdate(yDoc);
 
 // Send update to Liveblocks
 await liveblocks.sendYjsBinaryUpdate("my-room-id", update);
+```
+
+To update a subdocument instead of the main document, pass its `guid`.
+
+```ts
+await liveblocks.sendYjsBinaryUpdate("my-room-id", update, {
+  // Optional, update a subdocument instead. guid is its unique identifier
+  guid: "c4a755...",
+});
 ```
 
 To create a new room and initialize its Yjs document, call
@@ -894,6 +907,18 @@ and returns the same response.
 ```ts
 const binaryYjsUpdate =
   await liveblocks.getYjsDocumentAsBinaryUpdate("my-room-id");
+```
+
+To return a subdocument instead of the main document, pass its `guid`.
+
+```ts
+const binaryYjsUpdate = await liveblocks.getYjsDocumentAsBinaryUpdate(
+  "my-room-id",
+  {
+    // Optional, return a subdocument instead. guid is its unique identifier
+    guid: "c4a755...",
+  }
+);
 ```
 
 Read the [Yjs documentation](https://docs.yjs.dev/api/document-updates) to learn

--- a/docs/pages/api-reference/liveblocks-yjs.mdx
+++ b/docs/pages/api-reference/liveblocks-yjs.mdx
@@ -121,6 +121,19 @@ yProvider.on("sync", (sync: boolean) => /* ... */);
 yProvider.on("synced", (sync: boolean) => /* ... */);
 ```
 
+### LiveblocksProvider.on("subdocs") [#LiveblocksProvider.on.subdocs]
+
+Add an event listener for the `subdocs` event. The `subdocs` event is triggered
+when a [subdocument](https://docs.yjs.dev/api/subdocuments) has been added,
+removed, or loaded.
+
+```ts
+// Listen for the subdocs event
+yProvider.on("subdocs", ({ added, removed, loaded }) => {
+  // Subdocument change
+});
+```
+
 ### LiveblocksProvider.off("sync") [#LiveblocksProvider.off.sync]
 
 Remove an event listener for the `sync` event. The `sync` event is triggered
@@ -143,6 +156,26 @@ yProvider.off("sync", (sync: boolean) => /* ... */);
 yProvider.off("synced", (sync: boolean) => /* ... */);
 ```
 
+### LiveblocksProvider.off("subdocs") [#LiveblocksProvider.off.subdocs]
+
+Remove an event listener for the `subdocs` event. The `subdocs` event is
+triggered when a [subdocument](https://docs.yjs.dev/api/subdocuments) has been
+added, removed, or loaded.
+
+```ts
+const handleSubdocs = (params: {
+  added: Set<Y.Doc>;
+  removed: Set<Y.Doc>;
+  loaded: Set<Y.Doc>;
+}) => {
+  // Subdocument change
+};
+yProvider.on("subdocs", handleSubdocs);
+
+// Clean up subdocs event
+yProvider.off("subdocs", handleSubdocs);
+```
+
 ### LiveblocksProvider.once("sync") [#LiveblocksProvider.once.sync]
 
 Add a one-time event listener for the `sync` event. The `sync` event is
@@ -151,7 +184,7 @@ fire events when the document has loaded.
 
 ```ts
 // Listen for the sync event only once
-yProvider.on("sync", (isSynced: boolean) => {
+yProvider.once("sync", (isSynced: boolean) => {
   if (isSynced === true) {
     // Yjs content is synchronized and ready
   } else {
@@ -166,6 +199,19 @@ Aliased by `LiveblocksProvider.once("synced")`.
 // "sync" and "synced" both listen to the same event
 yProvider.once("sync", (sync: boolean) => /* ... */);
 yProvider.once("synced", (sync: boolean) => /* ... */);
+```
+
+### LiveblocksProvider.once("subdocs") [#LiveblocksProvider.once.subdocs]
+
+Add a one-time event listener for the `subdocs` event. The `subdocs` event is
+triggered when a [subdocument](https://docs.yjs.dev/api/subdocuments) has been
+added, removed, or loaded.
+
+```ts
+// Listen for the subdocs event only once
+yProvider.once("subdocs", ({ added, removed, loaded }) => {
+  // Subdocument change
+});
 ```
 
 ### LiveblocksProvider.emit("sync") [#LiveblocksProvider.emit.sync]
@@ -184,6 +230,20 @@ Aliased by `LiveblocksProvider.emit("synced")`.
 // "sync" and "synced" both listen to the same event
 yProvider.emit("sync" /* , ... */);
 yProvider.emit("synced" /* , ... */);
+```
+
+### LiveblocksProvider.emit("subdocs") [#LiveblocksProvider.emit.subdocs]
+
+Synchronously call each listener for the `subdocs` event in the order they were
+registered, passing arguments to each.
+
+```ts
+// Call each listener and pass arguments
+yProvider.emit("subdocs", {
+  added: new Y.Doc(),
+  removed: new Y.Doc(),
+  loaded: new Y.Doc(),
+});
 ```
 
 ### LiveblocksProvider.synced [#LiveblocksProvider.synced]

--- a/docs/pages/api-reference/liveblocks-yjs.mdx
+++ b/docs/pages/api-reference/liveblocks-yjs.mdx
@@ -29,7 +29,7 @@ clients in the room.
 You can connect by creating a Yjs document, then passing it to
 `LiveblocksProvider` along with the currently connected Liveblocks room.
 
-```ts highlight="11-13"
+```ts highlight="13-15"
 import * as Y from "yjs";
 import { createClient } from "@liveblocks/client";
 import LiveblocksProvider from "@liveblocks/yjs";
@@ -121,19 +121,6 @@ yProvider.on("sync", (sync: boolean) => /* ... */);
 yProvider.on("synced", (sync: boolean) => /* ... */);
 ```
 
-### LiveblocksProvider.on("subdocs") [#LiveblocksProvider.on.subdocs]
-
-Add an event listener for the `subdocs` event. The `subdocs` event is triggered
-when a [subdocument](https://docs.yjs.dev/api/subdocuments) has been added,
-removed, or loaded.
-
-```ts
-// Listen for the subdocs event
-yProvider.on("subdocs", ({ added, removed, loaded }) => {
-  // Subdocument change
-});
-```
-
 ### LiveblocksProvider.off("sync") [#LiveblocksProvider.off.sync]
 
 Remove an event listener for the `sync` event. The `sync` event is triggered
@@ -154,26 +141,6 @@ Aliased by `LiveblocksProvider.on("synced")`.
 // "sync" and "synced" both listen to the same event
 yProvider.off("sync", (sync: boolean) => /* ... */);
 yProvider.off("synced", (sync: boolean) => /* ... */);
-```
-
-### LiveblocksProvider.off("subdocs") [#LiveblocksProvider.off.subdocs]
-
-Remove an event listener for the `subdocs` event. The `subdocs` event is
-triggered when a [subdocument](https://docs.yjs.dev/api/subdocuments) has been
-added, removed, or loaded.
-
-```ts
-const handleSubdocs = (params: {
-  added: Set<Y.Doc>;
-  removed: Set<Y.Doc>;
-  loaded: Set<Y.Doc>;
-}) => {
-  // Subdocument change
-};
-yProvider.on("subdocs", handleSubdocs);
-
-// Clean up subdocs event
-yProvider.off("subdocs", handleSubdocs);
 ```
 
 ### LiveblocksProvider.once("sync") [#LiveblocksProvider.once.sync]
@@ -201,19 +168,6 @@ yProvider.once("sync", (sync: boolean) => /* ... */);
 yProvider.once("synced", (sync: boolean) => /* ... */);
 ```
 
-### LiveblocksProvider.once("subdocs") [#LiveblocksProvider.once.subdocs]
-
-Add a one-time event listener for the `subdocs` event. The `subdocs` event is
-triggered when a [subdocument](https://docs.yjs.dev/api/subdocuments) has been
-added, removed, or loaded.
-
-```ts
-// Listen for the subdocs event only once
-yProvider.once("subdocs", ({ added, removed, loaded }) => {
-  // Subdocument change
-});
-```
-
 ### LiveblocksProvider.emit("sync") [#LiveblocksProvider.emit.sync]
 
 Synchronously call each listener for the `sync` event in the order they were
@@ -230,20 +184,6 @@ Aliased by `LiveblocksProvider.emit("synced")`.
 // "sync" and "synced" both listen to the same event
 yProvider.emit("sync" /* , ... */);
 yProvider.emit("synced" /* , ... */);
-```
-
-### LiveblocksProvider.emit("subdocs") [#LiveblocksProvider.emit.subdocs]
-
-Synchronously call each listener for the `subdocs` event in the order they were
-registered, passing arguments to each.
-
-```ts
-// Call each listener and pass arguments
-yProvider.emit("subdocs", {
-  added: new Y.Doc(),
-  removed: new Y.Doc(),
-  loaded: new Y.Doc(),
-});
 ```
 
 ### LiveblocksProvider.synced [#LiveblocksProvider.synced]

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -826,7 +826,7 @@
     "/rooms/{roomId}/ydoc": {
       "get": {
         "summary": "Get Yjs document",
-        "description": "This endpoint returns a JSON representation of the room’s Yjs document. Corresponds to [`liveblocks.getYjsDocument`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc).",
+        "description": "This endpoint returns a JSON representation of the room’s Yjs document. To return a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.getYjsDocument`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc).",
         "tags": ["Yjs"],
         "parameters": [
           {
@@ -837,6 +837,15 @@
               "type": "string"
             },
             "description": "ID of the room"
+          },
+          {
+            "name": "guid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the subdocument"
           },
           {
             "schema": {
@@ -910,6 +919,15 @@
             "in": "path",
             "required": true,
             "description": "ID of the room"
+          },
+          {
+            "name": "guid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the subdocument"
           }
         ],
         "responses": {
@@ -934,7 +952,7 @@
           }
         },
         "operationId": "put-rooms-roomId-ydoc",
-        "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document.\n\nThe update is typically obtained by calling `Y.encodeStateAsUpdate(doc)`. See the [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more details. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc). When manually making this HTTP call, set the HTTP header `Content-Type` to `application/octet-stream`, and send the binary update (a `Uint8Array`) in the body of the HTTP request. This endpoint does not accept JSON, unlike most other endpoints.",
+        "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document. To send an update to a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).\n\nThe update is typically obtained by calling `Y.encodeStateAsUpdate(doc)`. See the [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more details. When manually making this HTTP call, set the HTTP header `Content-Type` to `application/octet-stream`, and send the binary update (a `Uint8Array`) in the body of the HTTP request. This endpoint does not accept JSON, unlike most other endpoints.",
         "requestBody": {
           "content": {
             "application/octet-stream": {
@@ -950,7 +968,7 @@
     "/rooms/{roomId}/ydoc-binary": {
       "get": {
         "summary": "Get Yjs document encoded as a binary Yjs update",
-        "description": "This endpoint returns the room’s Yjs document encoded as a single binary update. This can be used by `Y.applyUpdate(responseBody)` to get a copy of the document in your back end. See [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more information on working with updates. Corresponds to [`liveblocks.getYjsDocumentAsBinaryUpdate`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc-binary).",
+        "description": "This endpoint returns the room’s Yjs document encoded as a single binary update. This can be used by `Y.applyUpdate(responseBody)` to get a copy of the document in your back end. See [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more information on working with updates. To return a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.getYjsDocumentAsBinaryUpdate`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc-binary).",
         "tags": ["Yjs"],
         "parameters": [
           {
@@ -961,6 +979,15 @@
               "type": "string"
             },
             "description": "ID of the room"
+          },
+          {
+            "name": "guid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the subdocument"
           }
         ],
         "responses": {

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -826,7 +826,7 @@
     "/rooms/{roomId}/ydoc": {
       "get": {
         "summary": "Get Yjs document",
-        "description": "This endpoint returns a JSON representation of the room’s Yjs document. To return a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.getYjsDocument`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc).",
+        "description": "This endpoint returns a JSON representation of the room’s Yjs document. Corresponds to [`liveblocks.getYjsDocument`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc).",
         "tags": ["Yjs"],
         "parameters": [
           {
@@ -837,15 +837,6 @@
               "type": "string"
             },
             "description": "ID of the room"
-          },
-          {
-            "name": "guid",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "ID of the subdocument"
           },
           {
             "schema": {

--- a/guides/guides.json
+++ b/guides/guides.json
@@ -329,5 +329,12 @@
     "topics": ["authentication"],
     "technologies": ["nodejs"],
     "date": "2024-03-13"
+  },
+  {
+    "title": "How to use Yjs subdocuments",
+    "path": "/how-to-use-yjs-subdocuments",
+    "topics": ["data-fetching", "rest-api"],
+    "technologies": ["yjs", "nodejs", "javascript"],
+    "date": "2024-03-13"
   }
 ]

--- a/guides/pages/how-to-use-yjs-subdocuments.mdx
+++ b/guides/pages/how-to-use-yjs-subdocuments.mdx
@@ -10,10 +10,11 @@ through how to use them on client and server.
 
 ## When to use subdocuments
 
-Subdocuments are helpful when you have multiple _large_ Yjs documents that you
-wish to lazy load individually. Each subdocument works like a normal Yjs
-document, which means it must be loaded and updated separately to the main
-document.
+Subdocuments are helpful when you have multiple _large_ Yjs documents in the
+same room, and you wish to lazy-load them individually. Each subdocument works
+similarly to a normal Yjs document, allowing you to use
+[shared types](https://docs.yjs.dev/getting-started/working-with-shared-types),
+[awareness](https://docs.yjs.dev/getting-started/adding-awareness), and more.
 
 ### Not necessary for multiple text editors
 

--- a/guides/pages/how-to-use-yjs-subdocuments.mdx
+++ b/guides/pages/how-to-use-yjs-subdocuments.mdx
@@ -109,19 +109,21 @@ yProvider.loadSubdoc("c4a755...");
 
 ### Listening for changes
 
-To keep track of subdocument changes, you can use
-[`docs.on("subdocs")`](/docs/api-reference/liveblocks-yjs#LiveblocksProvider.on.subdocs).
+To keep track of subdocument changes, you can use `Y.Doc.on("subdocs")`.
 
-```ts
+```ts highlight="10-13"
 import { LiveblocksProvider } from "@liveblocks/yjs";
 import * as Y from "yjs";
 
 // Create main document and connect, disabling auto-loading of subdocuments
 const yDoc = new Y.Doc();
-const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+const yProvider = new LiveblocksProvider(room, yDoc, {
+  autoloadSubdocs: false,
+});
 
-yProvider.on("subdocs", ({ added, removed, loaded }) => {
+yDoc.on("subdocs", ({ added, removed, loaded }) => {
   // Subdocument change
+  // ...
 });
 ```
 

--- a/guides/pages/how-to-use-yjs-subdocuments.mdx
+++ b/guides/pages/how-to-use-yjs-subdocuments.mdx
@@ -1,0 +1,205 @@
+---
+meta:
+  title: "How to use Yjs subdocuments"
+  description: "Learn how to Yjs subdocuments on client and server"
+---
+
+Liveblocks Yjs supports [subdocuments](https://docs.yjs.dev/api/subdocuments),
+which allow you to nest Yjs documents inside each other. This guide takes you
+through how to use them on client and server.
+
+## When to use subdocuments
+
+Subdocuments are helpful when you have multiple _large_ Yjs documents that you
+wish to lazy load individually. Each subdocument works like a normal Yjs
+document, which means it must be loaded and updated separately to the main
+document.
+
+### Not necessary for multiple text editors
+
+Please note that **subdocuments are not necessary for displaying multiple text
+editors** on one page. For this use case, it’s often best to create a
+[`Y.Map`](https://docs.yjs.dev/api/shared-types/y.map) in your Yjs document, and
+place the contents of each editor inside. For example, if your text editor uses
+[`Y.XmlFragment`](https://docs.yjs.dev/api/shared-types/y.xmlfragment), here’s
+how to create this.
+
+```tsx
+// Create Yjs document with an `editors` map
+const yDoc = new Y.Doc();
+const yMap = yDoc.getMap("editors");
+
+// Create shared types and add to map
+const editorOne = new Y.XMLFragment();
+const editorTwo = new Y.XMLFragment();
+yMap.set("editor-1", editorOne);
+yMap.set("editor-2", editorTwo);
+
+// Pass `editorOne` and `editorTwo` to your text editors
+// ...
+```
+
+This is much simpler than using subdocuments. However, if the content of these
+editors is very large, or if your text editor only accepts a `Y.Doc`,
+subdocuments may be for you.
+
+## On the client
+
+Subdocuments can be stored in your Yjs tree like any other shared type. In this
+example we’ll create a [`Y.Map`](https://docs.yjs.dev/api/shared-types/y.map) to
+store them in, making sure to lazy load any subdocuments.
+
+```ts
+import { LiveblocksProvider } from "@liveblocks/yjs";
+import * as Y from "yjs";
+
+// Create main document and connect, disabling auto-loading of subdocuments
+const yDoc = new Y.Doc();
+const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+
+// Create a Y.Map to hold subdocuments
+const subdocMap = yDoc.getMap("subdocs");
+```
+
+### Create a subdocument [#create-a-subdocument]
+
+To create a new subdocument, create a `new Y.Doc()`, and use this it any other.
+
+```ts highlight="8-9,11-14,16-17"
+import { LiveblocksProvider } from "@liveblocks/yjs";
+import * as Y from "yjs";
+
+// Create main document and connect, disabling auto-loading of subdocuments
+const yDoc = new Y.Doc();
+const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+
+// Create a Y.Map to hold subdocuments
+const subdocMap = yDoc.getMap("subdocs");
+
+// Create subdocument
+const subdoc = new Y.Doc();
+yDoc.getMap().set("my-document", subdoc);
+subdoc.getText("default").insert(0, "This is a subdocument");
+
+// Make note of its `guid`, which is used for retrieving it later
+const guid = subdoc.guid; // e.g. "c4a755..."
+```
+
+Make sure to keep track of its `guid`.
+
+### Load the subdocument
+
+To load the subdocument on _another client_, use its `guid`.
+
+```ts highlight="8-9"
+import { LiveblocksProvider } from "@liveblocks/yjs";
+import * as Y from "yjs";
+
+// Create main document and connect, disabling auto-loading of subdocuments
+const yDoc = new Y.Doc();
+const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+
+// From another client, load the subdoc using the GUID from `subdoc.guid` or `doc.getSubdocGuids`
+yProvider.loadSubdoc("c4a755...");
+
+// Alternatively, get a reference to a subdocument from `doc.getSubdocs()` and then load
+// subdoc.load();
+```
+
+### Listening for changes
+
+To keep track of subdocument changes, you can use
+[`docs.on("subdocs")`](/docs/api-reference/liveblocks-yjs#LiveblocksProvider.on.subdocs).
+
+```ts
+import { LiveblocksProvider } from "@liveblocks/yjs";
+import * as Y from "yjs";
+
+// Create main document and connect, disabling auto-loading of subdocuments
+const yDoc = new Y.Doc();
+const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+
+yProvider.on("subdocs", ({ added, removed, loaded }) => {
+  // Subdocument change
+});
+```
+
+## On the server
+
+It’s possible to use your subdocument on the server, without connecting with a
+provider.
+
+### Fetching a subdocument
+
+When fetching a Yjs subdocument on the server, it’s recommended to use
+[`liveblocks.getYjsDocumentAsBinaryUpdate`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc-binary)
+with the `guid` of your subdocument. We stored the `guid` when we
+[created the subdocument](#create-a-subdocument).
+
+```ts highlight="9-13,15-17"
+import { Liveblocks } from "@liveblocks/node";
+import * as Y from "yjs";
+
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
+
+export function POST() {
+  // Get your Yjs subdocument as a binary update
+  const update = liveblocks.getYjsDocumentAsBinaryUpdate("my-room-id", {
+    // The `guid` of your subdocument, as noted earlier
+    guid: "c4a755...",
+  });
+
+  // Create a Yjs document for your subdoc and apply the update
+  const subdoc = new Y.Doc();
+  Y.applyUpdate(subdoc, new Uint8Array(update));
+
+  // `subdoc` can now be read
+  // ...
+}
+```
+
+We’ve now retrieved the subdocument, and it can be read, but any changes you
+make won’t be applied to other clients, and are only temporary.
+
+### Updating a subdocument
+
+To permanently apply changes to your subdocument, sending them to Liveblocks and
+other clients, you can use
+[`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).
+
+```ts highlight="19-20,22-23,25-29"
+import { Liveblocks } from "@liveblocks/node";
+import * as Y from "yjs";
+
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
+
+export function POST() {
+  // Get your Yjs subdocument as a binary update
+  const update = liveblocks.getYjsDocumentAsBinaryUpdate("my-room-id", {
+    // The `guid` of your subdocument, as noted earlier
+    guid: "c4a755...",
+  });
+
+  // Create a Yjs document for your subdoc and apply the update
+  const subdoc = new Y.Doc();
+  Y.applyUpdate(subdoc, new Uint8Array(update));
+
+  // Make changes to your `subdoc`, for example
+  subdoc.getText("my-text");
+
+  // Convert `subdoc` into a binary update
+  const subdocChanges = Y.encodeStateAsUpdate(subdoc);
+
+  // Send the changes to Liveblocks, and other clients
+  liveblocks.sendYjsBinaryUpdate("my-room-id", subdocChanges, {
+    // The `guid` of your subdocument, as noted earlier
+    guid: "c4a755...",
+  });
+}
+```
+
+After running this code, all connected users will see the update.


### PR DESCRIPTION
I've written up some things:
- API reference for the modified `@liveblocks/node` functions
- Some missing docs Yjs info 
- A guide on using subdocuments

Could @nimeshnayaju or @jrowny take a look at the guide? I won't have a chance to test any of the code snippets, so I'd like some eyes on this.