### PR TITLE
Remove bundle hooks

### DIFF
--- a/packages/liveblocks-react-ui/src/shared.ts
+++ b/packages/liveblocks-react-ui/src/shared.ts
@@ -5,6 +5,7 @@ import {
   useLiveblocksContextBundleOrNull__,
   useRoom,
   useRoomContextBundleOrNull__,
+  useSelf,
 } from "@liveblocks/react";
 import React from "react";
 
@@ -99,12 +100,16 @@ export function useMentionSuggestions(search?: string) {
   return mentionSuggestions;
 }
 
+function useCurrentUserIdFromRoom() {
+  return useSelf((user) => (typeof user.id === "string" ? user.id : null));
+}
+
 export function useCurrentUserId(): string | null {
   const roomContextBundle = useRoomContextBundleOrNull__();
   const liveblocksContextBundle = useLiveblocksContextBundleOrNull__();
 
   if (roomContextBundle !== null) {
-    return roomContextBundle[kInternal].useCurrentUserIdFromRoom();
+    return useCurrentUserIdFromRoom();
   } else if (liveblocksContextBundle !== null) {
     return liveblocksContextBundle[kInternal].useCurrentUserIdFromClient();
   } else {

--- a/packages/liveblocks-react-ui/src/shared.ts
+++ b/packages/liveblocks-react-ui/src/shared.ts
@@ -1,13 +1,13 @@
 import type { BaseUserMeta, Client } from "@liveblocks/core";
 import { kInternal, raise, stringify } from "@liveblocks/core";
 import {
+  ClientContext,
+  RoomContext,
   useClient,
-  useLiveblocksContextBundleOrNull__,
   useRoom,
-  useRoomContextBundleOrNull__,
   useSelf,
 } from "@liveblocks/react";
-import React from "react";
+import React, { useContext, useSyncExternalStore } from "react";
 
 type OpaqueClient = Client<BaseUserMeta>;
 
@@ -104,14 +104,22 @@ function useCurrentUserIdFromRoom() {
   return useSelf((user) => (typeof user.id === "string" ? user.id : null));
 }
 
-export function useCurrentUserId(): string | null {
-  const roomContextBundle = useRoomContextBundleOrNull__();
-  const liveblocksContextBundle = useLiveblocksContextBundleOrNull__();
+function useCurrentUserIdFromClient_withClient(client: OpaqueClient) {
+  const currentUserIdStore = client[kInternal].currentUserIdStore;
+  return useSyncExternalStore(
+    currentUserIdStore.subscribe,
+    currentUserIdStore.get,
+    currentUserIdStore.get
+  );
+}
 
-  if (roomContextBundle !== null) {
+export function useCurrentUserId(): string | null {
+  const client = useContext(ClientContext);
+  const room = useContext(RoomContext);
+  if (room !== null) {
     return useCurrentUserIdFromRoom();
-  } else if (liveblocksContextBundle !== null) {
-    return liveblocksContextBundle[kInternal].useCurrentUserIdFromClient();
+  } else if (client !== null) {
+    return useCurrentUserIdFromClient_withClient(client);
   } else {
     raise(
       "LiveblocksProvider or RoomProvider are missing from the React tree."

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -13,8 +13,9 @@ export { shallow } from "@liveblocks/client";
 
 // Export all the top-level hooks
 export {
-  createLiveblocksContext,
+  ClientContext,
   LiveblocksProvider,
+  createLiveblocksContext,
   useClient,
   useLiveblocksContextBundle,
   useInboxNotificationThread,

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -17,13 +17,9 @@ export {
   LiveblocksProvider,
   createLiveblocksContext,
   useClient,
-  useLiveblocksContextBundle,
   useInboxNotificationThread,
   useMarkAllInboxNotificationsAsRead,
   useMarkInboxNotificationAsRead,
-
-  // TODO Move these private APIs into another namespace eventually
-  useLiveblocksContextBundleOrNull as useLiveblocksContextBundleOrNull__,
 } from "./liveblocks";
 export {
   createRoomContext,
@@ -50,7 +46,6 @@ export {
   useRedo,
   useRemoveReaction,
   useRoom,
-  useRoomContextBundle,
   useRoomNotificationSettings,
   useStatus,
   useStorageRoot,
@@ -58,10 +53,6 @@ export {
   useUndo,
   useUpdateMyPresence,
   useUpdateRoomNotificationSettings,
-
-  // Maybe we can eventually move these private APIs into another namespace
-  // somehow, but making that decision later
-  useRoomContextBundleOrNull as useRoomContextBundleOrNull__,
 } from "./room";
 
 // Export the classic (non-Suspense) versions of our hooks

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -42,7 +42,7 @@ import type {
 
 type OpaqueClient = Client<BaseUserMeta>;
 
-const ClientContext = createContext<OpaqueClient | null>(null);
+export const ClientContext = createContext<OpaqueClient | null>(null);
 
 const missingUserError = new Error(
   "resolveUsers didn't return anything for this user ID."

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -355,16 +355,8 @@ function makeLiveblocksContextBundle<
 
       ...shared.suspense,
     },
-
-    [kInternal]: {
-      useCurrentUserIdFromClient: () =>
-        useCurrentUserIdFromClient_withClient(client),
-    },
   };
-
-  return Object.defineProperty(bundle, kInternal, {
-    enumerable: false,
-  });
+  return bundle;
 }
 
 function useInboxNotifications_withClient(client: OpaqueClient) {
@@ -578,15 +570,6 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
     store.get,
     store.get,
     selector
-  );
-}
-
-function useCurrentUserIdFromClient_withClient(client: OpaqueClient) {
-  const currentUserIdStore = client[kInternal].currentUserIdStore;
-  return useSyncExternalStore(
-    currentUserIdStore.subscribe,
-    currentUserIdStore.get,
-    currentUserIdStore.get
   );
 }
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -638,10 +638,6 @@ function makeRoomContextBundle<
 
       ...shared.suspense,
     },
-
-    [kInternal]: {
-      useCurrentUserIdFromRoom,
-    },
   };
 
   return Object.defineProperty(bundle, kInternal, {
@@ -1004,10 +1000,6 @@ function useSelf<P extends JsonObject, U extends BaseUserMeta, T>(
     wrappedSelector,
     isEqual
   );
-}
-
-function useCurrentUserIdFromRoom() {
-  return useSelf((user) => (typeof user.id === "string" ? user.id : null));
 }
 
 function useMyPresence<P extends JsonObject>(): [

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -17,13 +17,9 @@ export {
   createLiveblocksContext,
   LiveblocksProvider,
   useClient,
-  useLiveblocksContextBundle,
   useInboxNotificationThread,
   useMarkAllInboxNotificationsAsRead,
   useMarkInboxNotificationAsRead,
-
-  // TODO Move these private APIs into another namespace eventually
-  useLiveblocksContextBundleOrNull as useLiveblocksContextBundleOrNull__,
 } from "./liveblocks";
 export {
   createRoomContext,
@@ -50,7 +46,6 @@ export {
   useRedo,
   useRemoveReaction,
   useRoom,
-  useRoomContextBundle,
   useRoomNotificationSettings,
   useStatus,
   useStorageRoot,
@@ -58,9 +53,6 @@ export {
   useUndo,
   useUpdateMyPresence,
   useUpdateRoomNotificationSettings,
-
-  // TODO Move these private APIs into another namespace eventually
-  useRoomContextBundleOrNull as useRoomContextBundleOrNull__,
 } from "./room";
 
 // Export the Suspense versions of our hooks

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -13,6 +13,7 @@ export { shallow } from "@liveblocks/client";
 
 // Export all the top-level hooks
 export {
+  ClientContext,
   createLiveblocksContext,
   LiveblocksProvider,
   useClient,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -792,17 +792,6 @@ type RoomContextBundleCommon<
   useThreadSubscription(threadId: string): ThreadSubscription;
 };
 
-/**
- * @private
- *
- * Private methods and variables used in the core internals, but as a user
- * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
- * will probably happen if you do.
- */
-type PrivateRoomContextApi = {
-  useCurrentUserIdFromRoom(): string | null;
-};
-
 export type RoomContextBundle<
   P extends JsonObject,
   S extends LsonObject,
@@ -983,16 +972,7 @@ export type RoomContextBundle<
           }
       >;
     }
-> & {
-  /**
-   * @private
-   *
-   * Private methods and variables used in the core internals, but as a user
-   * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
-   * will probably happen if you do.
-   */
-  readonly [kInternal]: PrivateRoomContextApi;
-};
+>;
 
 /**
  * Properties that are the same in LiveblocksContext and LiveblocksContext["suspense"].

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -18,7 +18,6 @@ import type {
   CommentBody,
   CommentData,
   InboxNotificationData,
-  kInternal,
   LiveblocksError,
   PartialNullable,
   QueryMetadata,
@@ -1017,22 +1016,6 @@ type LiveblocksContextBundleCommon<M extends BaseMetadata> = {
   useInboxNotificationThread(inboxNotificationId: string): ThreadData<M>;
 };
 
-/**
- * @private
- *
- * Private methods and variables used in the core internals, but as a user
- * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
- * will probably happen if you do.
- */
-type PrivateLiveblocksContextApi = {
-  /**
-   * @private
-   *
-   * Returns the current user ID. Can only be used after making a call to a Notifications API.
-   */
-  useCurrentUserIdFromClient(): string | null;
-};
-
 export type LiveblocksContextBundle<
   U extends BaseUserMeta,
   M extends BaseMetadata,
@@ -1084,13 +1067,4 @@ export type LiveblocksContextBundle<
           }
       >;
     }
-> & {
-  /**
-   * @private
-   *
-   * Private methods and variables used in the core internals, but as a user
-   * of Liveblocks, NEVER USE ANY OF THESE DIRECTLY, because bad things
-   * will probably happen if you do.
-   */
-  readonly [kInternal]: PrivateLiveblocksContextApi;
-};
+>;


### PR DESCRIPTION
Removes the internal `useLiveblocksContextBundle` and `useRoomContextBundle` internal helper hooks. The concept of a "bundle" is now 100% an implementation detail, no longer visible on the outer API surface area.

As an aside, I made the `useCurrentUserId` helper hook a 100% implementation detail inside `@liveblocks/react-ui`, and was now able to completely remove the `[kInternal]` API fields from the "bundles". This should make the implementation much easier to understand, as there are way fewer layers to be aware of and change when we want to make a change here.

Here is the final, complete, implementation of the [`useCurrentUserId()` hook](https://github.com/liveblocks/liveblocks/blob/8de44ae3d44d4b6e03f0160d8f9a0e461054f53d/packages/liveblocks-react-ui/src/shared.ts#L103-L128). No support code needed inside `@liveblocks/react`, no private APIs, etc. So `@liveblocks/react` doesn't even have to know about this.
