### PR TITLE
Add upgrade command to `create-liveblocks-app`

### DIFF
--- a/docs/pages/platform/upgrading/2.0.mdx
+++ b/docs/pages/platform/upgrading/2.0.mdx
@@ -18,7 +18,8 @@ Breaking changes:
 - Rename `@liveblocks/react-comments` to `@liveblocks/react-ui` and
   `<CommentsConfig />` to `<LiveblocksUIConfig />` (codemod)
 - Rename `@liveblocks/node`'s `RoomInfo` to `RoomData` (codemod)
-- In `@liveblocks/node`, `client.getThread<MyMeta>()` no longer takes type params. Use global type augmentation instead.
+- In `@liveblocks/node`, `client.getThread<MyMeta>()` no longer takes type
+  params. Use global type augmentation instead.
 - Removal of the deprecated APIs
 - Maybe some Yjs package changes
 
@@ -37,9 +38,7 @@ upgrade. You can make a Git commit after every one of these changes.
    1. Do a search for `@liveblocks/react-comments` to find any remaining
       references and rename them manually, for example if you import the default
       styles from within your own CSS files using `@import`.
-1. Upgrade _all_ `@liveblocks/*` packages to `@latest`:
-   1. Run `npm i @liveblocks/client@latest @liveblocks/react@latest ...` for
-      every package you have
+1. Run `npx create-liveblocks-app@latest --upgrade`
 1. Run `tsc` again, no new errors should pop up at this point. If they do, they
    should only be from APIs that were long-deprecated and now removed. Adjust
    accordingly. See section above.

--- a/docs/pages/platform/upgrading/2.0.mdx
+++ b/docs/pages/platform/upgrading/2.0.mdx
@@ -38,7 +38,8 @@ upgrade. You can make a Git commit after every one of these changes.
    1. Do a search for `@liveblocks/react-comments` to find any remaining
       references and rename them manually, for example if you import the default
       styles from within your own CSS files using `@import`.
-1. Run `npx create-liveblocks-app@latest --upgrade`
+1. Upgrade _all_ `@liveblocks/*` packages to `@latest`:
+   1. Run `npx create-liveblocks-app@latest --upgrade`
 1. Run `tsc` again, no new errors should pop up at this point. If they do, they
    should only be from APIs that were long-deprecated and now removed. Adjust
    accordingly. See section above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9981,11 +9981,6 @@
         "win32"
       ]
     },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -10000,17 +9995,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -21588,17 +21572,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -22824,20 +22797,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-ms": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
-      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
-      "dependencies": {
-        "parse-ms": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prism-react-renderer": {
@@ -27844,17 +27803,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
-      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/zustand": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
@@ -27890,7 +27838,7 @@
         "command-line-args": "^5.2.1",
         "degit": "^2.8.4",
         "detect-package-manager": "^3.0.2",
-        "execa": "^9.2.0",
+        "execa": "4.0.3",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "prompts": "^2.4.2",
@@ -27979,76 +27927,36 @@
       }
     },
     "packages/create-liveblocks-app/node_modules/execa": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
-      "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.3",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^7.0.0",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^5.2.0",
-        "pretty-ms": "^9.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.0.0"
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.5.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "packages/create-liveblocks-app/node_modules/execa/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-liveblocks-app/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/create-liveblocks-app/node_modules/figures/node_modules/is-unicode-supported": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/create-liveblocks-app/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
+        "pump": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -28066,11 +27974,11 @@
       }
     },
     "packages/create-liveblocks-app/node_modules/human-signals": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
-      "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=8.12.0"
       }
     },
     "packages/create-liveblocks-app/node_modules/is-interactive": {
@@ -28078,28 +27986,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/create-liveblocks-app/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/create-liveblocks-app/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -28151,20 +28037,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "packages/create-liveblocks-app/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/create-liveblocks-app/node_modules/ora": {
       "version": "6.1.2",
       "license": "MIT",
@@ -28197,17 +28069,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/create-liveblocks-app/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -28256,17 +28117,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "packages/create-liveblocks-app/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/create-liveblocks-app/node_modules/type-fest": {
@@ -38282,11 +38132,6 @@
       "dev": true,
       "optional": true
     },
-    "@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
-    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -38296,11 +38141,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g=="
-    },
-    "@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
     },
     "@sinonjs/commons": {
       "version": "3.0.0",
@@ -41002,7 +40842,7 @@
         "degit": "^2.8.4",
         "detect-package-manager": "^3.0.2",
         "esbuild": "^0.15.12",
-        "execa": "*",
+        "execa": "4.0.3",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "prompts": "^2.4.2",
@@ -41042,53 +40882,27 @@
           }
         },
         "execa": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
