### PR TITLE
Fix `EnsureJson` helper

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -249,8 +249,8 @@ export type EnsureJson<T> =
 // Support for DevTools
 import type * as DevToolsMsg from "./devtools/protocol";
 export type { DevToolsMsg };
-import type * as DevTools from "./types/DevToolsTreeNode";
 import type { Json } from "./lib/Json";
+import type * as DevTools from "./types/DevToolsTreeNode";
 export type { DevTools };
 
 // Store

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -239,6 +239,8 @@ export type EnsureJson<T> =
   T extends Array<infer I> ? (EnsureJson<I>)[] :
   // Retain `unknown` fields, but just treat them as if they're Json | undefined
   [unknown] extends [T] ? Json | undefined :
+  // Dates become strings when serialized to JSON
+  T extends Date ? string :
   // Remove functions
   T extends (...args: any[]) => any ? never :
   // Resolve all other values explicitly

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -233,17 +233,22 @@ export { detectDupes };
  */
 // prettier-ignore
 export type EnsureJson<T> =
-  // Retain `unknown` fields
-  [unknown] extends [T] ? T :
+  // Retain all valid `JSON` fields
+  T extends Json ? T :
+  // Retain all valid arrays
+  T extends Array<infer I> ? (EnsureJson<I>)[] :
+  // Retain `unknown` fields, but just treat them as if they're Json | undefined
+  [unknown] extends [T] ? Json | undefined :
   // Remove functions
   T extends (...args: any[]) => any ? never :
   // Resolve all other values explicitly
-  { [K in keyof T]: EnsureJson<T[K]> };
+  { [K in keyof T as EnsureJson<T[K]> extends never ? never : K]: EnsureJson<T[K]> };
 
 // Support for DevTools
 import type * as DevToolsMsg from "./devtools/protocol";
 export type { DevToolsMsg };
 import type * as DevTools from "./types/DevToolsTreeNode";
+import type { Json } from "./lib/Json";
 export type { DevTools };
 
 // Store

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -235,8 +235,8 @@ export { detectDupes };
 export type EnsureJson<T> =
   // Retain `unknown` fields
   [unknown] extends [T] ? T :
-  // Retain functions
-  T extends (...args: unknown[]) => unknown ? T :
+  // Remove functions
+  T extends (...args: any[]) => any ? never :
   // Resolve all other values explicitly
   { [K in keyof T]: EnsureJson<T[K]> };
 

--- a/packages/liveblocks-core/test-d/EnsureJson.test-d.ts
+++ b/packages/liveblocks-core/test-d/EnsureJson.test-d.ts
@@ -29,6 +29,12 @@ interface IValid {
   items: IItem[];
 }
 
+interface IInvalid {
+  createdAt?: Date | number;
+  err: Error;
+  items: IItem[];
+}
+
 declare const u: EnsureJson<unknown>;
 declare const u6: EnsureJson<IInvalid>;
 
@@ -44,28 +50,18 @@ declare const uo: EnsureJson<{
   toString(): string;
 }>;
 
-{
-  expectType<Json | undefined>(u);
-  expectType<string[]>(ua1);
-  expectType<(number | string)[]>(ua2);
-  expectType<(number | string | boolean | null)[]>(ua3);
-  expectType<Valid[]>(ua4);
-  expectType<Valid[]>(ua5);
+expectType<Json | undefined>(u);
+expectType<string[]>(ua1);
+expectType<(number | string)[]>(ua2);
+expectType<(number | string | boolean | null)[]>(ua3);
+expectType<Valid[]>(ua4);
+expectType<Valid[]>(ua5);
 
-  expectType<{ hi?: Json; date?: number | string }>(uo);
-  expectAssignable<JsonObject>(uo);
-}
+expectType<{ hi?: Json; date?: number | string }>(uo);
+expectAssignable<JsonObject>(uo);
 
-interface IInvalid {
-  createdAt: Date;
-  err: Error;
-  items: IItem[];
-}
-
-{
-  expectType<{
-    createdAt: {};
-    err: { name: string; message: string; stack?: string; cause?: Json };
-    items: Item[];
-  }>(u6);
-}
+expectType<{
+  createdAt?: string | number; // Date became a string
+  err: { name: string; message: string; stack?: string; cause?: Json };
+  items: Item[];
+}>(u6);

--- a/packages/liveblocks-core/test-d/index.test-d.ts
+++ b/packages/liveblocks-core/test-d/index.test-d.ts
@@ -1,0 +1,71 @@
+import type { EnsureJson, Json, JsonObject } from "@liveblocks/core";
+import { expectAssignable, expectType } from "tsd";
+
+type Item = {
+  n?: number;
+  s: string;
+  b: boolean;
+  nu: null;
+  sn: string | number;
+  sno?: string | number;
+  xs: number[];
+};
+
+interface IItem {
+  n?: number;
+  s: string;
+  b: boolean;
+  nu: null;
+  sn: string | number;
+  sno?: string | number;
+  xs: number[];
+}
+
+type Valid = {
+  items: Item[];
+};
+
+interface IValid {
+  items: IItem[];
+}
+
+declare const u: EnsureJson<unknown>;
+declare const u6: EnsureJson<IInvalid>;
+
+declare const ua1: EnsureJson<string[]>;
+declare const ua2: EnsureJson<(number | string)[]>;
+declare const ua3: EnsureJson<(number | string | boolean | null)[]>;
+declare const ua4: EnsureJson<Valid[]>;
+declare const ua5: EnsureJson<IValid[]>;
+
+declare const uo: EnsureJson<{
+  hi?: unknown;
+  date?: number | string;
+  toString(): string;
+}>;
+
+{
+  expectType<Json | undefined>(u);
+  expectType<string[]>(ua1);
+  expectType<(number | string)[]>(ua2);
+  expectType<(number | string | boolean | null)[]>(ua3);
+  expectType<Valid[]>(ua4);
+  expectType<Valid[]>(ua5);
+
+  expectType<{ hi?: Json; date?: number | string }>(uo);
+  expectAssignable<JsonObject>(uo);
+}
+
+interface IInvalid {
+  createdAt: Date;
+  err: Error;
+  items: IItem[];
+}
+
+{
+  expectType<{
+    createdAt: {};
+    err: { name: string; message: string; stack?: string; cause?: Json };
+    items: Item[];
+  }>(u6);
+}


### PR DESCRIPTION
I noticed a bug in `EnsureJson` helper after upgrading our `zustand-flowchart` example. We should recursively remove all functions (like in this case `toString() => string`) from all nested types instead of retaining them as-is. Maybe this is an issue that came to light only on higher TS versions.
