### PR TITLE
Add filter query to get threads

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1099,8 +1099,8 @@ Some notes about the query language:
 - `boolean` values can be exact matched with `:`
   - Exact: `metadata['resolved']:false`
 - `string` values can be exact matched with `:` and prefix matched with `^`
-  - Exact: `metadata['org']:liveblocks:engineering`
-  - Prefix: `metadata['org']^liveblocks`
+  - Exact: `metadata['org']:'liveblocks:engineering'`
+  - Prefix: `metadata['org']^'liveblocks'`
 
 #### Liveblocks.createThread [#post-rooms-roomId-threads] [@badge=Beta]
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1079,6 +1079,29 @@ const { data: threads } = await liveblocks.getThreads({
 console.log(threads);
 ```
 
+It's also possible to filter threads by their metadata using a query parameter.
+
+```ts
+const { data: threads } = await liveblocks.getThreads({
+  roomId: "my-room-id",
+  query:
+    "metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3",
+});
+```
+
+Some notes about the query language:
+
+- Only the `AND` operator is supported, it can also be omitted and will default
+  to `AND`.
+  - Exact: `metadata['status']:'open' metadata['resolved']:false`
+- `number` values can be exact matched with `:`
+  - Exact: `metadata['priority']:3`
+- `boolean` values can be exact matched with `:`
+  - Exact: `metadata['resolved']:false`
+- `string` values can be exact matched with `:` and prefix matched with `^`
+  - Exact: `metadata['org']:liveblocks:engineering`
+  - Prefix: `metadata['org']^liveblocks`
+
 #### Liveblocks.createThread [#post-rooms-roomId-threads] [@badge=Beta]
 
 Creates a new thread within a specific room, using room ID and thread data. This

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1089,11 +1089,12 @@ const { data: threads } = await liveblocks.getThreads({
 });
 ```
 
-Some notes about the query language:
+The query language supports the following syntax:
 
 - Only the `AND` operator is supported, it can also be omitted and will default
-  to `AND`.
-  - Exact: `metadata['status']:'open' metadata['resolved']:false`
+  to `AND`
+  - Omitted: `metadata['status']:'open' metadata['resolved']:false`
+  - Explicit: `metadata['status']:'open' AND metadata['resolved']:false`
 - `number` values can be exact matched with `:`
   - Exact: `metadata['priority']:3`
 - `boolean` values can be exact matched with `:`

--- a/docs/pages/products/comments/metadata.mdx
+++ b/docs/pages/products/comments/metadata.mdx
@@ -43,7 +43,7 @@ Metadata can be set using the default components, React hooks, or by editing
 thread using the REST APIs. But before making any changes, it’s recommended to
 set your metadata type in your config file.
 
-```ts file="liveblocks.config.ts" highlight="13-18,28"
+```ts file="liveblocks.config.ts" highlight="19-24,34"
 import { createClient } from "@liveblocks/client";
 import { createRoomContext } from "@liveblocks/react";
 

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -1369,7 +1369,7 @@
             },
             "in": "query",
             "name": "query",
-            "description": "Query to filter threads. Ex: `metadata[\"status\"]:\"open\" AND metadata[\"resolved\"]:true AND metadata[\"priority\"]:1`"
+            "description": "Query to filter threads. For example, `metadata[\"status\"] AND metadata[\"resolved\"]:true`. Learn more in our guide on [filtering threads with the REST API](/docs/guides/how-to-filter-threads-with-the-rest-api)."
           }
         ],
         "operationId": "get-rooms-roomId-threads",

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -1362,6 +1362,14 @@
               "type": "string"
             },
             "description": "ID of the room"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "query",
+            "description": "Query to filter threads. Ex: `metadata[\"status\"]:\"open\" AND metadata[\"resolved\"]:true AND metadata[\"priority\"]:1`"
           }
         ],
         "operationId": "get-rooms-roomId-threads",

--- a/guides/guides.json
+++ b/guides/guides.json
@@ -343,5 +343,12 @@
     "topics": ["text-editors"],
     "technologies": ["yjs", "tiptap", "react"],
     "date": "2024-03-25"
