### PR TITLE
Prevent `LiveblocksProvider` nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - In `<RoomProvider>`, the props `initialPresence` and `initialStorage` are now
   only mandatory if your custom type requires them to be.
+- Nesting `<LiveblocksProvider>`s will now throw to prevent incorrect usage.
 
 ### `@liveblocks/react-ui`
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -325,6 +325,7 @@ function makeLiveblocksContextBundle<
   // NOTE: This version of the LiveblocksProvider does _not_ take any props.
   // This is because we already have a client bound to it.
   function LiveblocksProvider(props: PropsWithChildren) {
+    useEnsureNoLiveblocksProvider();
     return (
       <ClientContext.Provider value={client}>
         {props.children}
@@ -742,6 +743,18 @@ export function createSharedContext<U extends BaseUserMeta>(
 /**
  * @private This is an internal API.
  */
+function useEnsureNoLiveblocksProvider() {
+  const existing = useClientOrNull();
+  if (existing !== null) {
+    throw new Error(
+      "You can have at most one LiveblocksProvider in your React tree. Nesting is not supported."
+    );
+  }
+}
+
+/**
+ * @private This is an internal API.
+ */
 export function useClientOrNull<U extends BaseUserMeta>() {
   return useContext(ClientContext) as Client<U> | null;
 }
@@ -762,6 +775,7 @@ export function useClient<U extends BaseUserMeta>() {
 export function LiveblocksProviderWithClient(
   props: PropsWithChildren<{ client: OpaqueClient }>
 ) {
+  useEnsureNoLiveblocksProvider();
   return (
     <ClientContext.Provider value={props.client}>
       {props.children}

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -743,9 +743,9 @@ export function createSharedContext<U extends BaseUserMeta>(
 /**
  * @private This is an internal API.
  */
-function useEnsureNoLiveblocksProvider() {
+function useEnsureNoLiveblocksProvider(options?: { allowNesting?: boolean }) {
   const existing = useClientOrNull();
-  if (existing !== null) {
+  if (!options?.allowNesting && existing !== null) {
     throw new Error(
       "You can have at most one LiveblocksProvider in your React tree. Nesting is not supported."
     );
@@ -770,12 +770,18 @@ export function useClient<U extends BaseUserMeta>() {
 }
 
 /**
- * @private
+ * @private This is a private API.
  */
 export function LiveblocksProviderWithClient(
-  props: PropsWithChildren<{ client: OpaqueClient }>
+  props: PropsWithChildren<{
+    client: OpaqueClient;
+
+    // Private flag, used only to skip the nesting check if this is
+    // a LiveblocksProvider created implicitly by a factory-bound RoomProvider.
+    allowNesting?: boolean;
+  }>
 ) {
-  useEnsureNoLiveblocksProvider();
+  useEnsureNoLiveblocksProvider(props);
   return (
     <ClientContext.Provider value={props.client}>
       {props.children}

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -529,8 +529,15 @@ function makeRoomContextBundle<
   function RoomProvider_withImplicitLiveblocksProvider(
     props: RoomProviderProps<P, S>
   ) {
+    // NOTE: Normally, nesting LiveblocksProvider is not allowed. This
+    // factory-bound version of the RoomProvider will create an implicit
+    // LiveblocksProvider. This means that if an end user nests this
+    // RoomProvider under a LiveblocksProvider context, that would be an error.
+    // However, we'll allow that nesting only in this specific situation, and
+    // only because this wrapper will keep the Liveblocks context and the Room
+    // context consistent internally.
     return (
-      <LiveblocksProviderWithClient client={client}>
+      <LiveblocksProviderWithClient client={client} allowNesting>
         <RoomProvider {...props} />
       </LiveblocksProviderWithClient>
     );


### PR DESCRIPTION
It makes no sense to nest `LiveblocksProvider`s, and we should prevent it with an error if it would ever happen.

Currently this is possible, but leads to unpredictable behavior.

```tsx
<LiveblocksProvider /* options */>
  <LiveblocksProvider /* other options */>
    <MyApp />
  </LiveblocksProvider>
</LiveblocksProvider>
```

Things would get even weirder here, so all in all better to prevent it entirely:

```tsx
<LiveblocksProvider /* options */>
  <RoomProvider id="my-room">
    <LiveblocksProvider /* other options */>
      <MyApp />
    </LiveblocksProvider>
  </RoomProvider>
</LiveblocksProvider>
```

Fixes LB-873.
