### PR TITLE
Internal variable rename for clarification

### DIFF
--- a/packages/liveblocks-react-lexical/rollup.config.ts
+++ b/packages/liveblocks-react-lexical/rollup.config.ts
@@ -65,7 +65,7 @@ function createMainConfig(format: "cjs" | "esm"): RollupOptions {
       replace({
         values: {
           __VERSION__: JSON.stringify(pkg.version),
-          TSUP_FORMAT: JSON.stringify(format),
+          ROLLUP_FORMAT: JSON.stringify(format),
         },
         preventAssignment: true,
       }),

--- a/packages/liveblocks-react-lexical/src/version.ts
+++ b/packages/liveblocks-react-lexical/src/version.ts
@@ -1,6 +1,6 @@
 declare const __VERSION__: string;
-declare const TSUP_FORMAT: string;
+declare const ROLLUP_FORMAT: string;
 
 export const PKG_NAME = "@liveblocks/react-lexical";
 export const PKG_VERSION = typeof __VERSION__ === "string" && __VERSION__;
-export const PKG_FORMAT = typeof TSUP_FORMAT === "string" && TSUP_FORMAT;
+export const PKG_FORMAT = typeof ROLLUP_FORMAT === "string" && ROLLUP_FORMAT;

--- a/packages/liveblocks-react-ui/rollup.config.ts
+++ b/packages/liveblocks-react-ui/rollup.config.ts
@@ -57,7 +57,7 @@ function createMainConfig(format: "cjs" | "esm"): RollupOptions {
       replace({
         values: {
           __VERSION__: JSON.stringify(pkg.version),
-          TSUP_FORMAT: JSON.stringify(format),
+          ROLLUP_FORMAT: JSON.stringify(format),
         },
         preventAssignment: true,
       }),

--- a/packages/liveblocks-react-ui/src/version.ts
+++ b/packages/liveblocks-react-ui/src/version.ts
@@ -1,6 +1,6 @@
 declare const __VERSION__: string;
-declare const TSUP_FORMAT: string;
+declare const ROLLUP_FORMAT: string;
 
 export const PKG_NAME = "@liveblocks/react-ui";
 export const PKG_VERSION = typeof __VERSION__ === "string" && __VERSION__;
-export const PKG_FORMAT = typeof TSUP_FORMAT === "string" && TSUP_FORMAT;
+export const PKG_FORMAT = typeof ROLLUP_FORMAT === "string" && ROLLUP_FORMAT;


### PR DESCRIPTION
This PR renames `TSUP_FORMAT` to `ROLLUP_FORMAT` in Rollup-built projects to avoid confusion.