### PR TITLE
Use augmentation for `RoomInfo` type

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -3,7 +3,7 @@ import { createAuthManager } from "./auth-manager";
 import { isIdle } from "./connection";
 import { DEFAULT_BASE_URL } from "./constants";
 import type { LsonObject } from "./crdts/Lson";
-import type { DE, DM, DP, DS, DU } from "./custom-types";
+import type { DE, DM, DP, DRI, DS, DU } from "./custom-types";
 import { linkDevTools, setupDevTools, unlinkDevTools } from "./devtools";
 import { kInternal } from "./internal";
 import type { BatchStore } from "./lib/batch";
@@ -42,7 +42,6 @@ import {
 import type { CacheStore } from "./store";
 import { createClientStore } from "./store";
 import type { OptionalPromise } from "./types/OptionalPromise";
-import type { RoomInfo } from "./types/RoomInfo";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1_000;
@@ -111,7 +110,7 @@ type PrivateClientApi<U extends BaseUserMeta> = {
   readonly resolveMentionSuggestions: ClientOptions<U>["resolveMentionSuggestions"];
   readonly cacheStore: CacheStore<BaseMetadata>;
   readonly usersStore: BatchStore<U["info"] | undefined, [string]>;
-  readonly roomsInfoStore: BatchStore<RoomInfo | undefined, [string]>;
+  readonly roomsInfoStore: BatchStore<DRI | undefined, [string]>;
   readonly getRoomIds: () => string[];
 };
 
@@ -219,7 +218,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
    */
   resolveRoomsInfo?: (
     args: ResolveRoomsInfoArgs
-  ) => OptionalPromise<(RoomInfo | undefined)[] | undefined>;
+  ) => OptionalPromise<(DRI | undefined)[] | undefined>;
 
   /**
    * @internal To point the client to a different Liveblocks server. Only

--- a/packages/liveblocks-core/src/custom-types.ts
+++ b/packages/liveblocks-core/src/custom-types.ts
@@ -1,8 +1,8 @@
 import type { LsonObject } from "./crdts/Lson";
 import type { Json, JsonObject } from "./lib/Json";
+import type { BaseRoomInfo } from "./protocol/BaseRoomInfo";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { BaseMetadata } from "./protocol/Comments";
-import type { BaseRoomInfo } from "./protocol/BaseRoomInfo";
 
 declare global {
   /**

--- a/packages/liveblocks-core/src/custom-types.ts
+++ b/packages/liveblocks-core/src/custom-types.ts
@@ -2,6 +2,7 @@ import type { LsonObject } from "./crdts/Lson";
 import type { Json, JsonObject } from "./lib/Json";
 import type { BaseUserMeta } from "./protocol/BaseUserMeta";
 import type { BaseMetadata } from "./protocol/Comments";
+import type { BaseRoomInfo } from "./protocol/BaseRoomInfo";
 
 declare global {
   /**
@@ -17,7 +18,8 @@ type ExtendableTypes =
   | "Storage"
   | "UserMeta"
   | "RoomEvent"
-  | "ThreadMetadata";
+  | "ThreadMetadata"
+  | "RoomInfo";
 
 type ExtendedType<
   K extends ExtendableTypes,
@@ -39,3 +41,4 @@ export type DM = ExtendedType<
   BaseMetadata,
   "Invalid generic"
 >;
+export type DRI = ExtendedType<"RoomInfo", BaseRoomInfo, "Invalid generic">;

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -99,6 +99,7 @@ export {
   withTimeout,
 } from "./lib/utils";
 export type { CustomAuthenticationResult } from "./protocol/Authentication";
+export type { BaseRoomInfo } from "./protocol/BaseRoomInfo";
 export type { BaseUserMeta, IUserInfo } from "./protocol/BaseUserMeta";
 export type {
   BroadcastEventClientMsg,
@@ -195,7 +196,6 @@ export type {
 } from "./room";
 export type { GetThreadsOptions } from "./room";
 export { CommentsApiError } from "./room";
-export type { BaseRoomInfo } from "./protocol/BaseRoomInfo";
 export type { Immutable } from "./types/Immutable";
 export type {
   IWebSocket,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -64,7 +64,7 @@ export type {
 } from "./crdts/StorageUpdates";
 export type { ToImmutable } from "./crdts/utils";
 export { toPlainLson } from "./crdts/utils";
-export type { DE, DM, DP, DS, DU } from "./custom-types";
+export type { DE, DM, DP, DRI, DS, DU } from "./custom-types";
 export {
   legacy_patchImmutableObject,
   lsonToJson,
@@ -195,6 +195,7 @@ export type {
 } from "./room";
 export type { GetThreadsOptions } from "./room";
 export { CommentsApiError } from "./room";
+export type { BaseRoomInfo } from "./protocol/BaseRoomInfo";
 export type { Immutable } from "./types/Immutable";
 export type {
   IWebSocket,
@@ -215,7 +216,6 @@ export type {
   PlainLsonMap,
   PlainLsonObject,
 } from "./types/PlainLson";
-export type { RoomInfo } from "./types/RoomInfo";
 export type { RoomNotificationSettings } from "./types/RoomNotificationSettings";
 export type { User } from "./types/User";
 export { detectDupes };

--- a/packages/liveblocks-core/src/protocol/BaseRoomInfo.ts
+++ b/packages/liveblocks-core/src/protocol/BaseRoomInfo.ts
@@ -1,4 +1,4 @@
-export type RoomInfo = {
+export type BaseRoomInfo = {
   /**
    * The name of the room.
    */