-          "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
           "requires": {
-            "@sindresorhus/merge-streams": "^4.0.0",
-            "cross-spawn": "^7.0.3",
-            "figures": "^6.1.0",
-            "get-stream": "^9.0.0",
-            "human-signals": "^7.0.0",
-            "is-plain-obj": "^4.1.0",
-            "is-stream": "^4.0.1",
-            "npm-run-path": "^5.2.0",
-            "pretty-ms": "^9.0.0",
-            "signal-exit": "^4.1.0",
-            "strip-final-newline": "^4.0.0",
-            "yoctocolors": "^2.0.0"
-          },
-          "dependencies": {
-            "signal-exit": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-              "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-            }
-          }
-        },
-        "figures": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-          "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-          "requires": {
-            "is-unicode-supported": "^2.0.0"
-          },
-          "dependencies": {
-            "is-unicode-supported": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-              "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q=="
-            }
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "get-stream": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-          "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
-            "@sec-ant/readable-stream": "^0.4.1",
-            "is-stream": "^4.0.1"
+            "pump": "^3.0.0"
           }
         },
         "hosted-git-info": {
@@ -41100,22 +40914,12 @@
           }
         },
         "human-signals": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
-          "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q=="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
         },
         "is-interactive": {
           "version": "2.0.0"
-        },
-        "is-plain-obj": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
-        },
-        "is-stream": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
         },
         "is-unicode-supported": {
           "version": "1.3.0"
@@ -41143,14 +40947,6 @@
             "validate-npm-package-license": "^3.0.4"
           }
         },
-        "npm-run-path": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
         "ora": {
           "version": "6.1.2",
           "requires": {
@@ -41174,11 +40970,6 @@
             "index-to-position": "^0.1.2",
             "type-fest": "^4.7.1"
           }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
         },
         "read-pkg": {
           "version": "9.0.1",
@@ -41204,11 +40995,6 @@
           "requires": {
             "ansi-regex": "^6.0.1"
           }
-        },
-        "strip-final-newline": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-          "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
         },
         "type-fest": {
           "version": "4.20.0",
@@ -46329,11 +46115,6 @@
         "lines-and-columns": "^1.1.6"
       }
     },
-    "parse-ms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
-    },
     "parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -47076,14 +46857,6 @@
         "ansi-styles": {
           "version": "5.2.0"
         }
-      }
-    },
-    "pretty-ms": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
-      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
-      "requires": {
-        "parse-ms": "^4.0.0"
       }
     },
     "prism-react-renderer": {
@@ -50310,11 +50083,6 @@
     },
     "yocto-queue": {
       "version": "0.1.0"
-    },
-    "yoctocolors": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
-      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw=="
     },
     "zustand": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9981,6 +9981,11 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -9995,6 +10000,17 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -11101,8 +11117,9 @@
       }
     },
     "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "license": "MIT"
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -14651,6 +14668,17 @@
       "version": "1.1.0",
       "license": "MIT"
     },
