### PR TITLE
Allow upgrading to specific version using `create-liveblocks-app --upgrade`

### DIFF
--- a/packages/create-liveblocks-app/README.MD
+++ b/packages/create-liveblocks-app/README.MD
@@ -93,8 +93,9 @@ Options:
   --open
   Open browser without asking permission, when deploying to Vercel or getting API key
 
-  --upgrade
-  Upgrade all Liveblocks packages to their latest version.
+  --upgrade [version]
+  Upgrade all Liveblocks packages to a certain version. If no version passed, use `latest`/
+  e.g. `--upgrade` for latest, `--upgrade 2.0.0` for 2.0.0
 
   --help
   Find more info

--- a/packages/create-liveblocks-app/README.MD
+++ b/packages/create-liveblocks-app/README.MD
@@ -94,7 +94,7 @@ Options:
   Open browser without asking permission, when deploying to Vercel or getting API key
 
   --upgrade [version]
-  Upgrade all Liveblocks packages to a certain version. If no version passed, use `latest`/
+  Upgrade all Liveblocks packages to a certain version. If no version passed, use `latest`
   e.g. `--upgrade` for latest, `--upgrade 2.0.0` for 2.0.0
 
   --help

--- a/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
+++ b/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
@@ -89,6 +89,12 @@ export async function createLiveblocksApp() {
       flags.upgrade = "latest";
     }
 
+    flags.upgrade = flags.upgrade.trim();
+
+    if (flags.upgrade.startsWith("@")) {
+      return flags.upgrade.substring(1);
+    }
+
     flags.template = "upgrade";
   }
 

--- a/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
+++ b/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
@@ -83,9 +83,13 @@ export async function createLiveblocksApp() {
     flags.template = "init";
   }
 
