### PR TITLE
Add global `Liveblocks` namespace for augmentable types

### DIFF
--- a/packages/liveblocks-client/src/global.ts
+++ b/packages/liveblocks-client/src/global.ts
@@ -1,0 +1,19 @@
+import type {
+  BaseMetadata,
+  BaseUserMeta,
+  JsonObject,
+  LsonObject,
+} from "@liveblocks/core";
+
+declare global {
+  /**
+   * Namespace for user-defined Liveblocks types.
+   */
+  export namespace Liveblocks {
+    export interface Presence extends JsonObject {}
+    export interface Storage extends LsonObject {}
+    export interface UserMeta extends BaseUserMeta {}
+    export interface RoomEvent extends JsonObject {}
+    export interface ThreadMetadata extends BaseMetadata {}
+  }
+}

--- a/packages/liveblocks-client/src/global.ts
+++ b/packages/liveblocks-client/src/global.ts
@@ -9,6 +9,7 @@ declare global {
   /**
    * Namespace for user-defined Liveblocks types.
    */
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   export namespace Liveblocks {
     export interface Presence extends JsonObject {}
     export interface Storage extends LsonObject {}

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -4,6 +4,8 @@ import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
 
 detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
+// Global types, intended to be augmented by the end-user
+export * from "./global";
 export type {
   BaseMetadata,
   BaseUserMeta,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -26,7 +26,6 @@ import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/w
 import { selectedInboxNotifications } from "./comments/lib/selected-inbox-notifications";
 import { retryError } from "./lib/retry-error";
 import { useInitial } from "./lib/use-initial";
-import type { DU } from "./shared";
 import { createSharedContext } from "./shared";
 import type {
   InboxNotificationsState,
@@ -630,7 +629,7 @@ export function useLiveblocksContextBundle() {
 }
 
 export function createLiveblocksContext<
-  U extends BaseUserMeta = DU,
+  U extends BaseUserMeta = Liveblocks.UserMeta,
   M extends BaseMetadata = never, // TODO Change this to DM for 2.0
 >(client: OpaqueClient): LiveblocksContextBundle<U, M> {
   return getOrCreateContextBundle<U, M>(client);

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -68,7 +68,6 @@ import { retryError } from "./lib/retry-error";
 import { useInitial } from "./lib/use-initial";
 import { useLatest } from "./lib/use-latest";
 import { LiveblocksProvider, useClient, useClientOrNull } from "./liveblocks";
-import type { DE, DM, DP, DS, DU } from "./shared";
 import { createSharedContext } from "./shared";
 import type {
   CommentReactionOptions,
@@ -2348,6 +2347,12 @@ export function generateQueryKey(
 ) {
   return `${roomId}-${stringify(options ?? {})}`;
 }
+
+type DP = Liveblocks.Presence;
+type DS = Liveblocks.Storage;
+type DU = Liveblocks.UserMeta;
+type DE = Liveblocks.RoomEvent;
+type DM = Liveblocks.ThreadMetadata;
 
 // TODO in 2.0 Copy/paste all the docstrings onto these global hooks :(
 const __1 = RoomProvider<DP, DS, DU, DE>;

--- a/packages/liveblocks-react/src/shared.ts
+++ b/packages/liveblocks-react/src/shared.ts
@@ -1,11 +1,4 @@
-import type {
-  BaseMetadata,
-  BaseUserMeta,
-  Client,
-  Json,
-  JsonObject,
-  LsonObject,
-} from "@liveblocks/client";
+import type { BaseUserMeta, Client } from "@liveblocks/client";
 import { kInternal, raise } from "@liveblocks/core";
 import { useCallback, useEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
@@ -19,21 +12,6 @@ import type {
   UserState,
   UserStateSuccess,
 } from "./types";
-
-//
-// Default concrete types for each of the user-provided type placeholders.
-//
-
-/** DP = Default Presence type */
-export type DP = JsonObject;
-/** DS = Default Storage type */
-export type DS = LsonObject;
-/** DU = Default UserMeta type */
-export type DU = BaseUserMeta;
-/** DE = Default (Room)Event type */
-export type DE = Json;
-/** DM = Default Thread Metadata type */
-export type DM = BaseMetadata;
 
 /**
  * @private


### PR DESCRIPTION
This is currently deemed the best alternative. It implements [strategy 4 from this Notion doc](https://www.notion.so/liveblocks/Simplify-liveblocks-config-ts-for-the-common-case-118f5dcc7fc44b41aee4bf7a5ebaaebc?pvs=4#56e880b806594284adc20146eb737ea5). There still are issues to figure out, so we may need to revise this strategy after all. But until then, this will at least enable the wiring and ability to actually start playing with this setup.

Fixes LB-608.
Fixes LB-597.