### PR TITLE
Upgrade `@liveblocks/react-comments` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.11.1
+
+### `@liveblocks/react-comments`
+
+- Fix the composer’s placeholder to appear instantly instead of being initially
+  invisible.
+
 # v1.11.0
 
 ### `@liveblocks/node`

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,23 +76,22 @@
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "*",
-        "@liveblocks/node": "*",
-        "@liveblocks/react": "*",
-        "@liveblocks/react-comments": "*",
+        "@liveblocks/client": "^1.11.0",
+        "@liveblocks/node": "^1.11.0",
+        "@liveblocks/react": "^1.11.0",
+        "@liveblocks/react-comments": "^1.11.0",
         "@radix-ui/react-popover": "^1.0.7",
         "clsx": "^2.1.0",
-        "next": "^13.4.16",
+        "next": "^14.1.4",
         "react": "^18.2.0",
-        "react-cookie": "^7.0.1",
         "react-dom": "^18.2.0",
-        "react-error-boundary": "^4.0.11"
+        "react-error-boundary": "^4.0.13"
       },
       "devDependencies": {
-        "@types/node": "^20.4.2",
-        "@types/react": "^18.2.15",
-        "prettier": "^3.0.0",
-        "typescript": "^5.1.6"
+        "@types/node": "^20.11.30",
+        "@types/react": "^18.2.67",
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -8845,8 +8844,9 @@
       "license": "0BSD"
     },
     "node_modules/@types/is-hotkey": {
-      "version": "0.1.7",
-      "license": "MIT"
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.10.tgz",
+      "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -8900,9 +8900,9 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.199",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -8962,9 +8962,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.2.45",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
-      "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
+      "version": "18.2.71",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.71.tgz",
+      "integrity": "sha512-PxEsB9OjmQeYGffoWnYAd/r5FiJuUw2niFQHPc2v2idwh8wGPkkYzOHuinNJJY6NZqfoTCiOIizDOz38gYNsyw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -10238,7 +10238,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001527",
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10252,8 +10254,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -10572,8 +10573,9 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "license": "MIT"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -14559,8 +14561,9 @@
       }
     },
     "node_modules/is-hotkey": {
-      "version": "0.1.8",
-      "license": "MIT"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
     "node_modules/is-installed-globally": {
       "version": "1.0.0",
@@ -18789,9 +18792,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -19162,9 +19165,9 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
-      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -19293,9 +19296,9 @@
       }
     },
     "node_modules/react-virtuoso": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.6.0.tgz",
-      "integrity": "sha512-paQbkLA8U6dRe9srltWgPeoFCtNKqUYIcOpUR01JyznzaXWVzgZQE0M9KGi9vMoq8vHvHkGzuxJ6jDCS6uzePg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.4.tgz",
+      "integrity": "sha512-aYD+ClOCtYxURuT/GK5GamcD7XFTtmagKakEDQ07EyCPBUFy7Oc6xC2I24zSGcY5rDj+QZf/R5Iiks9Ael8pCA==",
       "engines": {
         "node": ">=10"
       },
@@ -19995,10 +19998,11 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.31",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "dependencies": {
-        "compute-scroll-into-view": "^1.0.20"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "node_modules/semver": {
@@ -20238,17 +20242,19 @@
       }
     },
     "node_modules/slate": {
-      "version": "0.94.1",
-      "license": "MIT",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.102.0.tgz",
+      "integrity": "sha512-RT+tHgqOyZVB1oFV9Pv99ajwh4OUCN9p28QWdnDTIzaN/kZxMsHeQN39UNAgtkZTVVVygFqeg7/R2jiptCvfyA==",
       "dependencies": {
-        "immer": "^9.0.6",
+        "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
       }
     },
     "node_modules/slate-history": {
-      "version": "0.93.0",
-      "license": "MIT",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
+      "integrity": "sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==",
       "dependencies": {
         "is-plain-object": "^5.0.0"
       },
@@ -20257,28 +20263,34 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.98.3",
-      "license": "MIT",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.102.0.tgz",
+      "integrity": "sha512-SAcFsK5qaOxXjm0hr/t2pvIxfRv6HJGzmWkG58TdH4LdJCsgKS1n6hQOakHPlRVCwPgwvngB6R+t3pPjv8MqwA==",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
+        "@types/is-hotkey": "^0.1.8",
+        "@types/lodash": "^4.14.200",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
         "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.65.3"
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.99.0"
       }
     },
