### PR TITLE
Fix broken e2e test for "room full" tests

### DIFF
--- a/e2e/next-sandbox/test/full-room.test.ts
+++ b/e2e/next-sandbox/test/full-room.test.ts
@@ -24,15 +24,15 @@ test.describe("Room completely full", () => {
     Promise.all(pagesToClose.map((page) => page.close()))
   );
 
-  skipOnCI("join a room with 20 clients", async ({}, testInfo) => {
+  skipOnCI("join a room with 10 clients", async ({}, testInfo) => {
     const room = genRoomId(testInfo);
     const url = `${TEST_URL}?room=${encodeURIComponent(room)}`;
 
     pagesToClose = [];
     const batches = [];
 
-    // Open 4 batches...
-    for (let i = 0; i < 4; i++) {
+    // Open 2 batches...
+    for (let i = 0; i < 2; i++) {
       const batch = await preparePages(url, { n: 5 }); // ...of 5 windows each
       batches.push(batch);
       pagesToClose.push(...batch);
@@ -47,7 +47,7 @@ test.describe("Room completely full", () => {
   });
 
   skipOnCI(
-    'join a room with 21 clients (will hit "room full")',
+    'join a room with 11 clients (will hit "room full")',
     async ({}, testInfo) => {
       const room = genRoomId(testInfo);
       const url = `${TEST_URL}?room=${encodeURIComponent(room)}`;
@@ -55,8 +55,8 @@ test.describe("Room completely full", () => {
       pagesToClose = [];
       const batches = [];
 
-      // Open 4 batches...
-      for (let i = 0; i < 4; i++) {
+      // Open 2 batches...
+      for (let i = 0; i < 2; i++) {
         const batch = await preparePages(url, { n: 5 }); // ...of 5 windows each
         batches.push(batch);
         pagesToClose.push(...batch);


### PR DESCRIPTION
These tests are only run when running locally (not on CI) for perf/load reasons. Recently, rooms are now created at [10 max simultaneous connections by default](https://github.com/liveblocks/liveblocks-cloudflare/commit/bd102c8014e49f01fdf71b09a417a2bb4ab19383#diff-21d3c3fb1dc17fc0f4b5939d4e97e4423e2f13be6e21e970ee5b84e4265807b4R184) (for new upcoming pricing changes), no longer 20, but this E2E test was not adjusted accordingly yet.