-  if (flags.upgrade) {
+  if (flags.upgrade !== undefined) {
+    // If --upgrade is specified without a version/tag, default to `latest`
+    if (flags.upgrade === null) {
+      flags.upgrade = "latest";
+    }
+
     flags.template = "upgrade";
-    flags.tag = flags.tag;
   }
 
   const initialQuestions: PromptObject<"template">[] = [

--- a/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
+++ b/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
@@ -85,6 +85,7 @@ export async function createLiveblocksApp() {
 
   if (flags.upgrade) {
     flags.template = "upgrade";
+    flags.tag = flags.tag;
   }
 
   const initialQuestions: PromptObject<"template">[] = [

--- a/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
+++ b/packages/create-liveblocks-app/bin/create-liveblocks-app.ts
@@ -79,23 +79,28 @@ export async function createLiveblocksApp() {
     flags.template = "next";
   }
 
+  // If --init specified, this is the config generator
   if (flags.init) {
     flags.template = "init";
   }
 
+  // If --upgrade specified, this is the upgrader
   if (flags.upgrade !== undefined) {
-    // If --upgrade is specified without a version/tag, default to `latest`
-    if (flags.upgrade === null) {
-      flags.upgrade = "latest";
-    }
-
-    flags.upgrade = flags.upgrade.trim();
-
-    if (flags.upgrade.startsWith("@")) {
-      return flags.upgrade.substring(1);
-    }
-
     flags.template = "upgrade";
+
+    if (flags.upgrade === null) {
+      // --upgrade flag but no package
+      flags.upgrade = "latest";
+    } else {
+      // --upgrade flag with package string
+      flags.upgrade = flags.upgrade.trim();
+      if (flags.upgrade.startsWith("@")) {
+        flags.upgrade = flags.upgrade.substring(1);
+      }
+    }
+  } else {
+    // If no --upgrade flag, use latest (when selecting "upgrade" in menu)
+    flags.upgrade = "latest";
   }
 
   const initialQuestions: PromptObject<"template">[] = [

--- a/packages/create-liveblocks-app/bin/flags.ts
+++ b/packages/create-liveblocks-app/bin/flags.ts
@@ -16,13 +16,7 @@ export const commandLineFlags: OptionDefinition[] = [
   },
   {
     name: "upgrade",
-    type: Boolean,
-  },
-  {
-    // Used only when `--upgrade` is also given
-    name: "tag",
     type: String,
-    defaultValue: "latest",
   },
   {
     name: "example",

--- a/packages/create-liveblocks-app/bin/flags.ts
+++ b/packages/create-liveblocks-app/bin/flags.ts
@@ -19,6 +19,12 @@ export const commandLineFlags: OptionDefinition[] = [
     type: Boolean,
   },
   {
+    // Used only when `--upgrade` is also given
+    name: "tag",
+    type: String,
+    defaultValue: "latest",
+  },
+  {
     name: "example",
     type: String,
   },

--- a/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
+++ b/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
@@ -11,7 +11,11 @@ function findLiveblocksDependencies(
   );
 }
 
-export async function create() {
+type Flags = {
+  tag: string;
+};
+
+export async function create(flags: Flags) {
   // === Read package.json ===============================================================
   let pkg: PackageJson;
 
@@ -84,7 +88,7 @@ export async function create() {
   if (depsToUpgrade.length > 0) {
     await execa(
       pkgManager,
-      [installCmd, ...depsToUpgrade.map((dep) => `${dep}@latest`)],
+      [installCmd, ...depsToUpgrade.map((dep) => `${dep}@${flags.tag}`)],
       { stdio: "inherit" }
     );
   }

--- a/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
+++ b/packages/create-liveblocks-app/bin/templates/upgrade/upgrade-template.ts
@@ -12,7 +12,7 @@ function findLiveblocksDependencies(
 }
 
 type Flags = {
-  tag: string;
+  upgrade: string;
 };
 
 export async function create(flags: Flags) {
@@ -54,7 +54,7 @@ export async function create(flags: Flags) {
     (d) => d === "@liveblocks/react-comments"
   );
 
-  // === Upgrade collected dependencies to latest ===========================================
+  // === Upgrade collected dependencies ====================================================
 
   const pkgManager = await detect();
 
@@ -88,7 +88,7 @@ export async function create(flags: Flags) {
   if (depsToUpgrade.length > 0) {
     await execa(
       pkgManager,
-      [installCmd, ...depsToUpgrade.map((dep) => `${dep}@${flags.tag}`)],
+      [installCmd, ...depsToUpgrade.map((dep) => `${dep}@${flags.upgrade}`)],
       { stdio: "inherit" }
     );
   }

--- a/packages/create-liveblocks-app/scripts/demo.js
+++ b/packages/create-liveblocks-app/scripts/demo.js
@@ -31,8 +31,6 @@ const pkgJson = `{
   }
 }`;
 
-const flags = "";
-
 /**
  * Use `npm run demo` and check in .demo folder
  */
@@ -45,7 +43,7 @@ fs.rmSync(testDir, { recursive: true, force: true });
 fs.mkdirSync(testDir);
 fs.writeFileSync(path.join(testDir, "package.json"), pkgJson);
 
-execSync(`node ${esbuildOptions.outfile} ${flags}`, {
+execSync(`node ${esbuildOptions.outfile} ${process.argv.slice(2)}`, {
   cwd: testDir,
   stdio: "inherit",
 });

--- a/packages/liveblocks-react-lexical/src/comments/ThreadPanel.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/ThreadPanel.tsx
@@ -2,7 +2,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import type { BaseMetadata, ThreadData } from "@liveblocks/core";
 import { useThreads } from "@liveblocks/react";
 import type { ThreadProps } from "@liveblocks/react-ui";
-import { Thread as DefaultThread, useOverrides } from "@liveblocks/react-ui";
+import { Thread as DefaultThread } from "@liveblocks/react-ui";
 import { $getNodeByKey } from "lexical";
 import type { ComponentProps, ComponentType } from "react";
 import React, { forwardRef, useCallback, useContext } from "react";


### PR DESCRIPTION
To upgrade all Liveblocks packages to the latest version:

    $ npx create-liveblocks-app@latest --upgrade

To upgrade all Liveblocks packages to the `beta` version:

    $ npx create-liveblocks-app@latest --upgrade beta

To upgrade all Liveblocks packages to a specific version:

    $ npx create-liveblocks-app@latest --upgrade 1.12.0
