### PR TITLE
Fix `nextjs-comments-notifications` example

### DIFF
--- a/examples/nextjs-comments-notifications/src/app/[room]/page.tsx
+++ b/examples/nextjs-comments-notifications/src/app/[room]/page.tsx
@@ -5,7 +5,7 @@ import { Loading } from "../../components/Loading";
 import { Composer, Thread } from "@liveblocks/react-comments";
 import { ClientSideSuspense } from "@liveblocks/react";
 import { ErrorBoundary } from "react-error-boundary";
-import { useExampleRoomId } from "../../example";
+import { useExampleRoomId } from "../../example.client";
 import { Suspense } from "react";
 
 /**

--- a/examples/nextjs-comments-notifications/src/components/Header.tsx
+++ b/examples/nextjs-comments-notifications/src/components/Header.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { InboxPopover } from "./InboxPopover";
 import { User } from "./User";
 import { useRoomInfo } from "../../liveblocks.config";
-import { useExampleRoomId } from "../example";
+import { useExampleRoomId } from "../example.client";
 import { ClientSideSuspense } from "@liveblocks/react";
 
 interface TitleRoomProps extends ComponentProps<"div"> {

--- a/examples/nextjs-comments-notifications/src/components/User.tsx
+++ b/examples/nextjs-comments-notifications/src/components/User.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { ComponentProps } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useUser } from "../../liveblocks.config";
-import { useExampleUserId } from "../example";
+import { useExampleUserId } from "../example.client";
 import { ClientSideSuspense } from "@liveblocks/react";
 
 function Avatar({ className, ...props }: ComponentProps<"div">) {

--- a/examples/nextjs-comments-notifications/src/example.client.ts
+++ b/examples/nextjs-comments-notifications/src/example.client.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { createExampleRoomId, createExampleUserId } from "./example";
+
+export function useExampleUserId() {
+  const params = useSearchParams();
+  const exampleId = params?.get("exampleId");
+  const examplePreview = params?.get("examplePreview");
+  const userId = useMemo(() => {
+    return createExampleUserId(Number(examplePreview), exampleId);
+  }, [exampleId, examplePreview]);
+
+  return userId;
+}
+
+export function useExampleRoomId(room: string) {
+  const params = useSearchParams();
+  const exampleId = params?.get("exampleId");
+  const roomId = useMemo(() => createExampleRoomId(room), [room]);
+  const exampleRoomId = useMemo(() => {
+    return exampleId ? `${roomId}-${exampleId}` : roomId;
+  }, [roomId, exampleId]);
+
+  return exampleRoomId;
+}

--- a/examples/nextjs-comments-notifications/src/example.ts
+++ b/examples/nextjs-comments-notifications/src/example.ts
@@ -30,7 +30,7 @@ export function createExampleUserId(
 
 export function setExampleId(url: string) {
   const params = new URLSearchParams(window.location.search);
-  const exampleId = params.get("exampleId");
+  const exampleId = params.get("exampleId") ?? undefined;
 
   return setQueryParams(url, { exampleId });
 }
@@ -38,7 +38,7 @@ export function setExampleId(url: string) {
 export function authWithExampleId(endpoint: string) {
   return async (room?: string) => {
     const params = new URLSearchParams(window.location.search);
-    const exampleId = params.get("exampleId");
+    const exampleId = params.get("exampleId") ?? undefined;
     const examplePreview = Number(params.get("examplePreview"));
 
     const userId = createExampleUserId(examplePreview, exampleId);

--- a/examples/nextjs-comments-notifications/src/example.ts
+++ b/examples/nextjs-comments-notifications/src/example.ts
@@ -1,6 +1,3 @@
-import { useSearchParams } from "next/navigation";
-import { useMemo } from "react";
-
 const PLACEHOLDER_BASE_URL = "https://localhost:9999";
 const ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*?:/;
 
@@ -29,28 +26,6 @@ export function createExampleUserId(
   }
 
   return userId;
-}
-
-export function useExampleUserId() {
-  const params = useSearchParams();
-  const exampleId = params?.get("exampleId");
-  const examplePreview = params?.get("examplePreview");
-  const userId = useMemo(() => {
-    return createExampleUserId(Number(examplePreview), exampleId);
-  }, [exampleId, examplePreview]);
-
-  return userId;
-}
-
-export function useExampleRoomId(room: string) {
-  const params = useSearchParams();
-  const exampleId = params?.get("exampleId");
-  const roomId = useMemo(() => createExampleRoomId(room), [room]);
-  const exampleRoomId = useMemo(() => {
-    return exampleId ? `${roomId}-${exampleId}` : roomId;
-  }, [roomId, exampleId]);
-
-  return exampleRoomId;
 }
 
 export function setExampleId(url: string) {


### PR DESCRIPTION
The `nextjs-comments-notifications` example is currently broken when the `exampleId` query param isn't set.

The error happens when generating mention suggestions:
- We do `URLSearchParams.get("exampleId")` in `resolveMentionSuggestions` then we pass it to the endpoint responsible for computing the mention suggestions
- But `URLSearchParams.get("exampleId")` returns `null` if it isn't set
- And unlike `undefined`, `null` gets stringified so the endpoint is called with `&exampleId=null`
- Which means that the endpoint receives a literal `"null"` value so it uses it and returns user IDs as `user-0-null` instead of `user-0`

(I also fixed the Next.js errors related to RSC)