### PR TITLE
Don't try to write missing `initialStorage` keys if current user has no write access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v2.0.4 (not released yet)
+
+### `@liveblocks/client`
+
+- Don’t attempt to write missing initialStorage keys if the current user has no
+  write access to storage. This will no longer throw, but issue a warning
+  message in the console.
+
 ## v2.0.3
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1815,11 +1815,19 @@ export function createRoom<
       context.root = LiveObject._fromItems<S>(message.items, pool);
     }
 
+    const canWrite = self.current?.canWrite ?? true;
+
     // Populate missing top-level keys using `initialStorage`
     const stackSizeBefore = context.undoStack.length;
     for (const key in context.initialStorage) {
       if (context.root.get(key) === undefined) {
-        context.root.set(key, cloneLson(context.initialStorage[key]));
+        if (canWrite) {
+          context.root.set(key, cloneLson(context.initialStorage[key]));
+        } else {
+          console.warn(
+            `Attempted to populate missing storage key '${key}', but current user has no write access`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
This PR changes the client so that it won’t attempt to write missing `initialStorage` keys if the current user has no write access to storage. This will no longer throw, but issue a warning message in the console. This came up in [this support question](https://discord.com/channels/913109211746009108/1251201132538363924/1251201132538363924).

Fixes LB-888.