### PR TITLE
Minor API doc fix

### DIFF
--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1250,7 +1250,7 @@ To delete an existing metadata property, set its value to `null`. Passing
 
 ```tsx
 const editThreadMetadata = useEditThreadMetadata();
-const thread = editThreadMetadata({ threadId: "th_xxx", metadata: {} });
+editThreadMetadata({ threadId: "th_xxx", metadata: {} });
 ```
 
 ### useMarkThreadAsRead [@badge=RoomProvider]

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1277,7 +1277,7 @@ Returns a function that edits a comment’s body.
 
 ```tsx
 const editComment = useEditComment();
-const comment = editComment({
+editComment({
   threadId: "th_xxx",
   commentId: "cm_xxx",
   body: {},


### PR DESCRIPTION
Calling `editThreadMetadata()` returns void.