### PR TITLE
set local state if required

### DIFF
--- a/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
@@ -216,7 +216,25 @@ export const LiveblocksPlugin = ({
 
   useEffect(() => {
     collabContext.name = username || "";
-  }, [collabContext, username]);
+    const provider = providerFactory(room.id, collabContext.yjsDocMap) as LiveblocksYjsProvider;
+    let localState = provider.awareness.getLocalState();
+    if (localState?.name !== collabContext.name) {
+      if (localState === null) {
+        // we don't have any local state, so set it
+        localState = {
+          anchorPos: null,
+          awarenessData: {},
+          color: cursorcolor,
+          focusPos: null,
+          focusing: false,
+          name: collabContext.name,
+        };
+      }
+      // update the name
+      localState.name = collabContext.name;
+      provider.awareness.setLocalState(localState);
+    }
+  }, [collabContext, username, room, cursorcolor, providerFactory]);
 
   useLayoutEffect(() => {
     const editable = editor.getRootElement();


### PR DESCRIPTION
This will check to see if username does not match what is set in local state and set awareness data manually (which is all the collabplugin does) in case it has failed to set properly. 