### PR TITLE
Fix regression: use default `{}` (empty record) if no value is passed at runtime

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -408,7 +408,10 @@ export function createClient<U extends BaseUserMeta = DU>(
     M extends BaseMetadata,
   >(
     roomId: string,
-    options: EnterOptions<NoInfr<P>, NoInfr<S>>
+    ...args: OptionalTupleUnless<
+      P & S,
+      [options: EnterOptions<NoInfr<P>, NoInfr<S>>]
+    >
   ): {
     room: Room<P, S, U, E, M>;
     leave: () => void;
@@ -418,6 +421,7 @@ export function createClient<U extends BaseUserMeta = DU>(
       return leaseRoom(existing);
     }
 
+    const options = args[0] ?? ({} as EnterOptions<P, S>);
     const initialPresence =
       (typeof options.initialPresence === "function"
         ? options.initialPresence(roomId)


### PR DESCRIPTION
Calling `.enterRoom('my-room')` (without options) would actually fail at runtime, even though type-wise it looked correct. This PR fixes that so that it also works at runtime.