### PR TITLE
Fix type signatures for `useSelf()` and `useOthers()`

### DIFF
--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -43,7 +43,7 @@
     "lint": "eslint src/",
     "lint:package": "publint --strict && attw --pack",
     "test": "jest --silent --verbose --color=always",
-    "test:types": "tsd",
+    "test:types": "ls test-d/* | xargs -n1 tsd --files",
     "test:watch": "jest --silent --verbose --color=always --watch"
   },
   "dependencies": {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2145,7 +2145,13 @@ function make_useOthersSuspense<
   U extends BaseUserMeta,
 >() {
   const useOthers = make_useOthers<P, U>();
-  return function useOthersSuspense<T>(
+
+  function useOthersSuspense(): readonly User<P, U>[];
+  function useOthersSuspense<T>(
+    selector: (others: readonly User<P, U>[]) => T,
+    isEqual?: (prev: T, curr: T) => boolean
+  ): T;
+  function useOthersSuspense<T>(
     selector?: (others: readonly User<P, U>[]) => T,
     isEqual?: (prev: T, curr: T) => boolean
   ): T | readonly User<P, U>[] {
@@ -2154,7 +2160,9 @@ function make_useOthersSuspense<
       selector as (others: readonly User<P, U>[]) => T,
       isEqual as (prev: T, curr: T) => boolean
     ) as T | readonly User<P, U>[];
-  };
+  }
+
+  return useOthersSuspense;
 }
 
 function useOthersConnectionIdsSuspense(): readonly number[] {

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -1,5 +1,5 @@
 import type { Json } from "@liveblocks/client";
-import { useRoom, useSelf, useOthers } from "@liveblocks/react";
+import * as classic from "@liveblocks/react";
 import * as suspense from "@liveblocks/react/suspense";
 import { expectType } from "tsd";
 
@@ -21,16 +21,27 @@ declare global {
 // Hook APIs
 // ---------------------------------------------------------
 
-const room = useRoom();
+// useRoom()
+{
+  const room = classic.useRoom();
+  expectType<number>(room.getPresence().cursor.x);
+  expectType<number>(room.getPresence().cursor.y);
+  expectType<Json | undefined>(room.getPresence().notAPresenceField);
+}
 
-// Global presence is now available
-expectType<number>(room.getPresence().cursor.x);
-expectType<number>(room.getPresence().cursor.y);
-expectType<Json | undefined>(room.getPresence().notAPresenceField);
+// useRoom() (suspense)
+{
+  const room = suspense.useRoom();
+  expectType<number>(room.getPresence().cursor.x);
+  expectType<number>(room.getPresence().cursor.y);
+  expectType<Json | undefined>(room.getPresence().notAPresenceField);
+}
+
+// ---------------------------------------------------------
 
 // useSelf()
 {
-  const me = useSelf();
+  const me = classic.useSelf();
   expectType<number | undefined>(me?.presence.cursor.x);
   expectType<number | undefined>(me?.presence.cursor.y);
   expectType<Json | undefined>(me?.presence.notAPresenceField);
@@ -46,7 +57,7 @@ expectType<Json | undefined>(room.getPresence().notAPresenceField);
 
 // useSelf(selector)
 {
-  const x = useSelf((me) => me.presence.cursor.x);
+  const x = classic.useSelf((me) => me.presence.cursor.x);
   expectType<number | null>(x);
 }
 
@@ -60,7 +71,7 @@ expectType<Json | undefined>(room.getPresence().notAPresenceField);
 
 // useOthers()
 {
-  const others = useOthers();
+  const others = classic.useOthers();
   expectType<number>(others[13].presence.cursor.x);
   expectType<number>(others[42].presence.cursor.y);
   expectType<boolean>(others[0].canWrite);
@@ -72,4 +83,26 @@ expectType<Json | undefined>(room.getPresence().notAPresenceField);
   expectType<number>(others[13].presence.cursor.x);
   expectType<number>(others[42].presence.cursor.y);
   expectType<boolean>(others[0].canWrite);
+}
+
+// useOthers(selector)
+{
+  const num = classic.useOthers((others) => others.length);
+  expectType<number>(num);
+
+  const xs = classic.useOthers((others) =>
+    others.map((o) => o.presence.cursor.x)
+  );
+  expectType<number[]>(xs);
+}
+
+// useOthers(selector) (suspense)
+{
+  const num = classic.useOthers((others) => others.length);
+  expectType<number>(num);
+
+  const xs = classic.useOthers((others) =>
+    others.map((o) => o.presence.cursor.x)
+  );
+  expectType<number[]>(xs);
 }

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -106,3 +106,21 @@ declare global {
   );
   expectType<number[]>(xs);
 }
+
+// useOthers(selector, eq)
+{
+  const xs = classic.useOthers(
+    (others) => others.map((o) => o.presence.cursor.x),
+    classic.shallow
+  );
+  expectType<number[]>(xs);
+}
+
+// useOthers(selector, eq) (suspense)
+{
+  const xs = suspense.useOthers(
+    (others) => others.map((o) => o.presence.cursor.x),
+    suspense.shallow
+  );
+  expectType<number[]>(xs);
+}

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -1,0 +1,56 @@
+import type { Json } from "@liveblocks/client";
+import { useRoom, useSelf, useOthers } from "@liveblocks/react";
+import * as suspense from "@liveblocks/react/suspense";
+import { expectType } from "tsd";
+
+//
+// User-provided type augmentations
+//
+declare global {
+  namespace Liveblocks {
+    interface Presence {
+      cursor: {
+        x: number;
+        y: number;
+      };
+    }
+  }
+}
+
+// ---------------------------------------------------------
+// Hook APIs
+// ---------------------------------------------------------
+
+const room = useRoom();
+
+// Global presence is now available
+expectType<number>(room.getPresence().cursor.x);
+expectType<number>(room.getPresence().cursor.y);
+expectType<Json | undefined>(room.getPresence().notAPresenceField);
+
+// useSelf()
+{
+  const me = useSelf();
+  expectType<number | undefined>(me?.presence.cursor.x);
+  expectType<number | undefined>(me?.presence.cursor.y);
+  expectType<Json | undefined>(me?.presence.notAPresenceField);
+}
+
+// useSelf() (suspense)
+{
+  const me = suspense.useSelf();
+  expectType<number>(me.presence.cursor.x);
+  expectType<number>(me.presence.cursor.y);
+  expectType<Json | undefined>(me.presence.notAPresenceField);
+}
+
+// ---------------------------------------------------------
+
+// useOthers()
+{
+  const others = useOthers();
+  expectType<number>(others[13].presence.cursor.x);
+  expectType<number>(others[42].presence.cursor.y);
+  expectType<boolean>(others[0].canWrite);
+}
+

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -44,6 +44,18 @@ expectType<Json | undefined>(room.getPresence().notAPresenceField);
   expectType<Json | undefined>(me.presence.notAPresenceField);
 }
 
+// useSelf(selector)
+{
+  const x = useSelf((me) => me.presence.cursor.x);
+  expectType<number | null>(x);
+}
+
+// useSelf(selector) (suspense)
+{
+  const x = suspense.useSelf((me) => me.presence.cursor.x);
+  expectType<number>(x);
+}
+
 // ---------------------------------------------------------
 
 // useOthers()
@@ -54,3 +66,10 @@ expectType<Json | undefined>(room.getPresence().notAPresenceField);
   expectType<boolean>(others[0].canWrite);
 }
 
