### PR TITLE
add rest api and node documentation for custom notifications

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1590,29 +1590,28 @@ console.log(inboxNotification);
 
 #### Liveblocks.triggerInboxNotification [#trigger-inbox-notification] [@badge=Beta]
 
-Triggers an inbox notification based on an activity that happened in your
-system. This is a wrapper around the
+Triggers a custom inbox notification. `kind` must start with a `$`, and
+represents the type of notification. `activityData` is used to send custom data
+with the notification, and properties can have `string`, `number`, or `boolean`
+values. This is a wrapper around the
 [Trigger Inbox Notification API](/docs/api-reference/rest-api-endpoints#post-inbox-notifications-trigger).
-
-`kind` must start with a `$`.
-
-`activityData` can have `string`, `number`, or `boolean`.
 
 ```ts
 await liveblocks.triggerInboxNotification({
-  // The ID of the user that will receive the inbox notification.
+  // The ID of the user that will receive the inbox notification
   userId: "steven@example.com",
 
-  // The type of notification, must start with a $.
+  // The custom notification kind, must start with a $
   kind: "$fileUploaded",
 
-  // The ID of the resource that is the subject of the activity.
-  subjectId: "file123",
+  // The ID of the resource that is the subject of the activity
+  subjectId: "my-file",
 
-  // Everything related to the activity that you need to render the inbox notification.
+  // Custom data related to the activity that you need to render the inbox notification
   activityData: {
     // data can be a string, number, or boolean
-    file: "url-to-file",
+    file: "https://example.com/my-file.zip",
+    size: 256,
     success: true,
   },
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1588,7 +1588,7 @@ const inboxNotification = await liveblocks.getInboxNotification({
 console.log(inboxNotification);
 ```
 
-#### Liveblocks.triggerInboxNotification [#trigger-inbox-notification] [@badge=Beta]
+#### Liveblocks.triggerInboxNotification [#post-inbox-notifications-trigger] [@badge=Beta]
 
 Triggers a custom inbox notification. `kind` must start with a `$`, and
 represents the type of notification. `activityData` is used to send custom data

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1521,21 +1521,6 @@ await liveblocks.removeCommentReaction({
 });
 ```
 
-#### Liveblocks.getInboxNotification [#get-users-userId-inboxNotifications-inboxNotificationId] [@badge=Beta]
-
-Returns a user’s inbox notification. This is a wrapper around the
-[Get Inbox Notification API](/docs/api-reference/rest-api-endpoints#get-users-userId-inboxNotifications-inboxNotificationId).
-
-```ts
-const inboxNotification = await liveblocks.getInboxNotification({
-  userId: "steven@example.com",
-  inboxNotificationId: "in_3dH7sF3...",
-});
-
-// { id: "in_3dH7sF3...", kind: "thread", ... }
-console.log(inboxNotification);
-```
-
 #### Liveblocks.getRoomNotificationSettings [#get-rooms-roomId-users-userId-notification-settings] [@badge=Beta]
 
 Returns a user’s notification settings for a specific room. This is a wrapper
@@ -1582,6 +1567,57 @@ around the
 await liveblocks.deleteRoomNotificationSettings({
   roomId: "my-room-id",
   userId: "steven@example.com",
+});
+```
+
+### Notifications
+
+#### Liveblocks.getInboxNotification [#get-users-userId-inboxNotifications-inboxNotificationId] [@badge=Beta]
+
+Returns a user’s inbox notification. This is a wrapper around the
+[Get Inbox Notification API](/docs/api-reference/rest-api-endpoints#get-users-userId-inboxNotifications-inboxNotificationId).
+
+```ts
+const inboxNotification = await liveblocks.getInboxNotification({
+  userId: "steven@example.com",
+  inboxNotificationId: "in_3dH7sF3...",
+});
+
+// { id: "in_3dH7sF3...", kind: "thread", ... }
+// or { id: "in_3dH7sF3...", kind: "$yourKind", ... }
+console.log(inboxNotification);
+```
+
+#### Liveblocks.triggerInboxNotification [#trigger-inbox-notification] [@badge=Beta]
+
+Triggers an inbox notification based on an activity that happened in your
+system. This is a wrapper around the
+[Trigger Inbox Notification API](/docs/api-reference/rest-api-endpoints#post-inbox-notifications-trigger).
+
+`kind` must start with a `$`.
+
+`activityData` can have `string`, `number`, or `boolean`.
+
+```ts
+await liveblocks.triggerInboxNotification({
+  // The ID of the user that will receive the inbox notification.
+  userId: "steven@example.com",
+
+  // The type of notification, must start with a $.
+  kind: "$fileUploaded",
+
+  // The ID of the resource that is the subject of the activity.
+  subjectId: "file123",
+
+  // Everything related to the activity that you need to render the inbox notification.
+  activityData: {
+    // data can be a string, number, or boolean
+    file: "url-to-file",
+    success: true,
+  },
+
+  // Optional
+  roomId: "my-room-id",
 });
 ```
 

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -2690,7 +2690,7 @@
         "x-badge": "Beta",
         "tags": ["Notifications"],
         "operationId": "post-inbox-notifications-trigger",
-        "description": "This endpoint triggers an inbox notification.",
+        "description": "This endpoint triggers an inbox notification. Corresponds to [`liveblocks.triggerInboxNotification`](/docs/api-reference/liveblocks-node#post-inbox-notifications-trigger).",
         "responses": {
           "200": {
             "description": "No Content"

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -2490,7 +2490,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InboxNotification"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/InboxNotificationThreadData"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InboxNotificationCustomData"
+                    }
+                  ]
                 }
               }
             }
