### PR TITLE
Use `file:` URLs to point to the local workspaces

### DIFF
--- a/scripts/link-example-locally.sh
+++ b/scripts/link-example-locally.sh
@@ -51,7 +51,7 @@ rm -f ./package-lock.json
 # Step 3: Replace @liveblocks dependencies in the current example by a "*"
 # reference, so they will be picked up from the local workspaces instead.
 for dep in $(jq -r '.dependencies | keys[]' package.json | grep -Ee '@liveblocks/'); do
-    jq ".dependencies.\"$dep\" = \"*\"" package.json | sponge package.json
+    jq ".dependencies.\"$dep\" = \"file:../../packages/liveblocks-${dep#@liveblocks/}\"" package.json | sponge package.json
 done
 
 # Step 4: Add this example to the top-level package.json to officially make it


### PR DESCRIPTION
Doing this because on some systems, the `*` version spec didn't seem to be enough, and in some examples we were still seeing Node resolution issues.
