### PR TITLE
Adds beautiful and helpful error messages for when the user-provided augmented types don't match their requirements

### DIFF
--- a/packages/liveblocks-core/src/globals/augmentation.ts
+++ b/packages/liveblocks-core/src/globals/augmentation.ts
@@ -21,24 +21,16 @@ type ExtendableTypes =
   | "ThreadMetadata"
   | "RoomInfo";
 
-type ExtendedType<
-  K extends ExtendableTypes,
-  B,
-  ErrorMessage,
-> = unknown extends Liveblocks[K]
+type ExtendedType<K extends ExtendableTypes, B> = unknown extends Liveblocks[K]
   ? B
   : Liveblocks[K] extends B
     ? Liveblocks[K]
-    : ErrorMessage;
+    : `The type you provided for '${K}' does not match its requirements. To learn how to fix this, see https://liveblocks.io/errors/${K}`;
 
 // TODO Craft actually useful error message, and documentation
-export type DP = ExtendedType<"Presence", JsonObject, "Invalid generic">;
-export type DS = ExtendedType<"Storage", LsonObject, "Invalid generic">;
-export type DU = ExtendedType<"UserMeta", BaseUserMeta, "Invalid generic">;
-export type DE = ExtendedType<"RoomEvent", Json, "Invalid generic">;
-export type DM = ExtendedType<
-  "ThreadMetadata",
-  BaseMetadata,
-  "Invalid generic"
->;
-export type DRI = ExtendedType<"RoomInfo", BaseRoomInfo, "Invalid generic">;
+export type DP = ExtendedType<"Presence", JsonObject>;
+export type DS = ExtendedType<"Storage", LsonObject>;
+export type DU = ExtendedType<"UserMeta", BaseUserMeta>;
+export type DE = ExtendedType<"RoomEvent", Json>;
+export type DM = ExtendedType<"ThreadMetadata", BaseMetadata>;
+export type DRI = ExtendedType<"RoomInfo", BaseRoomInfo>;

--- a/packages/liveblocks-core/src/globals/augmentation.ts
+++ b/packages/liveblocks-core/src/globals/augmentation.ts
@@ -27,7 +27,6 @@ type ExtendedType<K extends ExtendableTypes, B> = unknown extends Liveblocks[K]
     ? Liveblocks[K]
     : `The type you provided for '${K}' does not match its requirements. To learn how to fix this, see https://liveblocks.io/errors/${K}`;
 
-// TODO Craft actually useful error message, and documentation
 export type DP = ExtendedType<"Presence", JsonObject>;
 export type DS = ExtendedType<"Storage", LsonObject>;
 export type DU = ExtendedType<"UserMeta", BaseUserMeta>;


### PR DESCRIPTION
This is what the erorr message look like.

In your favorite IDE:
![In Vim](https://github.com/liveblocks/liveblocks/assets/83844/e12fea12-2a4d-445d-8ff7-a9f892c1ca3d)

In the console:
![In the console](https://github.com/liveblocks/liveblocks/assets/83844/aa1116f8-5302-489d-9890-b916e192aa31)

Fixes LB-736.