@@ -2672,6 +2679,42 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/inbox-notifications/trigger": {
+      "parameters": [],
+      "post": {
+        "summary": "Trigger inbox notification",
+        "x-badge": "Beta",
+        "tags": ["Notifications"],
+        "operationId": "post-inbox-notifications-trigger",
+        "description": "This endpoint triggers an inbox notification.",
+        "responses": {
+          "200": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Unprocessable Entity"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TriggerInboxNotification"
+              }
+            }
           }
         }
       }
@@ -3349,18 +3392,20 @@
           }
         ]
       },
-      "InboxNotification": {
-        "title": "InboxNotification",
+      "InboxNotificationThreadData": {
+        "title": "InboxNotificationThreadData",
         "type": "object",
         "properties": {
           "id": {
             "type": "string"
           },
           "kind": {
-            "type": "string",
-            "default": "thread"
+            "type": "string"
           },
           "threadId": {
+            "type": "string"
+          },
+          "roomId": {
             "type": "string"
           },
           "readAt": {
@@ -3373,6 +3418,35 @@
           }
         }
       },
+      "InboxNotificationCustomData": {
+        "title": "InboxNotificationCustomData",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "subjectId": {
+            "type": "string"
+          },
+          "roomId": {
+            "type": "string"
+          },
+          "readAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "notifiedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "activityData": {
+            "type": "object"
+          }
+        }
+      },
       "UserRoomNotificationSettings": {
         "title": "UserRoomNotificationSettings",
         "type": "object",
@@ -3381,6 +3455,38 @@
             "enum": ["all", "replies_and_mentions", "none"]
           }
         }
+      },
+      "TriggerInboxNotification": {
+        "title": "TriggerInboxNotification",
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "subjectId": {
+            "type": "string"
+          },
+          "roomId": {
+            "type": "string"
+          },
+          "activityData": {
+            "type": "object"
+          }
+        },
+        "required": ["userId", "kind", "subjectId", "activityData"],
+        "examples": [
+          {
+            "userId": "alice",
+            "kind": "file-uploaded",
+            "subjectId": "file123",
+            "activityData": {
+              "url": "url-to-file"
+            }
+          }
+        ]
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
### Description

- [x] Add REST API doc for trigger inbox notification endpoint.
- [ ] (ISSUE) Update REST API doc of the response schema for get inbox notification endpoint.
- [x] Update liveblocks-node documentation. 