### PR TITLE
Tweaks the type signatures for `useCreateThread` & friends

### DIFF
--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1263,7 +1263,7 @@ function useCreateThread<M extends BaseMetadata>() {
   return React.useCallback(
     (options: CreateThreadOptions<M>): ThreadData<M> => {
       const body = options.body;
-      const metadata: M = "metadata" in options ? options.metadata : ({} as M);
+      const metadata: M = (options.metadata ?? {}) as M;
 
       const threadId = createThreadId();
       const commentId = createCommentId();
@@ -1338,7 +1338,7 @@ function useEditThreadMetadata<M extends BaseMetadata>() {
   const room = useRoom();
   return React.useCallback(
     (options: EditThreadMetadataOptions<M>): void => {
-      if (!("metadata" in options)) {
+      if (!options.metadata) {
         return;
       }
 
@@ -2246,8 +2246,8 @@ export function createRoomContext<
   P extends JsonObject = DP,
   S extends LsonObject = DS,
   U extends BaseUserMeta = DU,
-  E extends Json = never, // TODO Change this to DE for 2.0
-  M extends BaseMetadata = never, // TODO Change this to DM for 2.0
+  E extends Json = DE,
+  M extends BaseMetadata = DM,
 >(client: OpaqueClient): RoomContextBundle<P, S, U, E, M> {
   return getOrCreateRoomContextBundle<P, S, U, E, M>(client);
 }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1398,9 +1398,7 @@ function useEditThreadMetadata<M extends BaseMetadata>() {
                 ...state.threads,
                 [threadId]: {
                   ...existingThread,
-                  metadata: metadata as [M] extends [never]
-                    ? Record<string, never>
-                    : M,
+                  metadata,
                 },
               },
               optimisticUpdates: updatedOptimisticUpdates,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -100,15 +100,15 @@ export type RoomInfoState =
   | RoomInfoStateError
   | RoomInfoStateSuccess;
 
-export type CreateThreadOptions<M extends BaseMetadata> = [M] extends [never]
-  ? { body: CommentBody }
-  : { body: CommentBody; metadata: M };
+export type CreateThreadOptions<M extends BaseMetadata> =
+  Record<string, never> extends M
+    ? { body: CommentBody; metadata?: M }
+    : { body: CommentBody; metadata: M };
 
-export type EditThreadMetadataOptions<M extends BaseMetadata> = [M] extends [
-  never,
-]
-  ? { threadId: string }
-  : { threadId: string; metadata: Resolve<PartialNullable<M>> };
+export type EditThreadMetadataOptions<M extends BaseMetadata> =
+  Record<string, never> extends M
+    ? { threadId: string; metadata?: Resolve<PartialNullable<M>> }
+    : { threadId: string; metadata: Resolve<PartialNullable<M>> };
 
 export type CreateCommentOptions = {
   threadId: string;

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -105,10 +105,10 @@ export type CreateThreadOptions<M extends BaseMetadata> =
     ? { body: CommentBody; metadata?: M }
     : { body: CommentBody; metadata: M };
 
-export type EditThreadMetadataOptions<M extends BaseMetadata> =
-  Record<string, never> extends M
-    ? { threadId: string; metadata?: Resolve<PartialNullable<M>> }
-    : { threadId: string; metadata: Resolve<PartialNullable<M>> };
+export type EditThreadMetadataOptions<M extends BaseMetadata> = {
+  threadId: string;
+  metadata: PartialNullable<M>;
+};
 
 export type CreateCommentOptions = {
   threadId: string;

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -346,6 +346,50 @@ declare global {
 
 // ---------------------------------------------------------
 
+// The useEditThreadMetadata() hook
+{
+  const editMetadata = classic.useEditThreadMetadata();
+  expectError(editMetadata({})); // no body = error
+
+  expectError(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+  );
+  expectError(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+  );
+
+  expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { color: null } })
+  );
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { color: "red" } })
+  );
+}
+
+// The useEditThreadMetadata() hook (suspense)
+{
+  const editMetadata = suspense.useEditThreadMetadata();
+  expectError(editMetadata({})); // no body = error
+
+  expectError(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+  );
+  expectError(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+  );
+
+  expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { color: null } })
+  );
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { color: "red" } })
+  );
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   expectType<boolean>(classic.useInboxNotifications().isLoading);

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -276,6 +276,76 @@ declare global {
 
 // ---------------------------------------------------------
 
+// The useCreateThread() hook
+{
+  const createThread = classic.useCreateThread();
+  expectError(createThread({})); // no body = error
+
+  // No metadata = error
+  expectError(
+    createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    })
+  );
+
+  const thread = createThread({
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+    metadata: { color: "red" },
+  });
+
+  expectType<"thread">(thread.type);
+  expectType<string>(thread.id);
+  expectType<string>(thread.roomId);
+  expectType<"comment">(thread.comments[0].type);
+  expectType<string>(thread.comments[0].id);
+  expectType<string>(thread.comments[0].threadId);
+
+  expectType<"red" | "blue">(thread.metadata.color);
+  expectError(thread.metadata.nonexisting);
+}
+
+// The useCreateThread() hook (suspense)
+{
+  const createThread = suspense.useCreateThread();
+  expectError(createThread({})); // no body = error
+
+  // No metadata = error
+  expectError(
+    createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    })
+  );
+
+  const thread = createThread({
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+    metadata: { color: "red" },
+  });
+
+  expectType<"thread">(thread.type);
+  expectType<string>(thread.id);
+  expectType<string>(thread.roomId);
+  expectType<"comment">(thread.comments[0].type);
+  expectType<string>(thread.comments[0].id);
+  expectType<string>(thread.comments[0].threadId);
+
+  expectType<"red" | "blue">(thread.metadata.color);
+  expectError(thread.metadata.nonexisting);
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   expectType<boolean>(classic.useInboxNotifications().isLoading);

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -390,6 +390,176 @@ declare global {
 
 // ---------------------------------------------------------
 
+// The useCreateComment() hook
+{
+  {
+    const createComment = classic.useCreateComment();
+    expectError(createComment({}));
+
+    const comment = createComment({
+      threadId: "th_xxx",
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    });
+
+    expectType<"comment">(comment.type);
+    expectType<string>(comment.id);
+    expectType<string>(comment.threadId);
+  }
+}
+
+// The useCreateComment() hook (suspense)
+{
+  const createComment = suspense.useCreateComment();
+  expectError(createComment({}));
+
+  const comment = createComment({
+    threadId: "th_xxx",
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+  });
+
+  expectType<"comment">(comment.type);
+  expectType<string>(comment.id);
+  expectType<string>(comment.threadId);
+}
+
+// ---------------------------------------------------------
+
+// The useEditComment() hook
+{
+  const editComment = classic.useEditComment();
+  expectError(editComment({}));
+
+  expectType<void>(
+    editComment({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      body: { version: 1, content: [] },
+    })
+  );
+}
+
+// The useEditComment() hook (suspense)
+{
+  const editComment = suspense.useEditComment();
+  expectError(editComment({}));
+
+  expectType<void>(
+    editComment({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      body: { version: 1, content: [] },
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
+// The useDeleteComment() hook
+{
+  const deleteComment = classic.useDeleteComment();
+
+  expectError(deleteComment({}));
+  expectError(deleteComment({ threadId: "th_xxx" }));
+  expectError(deleteComment({ commentId: "co_xxx" }));
+
+  expectType<void>(deleteComment({ threadId: "th_xxx", commentId: "co_xxx" }));
+}
+
+// The useDeleteComment() hook (suspense)
+{
+  const deleteComment = suspense.useDeleteComment();
+
+  expectError(deleteComment({}));
+  expectError(deleteComment({ threadId: "th_xxx" }));
+  expectError(deleteComment({ commentId: "co_xxx" }));
+
+  expectType<void>(deleteComment({ threadId: "th_xxx", commentId: "co_xxx" }));
+}
+
+// ---------------------------------------------------------
+
+// The useAddReaction() hook
+{
+  const addReaction = classic.useAddReaction();
+
+  expectError(addReaction({}));
+  expectError(addReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    addReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// The useAddReaction() hook (suspense)
+{
+  const addReaction = suspense.useAddReaction();
+
+  expectError(addReaction({}));
+  expectError(addReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    addReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
+// The useRemoveReaction() hook
+{
+  const removeReaction = classic.useRemoveReaction();
+
+  expectError(removeReaction({}));
+  expectError(removeReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    removeReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// The useRemoveReaction() hook (suspense)
+{
+  const removeReaction = suspense.useRemoveReaction();
+
+  expectError(removeReaction({}));
+  expectError(removeReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    removeReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   expectType<boolean>(classic.useInboxNotifications().isLoading);

--- a/packages/liveblocks-react/test-d/factories.test-d.ts
+++ b/packages/liveblocks-react/test-d/factories.test-d.ts
@@ -45,7 +45,7 @@ type M = MyThreadMetadata;
 const client = createClient({ publicApiKey: "pk_whatever" });
 
 const lbctx = createLiveblocksContext<U, M>(client);
-const ctx = createRoomContext<P, S, U, E>(client);
+const ctx = createRoomContext<P, S, U, E, M>(client);
 
 // ---------------------------------------------------------
 // Hook APIs
@@ -310,6 +310,147 @@ ctx.useErrorListener((err) => {
     expectType<string | undefined>(info.name);
     expectType<string | undefined>(info.url);
     expectType<undefined>(error);
+  }
+}
+
+// ---------------------------------------------------------
+
+// The useCreateThread() hook
+{
+  {
+    const untypedCtx = createRoomContext(client);
+    //    ^^^^^^^^^^ [1]
+    const createThread = untypedCtx.useCreateThread();
+    expectError(createThread({}));
+
+    const thread1 = createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    });
+
+    expectType<"thread">(thread1.type);
+    expectType<string>(thread1.id);
+    expectType<string>(thread1.roomId);
+    expectType<"comment">(thread1.comments[0].type);
+    expectType<string>(thread1.comments[0].id);
+    expectType<string>(thread1.comments[0].threadId);
+
+    expectType<string | number | boolean | undefined>(thread1.metadata.color);
+
+    // But... creating a thread _with_ metadata is now an error
+    const thread2 = createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+      metadata: { foo: "bar" },
+    });
+
+    expectType<string>(thread2.id);
+  }
+
+  {
+    const createThread = ctx.useCreateThread();
+    //                   ^^^ [2]
+    expectError(createThread({})); // no body = error
+
+    // No metadata = error
+    expectError(
+      createThread({
+        body: {
+          version: 1,
+          content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+        },
+      })
+    );
+
+    const thread = createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+      metadata: { color: "red" },
+    });
+
+    expectType<"thread">(thread.type);
+    expectType<string>(thread.id);
+    expectType<string>(thread.roomId);
+    expectType<"comment">(thread.comments[0].type);
+    expectType<string>(thread.comments[0].id);
+    expectType<string>(thread.comments[0].threadId);
+
+    expectType<"red" | "blue">(thread.metadata.color);
+  }
+}
+
+// The useCreateThread() hook (suspense)
+{
+  {
+    const untypedCtx = createRoomContext(client);
+    //    ^^^^^^^^^^ [3]
+    const createThread = untypedCtx.suspense.useCreateThread();
+    expectError(createThread({}));
+
+    const thread1 = createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    });
+
+    expectType<"thread">(thread1.type);
+    expectType<string>(thread1.id);
+    expectType<string>(thread1.roomId);
+    expectType<"comment">(thread1.comments[0].type);
+    expectType<string>(thread1.comments[0].id);
+    expectType<string>(thread1.comments[0].threadId);
+
+    expectType<string | number | boolean | undefined>(thread1.metadata.color);
+
+    const thread2 = createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+      metadata: { foo: "bar" },
+    });
+
+    expectType<string>(thread2.id);
+  }
+
+  {
+    const createThread = ctx.suspense.useCreateThread();
+    //                   ^^^ [4]
+    expectError(createThread({})); // no body = error
+
+    // No metadata = error
+    expectError(
+      createThread({
+        body: {
+          version: 1,
+          content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+        },
+      })
+    );
+
+    const thread = createThread({
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+      metadata: { color: "red" },
+    });
+
+    expectType<"thread">(thread.type);
+    expectType<string>(thread.id);
+    expectType<string>(thread.roomId);
+    expectType<"comment">(thread.comments[0].type);
+    expectType<string>(thread.comments[0].id);
+    expectType<string>(thread.comments[0].threadId);
+
+    expectType<"red" | "blue">(thread.metadata.color);
   }
 }
 

--- a/packages/liveblocks-react/test-d/factories.test-d.ts
+++ b/packages/liveblocks-react/test-d/factories.test-d.ts
@@ -456,6 +456,86 @@ ctx.useErrorListener((err) => {
 
 // ---------------------------------------------------------
 
+// The useEditThreadMetadata() hook
+{
+  {
+    const untypedCtx = createRoomContext(client);
+    //    ^^^^^^^^^^ [1]
+    const editMetadata = untypedCtx.useEditThreadMetadata();
+    expectError(editMetadata({}));
+
+    expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+    );
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+    );
+  }
+
+  {
+    const editMetadata = ctx.useEditThreadMetadata();
+    //                   ^^^ [2]
+    expectError(editMetadata({})); // no body = error
+
+    expectError(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+    );
+    expectError(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+    );
+
+    expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { color: null } })
+    );
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { color: "red" } })
+    );
+  }
+}
+
+// The useEditThreadMetadata() hook (suspense)
+{
+  {
+    const untypedCtx = createRoomContext(client);
+    const editMetadata = untypedCtx.suspense.useEditThreadMetadata();
+    //                   ^^^^^^^^^^^^^^^^^^^ [3]
+    expectError(editMetadata({}));
+
+    expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+    );
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+    );
+  }
+
+  {
+    const editMetadata = ctx.suspense.useEditThreadMetadata();
+    //                   ^^^^^^^^^^^^ [4]
+    expectError(editMetadata({})); // no body = error
+
+    expectError(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+    );
+    expectError(
+      editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+    );
+
+    expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { color: null } })
+    );
+    expectType<void>(
+      editMetadata({ threadId: "th_xxx", metadata: { color: "red" } })
+    );
+  }
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   const result = lbctx.useInboxNotifications();

