### PR TITLE
Don’t pass `UserMeta` generic to `Client` in `createLiveblocksContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   `undefined` will now be treated as an error.
 - Fix bug where `useUser` and `useRoomInfo` returned an extra `data` superfluous
   property.
+- Fix bug where customizing types on `createLiveblocksContext` would conflict
+  with the provided `Client`.
 
 ### `@liveblocks/react-comments`
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -57,7 +57,7 @@ export const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
 export function createLiveblocksContext<
   TUserMeta extends BaseUserMeta = BaseUserMeta,
   TThreadMetadata extends BaseMetadata = never,
->(client: Client<TUserMeta>): LiveblocksContextBundle<TUserMeta> {
+>(client: Client): LiveblocksContextBundle<TUserMeta> {
   const shared = createSharedContext<TUserMeta>(client);
 
   const store = client[kInternal]


### PR DESCRIPTION
Generics aren't applied everywhere (especially in `@liveblocks/client`) so the current version of `createLiveblocksContext` is hard to use in practice. This PR changes `createLiveblocksContext` to behave like `createRoomContext`.

![](https://github.com/liveblocks/liveblocks/assets/6959425/b159c6ea-bf2b-48b9-a88e-46ed3694a56e)