-    "node_modules/slate-react/node_modules/tiny-invariant": {
-      "version": "1.0.6",
-      "license": "MIT"
+    "node_modules/slate/node_modules/immer": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
+      "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -21456,7 +21468,6 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-warning": {
@@ -23735,7 +23746,7 @@
       "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.0.2",
+        "@floating-ui/react-dom": "^2.0.8",
         "@liveblocks/client": "1.11.0",
         "@liveblocks/core": "1.11.0",
         "@liveblocks/react": "1.11.0",
@@ -23744,10 +23755,10 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toggle": "^1.0.3",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "react-virtuoso": "^4.6.0",
-        "slate": "^0.94.1",
-        "slate-history": "^0.93.0",
-        "slate-react": "^0.98.1",
+        "react-virtuoso": "^4.7.4",
+        "slate": "^0.102.0",
+        "slate-history": "^0.100.0",
+        "slate-react": "^0.102.0",
         "use-sync-external-store": "^1.2.0"
       },
       "devDependencies": {
@@ -23785,30 +23796,38 @@
       }
     },
     "packages/liveblocks-react-comments/node_modules/@floating-ui/core": {
-      "version": "1.4.1",
-      "license": "MIT",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "dependencies": {
-        "@floating-ui/utils": "^0.1.1"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "packages/liveblocks-react-comments/node_modules/@floating-ui/dom": {
-      "version": "1.5.1",
-      "license": "MIT",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.4.1",
-        "@floating-ui/utils": "^0.1.1"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
     "packages/liveblocks-react-comments/node_modules/@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "license": "MIT",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/dom": "^1.6.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
+    },
+    "packages/liveblocks-react-comments/node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "packages/liveblocks-react-comments/node_modules/@mswjs/cookies": {
       "version": "0.1.7",
@@ -26702,7 +26721,7 @@
     "@liveblocks/react-comments": {
       "version": "file:packages/liveblocks-react-comments",
       "requires": {
-        "@floating-ui/react-dom": "^2.0.2",
+        "@floating-ui/react-dom": "^2.0.8",
         "@liveblocks/client": "1.11.0",
         "@liveblocks/core": "1.11.0",
         "@liveblocks/eslint-config": "*",
@@ -26731,14 +26750,14 @@
         "postcss-nesting": "^12.0.1",
         "postcss-reporter": "^7.0.5",
         "postcss-sort-media-queries": "^5.2.0",
-        "react-virtuoso": "^4.6.0",
+        "react-virtuoso": "^4.7.4",
         "rollup": "^3.28.0",
         "rollup-plugin-dts": "^5.3.1",
         "rollup-plugin-esbuild": "^5.0.0",
         "rollup-plugin-preserve-directives": "^0.2.0",
-        "slate": "^0.94.1",
-        "slate-history": "^0.93.0",
-        "slate-react": "^0.98.1",
+        "slate": "^0.102.0",
+        "slate-history": "^0.100.0",
+        "slate-react": "^0.102.0",
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
         "stylelint-order": "^6.0.3",
@@ -26747,23 +26766,34 @@
       },
       "dependencies": {
         "@floating-ui/core": {
-          "version": "1.4.1",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+          "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
           "requires": {
-            "@floating-ui/utils": "^0.1.1"
+            "@floating-ui/utils": "^0.2.1"
           }
         },
         "@floating-ui/dom": {
-          "version": "1.5.1",
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+          "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
           "requires": {
-            "@floating-ui/core": "^1.4.1",
-            "@floating-ui/utils": "^0.1.1"
+            "@floating-ui/core": "^1.0.0",
+            "@floating-ui/utils": "^0.2.0"
           }
         },
         "@floating-ui/react-dom": {
-          "version": "2.0.2",
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+          "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
           "requires": {
-            "@floating-ui/dom": "^1.5.1"
+            "@floating-ui/dom": "^1.6.1"
           }
+        },
+        "@floating-ui/utils": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+          "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
         },
         "@mswjs/cookies": {
           "version": "0.1.7",
@@ -31225,7 +31255,9 @@
       }
     },
     "@types/is-hotkey": {
-      "version": "0.1.7"
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.10.tgz",
+      "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4"
@@ -31274,9 +31306,9 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "@types/lodash": {
-      "version": "4.14.199",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -31329,9 +31361,9 @@
       "version": "15.7.5"
     },
     "@types/react": {
-      "version": "18.2.45",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
-      "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
+      "version": "18.2.71",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.71.tgz",
+      "integrity": "sha512-PxEsB9OjmQeYGffoWnYAd/r5FiJuUw2niFQHPc2v2idwh8wGPkkYzOHuinNJJY6NZqfoTCiOIizDOz38gYNsyw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -32171,7 +32203,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001527"
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -32398,7 +32432,9 @@
       "version": "4.1.1"
     },
     "compute-scroll-into-view": {
-      "version": "1.0.20"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "concat-map": {
       "version": "0.0.1"
@@ -35024,7 +35060,9 @@
       }
     },
     "is-hotkey": {
-      "version": "0.1.8"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
     "is-installed-globally": {
       "version": "1.0.0",
@@ -37750,9 +37788,9 @@
       "version": "1.2.1"
     },
     "prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true
     },
     "prettier-plugin-tailwindcss": {
@@ -37939,9 +37977,9 @@
       }
     },
     "react-error-boundary": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
-      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
@@ -37999,9 +38037,9 @@
       }
     },
     "react-virtuoso": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.6.0.tgz",
