### PR TITLE
[doc] update doc for thread metadata number of keys limit

### DIFF
--- a/docs/pages/products/comments/metadata.mdx
+++ b/docs/pages/products/comments/metadata.mdx
@@ -34,7 +34,7 @@ metadata: {
 }
 ```
 
-You can store up to 10 metadata properties per thread, and each property can be
+You can store up to 50 metadata properties per thread, and each property can be
 4000 characters long.
 
 ## Setting metadata


### PR DESCRIPTION
### Description

Update documentation for thread's metadata number of keys limit.