+    "node_modules/detect-package-manager": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-3.0.2.tgz",
+      "integrity": "sha512-8JFjJHutStYrfWwzfretQoyNGoZVW1Fsrp4JO9spa7h/fBfwgTMEIy4/LBzRDGsxwVPHU0q+T9YvwLDJoOApLQ==",
+      "dependencies": {
+        "execa": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "license": "Apache-2.0"
@@ -17739,6 +17767,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -21549,6 +21588,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -22774,6 +22824,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
+      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prism-react-renderer": {
@@ -27015,6 +27079,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -27769,6 +27844,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zustand": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
@@ -27803,9 +27889,12 @@
         "ansi-colors": "^4.1.3",
         "command-line-args": "^5.2.1",
         "degit": "^2.8.4",
+        "detect-package-manager": "^3.0.2",
+        "execa": "^9.2.0",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "prompts": "^2.4.2",
+        "read-pkg": "^9.0.1",
         "simple-git": "^3.16.0"
       },
       "bin": {
@@ -27889,11 +27978,128 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/create-liveblocks-app/node_modules/execa": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+      "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^7.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^5.2.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/human-signals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+      "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "packages/create-liveblocks-app/node_modules/is-interactive": {
       "version": "2.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -27923,6 +28129,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/create-liveblocks-app/node_modules/lru-cache": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/normalize-package-data": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.1.tgz",
+      "integrity": "sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/create-liveblocks-app/node_modules/ora": {
       "version": "6.1.2",
       "license": "MIT",
@@ -27939,6 +28181,51 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/parse-json": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+      "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "index-to-position": "^0.1.2",
+        "type-fest": "^4.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -27969,6 +28256,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/create-liveblocks-app/node_modules/type-fest": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.0.tgz",
+      "integrity": "sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/liveblocks-client": {
@@ -37973,6 +38282,11 @@
       "dev": true,
       "optional": true
     },
+    "@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -37982,6 +38296,11 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g=="
+    },
+    "@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
     },
     "@sinonjs/commons": {
       "version": "3.0.0",
@@ -38790,7 +39109,9 @@
       }
     },
     "@types/normalize-package-data": {
-      "version": "2.4.1"
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -40679,10 +41000,13 @@
         "command-line-args": "^5.2.1",
         "cross-env": "^7.0.3",
         "degit": "^2.8.4",
+        "detect-package-manager": "^3.0.2",
         "esbuild": "^0.15.12",
+        "execa": "*",
         "open": "^8.4.0",
         "ora": "^6.1.2",
         "prompts": "^2.4.2",
+        "read-pkg": "^9.0.1",
         "simple-git": "^3.16.0"
       },
       "dependencies": {
@@ -40717,8 +41041,81 @@
             "restore-cursor": "^4.0.0"
           }
         },
+        "execa": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+          "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
+          "requires": {
+            "@sindresorhus/merge-streams": "^4.0.0",
+            "cross-spawn": "^7.0.3",
+            "figures": "^6.1.0",
+            "get-stream": "^9.0.0",
+            "human-signals": "^7.0.0",
+            "is-plain-obj": "^4.1.0",
+            "is-stream": "^4.0.1",
+            "npm-run-path": "^5.2.0",
+            "pretty-ms": "^9.0.0",
+            "signal-exit": "^4.1.0",
+            "strip-final-newline": "^4.0.0",
+            "yoctocolors": "^2.0.0"
+          },
+          "dependencies": {
+            "signal-exit": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+              "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+            }
+          }
+        },
+        "figures": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+          "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+          "requires": {
+            "is-unicode-supported": "^2.0.0"
+          },
+          "dependencies": {
+            "is-unicode-supported": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+              "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q=="
+            }
+          }
+        },
+        "get-stream": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+          "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+          "requires": {
+            "@sec-ant/readable-stream": "^0.4.1",
+            "is-stream": "^4.0.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+          "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+          "requires": {
+            "lru-cache": "^10.0.1"
+          }
+        },
+        "human-signals": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+          "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q=="
+        },
         "is-interactive": {
           "version": "2.0.0"
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "is-stream": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
         },
         "is-unicode-supported": {
           "version": "1.3.0"
@@ -40728,6 +41125,30 @@
           "requires": {
             "chalk": "^5.0.0",
             "is-unicode-supported": "^1.1.0"
+          }
+        },
+        "lru-cache": {
+          "version": "10.2.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+          "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ=="
+        },
+        "normalize-package-data": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.1.tgz",
+          "integrity": "sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==",
+          "requires": {
+            "hosted-git-info": "^7.0.0",
+            "is-core-module": "^2.8.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
+        "npm-run-path": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+          "requires": {
+            "path-key": "^4.0.0"
           }
         },
         "ora": {
@@ -40744,6 +41165,33 @@
             "wcwidth": "^1.0.1"
           }
         },
+        "parse-json": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+          "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+          "requires": {
+            "@babel/code-frame": "^7.22.13",
+            "index-to-position": "^0.1.2",
+            "type-fest": "^4.7.1"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+        },
+        "read-pkg": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+          "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+          "requires": {
+            "@types/normalize-package-data": "^2.4.3",
+            "normalize-package-data": "^6.0.0",
+            "parse-json": "^8.0.0",
+            "type-fest": "^4.6.0",
+            "unicorn-magic": "^0.1.0"
+          }
+        },
         "restore-cursor": {
           "version": "4.0.0",
           "requires": {
@@ -40756,6 +41204,16 @@
           "requires": {
             "ansi-regex": "^6.0.1"
           }
+        },
+        "strip-final-newline": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+          "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
+        },
+        "type-fest": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.0.tgz",
+          "integrity": "sha512-MBh+PHUHHisjXf4tlx0CFWoMdjx8zCMLJHOjnV1prABYZFHqtFOyauCIK2/7w4oIfwkF8iNhLtnJEfVY2vn3iw=="
         }
       }
     },