+// useOthers() (suspense)
+{
+  const others = suspense.useOthers();
+  expectType<number>(others[13].presence.cursor.x);
+  expectType<number>(others[42].presence.cursor.y);
+  expectType<boolean>(others[0].canWrite);
+}

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -1,7 +1,7 @@
 import type { Json } from "@liveblocks/client";
 import * as classic from "@liveblocks/react";
 import * as suspense from "@liveblocks/react/suspense";
-import { expectType } from "tsd";
+import { expectError, expectType } from "tsd";
 
 //
 // User-provided type augmentations
@@ -9,10 +9,12 @@ import { expectType } from "tsd";
 declare global {
   namespace Liveblocks {
     interface Presence {
-      cursor: {
-        x: number;
-        y: number;
-      };
+      cursor: { x: number; y: number };
+    }
+
+    interface RoomEvent {
+      type: "emoji";
+      emoji: string;
     }
   }
 }
@@ -123,4 +125,22 @@ declare global {
     suspense.shallow
   );
   expectType<number[]>(xs);
+}
+
+// ---------------------------------------------------------
+
+// useBroadcastEvent()
+{
+  const broadcast = classic.useBroadcastEvent();
+  broadcast({ type: "emoji", emoji: "😍" });
+  expectError(broadcast({ type: "i-do-not-exist" }));
+  expectError(broadcast(new Date()));
+}
+
+// useBroadcastEvent() (suspense)
+{
+  const broadcast = suspense.useBroadcastEvent();
+  broadcast({ type: "emoji", emoji: "😍" });
+  expectError(broadcast({ type: "i-do-not-exist" }));
+  expectError(broadcast(new Date()));
 }

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
@@ -1,20 +1,128 @@
 import type { Json } from "@liveblocks/client";
