### PR TITLE
Filter rooms with startsWith and enable query parameter

### DIFF
--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -331,6 +331,9 @@ export class Liveblocks {
     params: {
       limit?: number;
       startingAfter?: string;
+      /**
+       * @deprecated Use `query` instead.
+       */
       metadata?: QueryRoomMetadata;
       userId?: string;
       groupIds?: string[];

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -93,6 +93,7 @@ export type RoomAccesses = Record<
   ["room:write"] | ["room:read", "room:presence:write"]
 >;
 export type RoomMetadata = Record<string, string | string[]>;
+type QueryRoomMetadata = Record<string, string>;
 
 export type RoomInfo = {
   type: "room";
@@ -323,15 +324,46 @@ export class Liveblocks {
    * @param params.userId (optional) A filter on users accesses.
    * @param params.metadata (optional) A filter on metadata. Multiple metadata keys can be used to filter rooms.
    * @param params.groupIds (optional) A filter on groups accesses. Multiple groups can be used.
+   * @param params.query (optional) A query to filter rooms by. It is based on our query language. You can filter by metadata and room ID.
    * @returns A list of rooms.
    */
   public async getRooms(
     params: {
       limit?: number;
       startingAfter?: string;
-      metadata?: RoomMetadata;
+      metadata?: QueryRoomMetadata;
       userId?: string;
       groupIds?: string[];
+      /**
+       * The query to filter rooms by. It is based on our query language.
+       * @example
+       * ```
+       * {
+       *   query: 'metadata["status"]:"open" AND roomId^"liveblocks:"'
+       * }
+       * ```
+       * @example
+       * ```
+       * {
+       *   query: {
+       *     metadata: {
+       *       status: "open",
+       *     },
+       *     roomId: {
+       *       startsWith: "liveblocks:"
+       *     }
+       *   }
+       * }
+       * ```
+       */
+      query?:
+        | string
+        | {
+            metadata?: QueryRoomMetadata;
+            roomId?: {
+              startsWith: string;
+            };
+          };
     } = {}
   ): Promise<{
     nextPage: string | null;
@@ -340,6 +372,14 @@ export class Liveblocks {
   }> {
     const path = url`/v2/rooms`;
 
+    let query: string | undefined;
+
+    if (typeof params.query === "string") {
+      query = params.query;
+    } else if (typeof params.query === "object") {
+      query = objectToQuery(params.query);
+    }
+
     const queryParams = {
       limit: params.limit,
       startingAfter: params.startingAfter,
@@ -347,11 +387,12 @@ export class Liveblocks {
       groupIds: params.groupIds ? params.groupIds.join(",") : undefined,
       // "Flatten" {metadata: {foo: "bar"}} to {"metadata.foo": "bar"}
       ...Object.fromEntries(
-        Object.entries(params.metadata ?? {}).map(([key, val]) => {
-          const value = Array.isArray(val) ? val.join(",") : val;
-          return [`metadata.${key}`, value];
-        })
+        Object.entries(params.metadata ?? {}).map(([key, val]) => [
+          `metadata.${key}`,
+          val,
+        ])
       ),
+      query,
     };
 
     const res = await this.get(path, queryParams);
@@ -887,16 +928,33 @@ export class Liveblocks {
    * Gets all the threads in a room.
    *
    * @param params.roomId The room ID to get the threads from.
+   * @param params.query The query to filter threads by. It is based on our query language and can filter by metadata.
    * @returns A list of threads.
    */
   public async getThreads<TThreadMetadata extends BaseMetadata>(params: {
     roomId: string;
     /**
-     * The query to filter threads by. It is based on our query language
+     * The query to filter threads by. It is based on our query language.
+     *
      * @example
-     * ```ts
+     * ```
      * {
-     *  query: "metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3"
+     *   query: "metadata['organization']^'liveblocks:' AND metadata['status']:'open' AND metadata['resolved']:false AND metadata['priority']:3"
+     * }
+     * ```
+     * @example
+     * ```
+     * {
+     *   query: {
+     *     metadata: {
+     *       status: "open",
+     *       resolved: false,
+     *       priority: 3,
+     *       organization: {
+     *         startsWith: "liveblocks:"
+     *       }
+     *     }
+     *   }
      * }
      * ```
      */


### PR DESCRIPTION
### Description

Enables room filtering with `roomId` starts with and enables query parameter. The query handles `metadata` and `roomId` filtering for now. It will handle most other parameters in the future, in a similar fashion to `getThreads`.

```ts
client.getRooms({
  query: {
    metadata: {
      color: "blue",
      size: "10",
    },
    roomId: {
      startsWith: "liveblocks:",
    },
  },
})

client.getRooms({
  query: 'roomId^"liveblocks:" AND metadata["color"]:"blue" AND metadata["size"]:"10"'
})
```

Also deprecates the `params.metadata` property.
```ts
client.getRooms({
  metadata // deprecated
})
```

#### Related issue(s)

https://github.com/liveblocks/liveblocks.io/issues/2116