### PR TITLE
Add updatedAt property to YDocUpdated type

### DIFF
--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -366,6 +366,11 @@ type YDocUpdatedEvent = {
   data: {
     projectId: string;
     roomId: string;
+    /**
+     * ISO 8601 datestring
+     * @example "2021-03-01T12:00:00.000Z"
+     */
+    updatedAt: string;
   };
 };
 


### PR DESCRIPTION
This property is missing from the types currently, but it's present on the webhook payload and is referenced in the docs.

Payload example:

<img width="722" alt="Screen Shot 2024-04-05 at 9 31 55 PM" src="https://github.com/liveblocks/liveblocks/assets/808159/3b12a743-3bb8-49d0-bbe2-51fc5e4b5cdd">

Docs reference:

<img width="811" alt="Screen Shot 2024-04-05 at 9 32 23 PM" src="https://github.com/liveblocks/liveblocks/assets/808159/96a00f0a-ee4f-4b8c-8a3a-c85b4a08df97">
