### PR TITLE
Remove `ref` from `TreeProps`

### DIFF
--- a/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
+++ b/packages/liveblocks-devtools/src/devtools/components/Tree.tsx
@@ -182,8 +182,7 @@ type TreeProps<TTreeNode extends DevTools.TreeNode | YLogsTreeNode> = Pick<
   ComponentProps<"div">,
   "className" | "style"
 > &
-  ArboristTreeProps<TTreeNode> &
-  RefAttributes<TreeApi<TTreeNode> | undefined>;
+  ArboristTreeProps<TTreeNode>;
 
 interface RowProps<TTreeNode extends DevTools.TreeNode>
   extends ComponentProps<"div"> {


### PR DESCRIPTION
`TreeProps` currently extends `RefAttributes` which contains a `LegacyRef` object and we spread the `TreeProps` as `{...props}` in the `ArboristTree` component which only accepts a `ForwardedRef` and replaces any previously passed ref.

`TreeProps` doesn't require an extra `ref` prop as we pass a forwarded ref already. This PR fixes that.