### PR TITLE
Fix type signatures in `@liveblocks/node` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0.1
+
+### `@liveblocks/node`
+
+- Fix type signatures of `client.identifyUser()` and `client.prepareSession()`
+  to require `userInfo` if it's mandatory according to your global `UserMeta`
+  type definition.
+
 ## v2.0.0
 
 This major release marks the maturity of Liveblocks. It contains new products

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1348,10 +1348,7 @@ export function createRoom<
   E extends Json,
   M extends BaseMetadata,
 >(
-  options: Omit<
-    RoomInitializers<P, S>,
-    "autoConnect" | "shouldInitiallyConnect"
-  >,
+  options: Omit<RoomInitializers<P, S>, "autoConnect">,
   config: RoomConfig
 ): Room<P, S, U, E, M> {
   const initialPresence =

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -72,13 +72,15 @@ type DateToString<T> = {
   [P in keyof T]: Date extends T[P] ? string : T[P];
 };
 
-export type CreateSessionOptions<U extends BaseUserMeta = DU> = {
-  userInfo: U["info"];
-};
+export type CreateSessionOptions<U extends BaseUserMeta = DU> =
+  Record<string, never> extends U["info"]
+    ? { userInfo?: U["info"] }
+    : { userInfo: U["info"] };
 
-export type IdentifyUserOptions<U extends BaseUserMeta = DU> = {
-  userInfo: U["info"];
-};
+export type IdentifyUserOptions<U extends BaseUserMeta = DU> =
+  Record<string, never> extends U["info"]
+    ? { userInfo?: U["info"] }
+    : { userInfo: U["info"] };
 
 export type AuthResponse = {
   status: number;
@@ -263,7 +265,13 @@ export class Liveblocks {
    * `other.info` property.
    *
    */
-  prepareSession(userId: string, options?: CreateSessionOptions<U>): Session {
+  prepareSession(
+    userId: string,
+    ...rest: Record<string, never> extends CreateSessionOptions<U>
+      ? [options?: CreateSessionOptions<U>]
+      : [options: CreateSessionOptions<U>]
+  ): Session {
+    const options = rest[0];
     return new Session(this.post.bind(this), userId, options?.userInfo);
   }
 
@@ -304,8 +312,12 @@ export class Liveblocks {
     identity:
       | string // Shorthand for userId
       | Identity,
-    options?: IdentifyUserOptions<U>
+    ...rest: Record<string, never> extends IdentifyUserOptions<U>
+      ? [options?: IdentifyUserOptions<U>]
+      : [options: IdentifyUserOptions<U>]
   ): Promise<AuthResponse> {
+    const options = rest[0];
+
     const path = url`/v2/identify-user`;
     const userId = typeof identity === "string" ? identity : identity.userId;
     const groupIds =

--- a/packages/liveblocks-node/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/augmentation.test-d.ts
@@ -53,14 +53,18 @@ declare global {
 async () => {
   const client = new Liveblocks({ secret: "sk_xxx" });
 
-  // .prepareSession()
+  // .prepareSession() without all mandatory userInfo is an error
   {
-    const session = await client.prepareSession("user-123");
-    session.allow("org1:*", session.READ_ACCESS);
-    const resp = await session.authorize();
-    expectType<number>(resp.status);
-    expectType<string>(resp.body);
-    expectType<Error | undefined>(resp.error);
+    expectError(await client.prepareSession("user-123"));
+    expectError(await client.prepareSession("user-123", {}));
+    // TODO: Re-enable this when tsd supports the TS2739 error
+    // expectError(await client.prepareSession("user-123", { userInfo: {} }));
+    expectError(
+      await client.prepareSession("user-123", { userInfo: { name: "Vincent" } })
+    );
+    expectError(
+      await client.prepareSession("user-123", { userInfo: { age: 42 } })
+    );
   }
 
   // .prepareSession() with user info
@@ -82,12 +86,18 @@ async () => {
     );
   }
 
-  // .identifyUser()
+  // .identifyUser() without all mandatory userInfo is an error
   {
-    const resp = await client.identifyUser("user-123");
-    expectType<number>(resp.status);
-    expectType<string>(resp.body);
-    expectType<Error | undefined>(resp.error);
+    expectError(await client.identifyUser("user-123"));
+    expectError(await client.identifyUser("user-123", {}));
+    // TODO: Re-enable this when tsd supports the TS2739 error
+    // expectError(await client.identifyUser("user-123", { userInfo: {} }));
+    expectError(
+      await client.identifyUser("user-123", { userInfo: { name: "Vincent" } })
+    );
+    expectError(
+      await client.identifyUser("user-123", { userInfo: { age: 42 } })
+    );
   }
 
   // .identifyUser() with user info


### PR DESCRIPTION
This PR fixes the type signature of `client.identifyUser()` and `client.prepareSession()` in our `@liveblocks/node` package, to require `userInfo` if it's mandatory according to your global `UserMeta` definition.
