### PR TITLE
Add `updatedAt` property to `YDocUpdatedEvent` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fixes a potential `RangeError: Maximum call stack size exceeded` in
   applications that produce many operations
 
+### `@liveblocks/node`
+
+- Add missing `updatedAt` property to `YDocUpdatedEvent` type.
+  ([@alexlande](https://github.com/alexlande))
+
 # v1.11.2
 
 ### `create-liveblocks-app`

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -366,6 +366,11 @@ type YDocUpdatedEvent = {
   data: {
     projectId: string;
     roomId: string;
+    /**
+     * ISO 8601 datestring
+     * @example "2021-03-01T12:00:00.000Z"
+     */
+    updatedAt: string;
   };
 };
 


### PR DESCRIPTION
Duplicate PR of https://github.com/liveblocks/liveblocks/pull/1556 to allow the tests to run.