--- a/packages/liveblocks-core/src/protocol/BaseRoomInfo.ts
+++ b/packages/liveblocks-core/src/protocol/BaseRoomInfo.ts
@@ -1,4 +1,8 @@
+import type { Json } from "../lib/Json";
+
 export type BaseRoomInfo = {
+  [key: string]: Json | undefined;
+
   /**
    * The name of the room.
    */

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -17,13 +17,13 @@ import type {
   BaseMetadata,
   CommentBody,
   CommentData,
+  DRI,
   InboxNotificationData,
   LiveblocksError,
   PartialNullable,
   QueryMetadata,
   Resolve,
   RoomEventMessage,
-  RoomInfo,
   RoomInitializers,
   ThreadData,
   ToImmutable,
@@ -91,7 +91,7 @@ export type RoomInfoStateError = {
 
 export type RoomInfoStateSuccess = {
   isLoading: false;
-  info: RoomInfo;
+  info: DRI;
   error?: never;
 };
 

--- a/packages/liveblocks-react/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.ts
@@ -33,6 +33,12 @@ declare global {
     ThreadMetadata: {
       color: "red" | "blue";
     };
+
+    RoomInfo: {
+      name: string;
+      url?: string;
+      type: "public" | "private";
+    };
   }
 }
 
@@ -262,6 +268,8 @@ declare global {
   expectType<boolean>(isLoading);
   expectType<string | undefined>(info?.name);
   expectType<string | undefined>(info?.url);
+  expectType<"public" | "private" | undefined>(info?.type);
+  expectError(info?.nonexisting);
   expectType<Error | undefined>(error);
 }
 
@@ -269,8 +277,10 @@ declare global {
 {
   const { info, error, isLoading } = suspense.useRoomInfo("room-id");
   expectType<false>(isLoading);
-  expectType<string | undefined>(info.name);
+  expectType<string>(info.name);
   expectType<string | undefined>(info.url);
+  expectType<"public" | "private">(info?.type);
+  expectError(info?.nonexisting);
   expectType<undefined>(error);
 }
 

--- a/packages/liveblocks-react/test-d/factories.test-d.ts
+++ b/packages/liveblocks-react/test-d/factories.test-d.ts
@@ -1,4 +1,5 @@
 import type {
+  Json,
   LiveList,
   LiveMap,
   LiveObject,
@@ -281,6 +282,7 @@ ctx.useErrorListener((err) => {
     expectType<boolean>(isLoading);
     expectType<string | undefined>(info?.name);
     expectType<string | undefined>(info?.url);
+    expectType<Json | undefined>(info?.nonexisting);
     expectType<Error | undefined>(error);
   }
   {
@@ -289,6 +291,7 @@ ctx.useErrorListener((err) => {
     expectType<boolean>(isLoading);
     expectType<string | undefined>(info?.name);
     expectType<string | undefined>(info?.url);
+    expectType<Json | undefined>(info?.nonexisting);
     expectType<Error | undefined>(error);
   }
 }
@@ -301,6 +304,7 @@ ctx.useErrorListener((err) => {
     expectType<false>(isLoading);
     expectType<string | undefined>(info.name);
     expectType<string | undefined>(info.url);
+    expectType<Json | undefined>(info.nonexisting);
     expectType<undefined>(error);
   }
   {
@@ -309,6 +313,7 @@ ctx.useErrorListener((err) => {
     expectType<false>(isLoading);
     expectType<string | undefined>(info.name);
     expectType<string | undefined>(info.url);
+    expectType<Json | undefined>(info.nonexisting);
     expectType<undefined>(error);
   }
 }

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.ts
@@ -219,6 +219,7 @@ import { expectAssignable, expectError, expectType } from "tsd";
   expectType<boolean>(isLoading);
   expectType<string | undefined>(info?.name);
   expectType<string | undefined>(info?.url);
+  expectType<Json | undefined>(info?.nonexisting);
   expectType<Error | undefined>(error);
 }
 
@@ -228,6 +229,7 @@ import { expectAssignable, expectError, expectType } from "tsd";
   expectType<false>(isLoading);
   expectType<string | undefined>(info.name);
   expectType<string | undefined>(info.url);
+  expectType<Json | undefined>(info?.nonexisting);
   expectType<undefined>(error);
 }
 


### PR DESCRIPTION
This PR replaces the static `RoomInfo` type by an augmentable version.

Fixes LB-717