### PR TITLE
useDeleteThread

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1198,7 +1198,7 @@ function createCommentsApi<M extends BaseMetadata>(
   }
 
   async function deleteThread({ threadId }: { threadId: string }) {
-    await fetchCommentsApi(`/threads/${encodeURIComponent(threadId)}`, {
+    await fetchJson(`/threads/${encodeURIComponent(threadId)}`, {
       method: "DELETE",
     });
   }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -484,6 +484,7 @@ type CommentsApi<M extends BaseMetadata> = {
     metadata: M | undefined;
     body: CommentBody;
   }): Promise<ThreadData<M>>;
+  deleteThread(options: { threadId: string }): Promise<void>;
   editThreadMetadata(options: {
     metadata: Patchable<M>;
     threadId: string;
@@ -1196,6 +1197,12 @@ function createCommentsApi<M extends BaseMetadata>(
     return convertToThreadData(thread);
   }
 
+  async function deleteThread({ threadId }: { threadId: string }) {
+    await fetchCommentsApi(`/threads/${encodeURIComponent(threadId)}`, {
+      method: "DELETE",
+    });
+  }
+
   async function editThreadMetadata({
     metadata,
     threadId,
@@ -1335,6 +1342,7 @@ function createCommentsApi<M extends BaseMetadata>(
     getThreads,
     getThread,
     createThread,
+    deleteThread,
     editThreadMetadata,
     createComment,
     editComment,

--- a/packages/liveblocks-core/src/store.ts
+++ b/packages/liveblocks-core/src/store.ts
@@ -461,7 +461,7 @@ export function applyOptimisticUpdates<M extends BaseMetadata>(
         break;
       }
 
-      case "delete-thread":
+      case "delete-thread": {
         const thread = result.threads[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
@@ -475,6 +475,7 @@ export function applyOptimisticUpdates<M extends BaseMetadata>(
           comments: [],
         };
         break;
+      }
       case "add-reaction": {
         const thread = result.threads[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update

--- a/packages/liveblocks-core/src/store.ts
+++ b/packages/liveblocks-core/src/store.ts
@@ -21,6 +21,7 @@ import type { RoomNotificationSettings } from "./types/RoomNotificationSettings"
 
 type OptimisticUpdate<M extends BaseMetadata> =
   | CreateThreadOptimisticUpdate<M>
+  | DeleteThreadOptimisticUpdate
   | EditThreadMetadataOptimisticUpdate<M>
   | CreateCommentOptimisticUpdate
   | EditCommentOptimisticUpdate
@@ -36,6 +37,14 @@ type CreateThreadOptimisticUpdate<M extends BaseMetadata> = {
   id: string;
   roomId: string;
   thread: ThreadData<M>;
+};
+
+type DeleteThreadOptimisticUpdate = {
+  type: "delete-thread";
+  id: string;
+  roomId: string;
+  threadId: string;
+  deletedAt: Date;
 };
 
 type EditThreadMetadataOptimisticUpdate<M extends BaseMetadata> = {
@@ -451,6 +460,21 @@ export function applyOptimisticUpdates<M extends BaseMetadata>(
 
         break;
       }
+
+      case "delete-thread":
+        const thread = result.threads[optimisticUpdate.threadId];
+        // If the thread doesn't exist in the cache, we do not apply the update
+        if (thread === undefined) {
+          break;
+        }
+
+        result.threads[optimisticUpdate.threadId] = {
+          ...result.threads[optimisticUpdate.threadId],
+          deletedAt: optimisticUpdate.deletedAt,
+          updatedAt: optimisticUpdate.deletedAt,
+          comments: [],
+        };
+        break;
       case "add-reaction": {
         const thread = result.threads[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update

--- a/packages/liveblocks-react/src/__tests__/_restMocks.ts
+++ b/packages/liveblocks-react/src/__tests__/_restMocks.ts
@@ -54,6 +54,16 @@ export function mockCreateThread(
   );
 }
 
+export function mockDeleteThread(
+  params: { threadId: string },
+  resolver: ResponseResolver<RestRequest<never, never>, RestContext, any>
+) {
+  return rest.delete(
+    `https://api.liveblocks.io/v2/c/rooms/room-id/threads/${params.threadId}`,
+    resolver
+  );
+}
+
 export function mockCreateComment(
   params: { threadId: string },
   resolver: ResponseResolver<

--- a/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
@@ -54,7 +54,7 @@ describe("useDeleteThread", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -103,7 +103,7 @@ describe("useDeleteThread", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),

--- a/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
@@ -1,0 +1,124 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { setupServer } from "msw/node";
+import React from "react";
+
+import { dummyThreadData } from "./_dummies";
+import MockWebSocket from "./_MockWebSocket";
+import { mockDeleteThread, mockGetThreads } from "./_restMocks";
+import { createRoomContextForTest } from "./_utils";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+beforeEach(() => {
+  MockWebSocket.reset();
+});
+
+afterEach(() => {
+  MockWebSocket.reset();
+  server.resetHandlers();
+});
+
+afterAll(() => server.close());
+
+describe("useDeleteThread", () => {
+  test("should delete a thread optimistically", async () => {
+    // const fakeCreatedAt = addMinutes(new Date(), 5);
+    const threads = [dummyThreadData()];
+    server.use(
+      mockGetThreads(async (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: threads,
+            inboxNotifications: [],
+            deletedThreads: [],
+            deletedInboxNotifications: [],
+            meta: {
+              requestedAt: new Date().toISOString(),
+            },
+          })
+        );
+      }),
+      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
+        return res(ctx.status(204));
+      })
+    );
+
+    const { RoomProvider, useThreads, useDeleteThread } =
+      createRoomContextForTest();
+
+    const { result, unmount } = renderHook(
+      () => ({
+        threads: useThreads().threads,
+        deleteThread: useDeleteThread(),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current.threads).toBeUndefined();
+
+    await waitFor(() => expect(result.current.threads).toEqual(threads));
+
+    await act(() => result.current.deleteThread(threads[0].id));
+
+    await waitFor(() => expect(result.current.threads).toEqual([]));
+
+    unmount();
+  });
+
+  test("should rollback optimistic deletion if server fails", async () => {
+    const threads = [dummyThreadData()];
+    server.use(
+      mockGetThreads(async (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: threads,
+            inboxNotifications: [],
+            deletedThreads: [],
+            deletedInboxNotifications: [],
+            meta: {
+              requestedAt: new Date().toISOString(),
+            },
+          })
+        );
+      }),
+      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
+        return res(ctx.status(500));
+      })
+    );
+
+    const { RoomProvider, useThreads, useDeleteThread } =
+      createRoomContextForTest();
+
+    const { result, unmount } = renderHook(
+      () => ({
+        threads: useThreads().threads,
+        deleteThread: useDeleteThread(),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id="room-id" initialPresence={{}}>
+            {children}
+          </RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current.threads).toBeUndefined();
+
+    await waitFor(() => expect(result.current.threads).toEqual(threads));
+
+    await act(() => result.current.deleteThread(threads[0].id));
+
+    await waitFor(() => expect(result.current.threads).toEqual(threads));
+
+    unmount();
+  });
+});

--- a/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
@@ -65,7 +65,10 @@ describe("useDeleteThread", () => {
 
     await waitFor(() => expect(result.current.threads).toEqual(threads));
 
-    await act(() => result.current.deleteThread(threads[0].id));
+    await act(() => {
+      result.current.deleteThread(threads[0].id);
+      return null;
+    });
 
     await waitFor(() => expect(result.current.threads).toEqual([]));
 
@@ -75,8 +78,8 @@ describe("useDeleteThread", () => {
   test("should rollback optimistic deletion if server fails", async () => {
     const threads = [dummyThreadData()];
     server.use(
-      mockGetThreads(async (_req, res, ctx) => {
-        return res(
+      mockGetThreads(async (_req, res, ctx) =>
+        res(
           ctx.json({
             data: threads,
             inboxNotifications: [],
@@ -86,11 +89,11 @@ describe("useDeleteThread", () => {
               requestedAt: new Date().toISOString(),
             },
           })
-        );
-      }),
-      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
-        return res(ctx.status(500));
-      })
+        )
+      ),
+      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) =>
+        res(ctx.status(500))
+      )
     );
 
     const { RoomProvider, useThreads, useDeleteThread } =
@@ -114,7 +117,10 @@ describe("useDeleteThread", () => {
 
     await waitFor(() => expect(result.current.threads).toEqual(threads));
 
-    await act(() => result.current.deleteThread(threads[0].id));
+    await act(() => {
+      result.current.deleteThread(threads[0].id);
+      return null;
+    });
 
     await waitFor(() => expect(result.current.threads).toEqual(threads));
 

--- a/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
@@ -24,7 +24,6 @@ afterAll(() => server.close());
 
 describe("useDeleteThread", () => {
   test("should delete a thread optimistically", async () => {
-    // const fakeCreatedAt = addMinutes(new Date(), 5);
     const threads = [dummyThreadData()];
     server.use(
       mockGetThreads(async (_req, res, ctx) => {

--- a/packages/liveblocks-react/src/comments/errors.ts
+++ b/packages/liveblocks-react/src/comments/errors.ts
@@ -16,6 +16,19 @@ export class CreateThreadError<M extends BaseMetadata> extends Error {
   }
 }
 
+export class DeleteThreadError extends Error {
+  constructor(
+    public cause: Error,
+    public context: {
+      roomId: string;
+      threadId: string;
+    }
+  ) {
+    super("Delete thread failed.");
+    this.name = "DeleteThreadError";
+  }
+}
+
 export class EditThreadMetadataError<M extends BaseMetadata> extends Error {
   constructor(
     public cause: Error,

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -32,6 +32,7 @@ export {
   useCanUndo,
   useCreateComment,
   useCreateThread,
+  useDeleteThread,
   useDeleteComment,
   useEditComment,
   useEditThreadMetadata,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -66,6 +66,7 @@ import {
   MarkInboxNotificationAsReadError,
   RemoveReactionError,
   UpdateNotificationSettingsError,
+  DeleteThreadError,
 } from "./comments/errors";
 import { createCommentId, createThreadId } from "./comments/lib/createIds";
 import { selectNotificationSettings } from "./comments/lib/select-notification-settings";
@@ -538,6 +539,7 @@ function makeRoomContextBundle<
     // context consistent internally.
     return (
       <LiveblocksProviderWithClient client={client} allowNesting>
+        {/* Why type error? */}
         <RoomProvider {...props} />
       </LiveblocksProviderWithClient>
     );
@@ -581,6 +583,7 @@ function makeRoomContextBundle<
     useThreads,
 
     useCreateThread,
+    useDeleteThread,
     useEditThreadMetadata,
     useCreateComment,
     useEditComment,
@@ -637,6 +640,7 @@ function makeRoomContextBundle<
       useThreads: useThreadsSuspense,
 
       useCreateThread,
+      useDeleteThread,
       useEditThreadMetadata,
       useCreateComment,
       useEditComment,
@@ -1384,6 +1388,59 @@ function useCreateThread<M extends BaseMetadata>(): (
       );
 
       return newThread;
+    },
+    [client, room]
+  );
+}
+
+function useDeleteThread(): (threadId: string) => void {
+  const client = useClient();
+  const room = useRoom();
+  return React.useCallback(
+    (threadId: string): void => {
+      const optimisticUpdateId = nanoid();
+
+      const { store, onMutationFailure } = getExtrasForClient(client);
+      store.pushOptimisticUpdate({
+        type: "delete-thread",
+        id: optimisticUpdateId,
+        roomId: room.id,
+        threadId,
+        deletedAt: new Date(),
+      });
+
+      const commentsAPI = room[kInternal].comments;
+      commentsAPI.deleteThread({ threadId }).then(
+        () => {
+          store.set((state) => {
+            const existingThread = state.threads[threadId];
+            if (existingThread === undefined) {
+              return state;
+            }
+
+            return {
+              ...state,
+              threads: {
+                ...state.threads,
+                [threadId]: {
+                  ...existingThread,
+                  updatedAt: new Date(),
+                  deletedAt: new Date(),
+                },
+              },
+              optimisticUpdates: state.optimisticUpdates.filter(
+                (update) => update.id !== optimisticUpdateId
+              ),
+            };
+          });
+        },
+        (err: Error) =>
+          onMutationFailure(
+            err,
+            optimisticUpdateId,
+            (err) => new DeleteThreadError(err, { roomId: room.id, threadId })
+          )
+      );
     },
     [client, room]
   );
@@ -2329,6 +2386,8 @@ const _useAddReaction: DefaultRoomContextBundle["useAddReaction"] =
 const _useMutation: DefaultRoomContextBundle["useMutation"] = useMutation;
 const _useCreateThread: DefaultRoomContextBundle["useCreateThread"] =
   useCreateThread;
+const _useDeleteThread: DefaultRoomContextBundle["useDeleteThread"] =
+  useDeleteThread;
 const _useEditThreadMetadata: DefaultRoomContextBundle["useEditThreadMetadata"] =
   useEditThreadMetadata;
 const _useEventListener: DefaultRoomContextBundle["useEventListener"] =
@@ -2371,6 +2430,7 @@ export {
   useCommentsErrorListener,
   useCreateComment,
   _useCreateThread as useCreateThread,
+  _useDeleteThread as useDeleteThread,
   useDeleteComment,
   useEditComment,
   _useEditThreadMetadata as useEditThreadMetadata,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -61,12 +61,12 @@ import {
   CreateCommentError,
   CreateThreadError,
   DeleteCommentError,
+  DeleteThreadError,
   EditCommentError,
   EditThreadMetadataError,
   MarkInboxNotificationAsReadError,
   RemoveReactionError,
   UpdateNotificationSettingsError,
-  DeleteThreadError,
 } from "./comments/errors";
 import { createCommentId, createThreadId } from "./comments/lib/createIds";
 import { selectNotificationSettings } from "./comments/lib/select-notification-settings";
@@ -2430,8 +2430,8 @@ export {
   useCommentsErrorListener,
   useCreateComment,
   _useCreateThread as useCreateThread,
-  _useDeleteThread as useDeleteThread,
   useDeleteComment,
+  _useDeleteThread as useDeleteThread,
   useEditComment,
   _useEditThreadMetadata as useEditThreadMetadata,
   useErrorListener,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -539,7 +539,6 @@ function makeRoomContextBundle<
     // context consistent internally.
     return (
       <LiveblocksProviderWithClient client={client} allowNesting>
-        {/* Why type error? */}
         <RoomProvider {...props} />
       </LiveblocksProviderWithClient>
     );

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -30,6 +30,7 @@ export {
   useCanUndo,
   useCreateComment,
   useCreateThread,
+  useDeleteThread,
   useDeleteComment,
   useEditComment,
   useEditThreadMetadata,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -730,6 +730,16 @@ type RoomContextBundleCommon<
   useCreateThread(): (options: CreateThreadOptions<M>) => ThreadData<M>;
 
   /**
+   * Returns a function that deletes a thread.
+   * If the thread has comments, they will also be deleted.
+   *
+   * @example
+   * const deleteThread = useDeleteThread();
+   * deleteThread("th_xxx");
+   */
+  useDeleteThread(): (threadId: string) => void;
+
+  /**
    * Returns a function that edits a thread's metadata.
    * To delete an existing metadata property, set its value to `null`.
    *


### PR DESCRIPTION
### Description

Adds a `useDeleteThread` hook. Only the thread owner can delete the thread. The thread owner is the user of the first comment in the thread.

```tsx
function Example() {
  const { threads } = useThreads();
  const self = useSelf();

  const deleteThread = useDeleteThread();

  return (
    <main>
      {threads.map((thread) => (
        <>
          {self.id === thread.comments[0].userId ? (
            <button onClick={() => deleteThread(thread.id)}>
              Delete thread below
            </button>
          ) : null}
          <Thread key={thread.id} thread={thread} className="thread" />
        </>
      ))}
      <Composer className="composer" />
    </main>
  );
}
```

<img width="657" alt="Screenshot 2024-06-19 at 3 46 42 PM" src="https://github.com/liveblocks/liveblocks/assets/6947265/9ca482b7-1606-45e6-b7d5-c5cca1e508af">
<img width="672" alt="Screenshot 2024-06-19 at 3 46 30 PM" src="https://github.com/liveblocks/liveblocks/assets/6947265/b32a68b8-e009-441a-a269-fb94f708a60a">
