### PR TITLE
Package fixes for `@liveblocks/react-lexical`

### DIFF
--- a/packages/liveblocks-react-lexical/package.json
+++ b/packages/liveblocks-react-lexical/package.json
@@ -3,6 +3,7 @@
   "version": "1.12.0-lexical4",
   "description": "A lexical react plugin to enable collaboration, comments, live cursors, and more.",
   "license": "Apache-2.0",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/liveblocks-react-lexical/package.json
+++ b/packages/liveblocks-react-lexical/package.json
@@ -26,9 +26,10 @@
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript --watch",
     "build": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
-    "start": "npm run dev",
     "format": "eslint --fix src/; stylelint --fix src/styles/; prettier --write src/",
     "lint": "eslint src/; stylelint src/styles/",
+    "lint:package": "publint --strict && attw --pack",
+    "start": "npm run dev",
     "test": "jest --silent --verbose --color=always",
     "test:watch": "jest --silent --verbose --color=always --watch"
   },

--- a/packages/liveblocks-react-lexical/package.json
+++ b/packages/liveblocks-react-lexical/package.json
@@ -18,11 +18,15 @@
         "default": "./dist/index.js"
       }
     },
-    "./styles.css": "./styles.css"
+    "./styles.css": {
+      "types": "./styles.css.d.ts",
+      "default": "./styles.css"
+    }
   },
   "files": [
     "dist/**",
     "**/*.css",
+    "**/*.css.d.ts",
     "**/*.css.map",
     "README.md"
   ],

--- a/packages/liveblocks-react-lexical/package.json
+++ b/packages/liveblocks-react-lexical/package.json
@@ -21,6 +21,8 @@
   },
   "files": [
     "dist/**",
+    "**/*.css",
+    "**/*.css.map",
     "README.md"
   ],
   "scripts": {

--- a/packages/liveblocks-react-lexical/rollup.config.ts
+++ b/packages/liveblocks-react-lexical/rollup.config.ts
@@ -97,6 +97,11 @@ function createTypesConfigs() {
           .replace(`${SRC_DIR}/`, `${DIST_DIR}/`)
           .replace(/\.ts$/, ".d.ts"),
       },
+      {
+        file: input
+          .replace(`${SRC_DIR}/`, `${DIST_DIR}/`)
+          .replace(/\.ts$/, ".d.mts"),
+      },
     ],
     plugins: [dts()],
   }));

--- a/packages/liveblocks-react-lexical/styles.css.d.ts
+++ b/packages/liveblocks-react-lexical/styles.css.d.ts
@@ -1,0 +1,1 @@
+declare module "@liveblocks/react-lexical/styles.css";


### PR DESCRIPTION
This PR enables package linting, and addresses the packaging issues found by the linter:

![Screen Shot 2024-06-03 at 09 36 55@2x](https://github.com/liveblocks/liveblocks/assets/83844/0b6833e2-6a4a-49c1-8b9d-135d55263362)
