### PR TITLE
Mention `startsWith` in `useThreads` docs

### DIFF
--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1193,13 +1193,19 @@ const { threads, error, isLoading } = useThreads();
 can be used to filter threads based on their metadata.
 
 ```tsx
-// Returns the threads with `metadata.color === "blue"` and `metadata.resolved === true`
+// Returns threads that match the entire `query`, e.g. { color: "blue", resolved: true, ... }
 const { threads } = useThreads({
   query: {
     metadata: {
-      // Custom metadata query goes here
+      // Filter for threads that contain specific string, boolean, and number data
       color: "blue",
       resolved: true,
+      priority: 3,
+
+      // Filter for threads with string metadata that starts with a certain value
+      organization: {
+        startsWith: "liveblocks:",
+      },
     },
   },
 });


### PR DESCRIPTION
I think this was missing.