### PR TITLE
Fix: avoid possible `RangeError: Maximum call stack size exceeded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.11.3
+
+### `@liveblocks/client`
+
+- Fixes a potential `RangeError: Maximum call stack size exceeded` in
+  applications that produce many operations
+
 # v1.11.2
 
 ### `create-liveblocks-app`

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1625,7 +1625,9 @@ export function createRoom<
       }
 
       if (activeBatch) {
-        activeBatch.ops.push(...ops);
+        for (const op of ops) {
+          activeBatch.ops.push(op);
+        }
         for (const [key, value] of storageUpdates) {
           activeBatch.updates.storageUpdates.set(
             key,
@@ -2538,7 +2540,10 @@ export function createRoom<
   }
 
   function dispatchOps(ops: Op[]) {
-    context.buffer.storageOperations.push(...ops);
+    const { storageOperations } = context.buffer;
+    for (const op of ops) {
+      storageOperations.push(op);
+    }
     flushNowOrSoon();
   }
 


### PR DESCRIPTION
Fixes #1576.
