### PR TITLE
Rename Monthly anonymous connection to Monthly public key connections to match emails

### DIFF
--- a/docs/pages/platform/limits.mdx
+++ b/docs/pages/platform/limits.mdx
@@ -20,11 +20,12 @@ To prevent abuse of our platform, we apply the following limits to all accounts.
 | Simultaneous connections per room    | Up to <Limits.StarterMaxConnectionsPerRoom />    | Up to <Limits.ProMaxConnectionsPerRoom />    | Custom     |
 | Simultaneous connections per project | Up to <Limits.StarterMaxConnectionsPerProject /> | Up to <Limits.ProMaxConnectionsPerProject /> | Custom     |
 | Team members per account             | <Limits.StarterTeamMembersPerAccount />          | <Limits.ProTeamMembersPerAccount />          | Custom     |
-| Monthly anonymous connections        | <Limits.StarterMaxAnonymousConnections />        | <Limits.ProMaxAnonymousConnections />        | Custom     |
+| Monthly public key connections       | <Limits.StarterMaxAnonymousConnections />        | <Limits.ProMaxAnonymousConnections />        | Custom     |
 
 #### Comments
 
 Comments is free up to <Limits.StarterMauMax /> monthly active users and
+
 <Limits.StarterMaxComments /> comments per month. You can get higher limits for
 an additional <Limits.ProStartingPriceComments />.
 
@@ -37,6 +38,7 @@ an additional <Limits.ProStartingPriceComments />.
 #### Notifications
 
 Notifications is free up to <Limits.StarterMauMax /> monthly active users and
+
 <Limits.StarterMaxNotifications /> notifications per month. You can get higher
 limits for an additional <Limits.ProStartingPriceNotifications />.
 
@@ -49,6 +51,7 @@ limits for an additional <Limits.ProStartingPriceNotifications />.
 #### Text editor
 
 Text editor is free up to <Limits.StarterMauMax /> monthly active users and
+
 <Limits.StarterTotalTextEditorStored /> data stored. You can get higher limits
 for an additional <Limits.ProStartingPriceTextEditor />.
 
@@ -61,6 +64,7 @@ for an additional <Limits.ProStartingPriceTextEditor />.
 #### Custom app
 
 Custom app is free up to <Limits.StarterMauMax /> monthly active users and
+
 <Limits.StarterTotalCustomAppStored /> data stored. You can get higher limits
 for an additional <Limits.ProStartingPriceCustomApp />.
 

--- a/docs/pages/platform/limits/fair-use-policy.mdx
+++ b/docs/pages/platform/limits/fair-use-policy.mdx
@@ -26,7 +26,7 @@ while maintaining the stability of our infrastructure.
 | Simultaneous connections per room    | Up to <Limits.StarterMaxConnectionsPerRoom />    | Up to <Limits.ProMaxConnectionsPerRoom />    | Custom     |
 | Simultaneous connections per project | Up to <Limits.StarterMaxConnectionsPerProject /> | Up to <Limits.ProMaxConnectionsPerProject /> | Custom     |
 | Team members per account             | <Limits.StarterTeamMembersPerAccount />          | <Limits.ProTeamMembersPerAccount />          | Custom     |
-| Monthly anonymous connections        | <Limits.StarterMaxAnonymousConnections />        | <Limits.ProMaxAnonymousConnections />        | Custom     |
+| Monthly public key connections       | <Limits.StarterMaxAnonymousConnections />        | <Limits.ProMaxAnonymousConnections />        | Custom     |
 
 To learn more about how monthly active users are calculated for each plan, take
 a look at the [plans](/docs/platform/plans) docs.


### PR DESCRIPTION
What I did:
- Rename Monthly anonymous connections to Monthly public key connectiosn to match what @stevenfabre corrected in the usage progress emails
![CleanShot 2024-05-30 at 15 52 32@2x](https://github.com/liveblocks/liveblocks/assets/10360044/e137dd60-8d76-4f84-82cd-51586bf16dd2)