@@ -41364,6 +41822,14 @@
     },
     "detect-node-es": {
       "version": "1.1.0"
+    },
+    "detect-package-manager": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-3.0.2.tgz",
+      "integrity": "sha512-8JFjJHutStYrfWwzfretQoyNGoZVW1Fsrp4JO9spa7h/fBfwgTMEIy4/LBzRDGsxwVPHU0q+T9YvwLDJoOApLQ==",
+      "requires": {
+        "execa": "^5.1.1"
+      }
     },
     "didyoumean": {
       "version": "1.2.2"
@@ -43364,6 +43830,11 @@
     },
     "indent-string": {
       "version": "4.0.0"
+    },
+    "index-to-position": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+      "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -45858,6 +46329,11 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
+    },
     "parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -46600,6 +47076,14 @@
         "ansi-styles": {
           "version": "5.2.0"
         }
+      }
+    },
+    "pretty-ms": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
+      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+      "requires": {
+        "parse-ms": "^4.0.0"
       }
     },
     "prism-react-renderer": {
@@ -49336,6 +49820,11 @@
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "peer": true
     },
+    "unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -49821,6 +50310,11 @@
     },
     "yocto-queue": {
       "version": "0.1.0"
+    },
+    "yoctocolors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw=="
     },
     "zustand": {
       "version": "4.4.1",

--- a/packages/create-liveblocks-app/README.MD
+++ b/packages/create-liveblocks-app/README.MD
@@ -9,23 +9,31 @@
 
 # `create-liveblocks-app`
 
-The easiest way to get started with a Liveblocks starter kit or example. 
+The easiest way to get started with a Liveblocks starter kit or example.
 
 ## Get started
 
 You can create a new Liveblocks project using the following command:
+
 ```
 npx create-liveblocks-app@latest
 ```
 
 The initial prompt allows you to set up one of the following:
-1. [Next.js Starter kit](https://liveblocks.io/starter-kit)—Our official starter kit for Next.js
-2. [An example from the Liveblocks repo](https://github.com/liveblocks/liveblocks/tree/main/examples)—Any example from `liveblocks/liveblocks`
 
-From there, follow the instructions to set up your app! You can also use the CLI to generate a `liveblocks.config.(js|ts)` config file.
+1. [Next.js Starter kit](https://liveblocks.io/starter-kit)—Our official starter
+   kit for Next.js
+2. [An example from the Liveblocks repo](https://github.com/liveblocks/liveblocks/tree/main/examples)—Any
+   example from `liveblocks/liveblocks`
+
+From there, follow the instructions to set up your app! You can also use the CLI
+to generate a `liveblocks.config.(js|ts)` config file.
 
 ### Flags (optional)
-If you wish, you can skip certain `create-liveblocks-app` prompts with the following flags. Please note that these are optional, and if no flags are used, you will be prompted about these options in the installer instead.
+
+If you wish, you can skip certain `create-liveblocks-app` prompts with the
+following flags. Please note that these are optional, and if no flags are used,
+you will be prompted about these options in the installer instead.
 
 ```
 npx create-liveblocks-app@latest [options]
@@ -34,96 +42,104 @@ Options:
 
   --init
   Generate a liveblocks.config.(js|ts) file in the current directory
-  
+
   --framework [`react`|`javascript`]
   The framework your config file uses. Option only for `--init`.
   e.g. `--framework react`
-  
+
   --suspense
   Use React Suspense hooks in the config file.  Option only for `--init` with React framework.
-  
+
   --no-suspense
   Don't use React Suspense hooks in the config file.  Option only for `--init` with React framework.
-  
+
   --typescript
   Use TypeScript in your config file.  Option only for `--init`.
-  
+
   --no-typescript
   Don't use TypeScript in your config file.  Option only for `--init`.
-  
+
   --comments
   Add helpful comments to the config file.  Option only for `--init`.
-  
+
   --no-comments
   Add helpful comments to the config file.  Option only for `--init`.
 
-  --next 
+  --next
   Use the Next.js Starter Kit
-  
+
   --example [example name]
-  Use a Liveblocks example, the name corresponding to the example name in the repo 
+  Use a Liveblocks example, the name corresponding to the example name in the repo
   e.g. `--example zustand-whiteboard` for https://github.com/liveblocks/liveblocks/tree/main/examples/zustand-whiteboard
-  
+
   --name [repo name]
   The name of the project/directory
   e.g. `--name my-liveblocks-project`
-  
+
   --package-manager [`npm`|`yarn`|`pnpm`]
   Select your package manager, default is `npm`
   e.g `--package-manager yarn`
-  
+
   --auth [`demo`|`github`|`auth0`]
-  Select your authentication method. Option only for Next.js Starter Kit. 
+  Select your authentication method. Option only for Next.js Starter Kit.
   e.g. `--auth github`
-  
+
   --install
   Install the project with the selected package manager
-  
+
   --no-install
   Don't install the project
-  
+
   --git
   Initialize git
-  
+
   --no-git
   Don't initialize git
-  
+
   --vercel
   Deploy on Vercel, and get Liveblocks API key
-  
+
   --no-vercel
   Don't deploy on Vercel
-  
+
   --api-key
   Get Liveblocks API key. Ignored if `--vercel` is used.
-  
+
   --no-api-key
   Don't get Liveblocks API key. Ignored if `--vercel` is used.
-  
+
   --open
-  Open browser without asking permission, when deploying to Vercel or getting API key 
-  
+  Open browser without asking permission, when deploying to Vercel or getting API key
+
+  --upgrade
+  Upgrade all Liveblocks packages to their latest version.
+
   --help
   Find more info
 ```
 
 #### Examples
+
 Next.js Starter Kit with no install:
+
 ```
 npx create-liveblocks-app@latest --next --no-install
 ```
 
 Example from Liveblocks repo with directory/project name specified:
+
 ```
 npx create-liveblocks-app@latest --example nextjs-live-avatars --name my-liveblocks-app
 ```
 
 Next.js Starter Kit with every option:
+
 ```
 npx create-liveblocks-app@latest --next --name my-project --auth github --package-manager npm --install --git  --vercel --open
 ```
 
 Generate a Liveblocks config file:
+
 ```
 npx create-liveblocks-app@latest --init
 ```

--- a/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
+++ b/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
@@ -7,14 +7,16 @@ import * as nextjsTemplate from "./templates/nextjs-starter-kit";
 import * as exampleTemplate from "./templates/example";
 import * as helpTemplate from "./templates/help";
 import * as initTemplate from "./templates/init";
+import * as upgradeTemplate from "./templates/upgrade";
 
-type TemplateName = "next" | "example" | "help" | "init";
+type TemplateName = "next" | "example" | "help" | "init" | "upgrade";
 
 const templates: { [K in TemplateName]: any } = {
   next: nextjsTemplate,
   example: exampleTemplate,
   help: helpTemplate,
   init: initTemplate,
+  upgrade: upgradeTemplate,
 };
 
 export async function createLiveblocksApp() {
@@ -83,6 +85,10 @@ export async function createLiveblocksApp() {
     flags.template = "init";
   }
 
+  if (flags.upgrade) {
+    flags.template = "upgrade";
+  }
+
   const initialQuestions: PromptObject<"template">[] = [
     {
       // Skip question if template already set
@@ -95,6 +101,10 @@ export async function createLiveblocksApp() {
         {
           title: "Create a liveblocks.config file",
           value: "init",
+        },
+        {
+          title: "Upgrade Liveblocks packages",
+          value: "upgrade",
         },
       ],
     },

--- a/packages/create-liveblocks-app/bin/templates/upgrade/index.ts
+++ b/packages/create-liveblocks-app/bin/templates/upgrade/index.ts
@@ -1,0 +1,1 @@
+export * from "./upgrade-template";

--- a/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
+++ b/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
@@ -1,6 +1,6 @@
 import c from "ansi-colors";
 import { detect } from "detect-package-manager";
-import { execa } from "execa";
+import execa from "execa";
 import { PackageJson, readPackage } from "read-pkg";
 
 function findLiveblocksDependencies(

--- a/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
+++ b/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
@@ -64,8 +64,4 @@ export async function create() {
   await execa(pkgManager, [installCommand, ...latestDependencies], {
     stdio: "inherit",
   });
-
-  // console.log(
-  //   `Executing ${pkgManager} ${installCommand} ${latestDependencies.join(" ")}`
-  // );
 }

--- a/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
+++ b/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
@@ -1,0 +1,71 @@
+import c from "ansi-colors";
+import { detect } from "detect-package-manager";
+import { execa } from "execa";
+import { PackageJson, readPackage } from "read-pkg";
+
+function findLiveblocksDependencies(
+  dependencies?: Partial<Record<string, string>>
+) {
+  return Object.keys(dependencies ?? {}).filter((dependency) =>
+    dependency?.startsWith("@liveblocks/")
+  );
+}
+
+export async function create() {
+  // === Read package.json ===============================================================
+  let pkg: PackageJson;
+
+  try {
+    pkg = await readPackage();
+  } catch (error) {
+    console.log(c.bold.redBright("  No package.json found"));
+
+    return;
+  }
+
+  // === Collect Liveblocks dependencies ==================================================
+
+  const depsToUpgrade = Array.from(
+    new Set([
+      ...findLiveblocksDependencies(pkg.dependencies),
+      ...findLiveblocksDependencies(pkg.devDependencies),
+    ])
+  );
+
+  if (depsToUpgrade.length === 0) {
+    console.log(c.bold.redBright("  No Liveblocks packages found"));
+    return;
+  }
+
+  const latestDependencies = depsToUpgrade.map((dep) => `${dep}@latest`);
+
+  // === Upgrade collected dependencies to latest ===========================================
+
+  const pkgManager = await detect();
+
+  let installCommand;
+
+  switch (pkgManager) {
+    case "yarn":
+    case "bun":
+    case "pnpm":
+      installCommand = "add";
+      break;
+    case "npm":
+    default:
+      installCommand = "install";
+      break;
+  }
+
+  console.log();
+  console.log(c.bold.magentaBright(`✨ Upgrading all Liveblocks packages`));
+  console.log();
+
+  await execa(pkgManager, [installCommand, ...latestDependencies], {
+    stdio: "inherit",
+  });
+
+  // console.log(
+  //   `Executing ${pkgManager} ${installCommand} ${latestDependencies.join(" ")}`
+  // );
+}

--- a/packages/create-liveblocks-app/package.json
+++ b/packages/create-liveblocks-app/package.json
@@ -23,9 +23,12 @@
     "ansi-colors": "^4.1.3",
     "command-line-args": "^5.2.1",
     "degit": "^2.8.4",
+    "detect-package-manager": "^3.0.2",
+    "execa": "4.0.3",
     "open": "^8.4.0",
     "ora": "^6.1.2",
     "prompts": "^2.4.2",
+    "read-pkg": "^9.0.1",
     "simple-git": "^3.16.0"
   },
   "bugs": {

--- a/packages/create-liveblocks-app/scripts/demo.js
+++ b/packages/create-liveblocks-app/scripts/demo.js
@@ -18,7 +18,6 @@ const pkgJson = `{
     "@liveblocks/client": "^1.11.0",
     "@liveblocks/node": "^1.11.0",
     "@liveblocks/react": "^1.11.0",
-    "@liveblocks/react-comments": "^1.11.0",
     "next": "^13.4.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/create-liveblocks-app/scripts/demo.js
+++ b/packages/create-liveblocks-app/scripts/demo.js
@@ -4,6 +4,34 @@ import { esbuildOptions } from "./esbuild.js";
 import fs from "fs";
 import path from "path";
 
+const pkgJson = `{
+  "name": "@liveblocks-examples/nextjs-comments",
+  "description": "This example shows how to build comments with Liveblocks and Next.js.",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@liveblocks/client": "^1.11.0",
+    "@liveblocks/node": "^1.11.0",
+    "@liveblocks/react": "^1.11.0",
+    "@liveblocks/react-comments": "^1.11.0",
+    "next": "^13.4.16",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11"
+  },
+  "devDependencies": {
+    "@types/node": "^20.4.2",
+    "@types/react": "^18.3.3",
+    "prettier": "^3.0.0",
+    "typescript": "^5.1.6"
+  }
+}`;
+
 const flags = "";
 
 /**
@@ -16,6 +44,7 @@ const testDir = path.join(process.cwd(), "./.demo");
 
 fs.rmSync(testDir, { recursive: true, force: true });
 fs.mkdirSync(testDir);
+fs.writeFileSync(path.join(testDir, "package.json"), pkgJson);
 
 execSync(`node ${esbuildOptions.outfile} ${flags}`, {
   cwd: testDir,


### PR DESCRIPTION
It's not the best place for it but in the interest of time, I think it's still beneficial so that we can have a simple command for that everywhere.

Ideally it would be more fleshed out and would live in `@liveblocks/upgrade` maybe (like [Astro](https://x.com/cpenned/status/1798819246136524873)), or in a future `liveblocks` general CLI.

@CTNicholas There were a few formatting changes so I'll wait for https://github.com/liveblocks/liveblocks/pull/1689 to land before merging this one.

### Usage

```
npx create-liveblocks-app@latest --upgrade
```