--- a/packages/liveblocks-react/test-d/factories.test-d.ts
+++ b/packages/liveblocks-react/test-d/factories.test-d.ts
@@ -460,8 +460,8 @@ ctx.useErrorListener((err) => {
 {
   {
     const untypedCtx = createRoomContext(client);
-    //    ^^^^^^^^^^ [1]
     const editMetadata = untypedCtx.useEditThreadMetadata();
+    //                   ^^^^^^^^^^ [1]
     expectError(editMetadata({}));
 
     expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
@@ -532,6 +532,176 @@ ctx.useErrorListener((err) => {
       editMetadata({ threadId: "th_xxx", metadata: { color: "red" } })
     );
   }
+}
+
+// ---------------------------------------------------------
+
+// The useCreateComment() hook
+{
+  {
+    const createComment = ctx.useCreateComment();
+    expectError(createComment({}));
+
+    const comment = createComment({
+      threadId: "th_xxx",
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    });
+
+    expectType<"comment">(comment.type);
+    expectType<string>(comment.id);
+    expectType<string>(comment.threadId);
+  }
+}
+
+// The useCreateComment() hook (suspense)
+{
+  const createComment = ctx.suspense.useCreateComment();
+  expectError(createComment({}));
+
+  const comment = createComment({
+    threadId: "th_xxx",
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+  });
+
+  expectType<"comment">(comment.type);
+  expectType<string>(comment.id);
+  expectType<string>(comment.threadId);
+}
+
+// ---------------------------------------------------------
+
+// The useEditComment() hook
+{
+  const editComment = ctx.useEditComment();
+  expectError(editComment({}));
+
+  expectType<void>(
+    editComment({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      body: { version: 1, content: [] },
+    })
+  );
+}
+
+// The useEditComment() hook (suspense)
+{
+  const editComment = ctx.suspense.useEditComment();
+  expectError(editComment({}));
+
+  expectType<void>(
+    editComment({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      body: { version: 1, content: [] },
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
+// The useDeleteComment() hook
+{
+  const deleteComment = ctx.useDeleteComment();
+
+  expectError(deleteComment({}));
+  expectError(deleteComment({ threadId: "th_xxx" }));
+  expectError(deleteComment({ commentId: "co_xxx" }));
+
+  expectType<void>(deleteComment({ threadId: "th_xxx", commentId: "co_xxx" }));
+}
+
+// The useDeleteComment() hook (suspense)
+{
+  const deleteComment = ctx.suspense.useDeleteComment();
+
+  expectError(deleteComment({}));
+  expectError(deleteComment({ threadId: "th_xxx" }));
+  expectError(deleteComment({ commentId: "co_xxx" }));
+
+  expectType<void>(deleteComment({ threadId: "th_xxx", commentId: "co_xxx" }));
+}
+
+// ---------------------------------------------------------
+
+// The useAddReaction() hook
+{
+  const addReaction = ctx.useAddReaction();
+
+  expectError(addReaction({}));
+  expectError(addReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    addReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// The useAddReaction() hook (suspense)
+{
+  const addReaction = ctx.suspense.useAddReaction();
+
+  expectError(addReaction({}));
+  expectError(addReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    addReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
+// The useRemoveReaction() hook
+{
+  const removeReaction = ctx.useRemoveReaction();
+
+  expectError(removeReaction({}));
+  expectError(removeReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    removeReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// The useRemoveReaction() hook (suspense)
+{
+  const removeReaction = ctx.suspense.useRemoveReaction();
+
+  expectError(removeReaction({}));
+  expectError(removeReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    removeReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/factories.test-d.ts
+++ b/packages/liveblocks-react/test-d/factories.test-d.ts
@@ -319,8 +319,8 @@ ctx.useErrorListener((err) => {
 {
   {
     const untypedCtx = createRoomContext(client);
-    //    ^^^^^^^^^^ [1]
     const createThread = untypedCtx.useCreateThread();
+    //                   ^^^^^^^^^^ [1]
     expectError(createThread({}));
 
     const thread1 = createThread({
@@ -389,8 +389,8 @@ ctx.useErrorListener((err) => {
 {
   {
     const untypedCtx = createRoomContext(client);
-    //    ^^^^^^^^^^ [3]
     const createThread = untypedCtx.suspense.useCreateThread();
+    //                   ^^^^^^^^^^^^^^^^^^^ [3]
     expectError(createThread({}));
 
     const thread1 = createThread({
@@ -422,7 +422,7 @@ ctx.useErrorListener((err) => {
 
   {
     const createThread = ctx.suspense.useCreateThread();
-    //                   ^^^ [4]
+    //                   ^^^^^^^^^^^^ [4]
     expectError(createThread({})); // no body = error
 
     // No metadata = error

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
@@ -307,6 +307,44 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
+// The useEditThreadMetadata() hook
+{
+  const editMetadata = classic.useEditThreadMetadata();
+  expectError(editMetadata({}));
+
+  expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+  );
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+  );
+}
+
+// The useEditThreadMetadata() hook (suspense)
+{
+  //        ---------------------
+  const editMetadata = suspense.useEditThreadMetadata();
+  expectError(editMetadata({})); // no body = error
+
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: null } })
+  );
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { nonexisting: 123 } })
+  );
+
+  expectType<void>(editMetadata({ threadId: "th_xxx", metadata: {} }));
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { color: null } })
+  );
+  expectType<void>(
+    editMetadata({ threadId: "th_xxx", metadata: { color: "red" } })
+  );
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   expectType<boolean>(classic.useInboxNotifications().isLoading);

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
@@ -233,6 +233,80 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
+// The useCreateThread() hook
+{
+  const createThread = classic.useCreateThread();
+  expectError(createThread({}));
+
+  const thread1 = createThread({
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+  });
+
+  expectType<"thread">(thread1.type);
+  expectType<string>(thread1.id);
+  expectType<string>(thread1.roomId);
+  expectType<"comment">(thread1.comments[0].type);
+  expectType<string>(thread1.comments[0].id);
+  expectType<string>(thread1.comments[0].threadId);
+
+  expectType<string | number | boolean | undefined>(thread1.metadata.color);
+
+  const thread2 = createThread({
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+    metadata: { foo: "bar" },
+  });
+
+  expectType<string>(thread2.id);
+  expectType<string | number | boolean | undefined>(thread2.metadata.foo);
+  expectType<string | number | boolean | undefined>(
+    thread2.metadata.nonexisting
+  );
+}
+
+// The useCreateThread() hook (suspense)
+{
+  const createThread = suspense.useCreateThread();
+  expectError(createThread({}));
+
+  const thread1 = createThread({
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+  });
+
+  expectType<"thread">(thread1.type);
+  expectType<string>(thread1.id);
+  expectType<string>(thread1.roomId);
+  expectType<"comment">(thread1.comments[0].type);
+  expectType<string>(thread1.comments[0].id);
+  expectType<string>(thread1.comments[0].threadId);
+
+  expectType<string | number | boolean | undefined>(thread1.metadata.foo);
+
+  const thread2 = createThread({
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+    metadata: { foo: "bar" },
+  });
+
+  expectType<string>(thread2.id);
+  expectType<string | number | boolean | undefined>(thread2.metadata.foo);
+  expectType<string | number | boolean | undefined>(
+    thread2.metadata.nonexisting
+  );
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   expectType<boolean>(classic.useInboxNotifications().isLoading);

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
@@ -345,6 +345,176 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
+// The useCreateComment() hook
+{
+  {
+    const createComment = classic.useCreateComment();
+    expectError(createComment({}));
+
+    const comment = createComment({
+      threadId: "th_xxx",
+      body: {
+        version: 1,
+        content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+      },
+    });
+
+    expectType<"comment">(comment.type);
+    expectType<string>(comment.id);
+    expectType<string>(comment.threadId);
+  }
+}
+
+// The useCreateComment() hook (suspense)
+{
+  const createComment = suspense.useCreateComment();
+  expectError(createComment({}));
+
+  const comment = createComment({
+    threadId: "th_xxx",
+    body: {
+      version: 1,
+      content: [{ type: "paragraph", children: [{ text: "hi" }] }],
+    },
+  });
+
+  expectType<"comment">(comment.type);
+  expectType<string>(comment.id);
+  expectType<string>(comment.threadId);
+}
+
+// ---------------------------------------------------------
+
+// The useEditComment() hook
+{
+  const editComment = classic.useEditComment();
+  expectError(editComment({}));
+
+  expectType<void>(
+    editComment({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      body: { version: 1, content: [] },
+    })
+  );
+}
+
+// The useEditComment() hook (suspense)
+{
+  const editComment = suspense.useEditComment();
+  expectError(editComment({}));
+
+  expectType<void>(
+    editComment({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      body: { version: 1, content: [] },
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
+// The useDeleteComment() hook
+{
+  const deleteComment = classic.useDeleteComment();
+
+  expectError(deleteComment({}));
+  expectError(deleteComment({ threadId: "th_xxx" }));
+  expectError(deleteComment({ commentId: "co_xxx" }));
+
+  expectType<void>(deleteComment({ threadId: "th_xxx", commentId: "co_xxx" }));
+}
+
+// The useDeleteComment() hook (suspense)
+{
+  const deleteComment = suspense.useDeleteComment();
+
+  expectError(deleteComment({}));
+  expectError(deleteComment({ threadId: "th_xxx" }));
+  expectError(deleteComment({ commentId: "co_xxx" }));
+
+  expectType<void>(deleteComment({ threadId: "th_xxx", commentId: "co_xxx" }));
+}
+
+// ---------------------------------------------------------
+
+// The useAddReaction() hook
+{
+  const addReaction = classic.useAddReaction();
+
+  expectError(addReaction({}));
+  expectError(addReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    addReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// The useAddReaction() hook (suspense)
+{
+  const addReaction = suspense.useAddReaction();
+
+  expectError(addReaction({}));
+  expectError(addReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(addReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    addReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
+// The useRemoveReaction() hook
+{
+  const removeReaction = classic.useRemoveReaction();
+
+  expectError(removeReaction({}));
+  expectError(removeReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    removeReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// The useRemoveReaction() hook (suspense)
+{
+  const removeReaction = suspense.useRemoveReaction();
+
+  expectError(removeReaction({}));
+  expectError(removeReaction({ threadId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ commentId: "th_xxx", emoji: "👍" }));
+  expectError(removeReaction({ threadId: "th_xxx", commentId: "th_xxx" }));
+
+  expectType<void>(
+    removeReaction({
+      threadId: "th_xxx",
+      commentId: "cm_xxx",
+      emoji: "👍",
+    })
+  );
+}
+
+// ---------------------------------------------------------
+
 // The useInboxNotifications() hook
 {
   expectType<boolean>(classic.useInboxNotifications().isLoading);


### PR DESCRIPTION
This vastly improves the DX of using `useCreateThread` & friends, and makes it behave nicely in both untyped and types contexts. See the type-level tests for all the details.

### TODO

- [x] `useCreateThread`
- [x] `useEditThreadMetadata`
- [x] `useCreateComment`
- [x] `useEditComment`
- [x] `useDeleteComment`
- [x] `useAddReaction`
- [x] `useRemoveReaction`

Fixes LB-605.
Fixes LB-676 (a lot of it, at least).