### PR TITLE
Re-enable some tsd tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dependency-cruiser": "^16.3.2",
         "prettier": "^3.2.5",
         "publint": "^0.2.8",
-        "tsd": "^0.31.0",
+        "tsd": "^0.31.1",
         "tsup": "^8.1.0",
         "turbo": "^1.13.4",
         "typescript": "<4.8"
@@ -25833,9 +25833,9 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.31.0.tgz",
-      "integrity": "sha512-yjBiQ5n8OMv/IZOuhDjBy0ZLCoJ7rky/RxRh5W4sJ0oNNCU/kf6s3puPAkGNi59PptDdkcpUm+RsKSdjR2YbNg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.31.1.tgz",
+      "integrity": "sha512-sSL84A0SFwx2xGMWrxlGaarKFSQszWjJS2vgNDDLwatytzg2aq6ShlwHsBYxRNmjzXISODwMva5ZOdAg/4AoOA==",
       "dev": true,
       "dependencies": {
         "@tsd/typescript": "~5.4.3",
@@ -48781,9 +48781,9 @@
       }
     },
     "tsd": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.31.0.tgz",
-      "integrity": "sha512-yjBiQ5n8OMv/IZOuhDjBy0ZLCoJ7rky/RxRh5W4sJ0oNNCU/kf6s3puPAkGNi59PptDdkcpUm+RsKSdjR2YbNg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.31.1.tgz",
+      "integrity": "sha512-sSL84A0SFwx2xGMWrxlGaarKFSQszWjJS2vgNDDLwatytzg2aq6ShlwHsBYxRNmjzXISODwMva5ZOdAg/4AoOA==",
       "dev": true,
       "requires": {
         "@tsd/typescript": "~5.4.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependency-cruiser": "^16.3.2",
     "prettier": "^3.2.5",
     "publint": "^0.2.8",
-    "tsd": "^0.31.0",
+    "tsd": "^0.31.1",
     "tsup": "^8.1.0",
     "turbo": "^1.13.4",
     "typescript": "<4.8"

--- a/packages/liveblocks-node/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/augmentation.test-d.ts
@@ -57,9 +57,7 @@ async () => {
   {
     expectError(await client.prepareSession("user-123"));
     expectError(await client.prepareSession("user-123", {}));
-    // TODO: Re-enable this when tsd supports the TS2739 error
-    // TODO See https://github.com/tsdjs/tsd/issues/215
-    // expectError(await client.prepareSession("user-123", { userInfo: {} }));
+    expectError(await client.prepareSession("user-123", { userInfo: {} }));
     expectError(
       await client.prepareSession("user-123", { userInfo: { name: "Vincent" } })
     );
@@ -91,9 +89,7 @@ async () => {
   {
     expectError(await client.identifyUser("user-123"));
     expectError(await client.identifyUser("user-123", {}));
-    // TODO: Re-enable this when tsd supports the TS2739 error
-    // TODO See https://github.com/tsdjs/tsd/issues/215
-    // expectError(await client.identifyUser("user-123", { userInfo: {} }));
+    expectError(await client.identifyUser("user-123", { userInfo: {} }));
     expectError(
       await client.identifyUser("user-123", { userInfo: { name: "Vincent" } })
     );
@@ -266,15 +262,13 @@ async () => {
     // Invalid calls
     expectError(client.editThreadMetadata({ roomId }));
     expectError(client.editThreadMetadata({ threadId }));
-    // TODO: Uncomment later, when tsd supports ts2739 error code
-    // TODO See https://github.com/tsdjs/tsd/issues/215
-    // expectError(
-    //   client.editThreadMetadata({
-    //     roomId: "my-room",
-    //     threadId: "th_xxx",
-    //     data: {},
-    //   })
-    // );
+    expectError(
+      client.editThreadMetadata({
+        roomId: "my-room",
+        threadId: "th_xxx",
+        data: {},
+      })
+    );
     expectError(
       client.editThreadMetadata({ roomId, threadId, data: { userId } })
     );

--- a/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
@@ -213,15 +213,13 @@ async () => {
     // Invalid calls
     expectError(client.editThreadMetadata({ roomId }));
     expectError(client.editThreadMetadata({ threadId }));
-    // TODO: Uncomment later, when tsd supports ts2739 error code
-    // TODO See https://github.com/tsdjs/tsd/issues/215
-    // expectError(
-    //   client.editThreadMetadata({
-    //     roomId: "my-room",
-    //     threadId: "th_xxx",
-    //     data: {},
-    //   })
-    // );
+    expectError(
+      client.editThreadMetadata({
+        roomId: "my-room",
+        threadId: "th_xxx",
+        data: {},
+      })
+    );
     expectError(
       client.editThreadMetadata({ roomId, threadId, data: { userId } })
     );

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -106,22 +106,18 @@ declare global {
   const RoomProvider = classic.RoomProvider;
 
   // Missing mandatory props is an error
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   <RoomProvider /* no room id */>
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    <RoomProvider /* no room id */>
+      <div />
+    </RoomProvider>
+  );
 
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   // Missing initialPresence is an error
-  //   <RoomProvider id="my-room">
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    // Missing initialPresence is an error
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     // Missing mandatory initialStorage is an error
@@ -183,22 +179,18 @@ declare global {
   const RoomProvider = suspense.RoomProvider;
 
   // Missing mandatory props is an error
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   <RoomProvider /* no room id */>
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    <RoomProvider /* no room id */>
+      <div />
+    </RoomProvider>
+  );
 
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   // Missing initialPresence is an error
-  //   <RoomProvider id="my-room">
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    // Missing initialPresence is an error
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     // Missing mandatory initialStorage is an error

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -118,22 +118,18 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   const RoomProvider = ctx.RoomProvider;
 
   // Missing mandatory props is an error
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   <RoomProvider>
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    <RoomProvider>
+      <div />
+    </RoomProvider>
+  );
 
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   // Missing mandatory initialPresence + initialStorage
-  //   <RoomProvider id="my-room">
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    // Missing mandatory initialPresence + initialStorage
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     // Missing mandatory initialStorage
@@ -188,21 +184,17 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
   const RoomProvider = ctx.suspense.RoomProvider;
 
   // Missing mandatory props is an error
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   <RoomProvider>
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    <RoomProvider>
+      <div />
+    </RoomProvider>
+  );
 
-  // TODO Add back when tsd supports error ts2739
-  // TODO See https://github.com/tsdjs/tsd/issues/215
-  // expectError(
-  //   <RoomProvider id="my-room">
-  //     <div />
-  //   </RoomProvider>
-  // );
+  expectError(
+    <RoomProvider id="my-room">
+      <div />
+    </RoomProvider>
+  );
 
   expectError(
     // Missing mandatory initialStorage


### PR DESCRIPTION
We can re-enable these type-level tests, [now that tsd supports them](https://github.com/tsdjs/tsd/pull/216).
