### PR TITLE
Widen `ActivityData` type, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `@liveblocks/react`
 
 - Tweak `useMutation` error message to be less confusing
+- Type fix: allow thread and activity metadata to contain `undefined` values
 - Large internal refactorings to support a simpler DX in a future version
 
 ## v1.12.0

--- a/packages/liveblocks-core/src/protocol/InboxNotifications.ts
+++ b/packages/liveblocks-core/src/protocol/InboxNotifications.ts
@@ -9,7 +9,10 @@ export type InboxNotificationThreadData = {
   readAt: Date | null;
 };
 
-export type ActivityData = Record<string, string | boolean | number>;
+export type ActivityData = Record<
+  string,
+  string | boolean | number | undefined
+>;
 
 type InboxNotificationActivity = {
   id: string;


### PR DESCRIPTION
Stumbled on `ActivityData`, and allowed `undefined` values here for the exact same reasons as in #1629.
