### PR TITLE
Refactor some of the `useCurrentUserId` complexity

### DIFF
--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -5,10 +5,7 @@ import {
   type CommentReaction as CommentReactionData,
   kInternal,
 } from "@liveblocks/core";
-import {
-  useRoomContextBundle,
-  useSharedContextBundle,
-} from "@liveblocks/react";
+import { useRoomContextBundle } from "@liveblocks/react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import type {
   ComponentPropsWithoutRef,
@@ -48,6 +45,7 @@ import type {
 } from "../primitives/Comment/types";
 import * as ComposerPrimitive from "../primitives/Composer";
 import { Timestamp } from "../primitives/Timestamp";
+import { useSharedContextBundle } from "../shared";
 import { MENTION_CHARACTER } from "../slate/plugins/mentions";
 import { classNames } from "../utils/class-names";
 import { useRefs } from "../utils/use-refs";

--- a/packages/liveblocks-react-comments/src/components/Comment.tsx
+++ b/packages/liveblocks-react-comments/src/components/Comment.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import {
-  type CommentData,
-  type CommentReaction as CommentReactionData,
-  kInternal,
+import type {
+  CommentData,
+  CommentReaction as CommentReactionData,
 } from "@liveblocks/core";
 import { useRoomContextBundle } from "@liveblocks/react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
@@ -45,7 +44,7 @@ import type {
 } from "../primitives/Comment/types";
 import * as ComposerPrimitive from "../primitives/Composer";
 import { Timestamp } from "../primitives/Timestamp";
-import { useSharedContextBundle } from "../shared";
+import { useCurrentUserId } from "../shared";
 import { MENTION_CHARACTER } from "../slate/plugins/mentions";
 import { classNames } from "../utils/class-names";
 import { useRefs } from "../utils/use-refs";
@@ -153,11 +152,7 @@ export function CommentMention({
   className,
   ...props
 }: CommentBodyMentionProps & CommentMentionProps) {
-  const {
-    [kInternal]: { useCurrentUserId },
-  } = useSharedContextBundle();
   const currentId = useCurrentUserId();
-
   return (
     <CommentPrimitive.Mention
       className={classNames("lb-comment-mention", className)}
@@ -229,9 +224,6 @@ export const CommentReaction = forwardRef<
   const { useAddReaction, useRemoveReaction } = useRoomContextBundle();
   const addReaction = useAddReaction();
   const removeReaction = useRemoveReaction();
-  const {
-    [kInternal]: { useCurrentUserId },
-  } = useSharedContextBundle();
   const currentId = useCurrentUserId();
   const isActive = useMemo(() => {
     return reaction.users.some((users) => users.id === currentId);
@@ -308,9 +300,6 @@ export const CommentNonInteractiveReaction = forwardRef<
   HTMLButtonElement,
   CommentNonInteractiveReactionProps
 >(({ reaction, overrides, ...props }, forwardedRef) => {
-  const {
-    [kInternal]: { useCurrentUserId },
-  } = useSharedContextBundle();
   const currentId = useCurrentUserId();
   const isActive = useMemo(() => {
     return reaction.users.some((users) => users.id === currentId);

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -360,10 +360,10 @@ const InboxNotificationThread = forwardRef<
     const {
       useRoomInfo,
       useInboxNotificationThread,
-      [kInternal]: { useCurrentUserId },
+      [kInternal]: { useCurrentUserIdFromClient },
     } = useLiveblocksContextBundle();
     const thread = useInboxNotificationThread(inboxNotification.id);
-    const currentUserId = useCurrentUserId();
+    const currentUserId = useCurrentUserIdFromClient();
     // TODO: If you provide `href` (or plan to), we shouldn't run this hook. We should find a way to conditionally run it.
     //       Because of batching and the fact that the same hook will be called within <Room /> in the notification's title,
     //       it's not a big deal, the only scenario where it would be superfluous would be if the user provides their own

--- a/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-comments/src/components/InboxNotification.tsx
@@ -5,7 +5,7 @@ import type {
   InboxNotificationData,
   InboxNotificationThreadData,
 } from "@liveblocks/core";
-import { assertNever, console, kInternal } from "@liveblocks/core";
+import { assertNever, console } from "@liveblocks/core";
 import { useLiveblocksContextBundle } from "@liveblocks/react";
 import { Slot } from "@radix-ui/react-slot";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
@@ -31,6 +31,7 @@ import type {
 } from "../overrides";
 import { useOverrides } from "../overrides";
 import { Timestamp } from "../primitives/Timestamp";
+import { useCurrentUserId } from "../shared";
 import type { SlotProp } from "../types";
 import { classNames } from "../utils/class-names";
 import { generateURL } from "../utils/url";
@@ -357,13 +358,10 @@ const InboxNotificationThread = forwardRef<
     forwardedRef
   ) => {
     const $ = useOverrides(overrides);
-    const {
-      useRoomInfo,
-      useInboxNotificationThread,
-      [kInternal]: { useCurrentUserIdFromClient },
-    } = useLiveblocksContextBundle();
+    const { useRoomInfo, useInboxNotificationThread } =
+      useLiveblocksContextBundle();
     const thread = useInboxNotificationThread(inboxNotification.id);
-    const currentUserId = useCurrentUserIdFromClient();
+    const currentUserId = useCurrentUserId();
     // TODO: If you provide `href` (or plan to), we shouldn't run this hook. We should find a way to conditionally run it.
     //       Because of batching and the fact that the same hook will be called within <Room /> in the notification's title,
     //       it's not a big deal, the only scenario where it would be superfluous would be if the user provides their own

--- a/packages/liveblocks-react-comments/src/components/internal/Avatar.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/Avatar.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentProps } from "react";
 import React, { useMemo } from "react";
-import { useSharedContextBundle } from "../../shared";
+import { useUser } from "@liveblocks/react";
 
 import { classNames } from "../../utils/class-names";
 import { getInitials } from "../../utils/get-initials";
@@ -15,7 +15,6 @@ export interface AvatarProps extends ComponentProps<"div"> {
 }
 
 export function Avatar({ userId, className, ...props }: AvatarProps) {
-  const { useUser } = useSharedContextBundle();
   const { user, isLoading } = useUser(userId);
   const resolvedUserName = useMemo(() => user?.name, [user]);
   const resolvedUserAvatar = useMemo(() => user?.avatar, [user]);

--- a/packages/liveblocks-react-comments/src/components/internal/Avatar.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/Avatar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useSharedContextBundle } from "@liveblocks/react";
 import type { ComponentProps } from "react";
 import React, { useMemo } from "react";
+import { useSharedContextBundle } from "../../shared";
 
 import { classNames } from "../../utils/class-names";
 import { getInitials } from "../../utils/get-initials";

--- a/packages/liveblocks-react-comments/src/components/internal/User.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/User.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { kInternal } from "@liveblocks/core";
+import { useUser } from "@liveblocks/react";
 import type { ComponentProps } from "react";
 import React, { useMemo } from "react";
 
 import { useOverrides } from "../../overrides";
-import { useSharedContextBundle } from "../../shared";
+import { useCurrentUserId } from "../../shared";
 import { capitalize } from "../../utils/capitalize";
 import { classNames } from "../../utils/class-names";
 
@@ -33,10 +33,6 @@ export function User({
   className,
   ...props
 }: UserProps) {
-  const {
-    useUser,
-    [kInternal]: { useCurrentUserId },
-  } = useSharedContextBundle();
   const currentId = useCurrentUserId();
   const { user, isLoading } = useUser(userId);
   const $ = useOverrides();

--- a/packages/liveblocks-react-comments/src/components/internal/User.tsx
+++ b/packages/liveblocks-react-comments/src/components/internal/User.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { kInternal } from "@liveblocks/core";
-import { useSharedContextBundle } from "@liveblocks/react";
 import type { ComponentProps } from "react";
 import React, { useMemo } from "react";
 
 import { useOverrides } from "../../overrides";
+import { useSharedContextBundle } from "../../shared";
 import { capitalize } from "../../utils/capitalize";
 import { classNames } from "../../utils/class-names";
 

--- a/packages/liveblocks-react-comments/src/shared.ts
+++ b/packages/liveblocks-react-comments/src/shared.ts
@@ -1,17 +1,17 @@
-import { raise } from "@liveblocks/core";
+import { kInternal, raise } from "@liveblocks/core";
 import {
   useLiveblocksContextBundleOrNull,
   useRoomContextBundleOrNull,
 } from "@liveblocks/react";
 
-export function useSharedContextBundle() {
+export function useCurrentUserId(): string | null {
   const roomContextBundle = useRoomContextBundleOrNull();
   const liveblocksContextBundle = useLiveblocksContextBundleOrNull();
 
   if (roomContextBundle !== null) {
-    return roomContextBundle;
+    return roomContextBundle[kInternal].useCurrentUserIdFromRoom();
   } else if (liveblocksContextBundle !== null) {
-    return liveblocksContextBundle;
+    return liveblocksContextBundle[kInternal].useCurrentUserIdFromClient();
   } else {
     raise(
       "LiveblocksProvider or RoomProvider are missing from the React tree."

--- a/packages/liveblocks-react-comments/src/shared.ts
+++ b/packages/liveblocks-react-comments/src/shared.ts
@@ -1,13 +1,9 @@
 import { raise } from "@liveblocks/core";
+import {
+  useLiveblocksContextBundleOrNull,
+  useRoomContextBundleOrNull,
+} from "@liveblocks/react";
 
-import { useLiveblocksContextBundleOrNull } from "./liveblocks";
-import { useRoomContextBundleOrNull } from "./room";
-
-/**
- * @private
- *
- * This is an internal API, use `createLiveblocksContext` or `createRoomContext` instead.
- */
 export function useSharedContextBundle() {
   const roomContextBundle = useRoomContextBundleOrNull();
   const liveblocksContextBundle = useLiveblocksContextBundleOrNull();

--- a/packages/liveblocks-react-comments/src/shared.ts
+++ b/packages/liveblocks-react-comments/src/shared.ts
@@ -1,12 +1,12 @@
 import { kInternal, raise } from "@liveblocks/core";
 import {
-  useLiveblocksContextBundleOrNull,
-  useRoomContextBundleOrNull,
+  useLiveblocksContextBundleOrNull__,
+  useRoomContextBundleOrNull__,
 } from "@liveblocks/react";
 
 export function useCurrentUserId(): string | null {
-  const roomContextBundle = useRoomContextBundleOrNull();
-  const liveblocksContextBundle = useLiveblocksContextBundleOrNull();
+  const roomContextBundle = useRoomContextBundleOrNull__();
+  const liveblocksContextBundle = useLiveblocksContextBundleOrNull__();
 
   if (roomContextBundle !== null) {
     return roomContextBundle[kInternal].useCurrentUserIdFromRoom();

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -5,7 +5,6 @@ import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
 detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export { ClientSideSuspense } from "./ClientSideSuspense";
-export { useSharedContextBundle } from "./shared";
 export type { MutationContext, UseThreadsOptions } from "./types";
 
 // Re-exports from @liveblocks/client, for convenience
@@ -56,6 +55,7 @@ export {
   useUndo,
   useUpdateMyPresence,
   useUpdateRoomNotificationSettings,
+  useRoomContextBundleOrNull, // PRIVATE API
 } from "./room";
 
 // Export the classic (non-Suspense) versions of our hooks

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -17,10 +17,12 @@ export {
   LiveblocksProvider,
   useClient,
   useLiveblocksContextBundle,
-  useLiveblocksContextBundleOrNull,
   useInboxNotificationThread,
   useMarkAllInboxNotificationsAsRead,
   useMarkInboxNotificationAsRead,
+
+  // TODO Move these private APIs into another namespace eventually
+  useLiveblocksContextBundleOrNull as useLiveblocksContextBundleOrNull__,
 } from "./liveblocks";
 export {
   createRoomContext,
@@ -55,7 +57,10 @@ export {
   useUndo,
   useUpdateMyPresence,
   useUpdateRoomNotificationSettings,
-  useRoomContextBundleOrNull, // PRIVATE API
+
+  // Maybe we can eventually move these private APIs into another namespace
+  // somehow, but making that decision later
+  useRoomContextBundleOrNull as useRoomContextBundleOrNull__,
 } from "./room";
 
 // Export the classic (non-Suspense) versions of our hooks

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -356,7 +356,8 @@ function makeLiveblocksContextBundle<
     },
 
     [kInternal]: {
-      useCurrentUserId: () => useCurrentUserId_withClient(client),
+      useCurrentUserIdFromClient: () =>
+        useCurrentUserIdFromClient_withClient(client),
     },
   };
 
@@ -579,7 +580,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
   );
 }
 
-function useCurrentUserId_withClient(client: OpaqueClient) {
+function useCurrentUserIdFromClient_withClient(client: OpaqueClient) {
   const currentUserIdStore = client[kInternal].currentUserIdStore;
   return useSyncExternalStore(
     currentUserIdStore.subscribe,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -712,7 +712,7 @@ function makeRoomContextBundle<
     },
 
     [kInternal]: {
-      useCurrentUserId,
+      useCurrentUserIdFromRoom,
       useMentionSuggestions,
     },
   };
@@ -1080,7 +1080,7 @@ function make_useSelf<P extends JsonObject, U extends BaseUserMeta>() {
   return useSelf;
 }
 
-function useCurrentUserId() {
+function useCurrentUserIdFromRoom() {
   const useSelf = make_useSelf<never, never>();
   return useSelf((user) => (typeof user.id === "string" ? user.id : null));
 }

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -5,7 +5,6 @@ import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
 detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export { ClientSideSuspense } from "./ClientSideSuspense";
-export { useSharedContextBundle } from "./shared";
 export type { MutationContext, UseThreadsOptions } from "./types";
 
 // Re-exports from @liveblocks/client, for convenience
@@ -56,6 +55,7 @@ export {
   useUndo,
   useUpdateMyPresence,
   useUpdateRoomNotificationSettings,
+  useRoomContextBundleOrNull, // PRIVATE API
 } from "./room";
 
 // Export the Suspense versions of our hooks

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -17,10 +17,12 @@ export {
   LiveblocksProvider,
   useClient,
   useLiveblocksContextBundle,
-  useLiveblocksContextBundleOrNull,
   useInboxNotificationThread,
   useMarkAllInboxNotificationsAsRead,
   useMarkInboxNotificationAsRead,
+
+  // TODO Move these private APIs into another namespace eventually
+  useLiveblocksContextBundleOrNull as useLiveblocksContextBundleOrNull__,
 } from "./liveblocks";
 export {
   createRoomContext,
@@ -55,7 +57,9 @@ export {
   useUndo,
   useUpdateMyPresence,
   useUpdateRoomNotificationSettings,
-  useRoomContextBundleOrNull, // PRIVATE API
+
+  // TODO Move these private APIs into another namespace eventually
+  useRoomContextBundleOrNull as useRoomContextBundleOrNull__,
 } from "./room";
 
 // Export the Suspense versions of our hooks

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -827,7 +827,7 @@ type RoomContextBundleCommon<
  */
 type PrivateRoomContextApi = {
   useMentionSuggestions(search?: string): string[] | undefined;
-  useCurrentUserId(): string | null;
+  useCurrentUserIdFromRoom(): string | null;
 };
 
 export type RoomContextBundle<
@@ -1083,7 +1083,7 @@ type PrivateLiveblocksContextApi = {
    *
    * Returns the current user ID. Can only be used after making a call to a Notifications API.
    */
-  useCurrentUserId(): string | null;
+  useCurrentUserIdFromClient(): string | null;
 };
 
 export type LiveblocksContextBundle<


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of #1649.

In order to get rid of the `useXxxBundle()` private/internal hooks which we'll no longer need, I first needed to get rid of the `useCurrentUserId` API. This caused me some headaches, because there are two instances internally, and depending on which context they're used in one or the other function will execute, but things were written in a way where you could not tell from the call site which one would get executed.

By moving the code around like this, hopefully these implementation detials will be easier to clean up a bit later.

For right now, it's important to check that I did not introduce a regression here — would love a confirmation the `react-comments` package is still working as-expected. Unit tests and E2E tests are obviously passing, but would like a smoke test! 🙏

