### PR TITLE
Move private `useMentionSuggestions` API into `react-ui` (instead of `react`)

### DIFF
--- a/packages/liveblocks-react-ui/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/_utils.tsx
@@ -39,5 +39,21 @@ function customRenderHook<Result, Props>(
   return renderHook(render, { wrapper: AllTheProviders, ...options });
 }
 
+export function generateFakeJwt(options: { userId: string }) {
+  // I tried to generate tokens with jose lib, but couldn't because of jest
+  return Promise.resolve(
+    `${btoa(JSON.stringify({ alg: "HS256" }))}.${btoa(
+      JSON.stringify({
+        k: "acc",
+        pid: "test_pid",
+        uid: options.userId,
+        perms: { "*": ["room:write"] },
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000 + 3600),
+      })
+    )}.${btoa("fake_signature")}`
+  );
+}
+
 export * from "@testing-library/react";
 export { customRender as render, customRenderHook as renderHook };

--- a/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
@@ -8,8 +8,8 @@ import { createClient } from "@liveblocks/core";
 import { createRoomContext } from "@liveblocks/react";
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
-import { useMentionSuggestions } from "../shared";
 
+import { useMentionSuggestions } from "../shared";
 import { generateFakeJwt } from "./_utils";
 
 // TODO: Dry up and create utils that wrap renderHook

--- a/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
@@ -4,11 +4,12 @@ import type {
   JsonObject,
   ResolveMentionSuggestionsArgs,
 } from "@liveblocks/core";
-import { createClient, kInternal } from "@liveblocks/core";
+import { createClient } from "@liveblocks/core";
+import { createRoomContext } from "@liveblocks/react";
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
+import { useMentionSuggestions } from "../shared";
 
-import { createRoomContext } from "../room";
 import { generateFakeJwt } from "./_utils";
 
 // TODO: Dry up and create utils that wrap renderHook