-      "integrity": "sha512-paQbkLA8U6dRe9srltWgPeoFCtNKqUYIcOpUR01JyznzaXWVzgZQE0M9KGi9vMoq8vHvHkGzuxJ6jDCS6uzePg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.4.tgz",
+      "integrity": "sha512-aYD+ClOCtYxURuT/GK5GamcD7XFTtmagKakEDQ07EyCPBUFy7Oc6xC2I24zSGcY5rDj+QZf/R5Iiks9Ael8pCA==",
       "requires": {}
     },
     "react-window": {
@@ -38458,9 +38496,11 @@
       }
     },
     "scroll-into-view-if-needed": {
-      "version": "2.2.31",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "requires": {
-        "compute-scroll-into-view": "^1.0.20"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "semver": {
@@ -38623,36 +38663,44 @@
       "version": "3.0.0"
     },
     "slate": {
-      "version": "0.94.1",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.102.0.tgz",
+      "integrity": "sha512-RT+tHgqOyZVB1oFV9Pv99ajwh4OUCN9p28QWdnDTIzaN/kZxMsHeQN39UNAgtkZTVVVygFqeg7/R2jiptCvfyA==",
       "requires": {
-        "immer": "^9.0.6",
+        "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "10.0.4",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
+          "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw=="
+        }
       }
     },
     "slate-history": {
-      "version": "0.93.0",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
+      "integrity": "sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==",
       "requires": {
         "is-plain-object": "^5.0.0"
       }
     },
     "slate-react": {
-      "version": "0.98.3",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.102.0.tgz",
+      "integrity": "sha512-SAcFsK5qaOxXjm0hr/t2pvIxfRv6HJGzmWkG58TdH4LdJCsgKS1n6hQOakHPlRVCwPgwvngB6R+t3pPjv8MqwA==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
+        "@types/is-hotkey": "^0.1.8",
+        "@types/lodash": "^4.14.200",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
         "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
-      },
-      "dependencies": {
-        "tiny-invariant": {
-          "version": "1.0.6"
-        }
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
       }
     },
     "slice-ansi": {
@@ -39426,8 +39474,7 @@
       "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A=="
     },
     "tiny-invariant": {
-      "version": "1.3.1",
-      "dev": true
+      "version": "1.3.1"
     },
     "tiny-warning": {
       "version": "1.0.3"

--- a/packages/liveblocks-react-comments/package.json
+++ b/packages/liveblocks-react-comments/package.json
@@ -48,7 +48,7 @@
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {
-    "@floating-ui/react-dom": "^2.0.2",
+    "@floating-ui/react-dom": "^2.0.8",
     "@liveblocks/client": "1.11.0",
     "@liveblocks/core": "1.11.0",
     "@liveblocks/react": "1.11.0",
@@ -57,10 +57,10 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "react-virtuoso": "^4.6.0",
-    "slate": "^0.94.1",
-    "slate-history": "^0.93.0",
-    "slate-react": "^0.98.1",
+    "react-virtuoso": "^4.7.4",
+    "slate": "^0.102.0",
+    "slate-history": "^0.100.0",
+    "slate-react": "^0.102.0",
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR upgrades `@liveblocks/react-comments` dependencies.

It fixes https://github.com/liveblocks/liveblocks.io/issues/1490 (placeholder being initially invisible), thanks to an upstream fix on Slate.

**Before:**

https://github.com/liveblocks/liveblocks/assets/6959425/904bc69f-863f-4219-965c-15964db79b4b

**After:**

https://github.com/liveblocks/liveblocks/assets/6959425/cd77880c-85fa-4fde-952c-f634d7dcacae