### PR TITLE
Make `initialPresence` and `initialStorage` optional…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v2.0.3 (not released yet)
+
+### `@liveblocks/client`
+
+- In `client.enterRoom()`, the options `initialPresence` and `initialStorage`
+  are now only mandatory if your custom type requires them to be.
+
+### `@liveblocks/react`
+
+- In `<RoomProvider>`, the props `initialPresence` and `initialStorage` are now
+  only mandatory if your custom type requires them to be.
+
 ## v2.0.2
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-client/test-d/client.augmentation-only-presence.test-d.ts
+++ b/packages/liveblocks-client/test-d/client.augmentation-only-presence.test-d.ts
@@ -1,0 +1,34 @@
+import { createClient, LiveList } from "@liveblocks/client";
+import { expectError } from "tsd";
+
+type MyPresence = {
+  cursor: { x: number; y: number };
+};
+
+declare global {
+  interface Liveblocks {
+    Presence: MyPresence;
+    // DO NOT ADD ANYTHING HERE!
+    // This test file contains tests that _only_ have Presence set
+  }
+}
+
+const client = createClient({ publicApiKey: "pk_xxx" });
+
+// Initial presence is required
+expectError(client.enterRoom("room"));
+expectError(client.enterRoom("room", {}));
+expectError(client.enterRoom("room", { initialPresence: {} }));
+expectError(client.enterRoom("room", { initialPresence: { foo: "" } }));
+expectError(client.enterRoom("room", { initialPresence: { bar: [1, 2, 3] } }));
+
+// Should be fine
+client.enterRoom("room", {
+  initialPresence: { cursor: { x: 1, y: 2 } },
+});
+client.enterRoom("room", {
+  initialPresence: { cursor: { x: 1, y: 2 } },
+  initialStorage: {
+    foo: new LiveList(["I", "can", new LiveList(["be", "whatever"])]),
+  },
+});

--- a/packages/liveblocks-client/test-d/client.augmentation-only-storage.test-d.ts
+++ b/packages/liveblocks-client/test-d/client.augmentation-only-storage.test-d.ts
@@ -1,0 +1,39 @@
+import {
+  createClient,
+  LiveList,
+  LiveMap,
+  LiveObject,
+} from "@liveblocks/client";
+import { expectError } from "tsd";
+
+type MyStorage = {
+  animals: LiveList<string>;
+  scores?: LiveMap<string, number>;
+  person?: LiveObject<{ name: string; age: number }>;
+};
+
+declare global {
+  interface Liveblocks {
+    Storage: MyStorage;
+    // DO NOT ADD ANYTHING HERE!
+    // This test file contains tests that _only_ have Storage set
+  }
+}
+
+const client = createClient({ publicApiKey: "pk_xxx" });
+
+// Initial storage is required
+expectError(client.enterRoom("room"));
+expectError(client.enterRoom("room", {}));
+expectError(client.enterRoom("room", { initialStorage: {} }));
+expectError(client.enterRoom("room", { initialStorage: { foo: "" } }));
+expectError(client.enterRoom("room", { initialStorage: { bar: [1, 2, 3] } }));
+
+// Should be fine
+client.enterRoom("room", {
+  initialStorage: { animals: new LiveList(["🦊"]) },
+});
+client.enterRoom("room", {
+  initialPresence: { can: ["be", "whatever"] },
+  initialStorage: { animals: new LiveList(["🦊"]) },
+});

--- a/packages/liveblocks-client/test-d/client.augmentation.test-d.ts
+++ b/packages/liveblocks-client/test-d/client.augmentation.test-d.ts
@@ -1,37 +1,63 @@
-import { createClient } from "@liveblocks/client";
+import {
+  createClient,
+  LiveList,
+  LiveMap,
+  LiveObject,
+} from "@liveblocks/client";
 import { expectError, expectType } from "tsd";
 
 type MyPresence = {
   cursor: { x: number; y: number };
 };
 
+type MyStorage = {
+  animals: LiveList<string>;
+  scores?: LiveMap<string, number>;
+  person?: LiveObject<{ name: string; age: number }>;
+};
+
 declare global {
   interface Liveblocks {
     Presence: MyPresence;
+    Storage: MyStorage;
   }
 }
 
 const client = createClient({ publicApiKey: "pk_xxx" });
 
 // .enterRoom()
-{
-  {
-    expectError(client.enterRoom("room", { initialPresence: { foo: "" } }));
-    expectError(
-      client.enterRoom("room", { initialPresence: { bar: [1, 2, 3] } })
-    );
-    expectError(
-      client.enterRoom("room", {
-        initialPresence: { cursor: { x: 1, y: "2" } },
-      })
-    );
-  }
+(async function () {
+  // Both initial presence + storage are required
+  expectError(client.enterRoom("room"));
+  expectError(client.enterRoom("room", {}));
+  expectError(client.enterRoom("room", { initialPresence: {} }));
+  expectError(client.enterRoom("room", { initialPresence: { foo: "" } }));
+  expectError(
+    client.enterRoom("room", { initialPresence: { bar: [1, 2, 3] } })
+  );
 
-  {
-    const { room } = client.enterRoom("room", {
+  // It's OK only if both are (correctly) set
+  const { room } = client.enterRoom("room", {
+    initialPresence: { cursor: { x: 1, y: 2 } },
+    initialStorage: { animals: new LiveList(["🦊"]) },
+  });
+  expectType<number>(room.getPresence()?.cursor.x);
+  expectType<number>(room.getPresence()?.cursor.y);
+  expectType<LiveList<string>>((await room.getStorage()).root.get("animals"));
+
+  // Invalid presence
+  expectError(
+    client.enterRoom("room", {
+      initialPresence: { cursor: { x: 1, y: "2" } },
+      initialStorage: { animals: new LiveList(["🦊"]) },
+    })
+  );
+
+  // Invalid storage
+  expectError(
+    client.enterRoom("room", {
       initialPresence: { cursor: { x: 1, y: 2 } },
-    });
-    expectType<number>(room.getPresence()?.cursor.x);
-    expectType<number>(room.getPresence()?.cursor.y);
-  }
-}
+      initialStorage: { animals: new LiveList([42]) },
+    })
+  );
+})();

--- a/packages/liveblocks-client/test-d/client.no-augmentation.test-d.ts
+++ b/packages/liveblocks-client/test-d/client.no-augmentation.test-d.ts
@@ -1,11 +1,57 @@
 import type { Json, JsonObject } from "@liveblocks/client";
 import { createClient } from "@liveblocks/client";
