### PR TITLE
Comments: Composer fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@
 
 ### `@liveblocks/react-ui`
 
-- Improve the composer if it's not handled. (via `onComposerSubmit`)
 - Prevent the composer from splitting text being composed.
-- Count whitespace as empty to prevent posting empty comments.
 - Handle parentheses around and within auto-links.
+- Count whitespace as empty to prevent posting empty comments.
+- Prevent clearing the composer if it's not handled. (via `onComposerSubmit`)
 
 ## v2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
-## v2.0.1
+## v2.0.1 (not released yet)
 
 ### `@liveblocks/node`
 
 - Fix type signatures of `client.identifyUser()` and `client.prepareSession()`
   to require `userInfo` if it's mandatory according to your global `UserMeta`
   type definition.
+
+### `@liveblocks/react-ui`
+
+- Don't clear the composer if it's not handled. (via `onComposerSubmit`)
+- Prevent the composer from splitting text being composed.
+- Count whitespace as empty to prevent posting empty comments.
+- Handle parentheses around and within auto-links.
 
 ## v2.0.0
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -853,13 +853,9 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
       ]
     );
 
-    useImperativeHandle(
-      forwardedRef,
-      () => {
-        return ReactEditor.toDOMNode(editor, editor) as HTMLDivElement;
-      },
-      [editor]
-    );
+    useImperativeHandle(forwardedRef, () => {
+      return ReactEditor.toDOMNode(editor, editor) as HTMLDivElement;
+    }, [editor]);
 
     // Manually focus the editor when `autoFocus` is true
     useEffect(() => {
@@ -1007,7 +1003,9 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
       (event: FormEvent<HTMLFormElement>) => {
         onSubmit?.(event);
 
-        if (event.isDefaultPrevented()) {
+        if (!onComposerSubmit || event.isDefaultPrevented()) {
+          event.preventDefault();
+
           return;
         }
 
@@ -1016,7 +1014,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
         );
         const comment = { body };
 
-        const promise = onComposerSubmit?.(comment, event);
+        const promise = onComposerSubmit(comment, event);
 
         event.preventDefault();
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -941,9 +941,13 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
     );
 
     const submit = useCallback(() => {
-      if (ref.current) {
-        requestSubmit(ref.current);
-      }
+      // We need to wait for the next frame in some cases like when composing diacritics,
+      // we want any native handling to be done first while still being handled on `keydown`.
+      requestAnimationFrame(() => {
+        if (ref.current) {
+          requestSubmit(ref.current);
+        }
+      });
     }, []);
 
     const clear = useCallback(() => {
@@ -1001,6 +1005,18 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
 
     const handleSubmit = useCallback(
       (event: FormEvent<HTMLFormElement>) => {
+        // In some situations (e.g. pressing Enter while composing diacritics), it's possible
+        // for the form to be submitted as empty even though we already checked whether the
+        // editor was empty when handling the key press.
+        const isEmpty = isEditorEmpty(editor, editor.children);
+
+        // We even prevent the user's `onSubmit` handler from being called if the editor is empty.
+        if (isEmpty) {
+          event.preventDefault();
+
+          return;
+        }
+
         onSubmit?.(event);
 
         if (!onComposerSubmit || event.isDefaultPrevented()) {
@@ -1024,7 +1040,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
           onSubmitEnd();
         }
       },
-      [editor.children, onComposerSubmit, onSubmit, onSubmitEnd]
+      [editor, onComposerSubmit, onSubmit, onSubmitEnd]
     );
 
     return (

--- a/packages/liveblocks-react-ui/src/slate/utils/is-empty.ts
+++ b/packages/liveblocks-react-ui/src/slate/utils/is-empty.ts
@@ -1,10 +1,39 @@
 import type { Descendant } from "slate";
 import { Editor as SlateEditor, Text as SlateText } from "slate";
 
+import { isEmptyString } from "./is-empty-string";
+
 export function isEmpty(editor: SlateEditor, children: Descendant[]) {
-  return (
-    children.length <= 1 &&
-    !SlateText.isText(children[0]) &&
-    SlateEditor.isEmpty(editor, children[0])
-  );
+  // No children
+  if (children.length === 0) {
+    return true;
+  }
+
+  // Check if all blocks are empty, stopping at the first non-empty block
+  for (const child of children) {
+    if (SlateText.isText(child)) {
+      // Non-empty text
+      if (!isEmptyString(child.text)) {
+        return false;
+      }
+    } else if (child.type === "paragraph") {
+      // Non-empty paragraph
+      if (
+        child.children.length > 1 ||
+        !(
+          SlateText.isText(child.children[0]) &&
+          isEmptyString(child.children[0].text)
+        )
+      ) {
+        return false;
+      }
+    } else {
+      // Non-empty other block
+      if (!SlateEditor.isEmpty(editor, child)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }

--- a/packages/liveblocks-react-ui/src/slate/utils/is-empty.ts
+++ b/packages/liveblocks-react-ui/src/slate/utils/is-empty.ts
@@ -4,11 +4,6 @@ import { Editor as SlateEditor, Text as SlateText } from "slate";
 import { isEmptyString } from "./is-empty-string";
 
 export function isEmpty(editor: SlateEditor, children: Descendant[]) {
-  // No children
-  if (children.length === 0) {
-    return true;
-  }
-
   // Check if all blocks are empty, stopping at the first non-empty block
   for (const child of children) {
     if (SlateText.isText(child)) {


### PR DESCRIPTION
This contains a few fixes and improvements for the Comments composer:

- Don't clear the composer if it's not handled (via `onComposerSubmit`), fixes LB-874
- Prevent the composer from splitting text being composed, fixes https://github.com/liveblocks/liveblocks/issues/1717
- Count whitespace as empty to prevent posting empty comments
- Handle parentheses around and within (if they are balanced, e.g. `https://google.com/hello(world))` will not contain the last parenthesis) auto-links, fixes LB-875

### To-do

- [ ] Follow-up on reports
- [x] More testing around the fix for https://github.com/liveblocks/liveblocks/issues/1717