-import { useRoom, useOthers /* etc etc */ } from "@liveblocks/react";
-import { expectType } from "tsd";
+import * as classic from "@liveblocks/react";
+import * as suspense from "@liveblocks/react/suspense";
+import { expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 // Hook APIs
 // ---------------------------------------------------------
 
-const room = useRoom();
+// useRoom()
+{
+  const room = classic.useRoom();
+  expectType<Json | undefined>(room.getPresence().cursor);
+  expectType<Json | undefined>(room.getPresence().notAPresenceField);
+}
 
-// When using imported hooks, without augmentation, the types are really generic
-expectType<Json | undefined>(room.getPresence().cursor);
-expectType<Json | undefined>(room.getPresence().notAPresenceField);
+// useRoom() (suspense)
+{
+  const room = suspense.useRoom();
+  expectType<Json | undefined>(room.getPresence().cursor);
+  expectType<Json | undefined>(room.getPresence().notAPresenceField);
+}
 
 // ---------------------------------------------------------
 
-const others = useOthers();
-expectType<Json | undefined>(others[13].presence.cursor);
-expectType<Json | undefined>(others[13].presence.notAPresenceField);
-expectType<boolean>(others[0].canWrite);
+// useSelf()
+{
+  const me = classic.useSelf();
+  expectType<Json | undefined>(me?.presence.cursor);
+  expectType<Json | undefined>(me?.presence.notAPresenceField);
+}
+
+// useSelf() (suspense)
+{
+  const me = suspense.useSelf();
+  expectType<Json | undefined>(me.presence.cursor);
+  expectType<Json | undefined>(me.presence.notAPresenceField);
+}
+
+// useSelf(selector)
+{
+  const x = classic.useSelf((me) => me.presence.cursor);
+  expectType<Json | undefined | null>(x);
+}
+
+// useSelf(selector) (suspense)
+{
+  const x = suspense.useSelf((me) => me.presence.cursor);
+  expectType<Json | undefined>(x);
+}
+
+// ---------------------------------------------------------
+
+// useOthers()
+{
+  const others = classic.useOthers();
+  expectType<Json | undefined>(others[13].presence.cursor);
+  expectType<boolean>(others[0].canWrite);
+}
+
+// useOthers() (suspense)
+{
+  const others = suspense.useOthers();
+  expectType<Json | undefined>(others[13].presence.cursor);
+  expectType<boolean>(others[0].canWrite);
+}
+
+// useOthers(selector)
+{
+  const num = classic.useOthers((others) => others.length);
+  expectType<number>(num);
+
+  const xs = classic.useOthers((others) =>
+    others.map((o) => o.presence.cursor)
+  );
+  expectType<(Json | undefined)[]>(xs);
+}
+
+// useOthers(selector) (suspense)
+{
+  const num = classic.useOthers((others) => others.length);
+  expectType<number>(num);
+
+  const xs = classic.useOthers((others) =>
+    others.map((o) => o.presence.cursor)
+  );
+  expectType<(Json | undefined)[]>(xs);
+}
+
+// useOthers(selector, eq)
+{
+  const xs = classic.useOthers(
+    (others) => others.map((o) => o.presence.cursor),
+    classic.shallow
+  );
+  expectType<(Json | undefined)[]>(xs);
+}
+
+// useOthers(selector, eq) (suspense)
+{
+  const xs = suspense.useOthers(
+    (others) => others.map((o) => o.presence.cursor),
+    suspense.shallow
+  );
+  expectType<(Json | undefined)[]>(xs);
+}
+
+// ---------------------------------------------------------
+
+// useBroadcastEvent()
+{
+  const broadcast = classic.useBroadcastEvent();
+  broadcast({ type: "emoji", emoji: "😍" });
+  broadcast({ type: "left", userId: "1234" });
+  broadcast({ a: [], b: "", c: 123, d: false, e: undefined, f: null }); // arbitrary JSON
+  expectError(broadcast({ notSerializable: new Date() }));
+  expectError(broadcast(new Date()));
+}
+
+// useBroadcastEvent() (suspense)
+{
+  const broadcast = suspense.useBroadcastEvent();
+  broadcast({ type: "emoji", emoji: "😍" });
+  broadcast({ type: "left", userId: "1234" });
+  broadcast({ a: [], b: "", c: 123, d: false, e: undefined, f: null }); // arbitrary JSON
+  expectError(broadcast({ notSerializable: new Date() }));
+  expectError(broadcast(new Date()));
+}

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
@@ -1,0 +1,20 @@
+import type { Json } from "@liveblocks/client";
+import { useRoom, useOthers /* etc etc */ } from "@liveblocks/react";
+import { expectType } from "tsd";
+
+// ---------------------------------------------------------
+// Hook APIs
+// ---------------------------------------------------------
+
+const room = useRoom();
+
+// When using imported hooks, without augmentation, the types are really generic
+expectType<Json | undefined>(room.getPresence().cursor);
+expectType<Json | undefined>(room.getPresence().notAPresenceField);
+
+// ---------------------------------------------------------
+
+const others = useOthers();
+expectType<Json | undefined>(others[13].presence.cursor);
+expectType<Json | undefined>(others[13].presence.notAPresenceField);
+expectType<boolean>(others[0].canWrite);


### PR DESCRIPTION
Overloads were not being exported correctly, so I made these mini-factories, too. I've also added more type-level tests (with `tsd`) to ensure we won't introduce regressions here.

Fixes LB-683.
