### PR TITLE
Small typo on id-tokens.mdx

### DIFF
--- a/docs/pages/authentication/id-token.mdx
+++ b/docs/pages/authentication/id-token.mdx
@@ -262,7 +262,7 @@ const room = await liveblocks.updateRoom("a32wQXid4A9", {
 });
 ```
 
-After calling this, ever user in the “engineering” group will have read-only
+After calling this, every user in the “engineering” group will have read-only
 access. To remove a group’s permissions, we can use
 [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomId)
 again, and set the permission type to `null`:


### PR DESCRIPTION
Minor typo fix, [here](https://liveblocks.io/docs/authentication/id-token#permissions-levels-groups-accesses-example), on the id-token page.  

Typo:

 > After calling this, ever user in the “engineering” group will have read-only access. 

Fix:

> After calling this, every user in the “engineering” group will have read-only access. 

