### PR TITLE
Fix `InboxNotification` props types

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -1344,14 +1344,14 @@ Override specific kinds of inbox notifications.
 <PropertiesList>
   <PropertiesListItem
     name="thread"
-    type="ComponentType<InboxNotificationThreadProps>"
+    type="ComponentType<InboxNotificationThreadKindProps>"
   >
     The component used to display thread notifications. Defaults to
     `InboxNotification.Thread`.
   </PropertiesListItem>
   <PropertiesListItem
     name="$${string}"
-    type="ComponentType<InboxNotificationCustomProps>"
+    type="ComponentType<InboxNotificationCustomKindProps>"
   >
     The component used to display a custom notification kind. Custom
     notification kinds must start with a `$`.

--- a/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
@@ -52,8 +52,6 @@ import { Room } from "./internal/Room";
 import { Tooltip } from "./internal/Tooltip";
 import { User } from "./internal/User";
 
-type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
-
 type ComponentTypeWithRef<
   T extends keyof JSX.IntrinsicElements,
   P,
@@ -61,12 +59,9 @@ type ComponentTypeWithRef<
 
 type InboxNotificationKinds = Record<
   `$${string}`,
-  ComponentTypeWithRef<
-    "a",
-    Optional<InboxNotificationCustomProps, "title" | "children">
-  >
+  ComponentTypeWithRef<"a", InboxNotificationCustomKindProps>
 > & {
-  thread: ComponentTypeWithRef<"a", InboxNotificationThreadProps>;
+  thread: ComponentTypeWithRef<"a", InboxNotificationThreadKindProps>;
 };
 
 interface InboxNotificationSharedProps {
@@ -146,6 +141,20 @@ export interface InboxNotificationCustomProps
    */
   markAsReadOnClick?: boolean;
 }
+
+export type InboxNotificationThreadKindProps = Omit<
+  InboxNotificationProps,
+  "kinds"
+> & {
+  inboxNotification: InboxNotificationThreadData;
+};
+
+export type InboxNotificationCustomKindProps = Omit<
+  InboxNotificationProps,
+  "kinds"
+> & {
+  inboxNotification: InboxNotificationCustomData;
+};
 
 interface InboxNotificationLayoutProps
   extends Omit<ComponentPropsWithoutRef<"a">, "title">,

--- a/packages/liveblocks-react-ui/src/index.ts
+++ b/packages/liveblocks-react-ui/src/index.ts
@@ -10,9 +10,11 @@ export type { ComposerProps } from "./components/Composer";
 export { Composer } from "./components/Composer";
 export type {
   InboxNotificationAvatarProps,
+  InboxNotificationCustomKindProps,
   InboxNotificationCustomProps,
   InboxNotificationIconProps,
   InboxNotificationProps,
+  InboxNotificationThreadKindProps,
   InboxNotificationThreadProps,
 } from "./components/InboxNotification";
 export { InboxNotification } from "./components/InboxNotification";


### PR DESCRIPTION
We were trying too hard to get away with one props type for each kind but it doesn't really scale, the props we give to the users in their `kinds` components shouldn't always match the component (e.g. `InboxNotification.Custom`) props.

Example: We don't give users `title` and `children` in custom kinds props, but we want these props to be required on `<InboxNotification.Custom />`.

Fixes LB-687