@@ -41,10 +42,7 @@ describe("useMentionSuggestions", () => {
   });
 
   test("should return the results from resolveMentionSuggestions", async () => {
-    const {
-      RoomProvider,
-      [kInternal]: { useMentionSuggestions },
-    } = createRoomContextForTest();
+    const { RoomProvider } = createRoomContextForTest();
 
     const { result, unmount } = renderHook(
       () => ({
@@ -71,10 +69,7 @@ describe("useMentionSuggestions", () => {
   });
 
   test("should update whenever the text changes", async () => {
-    const {
-      RoomProvider,
-      [kInternal]: { useMentionSuggestions },
-    } = createRoomContextForTest();
+    const { RoomProvider } = createRoomContextForTest();
 
     const { result, rerender, unmount } = renderHook(
       ({ text }: { text: string }) => ({
@@ -111,10 +106,9 @@ describe("useMentionSuggestions", () => {
     const resolveMentionSuggestions = jest.fn(
       ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
     );
-    const {
-      RoomProvider,
-      [kInternal]: { useMentionSuggestions },
-    } = createRoomContextForTest({ resolveMentionSuggestions });
+    const { RoomProvider } = createRoomContextForTest({
+      resolveMentionSuggestions,
+    });
 
     const { result, unmount } = renderHook(
       ({ text }: { text: string }) => ({
@@ -146,10 +140,9 @@ describe("useMentionSuggestions", () => {
     const resolveMentionSuggestions = jest.fn(
       ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
     );
-    const {
-      RoomProvider,
-      [kInternal]: { useMentionSuggestions },
-    } = createRoomContextForTest({ resolveMentionSuggestions });
+    const { RoomProvider } = createRoomContextForTest({
+      resolveMentionSuggestions,
+    });
 
     const { result, rerender, unmount } = renderHook(
       ({ text }: { text: string }) => ({
@@ -201,10 +194,9 @@ describe("useMentionSuggestions", () => {
     const resolveMentionSuggestions = jest.fn(
       ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
     );
-    const {
-      RoomProvider,
-      [kInternal]: { useMentionSuggestions },
-    } = createRoomContextForTest({ resolveMentionSuggestions });
+    const { RoomProvider } = createRoomContextForTest({
+      resolveMentionSuggestions,
+    });
 
     const { result, rerender, unmount } = renderHook(
       ({ text }: { text: string }) => ({

--- a/packages/liveblocks-react-ui/src/components/Comment.tsx
+++ b/packages/liveblocks-react-ui/src/components/Comment.tsx
@@ -4,7 +4,14 @@ import type {
   CommentData,
   CommentReaction as CommentReactionData,
 } from "@liveblocks/core";
-import { useRoomContextBundle } from "@liveblocks/react";
+import {
+  useAddReaction,
+  useDeleteComment,
+  useEditComment,
+  useMarkThreadAsRead,
+  useRemoveReaction,
+  useSelf,
+} from "@liveblocks/react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import type {
   ComponentPropsWithoutRef,
@@ -221,7 +228,6 @@ export const CommentReaction = forwardRef<
   HTMLButtonElement,
   CommentReactionProps
 >(({ comment, reaction, overrides, disabled, ...props }, forwardedRef) => {
-  const { useAddReaction, useRemoveReaction } = useRoomContextBundle();
   const addReaction = useAddReaction();
   const removeReaction = useRemoveReaction();
   const currentId = useCurrentUserId();
@@ -348,14 +354,6 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
     },
     forwardedRef
   ) => {
-    const {
-      useDeleteComment,
-      useEditComment,
-      useAddReaction,
-      useRemoveReaction,
-      useMarkThreadAsRead,
-      useSelf,
-    } = useRoomContextBundle();
     const ref = useRef<HTMLDivElement>(null);
     const mergedRefs = useRefs(forwardedRef, ref);
     const self = useSelf();

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { type BaseMetadata, kInternal } from "@liveblocks/core";
-import { useClient, useRoomContextBundle } from "@liveblocks/react";
+import {
+  useClient,
+  useCreateComment,
+  useCreateThread,
+  useEditComment,
+  useSelf,
+} from "@liveblocks/react";
 import type {
   ComponentPropsWithoutRef,
   FocusEvent,
@@ -293,7 +299,6 @@ const ComposerWithContext = forwardRef<
     const client = useClient();
     const hasResolveMentionSuggestions =
       client[kInternal].resolveMentionSuggestions !== undefined;
-    const { useSelf } = useRoomContextBundle();
     const self = useSelf();
     const isDisabled = useMemo(
       () => disabled || !self?.canComment,
@@ -447,8 +452,6 @@ export const Composer = forwardRef(
     }: ComposerProps<M>,
     forwardedRef: ForwardedRef<HTMLFormElement>
   ) => {
-    const { useCreateThread, useCreateComment, useEditComment } =
-      useRoomContextBundle();
     const createThread = useCreateThread();
     const createComment = useCreateComment();
     const editComment = useEditComment();

--- a/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
@@ -6,7 +6,11 @@ import type {
   InboxNotificationThreadData,
 } from "@liveblocks/core";
 import { assertNever, console } from "@liveblocks/core";
-import { useLiveblocksContextBundle } from "@liveblocks/react";
+import {
+  useInboxNotificationThread,
+  useMarkInboxNotificationAsRead,
+  useRoomInfo,
+} from "@liveblocks/react";
 import { Slot } from "@radix-ui/react-slot";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type {
@@ -189,7 +193,6 @@ const InboxNotificationLayout = forwardRef<
     const { Anchor } = useComponents(components);
     const Component = asChild ? Slot : Anchor;
     const [isMoreActionOpen, setMoreActionOpen] = useState(false);
-    const { useMarkInboxNotificationAsRead } = useLiveblocksContextBundle();
     const markInboxNotificationAsRead = useMarkInboxNotificationAsRead();
 
     const handleClick = useCallback(
@@ -358,8 +361,6 @@ const InboxNotificationThread = forwardRef<
     forwardedRef
   ) => {
     const $ = useOverrides(overrides);
-    const { useRoomInfo, useInboxNotificationThread } =
-      useLiveblocksContextBundle();
     const thread = useInboxNotificationThread(inboxNotification.id);
     const currentUserId = useCurrentUserId();
     // TODO: If you provide `href` (or plan to), we shouldn't run this hook. We should find a way to conditionally run it.

--- a/packages/liveblocks-react-ui/src/components/Thread.tsx
+++ b/packages/liveblocks-react-ui/src/components/Thread.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import type { BaseMetadata, CommentData, ThreadData } from "@liveblocks/core";
-import { useRoomContextBundle } from "@liveblocks/react";
+import {
+  useEditThreadMetadata,
+  useThreadSubscription,
+} from "@liveblocks/react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import type {
   ComponentPropsWithoutRef,
@@ -146,8 +149,6 @@ export const Thread = forwardRef(
     }: ThreadProps<M>,
     forwardedRef: ForwardedRef<HTMLDivElement>
   ) => {
-    const { useEditThreadMetadata, useThreadSubscription } =
-      useRoomContextBundle();
     const editThreadMetadata = useEditThreadMetadata();
     const $ = useOverrides(overrides);
     const firstCommentIndex = useMemo(() => {

--- a/packages/liveblocks-react-ui/src/components/internal/Avatar.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Avatar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { useUser } from "@liveblocks/react";
 import type { ComponentProps } from "react";
 import React, { useMemo } from "react";
-import { useUser } from "@liveblocks/react";
 
 import { classNames } from "../../utils/class-names";
 import { getInitials } from "../../utils/get-initials";

--- a/packages/liveblocks-react-ui/src/components/internal/Room.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Room.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLiveblocksContextBundle } from "@liveblocks/react";
+import { useRoomInfo } from "@liveblocks/react";
 import type { ComponentProps } from "react";
 import React, { useMemo } from "react";
 
@@ -11,7 +11,6 @@ export interface RoomProps extends ComponentProps<"span"> {
 }
 
 export function Room({ roomId, className, ...props }: RoomProps) {
-  const { useRoomInfo } = useLiveblocksContextBundle();
   const { info, isLoading } = useRoomInfo(roomId);
   const resolvedRoomName = useMemo(() => {
     return info?.name ?? roomId;

--- a/packages/liveblocks-react-ui/src/index.ts
+++ b/packages/liveblocks-react-ui/src/index.ts
@@ -22,3 +22,4 @@ export type { ThreadProps } from "./components/Thread";
 export { Thread } from "./components/Thread";
 export { LiveblocksUIConfig } from "./config";
 export type { ComposerSubmitComment } from "./primitives";
+export { useMentionSuggestions } from "./shared";

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -13,7 +13,7 @@ import {
   size,
   useFloating,
 } from "@floating-ui/react-dom";
-import { type CommentBody, kInternal } from "@liveblocks/core";
+import type { CommentBody } from "@liveblocks/core";
 import { useRoomContextBundle } from "@liveblocks/react";
 import { Slot } from "@radix-ui/react-slot";
 import type {
@@ -60,6 +60,7 @@ import {
 
 import { useLiveblocksUIConfig } from "../../config";
 import { FLOATING_ELEMENT_COLLISION_PADDING } from "../../constants";
+import { useMentionSuggestions } from "../../shared";
 import { withAutoFormatting } from "../../slate/plugins/auto-formatting";
 import { withAutoLinks } from "../../slate/plugins/auto-links";
 import { withEmptyClearFormatting } from "../../slate/plugins/empty-clear-formatting";
@@ -624,10 +625,7 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
     },
     forwardedRef
   ) => {
-    const {
-      [kInternal]: { useMentionSuggestions },
-      useSelf,
-    } = useRoomContextBundle();
+    const { useSelf } = useRoomContextBundle();
     const self = useSelf();
     const isDisabled = useMemo(
       () => disabled || !self?.canComment,

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -14,7 +14,7 @@ import {
   useFloating,
 } from "@floating-ui/react-dom";
 import type { CommentBody } from "@liveblocks/core";
-import { useRoomContextBundle } from "@liveblocks/react";
+import { useSelf } from "@liveblocks/react";
 import { Slot } from "@radix-ui/react-slot";
 import type {
   AriaAttributes,
@@ -625,7 +625,6 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
     },
     forwardedRef
   ) => {
-    const { useSelf } = useRoomContextBundle();
     const self = useSelf();
     const isDisabled = useMemo(
       () => disabled || !self?.canComment,
@@ -1069,7 +1068,6 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
 const ComposerSubmit = forwardRef<HTMLButtonElement, ComposerSubmitProps>(
   ({ children, disabled, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "button";
-    const { useSelf } = useRoomContextBundle();
     const { isEmpty } = useComposer();
     const self = useSelf();
     const isDisabled = useMemo(

--- a/packages/liveblocks-react-ui/src/shared.ts
+++ b/packages/liveblocks-react-ui/src/shared.ts
@@ -23,9 +23,12 @@ function getMentionSuggestionsCacheForClient(client: OpaqueClient) {
   return cache;
 }
 
-/** @internal */
-// Simplistic debounced search, we don't need to worry too much about
-// deduping and race conditions as there can only be one search at a time.
+/**
+ * @private For internal use only. Do not rely on this hook.
+ *
+ * Simplistic debounced search, we don't need to worry too much about deduping
+ * and race conditions as there can only be one search at a time.
+ */
 export function useMentionSuggestions(search?: string) {
   const client = useClient();
   const mentionSuggestionsCache = getMentionSuggestionsCacheForClient(client);

--- a/packages/liveblocks-react-ui/src/shared.ts
+++ b/packages/liveblocks-react-ui/src/shared.ts
@@ -1,8 +1,100 @@
-import { kInternal, raise } from "@liveblocks/core";
+import type { BaseUserMeta, Client } from "@liveblocks/core";
+import { kInternal, raise, stringify } from "@liveblocks/core";
 import {
+  useClient,
   useLiveblocksContextBundleOrNull__,
+  useRoom,
   useRoomContextBundleOrNull__,
 } from "@liveblocks/react";
+import React from "react";
+
+type OpaqueClient = Client<BaseUserMeta>;
+
+const MENTION_SUGGESTIONS_DEBOUNCE = 500;
+
+const _cachesByClient = new WeakMap<OpaqueClient, Map<string, string[]>>();
+
+function getMentionSuggestionsCacheForClient(client: OpaqueClient) {
+  let cache = _cachesByClient.get(client);
+  if (!cache) {
+    cache = new Map();
+    _cachesByClient.set(client, cache);
+  }
+  return cache;
+}
+
+/** @internal */
+// Simplistic debounced search, we don't need to worry too much about
+// deduping and race conditions as there can only be one search at a time.
+export function useMentionSuggestions(search?: string) {
+  const client = useClient();
+  const mentionSuggestionsCache = getMentionSuggestionsCacheForClient(client);
+
+  const room = useRoom();
+  const [mentionSuggestions, setMentionSuggestions] =
+    React.useState<string[]>();
+  const lastInvokedAt = React.useRef<number>();
+
+  React.useEffect(() => {
+    const resolveMentionSuggestions =
+      client[kInternal].resolveMentionSuggestions;
+
+    if (search === undefined || !resolveMentionSuggestions) {
+      return;
+    }
+
+    const resolveMentionSuggestionsArgs = { text: search, roomId: room.id };
+    const mentionSuggestionsCacheKey = stringify(resolveMentionSuggestionsArgs);
+    let debounceTimeout: number | undefined;
+    let isCanceled = false;
+
+    const getMentionSuggestions = async () => {
+      try {
+        lastInvokedAt.current = performance.now();
+        const mentionSuggestions = await resolveMentionSuggestions(
+          resolveMentionSuggestionsArgs
+        );
+
+        if (!isCanceled) {
+          setMentionSuggestions(mentionSuggestions);
+          mentionSuggestionsCache.set(
+            mentionSuggestionsCacheKey,
+            mentionSuggestions
+          );
+        }
+      } catch (error) {
+        console.error((error as Error)?.message);
+      }
+    };
+
+    if (mentionSuggestionsCache.has(mentionSuggestionsCacheKey)) {
+      // If there are already cached mention suggestions, use them immediately.
+      setMentionSuggestions(
+        mentionSuggestionsCache.get(mentionSuggestionsCacheKey)
+      );
+    } else if (
+      !lastInvokedAt.current ||
+      Math.abs(performance.now() - lastInvokedAt.current) >
+        MENTION_SUGGESTIONS_DEBOUNCE
+    ) {
+      // If on the debounce's leading edge (either because it's the first invokation or enough
+      // time has passed since the last debounce), get mention suggestions immediately.
+      void getMentionSuggestions();
+    } else {
+      // Otherwise, wait for the debounce delay.
+      debounceTimeout = window.setTimeout(() => {
+        void getMentionSuggestions();
+      }, MENTION_SUGGESTIONS_DEBOUNCE);
+    }
+
+    return () => {
+      isCanceled = true;
+      window.clearTimeout(debounceTimeout);
+    };
+  }, [room.id, search]);
+
+  return mentionSuggestions;
+}
 
 export function useCurrentUserId(): string | null {
   const roomContextBundle = useRoomContextBundleOrNull__();

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -826,7 +826,6 @@ type RoomContextBundleCommon<
  * will probably happen if you do.
  */
 type PrivateRoomContextApi = {
-  useMentionSuggestions(search?: string): string[] | undefined;
   useCurrentUserIdFromRoom(): string | null;
 };
 


### PR DESCRIPTION
As discussed [here](https://liveblocks.slack.com/archives/C06RE9H2JRM/p1717167889253859).

Fixes LB-709, and unblocks the removal of the `useXxxBundle()` pattern entirely, which is the next change I'll make.