### PR TITLE
Update banner to specify Next.js version and add link to PR

### DIFF
--- a/docs/pages/get-started/nextjs-lexical.mdx
+++ b/docs/pages/get-started/nextjs-lexical.mdx
@@ -13,8 +13,11 @@ package.
 
 <Banner title="Next.js 14" type="warning">
 
-  Our Lexical plugin is in beta, and is not currently compatible with Next.js 14.
-  We’re aware of this issue and a fix is coming soon.
+Our Lexical plugin is currently in beta and is not compatible with Next.js
+versions 14.2.0 and above. We recommend using Next.js 14.1 or disabling strict
+mode until a new version of Lexical is released. For more details and to follow
+the progress, please refer to the GitHub PR
+[here](https://github.com/facebook/lexical/pull/6271).
 
 </Banner>
 

--- a/docs/pages/get-started/react-lexical.mdx
+++ b/docs/pages/get-started/react-lexical.mdx
@@ -11,6 +11,16 @@ collaboration to your React application using the APIs from the
 [`@liveblocks/react-lexical`](/docs/api-reference/liveblocks-react-lexicals)
 package.
 
+<Banner title="Next.js 14" type="warning">
+
+Our Lexical plugin is currently in beta and is not compatible with Next.js
+versions 14.2.0 and above. We recommend using Next.js 14.1 or disabling strict
+mode until a new version of Lexical is released. For more details and to follow
+the progress, please refer to the GitHub PR
+[here](https://github.com/facebook/lexical/pull/6271).
+
+</Banner>
+
 <Banner title="Public beta">
 
 Lexical support is currently in beta. If you have any questions or feedback,

--- a/docs/pages/products/comments/styling-and-customization.mdx
+++ b/docs/pages/products/comments/styling-and-customization.mdx
@@ -14,7 +14,7 @@ helpful for localization.
 
 ## Default components
 
-The add the default components’s theme, import the
+To add the default components’ theme, import the
 [default styles](/docs/api-reference/liveblocks-react-ui#Default-styles) CSS
 file.
 

--- a/docs/pages/products/notifications/styling-and-customization.mdx
+++ b/docs/pages/products/notifications/styling-and-customization.mdx
@@ -11,7 +11,7 @@ through a range of means, such as CSS variables, class names, and more.
 
 ## Default components
 
-The add the default components’s theme, import the
+To add the default components’ theme, import the
 [default styles](/docs/api-reference/liveblocks-react-ui#Default-styles) CSS
 file.
 


### PR DESCRIPTION
This PR updates the banner used in https://liveblocks.io/docs/get-started/nextjs-lexical and https://liveblocks.io/docs/get-started/react-lexical with the Next.js version and link to the PR that fixes the issue.

Before:
![Screen Shot 2024-06-14 at 14 57 33](https://github.com/liveblocks/liveblocks/assets/35807215/2d3c3609-9e0e-4f52-884d-8b70506ac94a)


After:
![Screen Shot 2024-06-14 at 14 57 02](https://github.com/liveblocks/liveblocks/assets/35807215/49d7fe43-9aa1-4e07-983b-9ab4b5e6cbc6)
