### PR TITLE
Avoid legacy APIs in examples

### DIFF
--- a/examples/nuxtjs-live-avatars/app.vue
+++ b/examples/nuxtjs-live-avatars/app.vue
@@ -84,7 +84,7 @@ export default {
     this._room = room;
     this._leave = leave;
     this._unsubscribeOthers = room.events.others.subscribe(this.onOthersChange);
-    this._unsubscribeSelf = room.events.self.subscribe(this.onStatusChange);
+    this._unsubscribeSelf = room.events.self.subscribe(this.onSelfChange);
   },
   destroyed() {
     this._unsubscribeOthers();
@@ -101,7 +101,7 @@ export default {
         name: user.info?.name,
       }));
     },
-    onStatusChange(self) {
+    onSelfChange(self) {
       this.currentUser = self;
     },
   },

--- a/examples/nuxtjs-live-avatars/app.vue
+++ b/examples/nuxtjs-live-avatars/app.vue
@@ -83,19 +83,16 @@ export default {
     const { room, leave } = client.enterRoom(roomId);
     this._room = room;
     this._leave = leave;
-    this._unsubscribeOthers = room.subscribe("others", this.onOthersChange);
-    this._unsubscribeConnection = room.subscribe(
-      "connection",
-      this.onConnectionChange
-    );
+    this._unsubscribeOthers = room.events.others.subscribe(this.onOthersChange);
+    this._unsubscribeSelf = room.events.self.subscribe(this.onStatusChange);
   },
   destroyed() {
     this._unsubscribeOthers();
-    this._unsubscribeConnection();
+    this._unsubscribeSelf();
     this._leave();
   },
   methods: {
-    onOthersChange(others) {
+    onOthersChange({ others }) {
       // The avatar and name are coming from the authentication endpoint
       // See api.js for and https://liveblocks.io/docs/api-reference/liveblocks-node#authorize for more information
       this.others = others.map((user) => ({
@@ -104,8 +101,8 @@ export default {
         name: user.info?.name,
       }));
     },
-    onConnectionChange() {
-      this.currentUser = this._room.getSelf();
+    onStatusChange(self) {
+      this.currentUser = self;
     },
   },
 };

--- a/examples/sveltekit-live-avatars/src/components/App.svelte
+++ b/examples/sveltekit-live-avatars/src/components/App.svelte
@@ -15,18 +15,18 @@
   let currentUser = room.getSelf();
 
   // Subscribe to further changes
-  const unsubscribeOthers = room.subscribe("others", (others) => {
+  const unsubscribeOthers = room.events.others.subscribe(({ others }) => {
     users = others;
   });
 
-  const unsubscribeConnection = room.subscribe("connection", () => {
-    currentUser = room.getSelf();
+  const unsubscribeSelf = room.events.self.subscribe((self) => {
+    currentUser = self;
   });
 
   // Unsubscribe when unmounting
   onDestroy(() => {
     unsubscribeOthers();
-    unsubscribeConnection();
+    unsubscribeSelf();
   });
 
   $: hasMoreUsers = users ? [...users].length > 3 : false;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3164,8 +3164,7 @@ function isRoomEventName(value: string): value is RoomEventName {
     value === "history" ||
     value === "status" ||
     value === "storage-status" ||
-    value === "lost-connection" ||
-    value === "connection"
+    value === "lost-connection"
   );
 }
 


### PR DESCRIPTION
I found these two examples were still using legacy APIs. Specifically `room.subscribe("connection")` no longer exists. At first, I switched these over to `room.subscribe("status")` (which replaces the legacy socket connection API). However, when I did I noticed a small regression. When the `"connected"` event is emitted, the `.getSelf()` will still return `null`. The value of `.getSelf()` is only updated _after_ that connected event happens.

This may be a regression. I'd have to trace back to where it has been introduced.

However, we also have our event hub API, which is much nicer to use than the `.subscribe("...")` API, and it has a `room.events.self.subscribe()` which is triggered whenever "self" gets updated. This is a much nicer event to listen to anyway (than relying on `"status"` updates), so I've fixed that in these examples.

@CTNicholas Do you want to give these examples a quick test to validate I updated them correctly?
