### PR TITLE
Add missing type exports in `@liveblocks/yjs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Count whitespace as empty to prevent posting empty comments.
 - Prevent clearing the composer if it's not handled. (via `onComposerSubmit`)
 
+### `@liveblocks/yjs`
+
+- Add missing type exports
+
 ## v2.0.2
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -21,16 +21,21 @@ export type {
   CommentEditedEvent,
   CommentReactionAdded,
   CommentReactionRemoved,
+  CustomNotificationEvent,
   NotificationEvent,
   RoomCreatedEvent,
   RoomDeletedEvent,
   StorageUpdatedEvent,
+  TextMentionNotificationEvent,
   ThreadCreatedEvent,
+  ThreadDeletedEvent,
   ThreadMetadataUpdatedEvent,
+  ThreadNotificationEvent,
   UserEnteredEvent,
   UserLeftEvent,
   WebhookEvent,
   WebhookRequest,
+  YDocUpdatedEvent,
 } from "./webhooks";
 export { WebhookHandler } from "./webhooks";
 export type {


### PR DESCRIPTION
Fixes #1726.
