### PR TITLE
Update examples query parameter

### DIFF
--- a/examples/javascript-live-cursors/app.ts
+++ b/examples/javascript-live-cursors/app.ts
@@ -5,7 +5,7 @@ let roomId = "javascript-live-cursors";
 
 applyExampleRoomIdAndApiKey();
 
-if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+if (!/^pk_/.test(PUBLIC_KEY)) {
   console.warn(
     `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
       `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/javascript-live-cursors#getting-started.`

--- a/examples/javascript-live-cursors/app.ts
+++ b/examples/javascript-live-cursors/app.ts
@@ -3,7 +3,7 @@ import { createClient } from "@liveblocks/client";
 let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 let roomId = "javascript-live-cursors";
 
-overrideApiKeyAndRoomId();
+applyExampleRoomIdAndApiKey();
 
 if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
   console.warn(
@@ -120,16 +120,20 @@ function deleteCursor(user) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideApiKeyAndRoomId() {
+function applyExampleRoomIdAndApiKey() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
   const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
   const apiKey = query.get("apiKey");
-  const roomIdSuffix = query.get("roomId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
+  }
 
   if (apiKey) {
     PUBLIC_KEY = apiKey;
-  }
-
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
   }
 }

--- a/examples/javascript-todo-list/app.ts
+++ b/examples/javascript-todo-list/app.ts
@@ -6,7 +6,7 @@ async function run() {
 
   applyExampleRoomIdAndApiKey();
 
-  if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+  if (!/^pk_/.test(PUBLIC_KEY)) {
     console.warn(
       `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
         `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/javascript-todo-list#getting-started.`

--- a/examples/javascript-todo-list/app.ts
+++ b/examples/javascript-todo-list/app.ts
@@ -4,7 +4,7 @@ async function run() {
   let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
   let roomId = "javascript-todo-list";
 
-  overrideApiKeyAndRoomId();
+  applyExampleRoomIdAndApiKey();
 
   if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
     console.warn(
@@ -103,17 +103,21 @@ async function run() {
    * This function is used when deploying an example on liveblocks.io.
    * You can ignore it completely if you run the example locally.
    */
-  function overrideApiKeyAndRoomId() {
+  function applyExampleRoomIdAndApiKey() {
+    if (typeof window === "undefined") {
+      return;
+    }
+
     const query = new URLSearchParams(window?.location?.search);
+    const exampleId = query.get("exampleId");
     const apiKey = query.get("apiKey");
-    const roomIdSuffix = query.get("roomId");
+
+    if (exampleId) {
+      roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
+    }
 
     if (apiKey) {
       PUBLIC_KEY = apiKey;
-    }
-
-    if (roomIdSuffix) {
-      roomId = `${roomId}-${roomIdSuffix}`;
     }
   }
 

--- a/examples/nextjs-3d-builder/pages/_app.js
+++ b/examples/nextjs-3d-builder/pages/_app.js
@@ -5,7 +5,7 @@ import { LiveObject } from "@liveblocks/client";
 import { RoomProvider } from "../liveblocks.config";
 
 function App({ Component, pageProps }) {
-  const roomId = useOverrideRoomId("nextjs-3d-builder");
+  const roomId = useExampleRoomdId("nextjs-3d-builder");
 
   return (
     <RoomProvider
@@ -40,11 +40,11 @@ export default App;
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId) {
+function useExampleRoomdId(roomId) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments-ai/src/app/page.tsx
+++ b/examples/nextjs-comments-ai/src/app/page.tsx
@@ -27,7 +27,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-comments-ai");
+  const roomId = useExampleRoomId("nextjs-comments-ai");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
@@ -48,13 +48,13 @@ export default function Page() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params?.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments-audio/src/app/Room.tsx
+++ b/examples/nextjs-comments-audio/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ReactNode, useMemo } from "react";
 import { Toaster } from "sonner";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-comments-audio");
+  const roomId = useExampleRoomId("nextjs-comments-audio");
 
   return (
     <Tooltip.Provider delayDuration={0}>
@@ -29,13 +29,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments-emails/src/app/page.tsx
+++ b/examples/nextjs-comments-emails/src/app/page.tsx
@@ -27,7 +27,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-comments-emails");
+  const roomId = useExampleRoomId("nextjs-comments-emails");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
@@ -48,13 +48,13 @@ export default function Page() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params?.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments-overlay/src/app/Room.tsx
+++ b/examples/nextjs-comments-overlay/src/app/Room.tsx
@@ -5,7 +5,7 @@ import { RoomProvider } from "@/liveblocks.config";
 import { useSearchParams } from "next/navigation";
 
 export function Room({ children }: PropsWithChildren) {
-  const roomId = useOverrideRoomId("nextjs-comments-overlay");
+  const roomId = useExampleRoomId("nextjs-comments-overlay");
 
   return (
     <RoomProvider
@@ -15,19 +15,19 @@ export function Room({ children }: PropsWithChildren) {
       {children}
     </RoomProvider>
   );
+}
 
-  /**
-   * This function is used when deploying an example on liveblocks.io.
-   * You can ignore it completely if you run the example locally.
-   */
-  function useOverrideRoomId(roomId: string) {
-    const params = useSearchParams();
-    const roomIdParam = params.get("roomId");
+/**
+ * This function is used when deploying an example on liveblocks.io.
+ * You can ignore it completely if you run the example locally.
+ */
+function useExampleRoomId(roomId: string) {
+  const params = useSearchParams();
+  const exampleId = params?.get("exampleId");
 
-    const overrideRoomId = useMemo(() => {
-      return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-    }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-    return overrideRoomId;
-  }
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments-primitives/src/app/page.tsx
+++ b/examples/nextjs-comments-primitives/src/app/page.tsx
@@ -42,7 +42,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-comments-primitives");
+  const roomId = useExampleRoomId("nextjs-comments-primitives");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
@@ -65,13 +65,14 @@ export default function Page() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params?.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }
+

--- a/examples/nextjs-comments-tiptap/src/app/Room.tsx
+++ b/examples/nextjs-comments-tiptap/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { DocumentSpinner } from "@/components/Spinner";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-comments-tiptap");
+  const roomId = useExampleRoomId("nextjs-comments-tiptap");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments-video/src/app/Room.tsx
+++ b/examples/nextjs-comments-video/src/app/Room.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from "next/navigation";
 import * as Tooltip from "@radix-ui/react-tooltip";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-comments-video");
+  const roomId = useExampleRoomId("nextjs-comments-video");
 
   return (
     <Tooltip.Provider delayDuration={0}>
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-comments/src/app/page.tsx
+++ b/examples/nextjs-comments/src/app/page.tsx
@@ -27,7 +27,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-comments");
+  const roomId = useExampleRoomId("nextjs-comments");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
@@ -48,13 +48,13 @@ export default function Page() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params?.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-connection-status/app/Room.tsx
+++ b/examples/nextjs-connection-status/app/Room.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { ClientSideSuspense } from "@liveblocks/react";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-connection-status");
+  const roomId = useExampleRoomId("nextjs-connection-status");
 
   return (
     <RoomProvider
@@ -36,13 +36,13 @@ function Loading() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-dashboard/pages/_app.tsx
+++ b/examples/nextjs-dashboard/pages/_app.tsx
@@ -7,7 +7,7 @@ import "./globals.css";
 import Example from "./index";
 
 function App({ Component, pageProps }: AppProps) {
-  const roomId = useOverrideRoomId("nextjs-dashboard");
+  const roomId = useExampleRoomId("nextjs-dashboard");
   return (
     <RoomProvider
       id={roomId}
@@ -46,11 +46,11 @@ export default App;
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-form/pages/_app.tsx
+++ b/examples/nextjs-form/pages/_app.tsx
@@ -7,7 +7,7 @@ import React, { useMemo } from "react";
 import { LiveObject } from "@liveblocks/client";
 
 function App({ Component, pageProps }: AppProps) {
-  const roomId = useOverrideRoomId("nextjs-multiplayer-form");
+  const roomId = useExampleRoomId("nextjs-form");
 
   return (
     <RoomProvider
@@ -48,11 +48,11 @@ export default App;
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-avatars-advanced/pages/index.tsx
+++ b/examples/nextjs-live-avatars-advanced/pages/index.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import styles from "../styles/Index.module.css";
 
 export default function Example() {
-  const roomId = useOverrideRoomId("nextjs-live-avatars-advanced");
+  const roomId = useExampleRoomId("nextjs-live-avatars-advanced");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
@@ -20,11 +20,11 @@ export default function Example() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-avatars/pages/index.tsx
+++ b/examples/nextjs-live-avatars/pages/index.tsx
@@ -31,7 +31,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-live-avatars");
+  const roomId = useExampleRoomId("nextjs-live-avatars");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
@@ -59,11 +59,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-cursors-advanced/pages/index.tsx
+++ b/examples/nextjs-live-cursors-advanced/pages/index.tsx
@@ -5,7 +5,7 @@ import { useMemo, useRef } from "react";
 import styles from "../styles/Index.module.css";
 
 export default function Index() {
-  const roomId = useOverrideRoomId("nextjs-live-cursors-advanced");
+  const roomId = useExampleRoomId("nextjs-live-cursors-advanced");
 
   return (
     <RoomProvider
@@ -19,7 +19,7 @@ export default function Index() {
     >
       <Example />
     </RoomProvider>
-  )
+  );
 }
 
 function Example() {
@@ -42,11 +42,11 @@ function Example() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-cursors-chat/pages/index.tsx
+++ b/examples/nextjs-live-cursors-chat/pages/index.tsx
@@ -283,7 +283,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-live-cursors-chat");
+  const roomId = useExampleRoomId("nextjs-live-cursors-chat");
 
   return (
     <RoomProvider
@@ -344,11 +344,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-cursors-scroll/pages/index.tsx
+++ b/examples/nextjs-live-cursors-scroll/pages/index.tsx
@@ -169,7 +169,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-live-cursors-scroll");
+  const roomId = useExampleRoomId("nextjs-live-cursors-scroll");
 
   return (
     <RoomProvider
@@ -205,11 +205,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-cursors/pages/index.tsx
+++ b/examples/nextjs-live-cursors/pages/index.tsx
@@ -84,7 +84,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-live-cursors");
+  const roomId = useExampleRoomId("nextjs-live-cursors");
 
   return (
     <RoomProvider
@@ -120,11 +120,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-live-form-selection/pages/index.tsx
+++ b/examples/nextjs-live-form-selection/pages/index.tsx
@@ -120,7 +120,7 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-live-form-selection");
+  const roomId = useExampleRoomId("nextjs-live-form-selection");
 
   return (
     <RoomProvider
@@ -153,11 +153,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-nextauth-google-avatars/pages/index.tsx
+++ b/examples/nextjs-nextauth-google-avatars/pages/index.tsx
@@ -48,26 +48,13 @@ function Example() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-live-avatars-google");
+  const roomId = useExampleRoomId("nextjs-nextauth-google-avatars");
 
   return (
     <RoomProvider id={roomId} initialPresence={{}}>
       <Example />
     </RoomProvider>
   );
-}
-
-/**
- * This function is used when deploying an example on liveblocks.io.
- * You can ignore it completely if you run the example locally.
- */
-function useOverrideRoomId(roomId: string) {
-  const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
-  }, [query, roomId]);
-
-  return overrideRoomId;
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
@@ -96,3 +83,16 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     props: {},
   };
 };
+
+/**
+ * This function is used when deploying an example on liveblocks.io.
+ * You can ignore it completely if you run the example locally.
+ */
+function useExampleRoomId(roomId: string) {
+  const { query } = useRouter();
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
+  }, [query, roomId]);
+
+  return exampleRoomId;
+}

--- a/examples/nextjs-spreadsheet-advanced/src/pages/index.tsx
+++ b/examples/nextjs-spreadsheet-advanced/src/pages/index.tsx
@@ -158,7 +158,7 @@ const initialStorage = createInitialStorage(
 );
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-spreadsheet-advanced");
+  const roomId = useExampleRoomId("nextjs-spreadsheet-advanced");
 
   return (
     <RoomProvider
@@ -194,11 +194,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-todo-list/pages/index.tsx
+++ b/examples/nextjs-todo-list/pages/index.tsx
@@ -102,7 +102,7 @@ function Loading() {
 }
 
 export default function Page() {
-  const roomId = useOverrideRoomId("nextjs-todo-list-v2");
+  const roomId = useExampleRoomId("nextjs-todo-list");
 
   return (
     <RoomProvider
@@ -138,11 +138,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-whiteboard-advanced/src/index.tsx
+++ b/examples/nextjs-whiteboard-advanced/src/index.tsx
@@ -45,7 +45,7 @@ import ToolsBar from "./components/ToolsBar";
 const MAX_LAYERS = 100;
 
 export default function Room() {
-  const roomId = useOverrideRoomId("nextjs-whiteboard-advanced");
+  const roomId = useExampleRoomId("nextjs-whiteboard-advanced");
 
   return (
     <RoomProvider
@@ -559,11 +559,11 @@ function Canvas() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-whiteboard/pages/index.tsx
+++ b/examples/nextjs-whiteboard/pages/index.tsx
@@ -13,7 +13,7 @@ import styles from "../styles/index.module.css";
 import { useRouter } from "next/router";
 
 export default function Room() {
-  const roomId = useOverrideRoomId("nextjs-whiteboard");
+  const roomId = useExampleRoomId("nextjs-whiteboard");
   return (
     <RoomProvider
       id={roomId}
@@ -189,11 +189,11 @@ function Loading() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-blocknote-advanced/src/app/Room.tsx
+++ b/examples/nextjs-yjs-blocknote-advanced/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-blocknote-advanced");
+  const roomId = useExampleRoomId("nextjs-yjs-blocknote-advanced");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-blocknote/src/app/Room.tsx
+++ b/examples/nextjs-yjs-blocknote/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-blocknote");
+  const roomId = useExampleRoomId("nextjs-yjs-blocknote");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-codemirror/src/app/Room.tsx
+++ b/examples/nextjs-yjs-codemirror/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-codemirror");
+  const roomId = useExampleRoomId("nextjs-yjs-codemirror");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-lexical/src/app/Room.tsx
+++ b/examples/nextjs-yjs-lexical/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-slate");
+  const roomId = useExampleRoomId("nextjs-yjs-lexical");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-monaco/src/app/Room.tsx
+++ b/examples/nextjs-yjs-monaco/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-monaco");
+  const roomId = useExampleRoomId("nextjs-yjs-monaco");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-quill/src/app/Room.tsx
+++ b/examples/nextjs-yjs-quill/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-quill");
+  const roomId = useExampleRoomId("nextjs-yjs-quill");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-slate/src/app/Room.tsx
+++ b/examples/nextjs-yjs-slate/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-slate");
+  const roomId = useExampleRoomId("nextjs-yjs-slate");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-tiptap-advanced/src/app/Room.tsx
+++ b/examples/nextjs-yjs-tiptap-advanced/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { DocumentSpinner } from "@/primitives/Spinner";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-tiptap-advanced");
+  const roomId = useExampleRoomId("nextjs-yjs-tiptap-advanced");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nextjs-yjs-tiptap/src/app/Room.tsx
+++ b/examples/nextjs-yjs-tiptap/src/app/Room.tsx
@@ -7,7 +7,7 @@ import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "@/components/Loading";
 
 export function Room({ children }: { children: ReactNode }) {
-  const roomId = useOverrideRoomId("nextjs-yjs-tiptap");
+  const roomId = useExampleRoomId("nextjs-yjs-tiptap");
 
   return (
     <RoomProvider
@@ -27,13 +27,13 @@ export function Room({ children }: { children: ReactNode }) {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const params = useSearchParams();
-  const roomIdParam = params.get("roomId");
+  const exampleId = params?.get("exampleId");
 
-  const overrideRoomId = useMemo(() => {
-    return roomIdParam ? `${roomId}-${roomIdParam}` : roomId;
-  }, [roomId, roomIdParam]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/nuxtjs-live-avatars/app.vue
+++ b/examples/nuxtjs-live-avatars/app.vue
@@ -81,7 +81,7 @@ export default {
     };
   },
   mounted() {
-    overrideRoomId();
+    applyExampleRoomId();
 
     const { room, leave } = client.enterRoom(roomId, { initialPresence });
     this._room = room;
@@ -117,12 +117,16 @@ export default {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }
 </script>

--- a/examples/react-comments/src/main.tsx
+++ b/examples/react-comments/src/main.tsx
@@ -4,7 +4,8 @@ import App from "./App";
 import "./styles/globals.css";
 
 let roomId = "react-comments";
-overrideRoomId();
+
+applyExampleRoomId();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -16,11 +17,15 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/react-dashboard/src/App.js
+++ b/examples/react-dashboard/src/App.js
@@ -23,7 +23,7 @@ import Card from "./components/Card";
 
 let roomId = "react-dashboard";
 
-overrideRoomId();
+applyExampleRoomId();
 
 function Example() {
   const [myPresence, updateMyPresence] = useMyPresence();
@@ -253,11 +253,15 @@ export default function App() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/react-dashboard/src/liveblocks.config.js
+++ b/examples/react-dashboard/src/liveblocks.config.js
@@ -3,7 +3,7 @@ import { createRoomContext } from "@liveblocks/react";
 
 let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 
-if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+if (!/^pk_/.test(PUBLIC_KEY)) {
   console.warn(
     `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
       `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/react-dashboard#getting-started.`

--- a/examples/react-todo-list/src/index.js
+++ b/examples/react-todo-list/src/index.js
@@ -3,7 +3,8 @@ import App from "./App";
 import "./App.css";
 
 let roomId = "react-todo-list";
-overrideRoomId();
+
+applyExampleRoomId();
 
 const root = createRoot(document.getElementById("root"));
 root.render(<App roomId={roomId} />);
@@ -12,11 +13,15 @@ root.render(<App roomId={roomId} />);
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/react-todo-list/src/liveblocks.config.js
+++ b/examples/react-todo-list/src/liveblocks.config.js
@@ -3,7 +3,7 @@ import { createRoomContext } from "@liveblocks/react";
 
 let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 
-if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+if (!/^pk_/.test(PUBLIC_KEY)) {
   console.warn(
     `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
       `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/react-dashboard#getting-started.`
@@ -17,7 +17,13 @@ const client = createClient({
 });
 
 export const {
-  suspense: { RoomProvider, useStorage, useOthers, useUpdateMyPresence, useMutation },
+  suspense: {
+    RoomProvider,
+    useStorage,
+    useOthers,
+    useUpdateMyPresence,
+    useMutation,
+  },
 } = createRoomContext(client);
 
 /**

--- a/examples/redux-todo-list/pages/index.tsx
+++ b/examples/redux-todo-list/pages/index.tsx
@@ -10,7 +10,7 @@ import {
 
 let roomId = "redux-todo-list";
 
-overrideRoomId();
+applyExampleRoomId();
 
 function WhoIsHere() {
   const othersUsersCount = useAppSelector(
@@ -92,13 +92,15 @@ export default function TodoApp() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
+function applyExampleRoomId() {
   if (typeof window === "undefined") {
     return;
   }
-  const query = new URLSearchParams(window.location?.search);
-  const roomIdSuffix = query.get("roomId");
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/redux-whiteboard/pages/index.tsx
+++ b/examples/redux-whiteboard/pages/index.tsx
@@ -16,7 +16,8 @@ import {
 import styles from "./app.module.css";
 
 let roomId = "redux-whiteboard";
-overrideRoomId();
+
+applyExampleRoomId();
 
 export default function MyApp() {
   const shapes = useAppSelector((state) => state.shapes);
@@ -147,15 +148,15 @@ const Rectangle: React.FC<RectangleProps> = ({
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
+function applyExampleRoomId() {
   if (typeof window === "undefined") {
     return;
   }
 
-  const query = new URLSearchParams(window.location?.search);
-  const roomIdSuffix = query.get("roomId");
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/solidjs-live-avatars/src/index.jsx
+++ b/examples/solidjs-live-avatars/src/index.jsx
@@ -9,7 +9,7 @@ let roomId = "solidjs-live-avatars";
 
 applyExampleRoomIdAndApiKey();
 
-if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+if (!/^pk_/.test(PUBLIC_KEY)) {
   console.warn(
     `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
       `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/solidjs-live-avatars#getting-started.`

--- a/examples/solidjs-live-avatars/src/index.jsx
+++ b/examples/solidjs-live-avatars/src/index.jsx
@@ -7,7 +7,7 @@ import "./index.css";
 let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 let roomId = "solidjs-live-avatars";
 
-overrideApiKeyAndRoomId();
+applyExampleRoomIdAndApiKey();
 
 if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
   console.warn(
@@ -48,16 +48,20 @@ render(() => <App room={room} />, document.getElementById("root"));
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideApiKeyAndRoomId() {
+function applyExampleRoomIdAndApiKey() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
   const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
   const apiKey = query.get("apiKey");
-  const roomIdSuffix = query.get("roomId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
+  }
 
   if (apiKey) {
     PUBLIC_KEY = apiKey;
-  }
-
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
   }
 }

--- a/examples/solidjs-live-cursors/src/index.jsx
+++ b/examples/solidjs-live-cursors/src/index.jsx
@@ -7,7 +7,7 @@ import "./index.css";
 let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 let roomId = "solidjs-live-cursors";
 
-overrideApiKeyAndRoomId();
+applyExampleRoomIdAndApiKey();
 
 if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
   console.warn(
@@ -34,16 +34,20 @@ render(() => <App room={room} />, document.getElementById("root"));
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideApiKeyAndRoomId() {
+function applyExampleRoomIdAndApiKey() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
   const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
   const apiKey = query.get("apiKey");
-  const roomIdSuffix = query.get("roomId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
+  }
 
   if (apiKey) {
     PUBLIC_KEY = apiKey;
-  }
-
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
   }
 }

--- a/examples/solidjs-live-cursors/src/index.jsx
+++ b/examples/solidjs-live-cursors/src/index.jsx
@@ -9,7 +9,7 @@ let roomId = "solidjs-live-cursors";
 
 applyExampleRoomIdAndApiKey();
 
-if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+if (!/^pk_/.test(PUBLIC_KEY)) {
   console.warn(
     `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
       `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/solidjs-live-cursors#getting-started.`

--- a/examples/sveltekit-live-avatars/src/routes/+page.svelte
+++ b/examples/sveltekit-live-avatars/src/routes/+page.svelte
@@ -39,7 +39,7 @@
   // Set up the client on load
   // Check inside src/routes/api/liveblocks-auth.ts for the serverless function
   onMount(() => {
-    overrideRoomId();
+    applyExampleRoomId();
 
     const client = createClient({
       authEndpoint: "/api/liveblocks-auth",
@@ -62,12 +62,16 @@
    * This function is used when deploying an example on liveblocks.io.
    * You can ignore it completely if you run the example locally.
    */
-  function overrideRoomId() {
-    const query = new URLSearchParams(window?.location?.search);
-    const roomIdSuffix = query.get("roomId");
+  function applyExampleRoomId() {
+    if (typeof window === "undefined") {
+      return;
+    }
 
-    if (roomIdSuffix) {
-      roomId = `${roomId}-${roomIdSuffix}`;
+    const query = new URLSearchParams(window?.location?.search);
+    const exampleId = query.get("exampleId");
+
+    if (exampleId) {
+      roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
     }
   }
 </script>

--- a/examples/sveltekit-live-cursors/src/routes/+page.svelte
+++ b/examples/sveltekit-live-cursors/src/routes/+page.svelte
@@ -41,7 +41,7 @@
   // Set up the client on load
   // Check inside src/routes/api/liveblocks-auth.ts for the serverless function
   onMount(() => {
-    overrideRoomId();
+    applyExampleRoomId();
 
     const client = createClient({
       authEndpoint: "/api/liveblocks-auth",
@@ -65,12 +65,16 @@
    * This function is used when deploying an example on liveblocks.io.
    * You can ignore it completely if you run the example locally.
    */
-  function overrideRoomId() {
+  function applyExampleRoomId() {
+    if (typeof window === "undefined") {
+      return;
+    }
+    
     const query = new URLSearchParams(window?.location?.search);
-    const roomIdSuffix = query.get("roomId");
+    const exampleId = query.get("exampleId");
 
-    if (roomIdSuffix) {
-      roomId = `${roomId}-${roomIdSuffix}`;
+    if (exampleId) {
+      roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
     }
   }
 </script>

--- a/examples/vuejs-live-avatars/src/App.vue
+++ b/examples/vuejs-live-avatars/src/App.vue
@@ -22,7 +22,8 @@ const initialPresence = {
 };
 
 let roomId = "vuejs-live-avatars";
-overrideRoomId();
+
+applyExampleRoomId();
 
 // Join a room
 const { room, leave } = client.enterRoom<Presence>(roomId, { initialPresence });
@@ -36,12 +37,16 @@ onUnmounted(() => {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }
 </script>

--- a/examples/vuejs-live-cursors/src/App.vue
+++ b/examples/vuejs-live-cursors/src/App.vue
@@ -8,7 +8,8 @@ const initialPresence = {
 };
 
 let roomId = "vuejs-live-cursors";
-overrideRoomId();
+
+applyExampleRoomId();
 
 // Join a room
 const { room, leave } = client.enterRoom<Presence>(roomId, { initialPresence });
@@ -22,12 +23,16 @@ onUnmounted(() => {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }
 </script>

--- a/examples/zustand-flowchart/pages/index.tsx
+++ b/examples/zustand-flowchart/pages/index.tsx
@@ -19,7 +19,7 @@ export default function Index() {
     onConnect,
   } = useStore();
 
-  const roomId = useOverrideRoomId("zustand-flowchart");
+  const roomId = useExampleRoomId("zustand-flowchart");
 
   // Enter the Liveblocks room on load
   useEffect(() => {
@@ -73,11 +73,11 @@ export async function getStaticProps() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function useOverrideRoomId(roomId: string) {
+function useExampleRoomId(roomId: string) {
   const { query } = useRouter();
-  const overrideRoomId = useMemo(() => {
-    return query?.roomId ? `${roomId}-${query.roomId}` : roomId;
+  const exampleRoomId = useMemo(() => {
+    return query?.exampleId ? `${roomId}-${query.exampleId}` : roomId;
   }, [query, roomId]);
 
-  return overrideRoomId;
+  return exampleRoomId;
 }

--- a/examples/zustand-todo-list/src/App.tsx
+++ b/examples/zustand-todo-list/src/App.tsx
@@ -4,7 +4,7 @@ import "./App.css";
 
 let roomId = "zustand-todo-list";
 
-overrideRoomId();
+applyExampleRoomId();
 
 function WhoIsHere() {
   const othersUsersCount = useStore((state) => state.liveblocks.others.length);
@@ -91,11 +91,15 @@ export default function App() {
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/zustand-whiteboard/src/App.tsx
+++ b/examples/zustand-whiteboard/src/App.tsx
@@ -4,7 +4,7 @@ import "./App.css";
 
 let roomId = "zustand-whiteboard";
 
-overrideRoomId();
+applyExampleRoomId();
 
 export default function App() {
   const shapes = useStore((state) => state.shapes);
@@ -113,11 +113,15 @@ const Rectangle = ({
  * This function is used when deploying an example on liveblocks.io.
  * You can ignore it completely if you run the example locally.
  */
-function overrideRoomId() {
-  const query = new URLSearchParams(window?.location?.search);
-  const roomIdSuffix = query.get("roomId");
+function applyExampleRoomId() {
+  if (typeof window === "undefined") {
+    return;
+  }
 
-  if (roomIdSuffix) {
-    roomId = `${roomId}-${roomIdSuffix}`;
+  const query = new URLSearchParams(window?.location?.search);
+  const exampleId = query.get("exampleId");
+
+  if (exampleId) {
+    roomId = exampleId ? `${roomId}-${exampleId}` : roomId;
   }
 }

--- a/examples/zustand-whiteboard/src/store.ts
+++ b/examples/zustand-whiteboard/src/store.ts
@@ -8,7 +8,7 @@ let PUBLIC_KEY = "pk_YOUR_PUBLIC_KEY";
 
 overrideApiKey();
 
-if (!/^pk_(live|test)/.test(PUBLIC_KEY)) {
+if (!/^pk_/.test(PUBLIC_KEY)) {
   console.warn(
     `Replace "${PUBLIC_KEY}" by your public key from https://liveblocks.io/dashboard/apikeys.\n` +
       `Learn more: https://github.com/liveblocks/liveblocks/tree/main/examples/zustand-whiteboard#getting-started.`


### PR DESCRIPTION
This PR updates all examples to use the new example query parameter, `exampleId` instead of `roomId`.