+  },
+  {
+    "title": "How to filter threads with the REST API",
+    "path": "/how-to-filter-threads-with-the-rest-api",
+    "topics": ["comments", "rest-api"],
+    "technologies": ["react-comments"],
+    "date": "2024-04-10"
   }
 ]

--- a/guides/pages/how-to-filter-threads-with-the-rest-api.mdx
+++ b/guides/pages/how-to-filter-threads-with-the-rest-api.mdx
@@ -1,0 +1,67 @@
+---
+meta:
+  title: "How to filter threads with the REST API"
+  description:
+    "Learn how to filter for certain threads using their metadata with our REST
+    API"
+---
+
+When using Comments and retrieving threads with our REST API, it’s possible to
+filter for specific threads using
+[custom metadata](/docs/products/comments/metadata) and our custom query
+language. This enables the
+[Get Threads REST API](/docs/api-reference/rest-api-endpoints#get-rooms-roomId-threads)
+to have filtering that works the same as with
+[`useThreads`](/docs/api-reference/liveblocks-react#useThreads) and
+[`liveblocks.getThreads`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads).
+
+## Query language
+
+You can filter threads by their metadata, allowing you to select for certain
+properties, values, or even for string prefixes. Filters can be combined
+together using `AND` logic.
+
+### Cheatsheet
+
+```js
+// Threads with the `{ status }` metadata
+metadata['status']
+
+// Threads with both `{ status }` and `{ priority }` metadata
+metadata['status'] AND metadata['priority']
+
+// Threads with { status: 'open' } string metadata
+metadata['status']:'open'
+
+// Threads with { priority: 3 } number metadata
+metadata['priority']:3
+
+// Threads with { resolve: true } boolean metadata
+metadata['resolved']:false
+
+// Threads with `{ org }` string metadata that starts with "liveblocks"
+metadata['org']^'liveblocks'
+
+// A mixture of filters
+metadata['status'] AND metadata['status']:'open' AND metadata['org']^'liveblocks'
+```
+
+<Banner>
+
+The `AND` is optional and can actually be omitted, but we’re using it here for
+clarity.
+
+</Banner>
+
+### How to use
+
+To use the query language with the
+[REST API](/docs/api-reference/rest-api-endpoints#get-rooms-roomId-threads) pass
+your query string to the `query` parameter, for example:
+
+```
+https://api.liveblocks.io/v2/rooms/{roomId}/threads?query=metadata['status']
+```
+
+To learn more on _setting_ custom metadata on threads, make sure to
+[read our guide](/docs/products/comments/metadata).

--- a/guides/pages/how-to-filter-threads-with-the-rest-api.mdx
+++ b/guides/pages/how-to-filter-threads-with-the-rest-api.mdx
@@ -24,26 +24,35 @@ together using `AND` logic.
 ### Cheatsheet
 
 ```js
-// Threads with the `{ status }` metadata
-metadata['status']
-
-// Threads with both `{ status }` and `{ priority }` metadata
-metadata['status'] AND metadata['priority']
-
 // Threads with { status: 'open' } string metadata
 metadata['status']:'open'
+
+// Threads with `{ org }` string metadata that starts with "liveblocks:"
+metadata['org']^'liveblocks:'
 
 // Threads with { priority: 3 } number metadata
 metadata['priority']:3
 
-// Threads with { resolve: true } boolean metadata
+// Threads with { resolved: false } boolean metadata
 metadata['resolved']:false
 
-// Threads with `{ org }` string metadata that starts with "liveblocks"
-metadata['org']^'liveblocks'
+// Threads that do NOT have { status: 'closed' } string metadata
+-metadata['status']:'closed'
 
-// A mixture of filters
-metadata['status'] AND metadata['status']:'open' AND metadata['org']^'liveblocks'
+// Threads that with `{ org }` string metadata that does NOT start with "acme:"
+-metadata['org']^'acme:'
+
+// Threads that do NOT have { priority: 1 } number metadata
+-metadata['priority']:1
+
+// Threads that do NOT have { resolved: true } boolean metadata
+-metadata['resolved']:true
+
+// Combine queries with AND
+metadata['status']:'open' AND metadata['priority']:3
+
+// A more complex combination
+metadata['status']:'closed' AND -metadata['priority']:1 AND metadata['org']^'liveblocks:'
 ```
 
 <Banner>

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -466,6 +466,35 @@ describe("client", () => {
     });
   });
 
+  test("should return a filtered list of threads when a query parameter is used for getThreads", async () => {
+    server.use(
+      http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads`, (res) => {
+        expect(
+          decodeURIComponent(res.request.url).includes(
+            "?query=metadata['status']:'open'"
+          )
+        ).toBe(true);
+        return HttpResponse.json(
+          {
+            data: [thread],
+          },
+          { status: 200 }
+        );
+      })
+    );
+
+    const client = new Liveblocks({ secret: "sk_xxx" });
+
+    await expect(
+      client.getThreads({
+        roomId: "room1",
+        query: "metadata['status']:'open'",
+      })
+    ).resolves.toEqual({
+      data: [thread],
+    });
+  });
+
   test("should return the specified thread when getThread receives a successful response", async () => {
     server.use(
       http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads/:threadId`, () => {

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -885,12 +885,31 @@ export class Liveblocks {
    * @param params.roomId The room ID to get the threads from.
    * @returns A list of threads.
    */
-  public async getThreads(params: {
-    roomId: string;
-  }): Promise<{ data: ThreadData[] }> {
+  public async getThreads(
+    params: {
+      roomId: string;
+    },
+    options: {
+      /**
+       * The query to filter threads by. It is based on our query language
+       * @example
+       * ```ts
+       * {
+       *  query: "metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3"
+       * }
+       * ```
+       */
+      query?: string;
+    } = {}
+  ): Promise<{ data: ThreadData[] }> {
     const { roomId } = params;
+    let path = url`/v2/rooms/${roomId}/threads`;
 
-    const res = await this.get(url`/v2/rooms/${roomId}/threads`);
+    if (options.query) {
+      path = url`${path}?query=${options.query}`;
+    }
+
+    const res = await this.get(path);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -885,28 +885,24 @@ export class Liveblocks {
    * @param params.roomId The room ID to get the threads from.
    * @returns A list of threads.
    */
-  public async getThreads(
-    params: {
-      roomId: string;
-    },
-    options: {
-      /**
-       * The query to filter threads by. It is based on our query language
-       * @example
-       * ```ts
-       * {
-       *  query: "metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3"
-       * }
-       * ```
-       */
-      query?: string;
-    } = {}
-  ): Promise<{ data: ThreadData[] }> {
+  public async getThreads(params: {
+    roomId: string;
+    /**
+     * The query to filter threads by. It is based on our query language
+     * @example
+     * ```ts
+     * {
+     *  query: "metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3"
+     * }
+     * ```
+     */
+    query?: string;
+  }): Promise<{ data: ThreadData[] }> {
     const { roomId } = params;
     let path = url`/v2/rooms/${roomId}/threads`;
 
-    if (options.query) {
-      path = url`${path}?query=${options.query}`;
+    if (params.query) {
+      path = url`${path}?query=${params.query}`;
     }
 
     const res = await this.get(path);

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -899,13 +899,10 @@ export class Liveblocks {
     query?: string;
   }): Promise<{ data: ThreadData[] }> {
     const { roomId } = params;
-    let path = url`/v2/rooms/${roomId}/threads`;
 
-    if (params.query) {
-      path = url`${path}?query=${params.query}`;
-    }
-
-    const res = await this.get(path);
+    const res = await this.get(url`/v2/rooms/${roomId}/threads`, {
+      query: params.query,
+    });
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);


### PR DESCRIPTION
### Description

Adds query to filter threads by metadata for `GET /rooms/{roomId}/threads`
Ex:
`/rooms/foo/threads?query=metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3`
which can be added using the `options.query` in the node client.

```ts
getThreads(
    { 
      roomId: "foo",
      query: "metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3"
    }
)
```



- [x] REST API doc
- [x] Node client method 
- [x] Node client doc 

In a follow up PR, we will handle typed metadata
```ts
getThreads<ThreadMetadata>(
    { 
      roomId: "foo",
      query: {
          metadata: {
              resolved: true,
              status: "open",
              priority: 3,
              org: {
                 startsWith: "liveblocks"
              }
          }
      }
    }
)
```
