### PR TITLE
Fix pointer events in whiteboard-advanced example

### DIFF
--- a/examples/nextjs-whiteboard-advanced/src/components/ToolsBar/index.module.css
+++ b/examples/nextjs-whiteboard-advanced/src/components/ToolsBar/index.module.css
@@ -6,6 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 }
 
 .tools_panel {
@@ -15,6 +16,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: all;
 }
 
 .tools_panel_section {


### PR DESCRIPTION
Small CSS fix that will allow you to use the part of the canvas to the left and right of the toolbar in our whiteboard advanced example. Before this change, those areas were blocked by an invisible box, see video:

https://github.com/liveblocks/liveblocks/assets/83844/bf81aaf1-3c85-41f9-9c52-2ec7c29191de