-import { expectType } from "tsd";
+import { expectError, expectType } from "tsd";
 
 const client = createClient({ publicApiKey: "pk_xxx" });
 
 // .enterRoom()
 {
+  {
+    // No options at all is fine
+    // XXX Enable this test as well, once all the others work!
+    // const { room } = client.enterRoom("my-room");
+    // expectType<JsonObject>(room.getPresence());
+  }
+
+  {
+    // No initial props is also fine
+    const { room } = client.enterRoom("my-room", { autoConnect: true });
+    expectType<JsonObject>(room.getPresence());
+  }
+
+  {
+    // No options at all is fine if not using the global presence
+    const { room } = client.enterRoom<JsonObject>("my-room", {
+      autoConnect: true,
+    });
+    expectType<JsonObject>(room.getPresence());
+  }
+
+  {
+    // Initial presence is required
+    expectError<{ foo: string }>(client.enterRoom("room"));
+    expectError<{ foo: string }>(client.enterRoom("room", {}));
+    expectError<{ foo: string }>(
+      client.enterRoom("room", { initialPresence: {} })
+    );
+    expectError<{ foo: string }>(
+      client.enterRoom("room", { initialPresence: { bar: "" } })
+    );
+  }
+
+  {
+    // Initial presence is not required when it has only optional fields
+    // XXX Enable this test as well, once all the others work!
+    // client.enterRoom<{ foo?: string; bar?: number }>("room");
+    client.enterRoom<{ foo?: string; bar?: number }>("room", {});
+    client.enterRoom<{ foo?: string; bar?: number }>("room", {
+      initialPresence: {},
+    });
+    client.enterRoom<{ foo?: string; bar?: number }>("room", {
+      initialPresence: { foo: "" },
+    });
+  }
+
   {
     const { room } = client.enterRoom("my-room", {
       initialPresence: { foo: null },

--- a/packages/liveblocks-client/test-d/client.no-augmentation.test-d.ts
+++ b/packages/liveblocks-client/test-d/client.no-augmentation.test-d.ts
@@ -41,6 +41,18 @@ const client = createClient({ publicApiKey: "pk_xxx" });
   }
 
   {
+    // Initial presence is required... unless it's not required
+    client.enterRoom<{ foo?: string }>("room");
+    client.enterRoom<{ foo?: string }>("room", {});
+    client.enterRoom<{ foo?: string }>("room", { initialPresence: {} });
+    expectError(
+      client.enterRoom<{ foo?: string }>("room", {
+        initialPresence: { bar: "" },
+      })
+    );
+  }
+
+  {
     // Initial presence is not required when it has only optional fields
     client.enterRoom<{ foo?: string; bar?: number }>("room");
     client.enterRoom<{ foo?: string; bar?: number }>("room", {});

--- a/packages/liveblocks-client/test-d/client.no-augmentation.test-d.ts
+++ b/packages/liveblocks-client/test-d/client.no-augmentation.test-d.ts
@@ -8,9 +8,8 @@ const client = createClient({ publicApiKey: "pk_xxx" });
 {
   {
     // No options at all is fine
-    // XXX Enable this test as well, once all the others work!
-    // const { room } = client.enterRoom("my-room");
-    // expectType<JsonObject>(room.getPresence());
+    const { room } = client.enterRoom("my-room");
+    expectType<JsonObject>(room.getPresence());
   }
 
   {
@@ -29,20 +28,21 @@ const client = createClient({ publicApiKey: "pk_xxx" });
 
   {
     // Initial presence is required
-    expectError<{ foo: string }>(client.enterRoom("room"));
-    expectError<{ foo: string }>(client.enterRoom("room", {}));
-    expectError<{ foo: string }>(
-      client.enterRoom("room", { initialPresence: {} })
+    expectError(client.enterRoom<{ foo: string }>("room"));
+    expectError(client.enterRoom<{ foo: string }>("room", {}));
+    expectError(
+      client.enterRoom<{ foo: string }>("room", { initialPresence: {} })
     );
-    expectError<{ foo: string }>(
-      client.enterRoom("room", { initialPresence: { bar: "" } })
+    expectError(
+      client.enterRoom<{ foo: string }>("room", {
+        initialPresence: { bar: "" },
+      })
     );
   }
 
   {
     // Initial presence is not required when it has only optional fields
-    // XXX Enable this test as well, once all the others work!
-    // client.enterRoom<{ foo?: string; bar?: number }>("room");
+    client.enterRoom<{ foo?: string; bar?: number }>("room");
     client.enterRoom<{ foo?: string; bar?: number }>("room", {});
     client.enterRoom<{ foo?: string; bar?: number }>("room", {
       initialPresence: {},

--- a/packages/liveblocks-core/e2e/utils.ts
+++ b/packages/liveblocks-core/e2e/utils.ts
@@ -13,15 +13,15 @@ import type { LiveObject } from "../src/crdts/LiveObject";
 import type { LsonObject } from "../src/crdts/Lson";
 import type { ToImmutable } from "../src/crdts/utils";
 import { createClient } from "../src/client";
-import type { BaseMetadata } from "../src";
+import type { BaseMetadata, NoInfr } from "../src";
 
 async function initializeRoomForTest<
-  P extends JsonObject,
-  S extends LsonObject,
-  U extends BaseUserMeta,
-  E extends Json,
-  M extends BaseMetadata,
->(roomId: string, initialPresence: P, initialStorage?: S) {
+  P extends JsonObject = JsonObject,
+  S extends LsonObject = LsonObject,
+  U extends BaseUserMeta = BaseUserMeta,
+  E extends Json = Json,
+  M extends BaseMetadata = BaseMetadata,
+>(roomId: string, initialPresence: NoInfr<P>, initialStorage: NoInfr<S>) {
   const publicApiKey = process.env.LIVEBLOCKS_PUBLIC_KEY;
 
   if (publicApiKey == null) {
@@ -73,7 +73,7 @@ async function initializeRoomForTest<
   const { room, leave } = client.enterRoom<P, S, E, M>(roomId, {
     initialPresence,
     initialStorage,
-  });
+  } as any);
   await waitUntilStatus(room, "connected");
 
   return {
@@ -96,8 +96,8 @@ export function prepareTestsConflicts<S extends LsonObject>(
   callback: (args: {
     root1: LiveObject<S>;
     root2: LiveObject<S>;
-    room2: Room<never, S, never, never, never>;
-    room1: Room<never, S, never, never, never>;
+    room2: Room<JsonObject, S>;
+    room1: Room<JsonObject, S>;
 
     /**
      * Assert that room1 and room2 storage are equal to the provided immutable
@@ -115,14 +115,15 @@ export function prepareTestsConflicts<S extends LsonObject>(
   return async () => {
     const roomName = "storage-requirements-e2e-tests-" + new Date().getTime();
 
-    const actor1 = await initializeRoomForTest<never, S, never, never, never>(
+    const actor1 = await initializeRoomForTest<JsonObject, S>(
       roomName,
-      {} as never,
+      {},
       initialStorage
     );
-    const actor2 = await initializeRoomForTest<never, S, never, never, never>(
+    const actor2 = await initializeRoomForTest<JsonObject, S>(
       roomName,
-      {} as never
+      {},
+      {} as S
     );
 
     const { root: root1 } = await actor1.room.getStorage();

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -103,7 +103,7 @@ function createTestableRoom<
   const { wss, delegates } = defineBehavior(authBehavior, socketBehavior);
 
   const room = createRoom<P, S, U, E, M>(
-    { initialPresence, initialStorage },
+    { initialPresence, initialStorage: initialStorage ?? ({} as S) },
     makeRoomConfig(delegates, config)
   );
 
@@ -130,7 +130,10 @@ describe("room / auth", () => {
 
   test("when auth-manager throws StopRetrying error - should fail", async () => {
     const room = createRoom(
-      { initialPresence: {} as never },
+      {
+        initialPresence: {},
+        initialStorage: {},
+      },
       {
         ...makeRoomConfig({
           authenticate: () => {

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -28,13 +28,7 @@ import type {
   InboxNotificationData,
   InboxNotificationDeleteInfo,
 } from "./protocol/InboxNotifications";
-import type {
-  OpaqueRoom,
-  Polyfills,
-  Room,
-  RoomDelegates,
-  RoomInitializers,
-} from "./room";
+import type { OpaqueRoom, Polyfills, Room, RoomDelegates } from "./room";
 import {
   createRoom,
   makeAuthDelegateForRoom,
@@ -87,18 +81,40 @@ export type EnterOptions<
   P extends JsonObject = DP,
   S extends LsonObject = DS,
 > = Resolve<
+  // XXX Maybe inline RoomInitializers<P, S> here again later?
   // Enter options are just room initializers, plus an internal option
-  RoomInitializers<P, S> & {
+  {
     /**
-     * Only necessary when you’re using Liveblocks with React v17 or lower.
-     *
-     * If so, pass in a reference to `ReactDOM.unstable_batchedUpdates` here.
-     * This will allow Liveblocks to circumvent the so-called "zombie child
-     * problem". To learn more, see
-     * https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child
+     * The initial Presence to use and announce when you enter the Room. The
+     * Presence is available on all users in the Room (me & others).
      */
-    unstable_batchedUpdates?: (cb: () => void) => void;
-  }
+    initialPresence: P | ((roomId: string) => P);
+  } & Partial<{
+    /**
+     * The initial Storage to use when entering a new Room.
+     */
+    initialStorage: S | ((roomId: string) => S);
+  }> & {
+      /**
+       * Whether or not the room automatically connects to Liveblock servers.
+       * Default is true.
+       *
+       * Usually set to false when the client is used from the server to not call
+       * the authentication endpoint or connect via WebSocket.
+       */
+      autoConnect?: boolean;
+    } & {
+      // ------------------------------------------------------------------------
+      /**
+       * Only necessary when you’re using Liveblocks with React v17 or lower.
+       *
+       * If so, pass in a reference to `ReactDOM.unstable_batchedUpdates` here.
+       * This will allow Liveblocks to circumvent the so-called "zombie child
+       * problem". To learn more, see
+       * https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child
+       */
+      unstable_batchedUpdates?: (cb: () => void) => void;
+    }
 >;
 
 /**

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -393,7 +393,7 @@ export function createClient<U extends BaseUserMeta = DU>(
     const newRoom = createRoom<P, S, U, E, M>(
       {
         initialPresence: options.initialPresence ?? {},
-        initialStorage: options.initialStorage,
+        initialStorage: options.initialStorage ?? ({} as S),
       },
       {
         roomId,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -29,6 +29,7 @@ import type {
 } from "./protocol/InboxNotifications";
 import type {
   OpaqueRoom,
+  OptionalTupleUnless,
   PartialUnless,
   Polyfills,
   Room,
@@ -197,7 +198,10 @@ export type Client<U extends BaseUserMeta = DU> = {
     M extends BaseMetadata = DM,
   >(
     roomId: string,
-    options: EnterOptions<NoInfr<P>, NoInfr<S>>
+    ...args: OptionalTupleUnless<
+      P & S,
+      [options: EnterOptions<NoInfr<P>, NoInfr<S>>]
+    >
   ): {
     room: Room<P, S, U, E, M>;
     leave: () => void;

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -390,11 +390,18 @@ export function createClient<U extends BaseUserMeta = DU>(
       "Please provide an initial presence value for the current user when entering the room."
     );
 
+    const initialPresence =
+      (typeof options.initialPresence === "function"
+        ? options.initialPresence(roomId)
+        : options.initialPresence) ?? ({} as P);
+
+    const initialStorage =
+      (typeof options.initialStorage === "function"
+        ? options.initialStorage(roomId)
+        : options.initialStorage) ?? ({} as S);
+
     const newRoom = createRoom<P, S, U, E, M>(
-      {
-        initialPresence: options.initialPresence ?? {},
-        initialStorage: options.initialStorage ?? ({} as S),
-      },
+      { initialPresence, initialStorage },
       {
         roomId,
         throttleDelay,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -98,12 +98,15 @@ export type EnterOptions<
       initialPresence: P | ((roomId: string) => P);
     }
   > &
-    Partial<{
-      /**
-       * The initial Storage to use when entering a new Room.
-       */
-      initialStorage: S | ((roomId: string) => S);
-    }> & {
+    PartialUnless<
+      S,
+      {
+        /**
+         * The initial Storage to use when entering a new Room.
+         */
+        initialStorage: S | ((roomId: string) => S);
+      }
+    > & {
       /**
        * Whether or not the room automatically connects to Liveblock servers.
        * Default is true.

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -83,13 +83,32 @@ export type ResolveRoomsInfoArgs = {
   roomIds: string[];
 };
 
-export type EnterOptions<
-  P extends JsonObject = DP,
-  S extends LsonObject = DS,
-> = Resolve<
-  // XXX Maybe inline RoomInitializers<P, S> here again later?
-  // Enter options are just room initializers, plus an internal option
-  PartialUnless<
+export type EnterOptions<P extends JsonObject = DP, S extends LsonObject = DS> =
+  // prettier-ignore
+  Resolve<
+  {
+    /**
+     * Whether or not the room automatically connects to Liveblock servers.
+     * Default is true.
+     *
+     * Usually set to false when the client is used from the server to not call
+     * the authentication endpoint or connect via WebSocket.
+     */
+    autoConnect?: boolean;
+
+    /**
+     * Only necessary when you’re using Liveblocks with React v17 or lower.
+     *
+     * If so, pass in a reference to `ReactDOM.unstable_batchedUpdates` here.
+     * This will allow Liveblocks to circumvent the so-called "zombie child
+     * problem". To learn more, see
+     * https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child
+     */
+    unstable_batchedUpdates?: (cb: () => void) => void;
+  }
+
+  // Initial presence is only mandatory if the custom type requires it to be
+  & PartialUnless<
     P,
     {
       /**
@@ -98,36 +117,18 @@ export type EnterOptions<
        */
       initialPresence: P | ((roomId: string) => P);
     }
-  > &
-    PartialUnless<
-      S,
-      {
-        /**
-         * The initial Storage to use when entering a new Room.
-         */
-        initialStorage: S | ((roomId: string) => S);
-      }
-    > & {
+  >
+  
+  // Initial storage is only mandatory if the custom type requires it to be
+  & PartialUnless<
+    S,
+    {
       /**
-       * Whether or not the room automatically connects to Liveblock servers.
-       * Default is true.
-       *
-       * Usually set to false when the client is used from the server to not call
-       * the authentication endpoint or connect via WebSocket.
+       * The initial Storage to use when entering a new Room.
        */
-      autoConnect?: boolean;
-    } & {
-      // ------------------------------------------------------------------------
-      /**
-       * Only necessary when you’re using Liveblocks with React v17 or lower.
-       *
-       * If so, pass in a reference to `ReactDOM.unstable_batchedUpdates` here.
-       * This will allow Liveblocks to circumvent the so-called "zombie child
-       * problem". To learn more, see
-       * https://liveblocks.io/docs/guides/troubleshooting#stale-props-zombie-child
-       */
-      unstable_batchedUpdates?: (cb: () => void) => void;
+      initialStorage: S | ((roomId: string) => S);
     }
+  >
 >;
 
 /**

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -199,7 +199,6 @@ export type {
   PartialUnless,
   Room,
   RoomEventMessage,
-  RoomInitializers,
   StorageStatus,
 } from "./room";
 export type { GetThreadsOptions } from "./room";

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -195,6 +195,8 @@ export type {
   BroadcastOptions,
   History,
   OpaqueRoom,
+  OptionalTupleUnless,
+  PartialUnless,
   Room,
   RoomEventMessage,
   RoomInitializers,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -908,13 +908,25 @@ type OptionalTuple<T extends any[]> = { [K in keyof T]?: T[K] };
  * Returns Partial<T> if all fields on C are optional, T otherwise.
  */
 export type PartialUnless<C, T> =
-  Record<string, never> extends C ? Partial<T> : T;
+  Record<string, never> extends C
+    ? Partial<T>
+    : // Extra test. We'll want to treat "never" as if the empty object is
+      // assignable to it, because otherwise it will not
+      [C] extends [never]
+      ? Partial<T>
+      : T;
 
 /**
  * Returns OptionalTupleUnless<T> if all fields on C are optional, T otherwise.
  */
 export type OptionalTupleUnless<C, T extends any[]> =
-  Record<string, never> extends C ? OptionalTuple<T> : T;
+  Record<string, never> extends C
+    ? OptionalTuple<T>
+    : // Extra test. We'll want to treat "never" as if the empty object is
+      // assignable to it, because otherwise it will not
+      [C] extends [never]
+      ? OptionalTuple<T>
+      : T;
 
 export type RoomDelegates = Omit<Delegates<AuthValue>, "canZombie">;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -896,6 +896,27 @@ export type Polyfills = {
   WebSocket?: IWebSocket;
 };
 
+/**
+ * Makes all tuple positions optional.
+ * Example, turns:
+ *   [foo: string; bar: number]
+ * into:
+ *   [foo?: string; bar?: number]
+ */
+type OptionalTuple<T extends any[]> = { [K in keyof T]?: T[K] };
+
+/**
+ * Returns Partial<T> if all fields on C are optional, T otherwise.
+ */
+export type PartialUnless<C, T> =
+  Record<string, never> extends C ? Partial<T> : T;
+
+/**
+ * Returns OptionalTupleUnless<T> if all fields on C are optional, T otherwise.
+ */
+export type OptionalTupleUnless<C, T extends any[]> =
+  Record<string, never> extends C ? OptionalTuple<T> : T;
+
 export type RoomInitializers<
   P extends JsonObject,
   S extends LsonObject,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -852,7 +852,7 @@ type RoomState<
   readonly others: OthersRef<P, U>;
 
   idFactory: IdFactory | null;
-  initialStorage?: S;
+  initialStorage: S;
 
   clock: number;
   opClock: number;
@@ -920,8 +920,7 @@ export type OptionalTupleUnless<C, T extends any[]> =
 /** @internal */
 type CreateRoomOptions<P extends JsonObject, S extends LsonObject> = {
   initialPresence: P | ((roomId: string) => P);
-  initialStorage?: S | ((roomId: string) => S);
-  //            ^ XXX Make this mandatory in this signature eventually (but not _necessarily_ in the public APIs)
+  initialStorage: S | ((roomId: string) => S);
 };
 
 export type RoomInitializers<

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -917,12 +917,6 @@ export type PartialUnless<C, T> =
 export type OptionalTupleUnless<C, T extends any[]> =
   Record<string, never> extends C ? OptionalTuple<T> : T;
 
-/** @internal */
-type CreateRoomOptions<P extends JsonObject, S extends LsonObject> = {
-  initialPresence: P;
-  initialStorage: S;
-};
-
 export type RoomInitializers<
   P extends JsonObject,
   S extends LsonObject,
@@ -1380,7 +1374,10 @@ export function createRoom<
   U extends BaseUserMeta,
   E extends Json,
   M extends BaseMetadata,
->(options: CreateRoomOptions<P, S>, config: RoomConfig): Room<P, S, U, E, M> {
+>(
+  options: { initialPresence: P; initialStorage: S },
+  config: RoomConfig
+): Room<P, S, U, E, M> {
   const initialPresence = options.initialPresence; // ?? {};
   const initialStorage = options.initialStorage; // ?? {};
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -43,7 +43,6 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import { objectToQuery } from "./lib/objectToQuery";
 import { asPos } from "./lib/position";
-import type { Resolve } from "./lib/Resolve";
 import type { QueryParams } from "./lib/url";
 import { urljoin } from "./lib/url";
 import { compact, deepClone, tryParseJson } from "./lib/utils";
@@ -916,35 +915,6 @@ export type PartialUnless<C, T> =
  */
 export type OptionalTupleUnless<C, T extends any[]> =
   Record<string, never> extends C ? OptionalTuple<T> : T;
-
-export type RoomInitializers<
-  P extends JsonObject,
-  S extends LsonObject,
-> = Resolve<
-  Resolve<
-    {
-      /**
-       * The initial Presence to use and announce when you enter the Room. The
-       * Presence is available on all users in the Room (me & others).
-       */
-      initialPresence: P | ((roomId: string) => P);
-    } & Partial<{
-      /**
-       * The initial Storage to use when entering a new Room.
-       */
-      initialStorage: S | ((roomId: string) => S);
-    }>
-  > & {
-    /**
-     * Whether or not the room automatically connects to Liveblock servers.
-     * Default is true.
-     *
-     * Usually set to false when the client is used from the server to not call
-     * the authentication endpoint or connect via WebSocket.
-     */
-    autoConnect?: boolean;
-  }
->;
 
 export type RoomDelegates = Omit<Delegates<AuthValue>, "canZombie">;
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -919,8 +919,8 @@ export type OptionalTupleUnless<C, T extends any[]> =
 
 /** @internal */
 type CreateRoomOptions<P extends JsonObject, S extends LsonObject> = {
-  initialPresence: P | ((roomId: string) => P);
-  initialStorage: S | ((roomId: string) => S);
+  initialPresence: P;
+  initialStorage: S;
 };
 
 export type RoomInitializers<
@@ -1381,14 +1381,8 @@ export function createRoom<
   E extends Json,
   M extends BaseMetadata,
 >(options: CreateRoomOptions<P, S>, config: RoomConfig): Room<P, S, U, E, M> {
-  const initialPresence =
-    typeof options.initialPresence === "function"
-      ? options.initialPresence(config.roomId)
-      : options.initialPresence;
-  const initialStorage =
-    typeof options.initialStorage === "function"
-      ? options.initialStorage(config.roomId)
-      : options.initialStorage;
+  const initialPresence = options.initialPresence; // ?? {};
+  const initialStorage = options.initialStorage; // ?? {};
 
   const [inBackgroundSince, uninstallBgTabSpy] = installBackgroundTabSpy();
 

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -21,6 +21,8 @@ import type {
   Json,
   JsonObject,
   LsonObject,
+  OptionalTupleUnless,
+  PartialUnless,
   Patchable,
   PlainLsonObject,
   QueryMetadata,
@@ -73,14 +75,12 @@ type DateToString<T> = {
 };
 
 export type CreateSessionOptions<U extends BaseUserMeta = DU> =
-  Record<string, never> extends U["info"]
-    ? { userInfo?: U["info"] }
-    : { userInfo: U["info"] };
+  //
+  PartialUnless<U["info"], { userInfo: U["info"] }>;
 
 export type IdentifyUserOptions<U extends BaseUserMeta = DU> =
-  Record<string, never> extends U["info"]
-    ? { userInfo?: U["info"] }
-    : { userInfo: U["info"] };
+  //
+  PartialUnless<U["info"], { userInfo: U["info"] }>;
 
 export type AuthResponse = {
   status: number;
@@ -101,7 +101,7 @@ export type CreateThreadOptions<M extends BaseMetadata> = {
   roomId: string;
   data: {
     comment: { userId: string; createdAt?: Date; body: CommentBody };
-  } & (Record<string, never> extends M ? { metadata?: M } : { metadata: M });
+  } & PartialUnless<M, { metadata: M }>;
 };
 
 export type RoomPermission =
@@ -267,9 +267,10 @@ export class Liveblocks {
    */
   prepareSession(
     userId: string,
-    ...rest: Record<string, never> extends CreateSessionOptions<U>
-      ? [options?: CreateSessionOptions<U>]
-      : [options: CreateSessionOptions<U>]
+    ...rest: OptionalTupleUnless<
+      CreateSessionOptions<U>,
+      [options: CreateSessionOptions<U>]
+    >
   ): Session {
     const options = rest[0];
     return new Session(this.post.bind(this), userId, options?.userInfo);
@@ -312,9 +313,10 @@ export class Liveblocks {
     identity:
       | string // Shorthand for userId
       | Identity,
-    ...rest: Record<string, never> extends IdentifyUserOptions<U>
-      ? [options?: IdentifyUserOptions<U>]
-      : [options: IdentifyUserOptions<U>]
+    ...rest: OptionalTupleUnless<
+      IdentifyUserOptions<U>,
+      [options: IdentifyUserOptions<U>]
+    >
   ): Promise<AuthResponse> {
     const options = rest[0];
 

--- a/packages/liveblocks-node/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/augmentation.test-d.ts
@@ -58,6 +58,7 @@ async () => {
     expectError(await client.prepareSession("user-123"));
     expectError(await client.prepareSession("user-123", {}));
     // TODO: Re-enable this when tsd supports the TS2739 error
+    // TODO See https://github.com/tsdjs/tsd/issues/215
     // expectError(await client.prepareSession("user-123", { userInfo: {} }));
     expectError(
       await client.prepareSession("user-123", { userInfo: { name: "Vincent" } })
@@ -91,6 +92,7 @@ async () => {
     expectError(await client.identifyUser("user-123"));
     expectError(await client.identifyUser("user-123", {}));
     // TODO: Re-enable this when tsd supports the TS2739 error
+    // TODO See https://github.com/tsdjs/tsd/issues/215
     // expectError(await client.identifyUser("user-123", { userInfo: {} }));
     expectError(
       await client.identifyUser("user-123", { userInfo: { name: "Vincent" } })
@@ -265,6 +267,7 @@ async () => {
     expectError(client.editThreadMetadata({ roomId }));
     expectError(client.editThreadMetadata({ threadId }));
     // TODO: Uncomment later, when tsd supports ts2739 error code
+    // TODO See https://github.com/tsdjs/tsd/issues/215
     // expectError(
     //   client.editThreadMetadata({
     //     roomId: "my-room",

--- a/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
@@ -214,6 +214,7 @@ async () => {
     expectError(client.editThreadMetadata({ roomId }));
     expectError(client.editThreadMetadata({ threadId }));
     // TODO: Uncomment later, when tsd supports ts2739 error code
+    // TODO See https://github.com/tsdjs/tsd/issues/215
     // expectError(
     //   client.editThreadMetadata({
     //     roomId: "my-room",

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -776,7 +776,6 @@ function RoomProviderInner<
     unstable_batchedUpdates: props.unstable_batchedUpdates,
     autoConnect: props.autoConnect ?? typeof window !== "undefined",
   }) as EnterOptions<P, S>;
-  // XXX This Should™ not have to be necessary? Figure out why.
 
   const [{ room }, setRoomLeavePair] = React.useState(() =>
     stableEnterRoom(roomId, {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -668,28 +668,29 @@ function RoomProvider<
   // Produce a version of client.enterRoom() that when called for the same
   // room ID multiple times, will not keep producing multiple leave
   // functions, but instead return the cached one.
-  const stableEnterRoom = React.useCallback(
-    (
-      roomId: string,
-      options: EnterOptions<P, S>
-    ): RoomLeavePair<P, S, U, E, M> => {
-      const cached = cache.get(roomId);
-      if (cached) return cached;
+  const stableEnterRoom: typeof client.enterRoom<P, S, E, M> =
+    React.useCallback(
+      (
+        roomId: string,
+        options: EnterOptions<P, S>
+      ): RoomLeavePair<P, S, U, E, M> => {
+        const cached = cache.get(roomId);
+        if (cached) return cached;
 
-      const rv = client.enterRoom<P, S, E, M>(roomId, options);
+        const rv = client.enterRoom<P, S, E, M>(roomId, options);
 
-      // Wrap the leave function to also delete the cached value
-      const origLeave = rv.leave;
-      rv.leave = () => {
-        origLeave();
-        cache.delete(roomId);
-      };
+        // Wrap the leave function to also delete the cached value
+        const origLeave = rv.leave;
+        rv.leave = () => {
+          origLeave();
+          cache.delete(roomId);
+        };
 
-      cache.set(roomId, rv);
-      return rv;
-    },
-    [client, cache]
-  );
+        cache.set(roomId, rv);
+        return rv;
+      },
+      [client, cache]
+    );
 
   //
   // RATIONALE:
@@ -710,8 +711,24 @@ function RoomProvider<
   // use by some party that hasn't called `leave()` on it yet, thus causing the
   // Room to not be freed and destroyed when the component unmounts later.
   //
-  return <RoomProviderInner {...props} stableEnterRoom={stableEnterRoom} />;
+  return (
+    <RoomProviderInner<P, S, U, E, M>
+      {...(props as any)}
+      stableEnterRoom={stableEnterRoom}
+    />
+  );
 }
+
+type EnterRoomType<
+  P extends JsonObject,
+  S extends LsonObject,
+  U extends BaseUserMeta,
+  E extends Json,
+  M extends BaseMetadata,
+> = (
+  roomId: string,
+  options: EnterOptions<P, S>
+) => RoomLeavePair<P, S, U, E, M>;
 
 /** @internal */
 function RoomProviderInner<
@@ -722,13 +739,10 @@ function RoomProviderInner<
   M extends BaseMetadata,
 >(
   props: RoomProviderProps<P, S> & {
-    stableEnterRoom: (
-      roomId: string,
-      options: EnterOptions<P, S>
-    ) => RoomLeavePair<P, S, U, E, M>;
+    stableEnterRoom: EnterRoomType<P, S, U, E, M>;
   }
 ) {
-  const client = useClient();
+  const client = useClient<U>();
   const { id: roomId, stableEnterRoom } = props;
 
   if (process.env.NODE_ENV !== "production") {
@@ -761,7 +775,8 @@ function RoomProviderInner<
     initialStorage: props.initialStorage,
     unstable_batchedUpdates: props.unstable_batchedUpdates,
     autoConnect: props.autoConnect ?? typeof window !== "undefined",
-  });
+  }) as EnterOptions<P, S>;
+  // XXX This Should™ not have to be necessary? Figure out why.
 
   const [{ room }, setRoomLeavePair] = React.useState(() =>
     stableEnterRoom(roomId, {

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -20,6 +20,7 @@ import type {
   DRI,
   InboxNotificationData,
   LiveblocksError,
+  PartialUnless,
   Patchable,
   QueryMetadata,
   Resolve,
@@ -102,10 +103,12 @@ export type RoomInfoState =
   | RoomInfoStateError
   | RoomInfoStateSuccess;
 
+// prettier-ignore
 export type CreateThreadOptions<M extends BaseMetadata> =
-  Record<string, never> extends M
-    ? { body: CommentBody; metadata?: M }
-    : { body: CommentBody; metadata: M };
+  Resolve<
+    { body: CommentBody }
+    & PartialUnless<M, { metadata: M }>
+  >;
 
 export type EditThreadMetadataOptions<M extends BaseMetadata> = {
   threadId: string;

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -233,11 +233,9 @@ export type RoomNotificationSettingsState =
   | RoomNotificationSettingsStateError
   | RoomNotificationSettingsStateSuccess;
 
-// XXX Fix this later
-export type RoomProviderProps<
-  P extends JsonObject,
-  S extends LsonObject,
-> = Resolve<
+export type RoomProviderProps<P extends JsonObject, S extends LsonObject> =
+  // prettier-ignore
+  Resolve<
   {
     /**
      * The id of the room you want to connect to
@@ -270,7 +268,10 @@ export type RoomProviderProps<
      * Not necessary when you're on React v18 or later.
      */
     unstable_batchedUpdates?: (cb: () => void) => void;
-  } & PartialUnless<
+  }
+
+  // Initial presence is only mandatory if the custom type requires it to be
+  & PartialUnless<
     P,
     {
       /**
@@ -279,16 +280,18 @@ export type RoomProviderProps<
        */
       initialPresence: P | ((roomId: string) => P);
     }
-  > &
-    PartialUnless<
-      S,
-      {
-        /**
-         * The initial Storage to use when entering a new Room.
-         */
-        initialStorage: S | ((roomId: string) => S);
-      }
-    >
+  >
+
+  // Initial storage is only mandatory if the custom type requires it to be
+  & PartialUnless<
+    S,
+    {
+      /**
+       * The initial Storage to use when entering a new Room.
+       */
+      initialStorage: S | ((roomId: string) => S);
+    }
+  >
 >;
 
 /**

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -25,7 +25,6 @@ import type {
   QueryMetadata,
   Resolve,
   RoomEventMessage,
-  RoomInitializers,
   ThreadData,
   ToImmutable,
 } from "@liveblocks/core";
@@ -234,6 +233,7 @@ export type RoomNotificationSettingsState =
   | RoomNotificationSettingsStateError
   | RoomNotificationSettingsStateSuccess;
 
+// XXX Fix this later
 export type RoomProviderProps<
   P extends JsonObject,
   S extends LsonObject,
@@ -244,33 +244,45 @@ export type RoomProviderProps<
      */
     id: string;
     children: React.ReactNode;
-
+  } & {
     /**
-     * Whether or not the room should connect to Liveblocks servers
-     * when the RoomProvider is rendered.
-     *
-     * By default equals to `typeof window !== "undefined"`,
-     * meaning the RoomProvider tries to connect to Liveblocks servers
-     * only on the client side.
+     * The initial Presence to use and announce when you enter the Room. The
+     * Presence is available on all users in the Room (me & others).
      */
-    autoConnect?: boolean;
+    initialPresence: P | ((roomId: string) => P);
+  } & Partial<{
+      /**
+       * The initial Storage to use when entering a new Room.
+       */
+      initialStorage: S | ((roomId: string) => S);
+    }> & {
+      // --------------------------------------------------------------------
+      /**
+       * Whether or not the room should connect to Liveblocks servers
+       * when the RoomProvider is rendered.
+       *
+       * By default equals to `typeof window !== "undefined"`,
+       * meaning the RoomProvider tries to connect to Liveblocks servers
+       * only on the client side.
+       */
+      autoConnect?: boolean;
 
-    /**
-     * If you're on React 17 or lower, pass in a reference to
-     * `ReactDOM.unstable_batchedUpdates` or
-     * `ReactNative.unstable_batchedUpdates` here.
-     *
-     * @example
-     * import { unstable_batchedUpdates } from "react-dom";
-     *
-     * <RoomProvider ... unstable_batchedUpdates={unstable_batchedUpdates} />
-     *
-     * This will prevent you from running into the so-called "stale props"
-     * and/or "zombie child" problem that React 17 and lower can suffer from.
-     * Not necessary when you're on React v18 or later.
-     */
-    unstable_batchedUpdates?: (cb: () => void) => void;
-  } & RoomInitializers<P, S>
+      /**
+       * If you're on React 17 or lower, pass in a reference to
+       * `ReactDOM.unstable_batchedUpdates` or
+       * `ReactNative.unstable_batchedUpdates` here.
+       *
+       * @example
+       * import { unstable_batchedUpdates } from "react-dom";
+       *
+       * <RoomProvider ... unstable_batchedUpdates={unstable_batchedUpdates} />
+       *
+       * This will prevent you from running into the so-called "stale props"
+       * and/or "zombie child" problem that React 17 and lower can suffer from.
+       * Not necessary when you're on React v18 or later.
+       */
+      unstable_batchedUpdates?: (cb: () => void) => void;
+    }
 >;
 
 /**

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -244,45 +244,51 @@ export type RoomProviderProps<
      */
     id: string;
     children: React.ReactNode;
-  } & {
-    /**
-     * The initial Presence to use and announce when you enter the Room. The
-     * Presence is available on all users in the Room (me & others).
-     */
-    initialPresence: P | ((roomId: string) => P);
-  } & Partial<{
-      /**
-       * The initial Storage to use when entering a new Room.
-       */
-      initialStorage: S | ((roomId: string) => S);
-    }> & {
-      // --------------------------------------------------------------------
-      /**
-       * Whether or not the room should connect to Liveblocks servers
-       * when the RoomProvider is rendered.
-       *
-       * By default equals to `typeof window !== "undefined"`,
-       * meaning the RoomProvider tries to connect to Liveblocks servers
-       * only on the client side.
-       */
-      autoConnect?: boolean;
 
+    /**
+     * Whether or not the room should connect to Liveblocks servers
+     * when the RoomProvider is rendered.
+     *
+     * By default equals to `typeof window !== "undefined"`,
+     * meaning the RoomProvider tries to connect to Liveblocks servers
+     * only on the client side.
+     */
+    autoConnect?: boolean;
+
+    /**
+     * If you're on React 17 or lower, pass in a reference to
+     * `ReactDOM.unstable_batchedUpdates` or
+     * `ReactNative.unstable_batchedUpdates` here.
+     *
+     * @example
+     * import { unstable_batchedUpdates } from "react-dom";
+     *
+     * <RoomProvider ... unstable_batchedUpdates={unstable_batchedUpdates} />
+     *
+     * This will prevent you from running into the so-called "stale props"
+     * and/or "zombie child" problem that React 17 and lower can suffer from.
+     * Not necessary when you're on React v18 or later.
+     */
+    unstable_batchedUpdates?: (cb: () => void) => void;
+  } & PartialUnless<
+    P,
+    {
       /**
-       * If you're on React 17 or lower, pass in a reference to
-       * `ReactDOM.unstable_batchedUpdates` or
-       * `ReactNative.unstable_batchedUpdates` here.
-       *
-       * @example
-       * import { unstable_batchedUpdates } from "react-dom";
-       *
-       * <RoomProvider ... unstable_batchedUpdates={unstable_batchedUpdates} />
-       *
-       * This will prevent you from running into the so-called "stale props"
-       * and/or "zombie child" problem that React 17 and lower can suffer from.
-       * Not necessary when you're on React v18 or later.
+       * The initial Presence to use and announce when you enter the Room. The
+       * Presence is available on all users in the Room (me & others).
        */
-      unstable_batchedUpdates?: (cb: () => void) => void;
+      initialPresence: P | ((roomId: string) => P);
     }
+  > &
+    PartialUnless<
+      S,
+      {
+        /**
+         * The initial Storage to use when entering a new Room.
+         */
+        initialStorage: S | ((roomId: string) => S);
+      }
+    >
 >;
 
 /**

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -112,15 +112,34 @@ declare global {
   //     <div />
   //   </RoomProvider>
   // );
+
   expectError(
+    // Missing mandatory initialPresence + initialStorage
     <RoomProvider id="my-room">
       <div />
     </RoomProvider>
   );
 
-  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
-    <div />
-  </RoomProvider>;
+  expectError(
+    // Missing mandatory initialPresence
+    <RoomProvider
+      id="my-room"
+      initialStorage={{
+        animals: new LiveList([]),
+        person: new LiveObject(),
+        scores: new LiveMap(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
+
+  expectError(
+    // Missing mandatory initialStorage
+    <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     <RoomProvider
@@ -160,15 +179,34 @@ declare global {
   //     <div />
   //   </RoomProvider>
   // );
+
   expectError(
+    // Missing mandatory initialPresence + initialStorage
     <RoomProvider id="my-room">
       <div />
     </RoomProvider>
   );
 
-  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
-    <div />
-  </RoomProvider>;
+  expectError(
+    // Missing mandatory initialPresence
+    <RoomProvider
+      id="my-room"
+      initialStorage={{
+        animals: new LiveList([]),
+        person: new LiveObject(),
+        scores: new LiveMap(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
+
+  expectError(
+    // Missing mandatory initialStorage
+    <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     <RoomProvider

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 React; // To silence tsd warning
 
-import type { LiveList, LiveMap, LiveObject } from "@liveblocks/core";
+import { LiveList, LiveMap, LiveObject } from "@liveblocks/core";
 import * as classic from "@liveblocks/react";
 import * as suspense from "@liveblocks/react/suspense";
 import { expectAssignable, expectError, expectType } from "tsd";
@@ -99,6 +99,102 @@ declare global {
     authEndpoint="/api/auth"
     resolveUsers={async () => [{ name: "Vincent", age: 42 }]}
   />;
+}
+
+// RoomProvider
+{
+  const RoomProvider = classic.RoomProvider;
+
+  // Missing mandatory props is an error
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider>
+  //     <div />
+  //   </RoomProvider>
+  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+    <div />
+  </RoomProvider>;
+
+  expectError(
+    <RoomProvider
+      id="my-room"
+      initialPresence={{ cursor: { x: 0, y: 0 } }}
+      initialStorage={{
+        // Incorrect storage shape
+        foo: new LiveList([]),
+        bar: new LiveObject(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      animals: new LiveList([]),
+      person: new LiveObject(),
+      scores: new LiveMap(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
+}
+
+// RoomProvider (suspense)
+{
+  const RoomProvider = suspense.RoomProvider;
+
+  // Missing mandatory props is an error
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider>
+  //     <div />
+  //   </RoomProvider>
+  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+    <div />
+  </RoomProvider>;
+
+  expectError(
+    <RoomProvider
+      id="my-room"
+      initialPresence={{ cursor: { x: 0, y: 0 } }}
+      initialStorage={{
+        // Incorrect storage shape
+        foo: new LiveList([]),
+        bar: new LiveObject(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      animals: new LiveList([]),
+      person: new LiveObject(),
+      scores: new LiveMap(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -108,20 +108,28 @@ declare global {
   // Missing mandatory props is an error
   // TODO Add back when tsd supports error ts2739
   // expectError(
-  //   <RoomProvider>
+  //   <RoomProvider /* no room id */>
+  //     <div />
+  //   </RoomProvider>
+  // );
+
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   // Missing initialPresence is an error
+  //   <RoomProvider id="my-room">
   //     <div />
   //   </RoomProvider>
   // );
 
   expectError(
-    // Missing mandatory initialPresence + initialStorage
-    <RoomProvider id="my-room">
+    // Missing mandatory initialStorage is an error
+    <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
       <div />
     </RoomProvider>
   );
 
   expectError(
-    // Missing mandatory initialPresence
+    // Missing mandatory initialPresence is an error
     <RoomProvider
       id="my-room"
       initialStorage={{
@@ -175,20 +183,28 @@ declare global {
   // Missing mandatory props is an error
   // TODO Add back when tsd supports error ts2739
   // expectError(
-  //   <RoomProvider>
+  //   <RoomProvider /* no room id */>
+  //     <div />
+  //   </RoomProvider>
+  // );
+
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   // Missing initialPresence is an error
+  //   <RoomProvider id="my-room">
   //     <div />
   //   </RoomProvider>
   // );
 
   expectError(
-    // Missing mandatory initialPresence + initialStorage
-    <RoomProvider id="my-room">
+    // Missing mandatory initialStorage is an error
+    <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
       <div />
     </RoomProvider>
   );
 
   expectError(
-    // Missing mandatory initialPresence
+    // Missing mandatory initialPresence is an error
     <RoomProvider
       id="my-room"
       initialStorage={{

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -107,6 +107,7 @@ declare global {
 
   // Missing mandatory props is an error
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   <RoomProvider /* no room id */>
   //     <div />
@@ -114,6 +115,7 @@ declare global {
   // );
 
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   // Missing initialPresence is an error
   //   <RoomProvider id="my-room">
@@ -182,6 +184,7 @@ declare global {
 
   // Missing mandatory props is an error
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   <RoomProvider /* no room id */>
   //     <div />
@@ -189,6 +192,7 @@ declare global {
   // );
 
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   // Missing initialPresence is an error
   //   <RoomProvider id="my-room">

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -125,12 +125,13 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   //   </RoomProvider>
   // );
 
-  expectError(
-    // Missing mandatory initialPresence + initialStorage
-    <RoomProvider id="my-room">
-      <div />
-    </RoomProvider>
-  );
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   // Missing mandatory initialPresence + initialStorage
+  //   <RoomProvider id="my-room">
+  //     <div />
+  //   </RoomProvider>
+  // );
 
   expectError(
     // Missing mandatory initialStorage
@@ -192,12 +193,12 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   //   </RoomProvider>
   // );
 
-  expectError(
-    // Missing mandatory initialPresence + initialStorage
-    <RoomProvider id="my-room">
-      <div />
-    </RoomProvider>
-  );
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider id="my-room">
+  //     <div />
+  //   </RoomProvider>
+  // );
 
   expectError(
     // Missing mandatory initialStorage

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -119,6 +119,7 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
 
   // Missing mandatory props is an error
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   <RoomProvider>
   //     <div />
@@ -126,6 +127,7 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   // );
 
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   // Missing mandatory initialPresence + initialStorage
   //   <RoomProvider id="my-room">
@@ -187,6 +189,7 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
 
   // Missing mandatory props is an error
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   <RoomProvider>
   //     <div />
@@ -194,6 +197,7 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   // );
 
   // TODO Add back when tsd supports error ts2739
+  // TODO See https://github.com/tsdjs/tsd/issues/215
   // expectError(
   //   <RoomProvider id="my-room">
   //     <div />

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -124,15 +124,34 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   //     <div />
   //   </RoomProvider>
   // );
+
   expectError(
+    // Missing mandatory initialPresence + initialStorage
     <RoomProvider id="my-room">
       <div />
     </RoomProvider>
   );
 
-  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
-    <div />
-  </RoomProvider>;
+  expectError(
+    // Missing mandatory initialStorage
+    <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+      <div />
+    </RoomProvider>
+  );
+
+  expectError(
+    // Missing mandatory initialPresence
+    <RoomProvider
+      id="my-room"
+      initialStorage={{
+        animals: new LiveList([]),
+        person: new LiveObject(),
+        scores: new LiveMap(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     // Incorrect initialStorage
@@ -172,15 +191,34 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   //     <div />
   //   </RoomProvider>
   // );
+
   expectError(
+    // Missing mandatory initialPresence + initialStorage
     <RoomProvider id="my-room">
       <div />
     </RoomProvider>
   );
 
-  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
-    <div />
-  </RoomProvider>;
+  expectError(
+    // Missing mandatory initialStorage
+    <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+      <div />
+    </RoomProvider>
+  );
+
+  expectError(
+    // Missing mandatory initialPresence
+    <RoomProvider
+      id="my-room"
+      initialStorage={{
+        animals: new LiveList([]),
+        person: new LiveObject(),
+        scores: new LiveMap(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     // Incorrect initialStorage

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -1,14 +1,8 @@
 import React from "react";
 React; // To silence tsd warning
 
-import type {
-  Json,
-  LiveList,
-  LiveMap,
-  LiveObject,
-  Room,
-  User,
-} from "@liveblocks/client";
+import type { Json, Room, User } from "@liveblocks/client";
+import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import { createClient } from "@liveblocks/client";
 import { createLiveblocksContext, createRoomContext } from "@liveblocks/react";
 import { expectAssignable, expectError, expectType } from "tsd";
@@ -117,6 +111,102 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
       resolveUsers={async () => [{ name: "Vincent", age: 42 }]}
     />
   );
+}
+
+// RoomProvider
+{
+  const RoomProvider = ctx.RoomProvider;
+
+  // Missing mandatory props is an error
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider>
+  //     <div />
+  //   </RoomProvider>
+  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+    <div />
+  </RoomProvider>;
+
+  expectError(
+    // Incorrect initialStorage
+    <RoomProvider
+      id="my-room"
+      initialPresence={{ cursor: { x: 0, y: 0 } }}
+      initialStorage={{
+        foo: new LiveList([]),
+        bar: new LiveObject(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      animals: new LiveList([]),
+      person: new LiveObject(),
+      scores: new LiveMap(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
+}
+
+// RoomProvider (suspense)
+{
+  const RoomProvider = ctx.suspense.RoomProvider;
+
+  // Missing mandatory props is an error
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider>
+  //     <div />
+  //   </RoomProvider>
+  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+    <div />
+  </RoomProvider>;
+
+  expectError(
+    // Incorrect initialStorage
+    <RoomProvider
+      id="my-room"
+      initialPresence={{ cursor: { x: 0, y: 0 } }}
+      initialStorage={{
+        foo: new LiveList([]),
+        bar: new LiveObject(),
+      }}
+    >
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      animals: new LiveList([]),
+      person: new LiveObject(),
+      scores: new LiveMap(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -68,25 +68,37 @@ import { expectAssignable, expectError, expectType } from "tsd";
 {
   const RoomProvider = classic.RoomProvider;
 
-  // Missing mandatory props is an error
-  // TODO Add back when tsd supports error ts2739
-  // expectError(
-  //   <RoomProvider>
-  //     <div />
-  //   </RoomProvider>
-  // );
+  // Missing mandatory room ID is an error
+  expectError(
+    <RoomProvider /* no room id */>
+      <div />
+    </RoomProvider>
+  );
 
   <RoomProvider id="my-room">
     <div />
   </RoomProvider>;
 
-  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ anything: ["is", "fine", "here"] }}
+  >
     <div />
   </RoomProvider>;
 
   <RoomProvider
     id="my-room"
-    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      foo: new LiveList([]),
+      bar: new LiveObject(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ anything: ["is", "fine", "here"] }}
     initialStorage={{
       foo: new LiveList([]),
       bar: new LiveObject(),
@@ -100,25 +112,37 @@ import { expectAssignable, expectError, expectType } from "tsd";
 {
   const RoomProvider = suspense.RoomProvider;
 
-  // Missing mandatory props is an error
-  // TODO Add back when tsd supports error ts2739
-  // expectError(
-  //   <RoomProvider>
-  //     <div />
-  //   </RoomProvider>
-  // );
+  // Missing mandatory room ID is an error
+  expectError(
+    <RoomProvider /* no room id */>
+      <div />
+    </RoomProvider>
+  );
 
   <RoomProvider id="my-room">
     <div />
   </RoomProvider>;
 
-  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ anything: ["is", "fine", "here"] }}
+  >
     <div />
   </RoomProvider>;
 
   <RoomProvider
     id="my-room"
-    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      foo: new LiveList([]),
+      bar: new LiveObject(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ anything: ["is", "fine", "here"] }}
     initialStorage={{
       foo: new LiveList([]),
       bar: new LiveObject(),

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -75,11 +75,10 @@ import { expectAssignable, expectError, expectType } from "tsd";
   //     <div />
   //   </RoomProvider>
   // );
-  expectError(
-    <RoomProvider id="my-room">
-      <div />
-    </RoomProvider>
-  );
+
+  <RoomProvider id="my-room">
+    <div />
+  </RoomProvider>;
 
   <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
     <div />
@@ -108,11 +107,10 @@ import { expectAssignable, expectError, expectType } from "tsd";
   //     <div />
   //   </RoomProvider>
   // );
-  expectError(
-    <RoomProvider id="my-room">
-      <div />
-    </RoomProvider>
-  );
+
+  <RoomProvider id="my-room">
+    <div />
+  </RoomProvider>;
 
   <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
     <div />

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 React; // To silence tsd warning
 
-import type { BaseMetadata, Json, Lson } from "@liveblocks/client";
+import {
+  BaseMetadata,
+  Json,
+  LiveList,
+  LiveObject,
+  Lson,
+} from "@liveblocks/client";
 import * as classic from "@liveblocks/react";
 import * as suspense from "@liveblocks/react/suspense";
 import { expectAssignable, expectError, expectType } from "tsd";
@@ -56,6 +62,72 @@ import { expectAssignable, expectError, expectType } from "tsd";
     authEndpoint="/api/auth"
     resolveUsers={async () => [{ name: "Vincent", age: 42 }]}
   />;
+}
+
+// RoomProvider
+{
+  const RoomProvider = classic.RoomProvider;
+
+  // Missing mandatory props is an error
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider>
+  //     <div />
+  //   </RoomProvider>
+  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+    <div />
+  </RoomProvider>;
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      foo: new LiveList([]),
+      bar: new LiveObject(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
+}
+
+// RoomProvider (suspense)
+{
+  const RoomProvider = suspense.RoomProvider;
+
+  // Missing mandatory props is an error
+  // TODO Add back when tsd supports error ts2739
+  // expectError(
+  //   <RoomProvider>
+  //     <div />
+  //   </RoomProvider>
+  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
+
+  <RoomProvider id="my-room" initialPresence={{ cursor: { x: 0, y: 0 } }}>
+    <div />
+  </RoomProvider>;
+
+  <RoomProvider
+    id="my-room"
+    initialPresence={{ cursor: { x: 0, y: 0 } }}
+    initialStorage={{
+      foo: new LiveList([]),
+      bar: new LiveObject(),
+    }}
+  >
+    <div />
+  </RoomProvider>;
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
…but only if they truly are optional in your type definition.

Some examples:

```tsx
declare global {
  interface Liveblocks {
    // Not using Presence here
  }
}

// ✅ No longer needed if you're not using/interested in Presence
<RoomProvider initialPresence={{}}>...</RoomProvider>
<RoomProvider>...</RoomProvider>
```

```tsx
declare global {
  interface Liveblocks {
    Presence: {
      cursor: { x: number; y: number },
      foo?: string,
    }
  }
}

// ❌ Now a TS error: missing mandatory `initialPresence` prop
<RoomProvider>...</RoomProvider>

// ❌ Now a TS error: missing field `cursor`
<RoomProvider initialPresence={{}}>...</RoomProvider>
```

```tsx
declare global {
  interface Liveblocks {
    Presence: {
      cursor?: { x: number; y: number },  // 👈 Only changed this line
      foo?: string,
    }
  }
}

// ✅ Now perfectly fine!
<RoomProvider>...</RoomProvider>

// ✅ Now perfectly fine!
<RoomProvider initialPresence={{}}>...</RoomProvider>
```

Same logic applies to the `initialStorage` prop.
