### PR TITLE
Remove need for thunking in `<ClientSideSuspense>`

### DIFF
--- a/e2e/next-sandbox/pages/comments/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/comments/with-suspense.tsx
@@ -18,7 +18,7 @@ export default function Home() {
   return (
     <RoomProvider id={roomId} initialPresence={{} as never}>
       <ClientSideSuspense fallback="Loading...">
-        {() => <Sandbox />}
+        <Sandbox />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/e2e/next-sandbox/pages/inbox-notifications/index.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/index.tsx
@@ -60,7 +60,7 @@ function WithRoomProvider(props: React.PropsWithChildren) {
   return (
     <RoomProvider id={roomId} initialPresence={{} as never}>
       <ClientSideSuspense fallback="Loading...">
-        {() => props.children}
+        {props.children}
       </ClientSideSuspense>
     </RoomProvider>
   );
@@ -70,7 +70,7 @@ function WithLiveblocksProvider(props: React.PropsWithChildren) {
   return (
     <LiveblocksProvider>
       <ClientSideSuspense fallback="Loading...">
-        {() => props.children}
+        {props.children}
       </ClientSideSuspense>
     </LiveblocksProvider>
   );

--- a/e2e/next-sandbox/pages/presence/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/presence/with-suspense.tsx
@@ -59,12 +59,8 @@ export default function Home() {
       {isVisible && (
         <RoomProvider id={roomId} initialPresence={{}}>
           <ClientSideSuspense fallback="Loading...">
-            {() => (
-              <>
-                <PresenceSandbox />
-                <EventSandbox />
-              </>
-            )}
+            <PresenceSandbox />
+            <EventSandbox />
           </ClientSideSuspense>
         </RoomProvider>
       )}

--- a/e2e/next-sandbox/pages/storage/list-with-suspense.tsx
+++ b/e2e/next-sandbox/pages/storage/list-with-suspense.tsx
@@ -38,7 +38,7 @@ export default function Home() {
       initialStorage={{ items: new LiveList() }}
     >
       <ClientSideSuspense fallback={<div>Loading...</div>}>
-        {() => <Sandbox />}
+        <Sandbox />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/packages/liveblocks-react/src/ClientSideSuspense.tsx
+++ b/packages/liveblocks-react/src/ClientSideSuspense.tsx
@@ -1,9 +1,11 @@
-import type { ReactElement, ReactNode } from "react";
+import type { ReactNode } from "react";
 import * as React from "react";
 
 type Props = {
-  fallback: NonNullable<ReactNode> | null;
-  children: () => ReactNode | undefined;
+  fallback: ReactNode;
+  children: // TODO Restore this again later
+  // (() => ReactNode | undefined) |
+  ReactNode | undefined;
 };
 
 /**
@@ -19,11 +21,11 @@ type Props = {
  * To:
  *
  *   <ClientSideSuspense fallback={<Loading />}>
- *     {() => <MyRealComponent a={1} />}
+ *     <MyRealComponent a={1} />
  *   </ClientSideSuspense>
  *
  */
-export function ClientSideSuspense(props: Props): ReactElement {
+export function ClientSideSuspense(props: Props) {
   const [mounted, setMounted] = React.useState(false);
 
   React.useEffect(() => {
@@ -34,7 +36,7 @@ export function ClientSideSuspense(props: Props): ReactElement {
 
   return (
     <React.Suspense fallback={props.fallback}>
-      {mounted ? props.children() : props.fallback}
+      {mounted ? props.children : props.fallback}
     </React.Suspense>
   );
 }


### PR DESCRIPTION
The goal is to no longer require:

```tsx
<ClientSideSuspense fallback={<Loading />}>
  {() => <MyComponent />
</ClientSideSuspense>
```

But instead allow this:

```tsx
<ClientSideSuspense fallback={<Loading />}>
  <MyComponent />
</ClientSideSuspense>
```

### Roll-out plan

I plan to remove the ability to pass in a thunk here first, release that as 2.0.0-alpha2 today, use that to force a rewrite of all examples by removing that, and then restore the ability to allow passing a thunk again for backward-compatibility. We're not going to force people to upgrade, but they can.

We should also update the documentation.
