### PR TITLE
Cleans up all remaining empty `initialPresence={{}}`

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -625,7 +625,7 @@ Note that it’s possible to [add types to your room](#typing-your-data).
   <PropertiesListItem name="roomId" type="string" required>
     The ID of the room you’re connecting to.
   </PropertiesListItem>
-  <PropertiesListItem name="options.initialPresence" type="JsonObject" required>
+  <PropertiesListItem name="options.initialPresence" type="JsonObject">
     The initial Presence of the user entering the room. Each user has their own
     presence, and this is readable for all other connected users. A user’s
     Presence resets every time they disconnect. This object must be

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -422,7 +422,7 @@ resolveUsers: async ({ userIds }) => {
 
 You can also return custom information, for example, a user’s `color`:
 
-```ts highlight="9"
+```ts
 resolveUsers: async ({ userIds }) => {
   // ["marc@example.com"];
   console.log(userIds);
@@ -431,7 +431,9 @@ resolveUsers: async ({ userIds }) => {
     {
       name: "Marc",
       avatar: "https://example.com/marc.png",
+      // +++
       color: "purple",
+      // +++
     },
   ];
 };
@@ -654,8 +656,9 @@ cursor coordinates, or their current selection. Each user has their own
 presence, and this is readable for all other connected users. Set your initial
 Presence value by using `initialPresence`.
 
-```ts highlight="2-8"
+```ts
 const { room, leave } = client.enterRoom("my-room-id", {
+  // +++
   initialPresence: {
     cursor: null,
     colors: ["red", "purple"],
@@ -663,6 +666,7 @@ const { room, leave } = client.enterRoom("my-room-id", {
       id: 72426,
     },
   },
+  // +++
 
   // Other options
   // ...
@@ -680,16 +684,18 @@ shapes on a whiteboard, nodes on a flowchart, or text in a form. The first time
 a room is entered, you can set an initial value by using `initialStorage`. Note
 that this value is only read a single time.
 
-```ts highlight="4-9"
+```ts
 import { LiveList, LiveObject } from "@liveblocks/client";
 
 const { room, leave } = client.enterRoom("my-room-id", {
+  // +++
   initialStorage: {
     title: "Untitled",
     shapes: new LiveList([
       new LiveObject({ type: "rectangle", color: "yellow" }),
     ]),
   },
+  // +++
 
   // Other options
   // ...
@@ -959,11 +965,13 @@ so it may be deprecated and replaced with something else.
 
 </Banner>
 
-```ts highlight="4"
+```ts
 room.broadcastEvent(
   { type: "REACTION", emoji: "🔥" },
   {
+    // +++
     shouldQueueEventIfNotReady: true,
+    // +++
   }
 );
 ```
@@ -1268,10 +1276,11 @@ that’s run when another user calls [`Room.broadcastEvent`][]. Provides the
 `event` along with the `user` and their `connectionId` of the user that sent the
 message. Returns an unsubscribe function.
 
-```ts highlight="4-10"
+```ts
 // User 1
 room.broadcastEvent({ type: "REACTION", emoji: "🔥" });
 
+// +++
 // User 2
 const unsubscribe = room.subscribe("event", ({ event, user, connectionId }) => {
   //                                                  ^^^^ Will be User 1
@@ -1279,6 +1288,7 @@ const unsubscribe = room.subscribe("event", ({ event, user, connectionId }) => {
     // Do something
   }
 });
+// +++
 ```
 
 <PropertiesList title="Returns">
@@ -2256,7 +2266,7 @@ temporary.
 
 To type the Storage values you receive, make sure to set your `Storage` type.
 
-```ts highlight="liveblocks.config.ts"
+```ts file="liveblocks.config.ts"
 import { LiveList } from "@liveblocks/client";
 
 declare global {
@@ -3829,39 +3839,47 @@ const { room, leave } = client.getRoom<Presence, Storage, UserMeta, RoomEvent>(
 and other functions. Some of its values are set when
 [typing your room](#typing-your-data), here are some example values:
 
-```ts file="liveblocks.config.ts" highlight="4-6,11-14"
+```ts file="liveblocks.config.ts"
 declare global {
   interface Liveblocks {
     // Each user's Presence
+    // +++
     Presence: {
       cursor: { x: number; y: number };
     };
+    // +++
 
     UserMeta: {
       id: string;
       // Custom user info set when authenticating with a secret key
+      // +++
       info: {
         name: string;
         avatar: string;
       };
+      // +++
     };
   }
 }
 ```
 
-```ts highlight="5-7,9-12"
+```ts
 const { room, leave } = client.enterRoom("my-room-id");
 
 // {
 //   connectionId: 52,
+//   +++
 //   presence: {
 //     cursor: { x: 263, y: 786 },
 //   },
+//   +++
 //   id: "mislav.abha@example.com",
+//   +++
 //   info: {
 //     name: "Mislav Abha",
 //     avatar: "/mislav.png",
 //   },
+//   +++
 //   canWrite: true,
 //   canComment: true,
 // }

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1725,7 +1725,6 @@ function App() {
   return (
     <RoomProvider
       id="my-room-name"
-      initialPresence={{}}
       initialStorage={{ animals: new LiveList(["Fido"]) }}
     >
       {/* children */}
@@ -1811,7 +1810,6 @@ function App() {
   return (
     <RoomProvider
       id="my-room-name"
-      initialPresence={{}}
       initialStorage={{
         people: new LiveMap([
           "alicia",

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -141,16 +141,18 @@ replacement for `Suspense`. This is helpful as our Suspense hooks will throw an
 error when they’re run on the server, and this component avoids this issue by
 always rendering the `fallback` on the server.
 
-```tsx highlight="7-9"
+```tsx
 import { ClientSideSuspense } from "@liveblocks/react/suspense";
 
 function Page() {
   return (
     <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
       <RoomProvider id="my-room-id">
+        +++
         <ClientSideSuspense fallback={<div>Loading…</div>}>
           <App />
         </ClientSideSuspense>
+        +++
       </RoomProvider>
     </LiveblocksProvider>
   );
@@ -164,7 +166,7 @@ Instead of wrapping your entire Liveblocks application inside a single
 different parts of your application, and each will work as a loading fallback
 for any components further down your tree.
 
-```tsx highlight="10-12,16-18"
+```tsx
 import { ClientSideSuspense } from "@liveblocks/react/suspense";
 
 function Page() {
@@ -174,15 +176,19 @@ function Page() {
         <header>My title</header>
 
         <main>
+          +++
           <ClientSideSuspense fallback={<div>Loading…</div>}>
             <Canvas />
           </ClientSideSuspense>
+          +++
         </main>
 
         <aside>
+          +++
           <ClientSideSuspense fallback={<div>Loading…</div>}>
             <LiveAvatars />
           </ClientSideSuspense>
+          +++
         </aside>
       </RoomProvider>
     </LiveblocksProvider>
@@ -678,7 +684,7 @@ function App() {
 
 You can also return custom information, for example, a user’s `color`:
 
-```tsx highlight="14"
+```tsx
 import { LiveblocksProvider } from "@liveblocks/react/suspense";
 
 function App() {
@@ -692,7 +698,9 @@ function App() {
           {
             name: "Marc",
             avatar: "https://example.com/marc.png",
+            // +++
             color: "purple",
+            // +++
           },
         ];
       }}
@@ -951,11 +959,7 @@ user, and Storage values for the room can be set.
 import { RoomProvider } from "@liveblocks/react/suspense";
 
 function App() {
-  return (
-    <RoomProvider id="my-room-id">
-      {/* children */}
-    </RoomProvider>
-  );
+  return <RoomProvider id="my-room-id">{/* children */}</RoomProvider>;
 }
 ```
 
@@ -995,20 +999,24 @@ cursor coordinates, or their current selection. Each user has their own
 presence, and this is readable for all other connected users. Set your initial
 Presence value by using `initialPresence`.
 
-```tsx highlight="7-12"
+```tsx
 import { RoomProvider } from "@liveblocks/react/suspense";
 
 function App() {
   return (
     <RoomProvider
       id="my-room"
+      // +++
       initialPresence={{
         cursor: null,
         colors: ["red", "purple"],
         selection: {
           id: 72426,
-        }}
+        }
+      }
+      // +++
     >
+
       {/* children */}
     </RoomProvider>
   );
@@ -1026,7 +1034,7 @@ shapes on a whiteboard, nodes on a flowchart, or text in a form. The first time
 a room is entered, you can set an initial value by using `initialStorage`. Note
 that this value is only read a single time.
 
-```tsx highlight="9-15"
+```tsx
 import { LiveList, LiveObject, LiveMap } from "@liveblocks/client";
 import { RoomProvider } from "@liveblocks/react/suspense";
 
@@ -1035,6 +1043,7 @@ function App() {
     <RoomProvider
       id="my-room"
       initialPresence={}
+      // +++
       initialStorage={{
         title: "Untitled",
         names: new LiveList(["Steven", "Guillaume"]),
@@ -1043,6 +1052,7 @@ function App() {
           ["djs3g5", new LiveObject({ type: "circle", color: "yellow" })],
         ]),
       }}
+      // +++
     >
       {/* children */}
     </RoomProvider>
@@ -1072,7 +1082,7 @@ recommend typing your app using the newer method instead. When using
 `createRoomContext` it can be helpful to use it in `liveblocks.config.ts` and
 re-export your typed hooks as below.
 
-```tsx file="liveblocks.config.ts" highlight="15-23"
+```tsx file="liveblocks.config.ts"
 import { createClient } from "@liveblocks/client";
 import { createRoomContext } from "@liveblocks/react";
 
@@ -1087,6 +1097,7 @@ type UserMeta = {};
 type RoomEvent = {};
 type ThreadMetadata = {};
 
+// +++
 export const {
   RoomProvider,
   useMyPresence,
@@ -1096,6 +1107,7 @@ export const {
 } = createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(
   client
 );
+// +++
 ```
 
 #### Suspense with createRoomContext [#createRoomContext-Suspense]
@@ -1103,7 +1115,7 @@ export const {
 To use the React suspense version of our hooks with `createRoomContext`, you can
 export from the `suspense` property instead.
 
-```tsx file="liveblocks.config.ts" highlight="16-22"
+```tsx file="liveblocks.config.ts"
 import { createClient } from "@liveblocks/client";
 import { createRoomContext } from "@liveblocks/react";
 
@@ -1119,6 +1131,7 @@ type RoomEvent = {};
 type ThreadMetadata = {};
 
 export const {
+  // +++
   suspense: {
     RoomProvider,
     useMyPresence,
@@ -1126,6 +1139,7 @@ export const {
     // Other suspense hooks
     // ...
   },
+  // +++
 } = createRoomContext<Presence, Storage, UserMeta, RoomEvent, ThreadMetadata>(
   client
 );
@@ -1581,16 +1595,20 @@ The reason this hook exists is to enable the most efficient rerendering model
 for high-frequency updates to other’s presences, which is the following
 structure:
 
-```tsx file="Cursors.tsx" highlight="2-3,4,9"
+```tsx file="Cursors.tsx"
 const Cursors =
+  // +++
   // (1) Wrap parent component in a memo and make sure it takes no props
   React.memo(function () {
     const othersConnectionIds = useOthersConnectionIds(); // (2)
+    // +++
     return (
       <>
         {othersConnectionIds.map((connectionId) => (
           <Cursor
+            // +++
             key={connectionId} // (3)
+            // +++
             connectionId={connectionId}
           />
         ))}
@@ -1599,9 +1617,11 @@ const Cursors =
   });
 ```
 
-```tsx file="Cursor.tsx" highlight="2"
+```tsx file="Cursor.tsx"
 function Cursor({ connectionId }) {
+  // +++
   const { x, y } = useOther(connectionId, (other) => other.presence.cursor); // (4)
+  // +++
   return <Cursor x={x} y={y} />;
 }
 ```
@@ -1622,12 +1642,14 @@ return `null`.
 Returns a callback that lets you broadcast custom events to other users in the
 room.
 
-```ts highlight="3-5"
+```ts
 import { useBroadcastEvent } from "@liveblocks/react/suspense";
 
+// +++
 // On client A
 const broadcast = useBroadcastEvent();
 broadcast({ type: "EMOJI", emoji: "🔥" });
+// +++
 
 // On client B
 useEventListener(({ event, user, connectionId }) => {
@@ -1646,13 +1668,14 @@ the user that sent the message. If an event was sent from the
 [Broadcast to a room](/docs/api-reference/rest-api-endpoints#post-broadcast-event)
 REST API, `connectionId` will be `-1`.
 
-```ts highlight="7-13"
+```ts
 import { useEventListener } from "@liveblocks/react/suspense";
 
 // On client A
 const broadcast = useBroadcastEvent();
 broadcast({ type: "EMOJI", emoji: "🔥" });
 
+// +++
 // On client B
 useEventListener(({ event, user, connectionId }) => {
   //                       ^^^^ Will be Client A
@@ -1660,6 +1683,7 @@ useEventListener(({ event, user, connectionId }) => {
     // Do something
   }
 });
+// +++
 ```
 
 The `user` property will indicate which User instance sent the message. This
@@ -1717,7 +1741,7 @@ declare global {
 
 You can then set an initial value in [`RoomProvider`][].
 
-```tsx highlight="9"
+```tsx
 import { LiveList } from "@liveblocks/client";
 import { RoomProvider } from "@liveblocks/react/suspense";
 
@@ -1725,7 +1749,9 @@ function App() {
   return (
     <RoomProvider
       id="my-room-name"
+      // +++
       initialStorage={{ animals: new LiveList(["Fido"]) }}
+      // +++
     >
       {/* children */}
     </RoomProvider>
@@ -1802,7 +1828,7 @@ declare global {
 
 Here’s an example of setting `initialStorage` for this type.
 
-```tsx highlight="10-16"
+```tsx
 import { LiveObject, LiveList, LiveMap } from "@liveblocks/client";
 import { RoomProvider } from "@liveblocks/react/suspense";
 
@@ -1811,6 +1837,7 @@ function App() {
     <RoomProvider
       id="my-room-name"
       initialStorage={{
+        // +++
         people: new LiveMap([
           "alicia",
           new LiveObject({
@@ -1818,6 +1845,7 @@ function App() {
             pets: new LiveList(["Fido", "Felix"]),
           }),
         ]),
+        // +++
       }}
     >
       {/* children */}
@@ -2029,7 +2057,7 @@ Both are equally fine, just a matter of preference.
 
 #### With dependency arrays [#useMutation-dep-arrays]
 
-```tsx highlight="9"
+```tsx
 // Local state maintained outside Liveblocks
 const [currentColor, setCurrentColor] = useState("red");
 
@@ -2038,7 +2066,9 @@ const fillWithCurrentColor = useMutation(
     storage.get("shapes").get("circle1").set("fill", currentColor);
     setMyPresence({ lastUsedColor: currentColor });
   },
+  // +++
   [currentColor] // Works just like it would in useCallback
+  // +++
 );
 
 // JSX
@@ -2057,10 +2087,12 @@ the correct use of your dependency arrays.
 
 Alternatively, you can add extra parameters to your callback function:
 
-```tsx highlight="2,3,11,12"
+```tsx
 const fill = useMutation(
+  // +++
   // Note the second argument
   ({ storage, setMyPresence }, color: string) => {
+    // +++
     storage.get("shapes").get("circle1").set("fill", color);
     setMyPresence({ lastUsedColor: color });
   },
@@ -2068,8 +2100,10 @@ const fill = useMutation(
 );
 
 // JSX
+// +++
 return <button onClick={() => fill("red")} />;
 //                            ^^^^^^^^^^^ Now fill takes a color argument
+// +++
 ```
 
 #### Depending on current presence [#useMutation-presence]
@@ -2081,13 +2115,17 @@ in case your mutation depends on it.
 For example, here’s a mutation that will delete all the shapes selected by the
 current user.
 
-```tsx highlight="3,6"
+```tsx
 const deleteSelectedShapes = useMutation(
   // You can use current "self" or "others" state in the mutation
+  // +++
   ({ storage, self, others, setMyPresence }) => {
+    // +++
     // Delete the selected shapes
     const shapes = storage.get("shapes");
+    // +++
     for (const shapeId of self.presence.selectedShapeIds) {
+      // +++
       shapes.delete(shapeId);
     }
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -967,7 +967,7 @@ function App() {
     [authentication](/docs/authentication) for your app, it can helpful to
     decide on a naming pattern for your room IDs.
   </PropertiesListItem>
-  <PropertiesListItem name="initialPresence" type="JsonObject" required>
+  <PropertiesListItem name="initialPresence" type="JsonObject">
     The initial Presence of the user entering the room. Each user has their own
     presence, and this is readable for all other connected users. A user’s
     Presence resets every time they disconnect. This object must be

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1012,11 +1012,10 @@ function App() {
         colors: ["red", "purple"],
         selection: {
           id: 72426,
-        }
-      }
+        },
+      }}
       // +++
     >
-
       {/* children */}
     </RoomProvider>
   );

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -102,7 +102,7 @@ hear from you.
           <LiveblocksProvider publicApiKey={"{{PUBLIC_KEY}}"}>
             <RoomProvider id="my-room">
               <ClientSideSuspense fallback={<div>Loading…</div>}>
-                {() => <CollaborativeEditor />}
+                <CollaborativeEditor />
               </ClientSideSuspense>
             </RoomProvider>
           </LiveblocksProvider>

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -68,13 +68,13 @@ hear from you.
 
       export default function App() {
         return (
-          // --
+          // +++
           <LiveblocksProvider publicApiKey={"{{PUBLIC_KEY}}"}>
             <RoomProvider id="my-room">
               {/* ... */}
             </RoomProvider>
           </LiveblocksProvider>
-          // --
+          // +++
         );
       }
       ```

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -57,7 +57,7 @@ hear from you.
       collaborate, and to create a realtime experience, multiple users must
       be connected to the same room. Set up a Liveblocks client with [`LiveblocksProvider`](/docs/api-reference/liveblocks-react#LiveblocksProvider), and join a room with [`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider).
 
-      ```tsx file="App.tsx" highlight="11-15"
+      ```tsx file="App.tsx"
       "use client";
 
       import {
@@ -68,11 +68,13 @@ hear from you.
 
       export default function App() {
         return (
+          // --
           <LiveblocksProvider publicApiKey={"{{PUBLIC_KEY}}"}>
             <RoomProvider id="my-room">
               {/* ... */}
             </RoomProvider>
           </LiveblocksProvider>
+          // --
         );
       }
       ```

--- a/e2e/next-sandbox/pages/batching.tsx
+++ b/e2e/next-sandbox/pages/batching.tsx
@@ -27,11 +27,7 @@ const {
 export default function Home() {
   const roomId = getRoomFromUrl();
   return (
-    <RoomProvider
-      id={roomId}
-      initialPresence={{}}
-      initialStorage={{ liveMap: new LiveMap() }}
-    >
+    <RoomProvider id={roomId} initialStorage={{ liveMap: new LiveMap() }}>
       <Sandbox />
     </RoomProvider>
   );

--- a/e2e/next-sandbox/pages/presence/index.tsx
+++ b/e2e/next-sandbox/pages/presence/index.tsx
@@ -55,7 +55,7 @@ export default function Home() {
       </div>
 
       {isVisible && (
-        <RoomProvider id={roomId} initialPresence={{}}>
+        <RoomProvider id={roomId}>
           <PresenceSandbox />
           <EventSandbox />
         </RoomProvider>

--- a/e2e/next-sandbox/pages/presence/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/presence/with-suspense.tsx
@@ -57,7 +57,7 @@ export default function Home() {
       </div>
 
       {isVisible && (
-        <RoomProvider id={roomId} initialPresence={{}}>
+        <RoomProvider id={roomId}>
           <ClientSideSuspense fallback="Loading...">
             <PresenceSandbox />
             <EventSandbox />

--- a/examples/nextjs-notifications-custom/src/app/page.tsx
+++ b/examples/nextjs-notifications-custom/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Page() {
         return rooms;
       }}
     >
-      <RoomProvider id={roomId} initialPresence={{}}>
+      <RoomProvider id={roomId}>
         <CustomNotifications />
       </RoomProvider>
     </LiveblocksProvider>

--- a/guides/pages/fixing-nextjs-server-component-errors.mdx
+++ b/guides/pages/fixing-nextjs-server-component-errors.mdx
@@ -21,7 +21,6 @@ export default function Layout({ children }: { children: ReactNode }) {
       <body>
         <RoomProvider
           id="my-room-name"
-          initialPresence={{}}
           initialStorage={{
             // ❌ This line causes the error
             session: new LiveObject(),

--- a/guides/pages/how-to-create-a-collaborative-online-whiteboard-with-react-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-online-whiteboard-with-react-and-liveblocks.mdx
@@ -114,7 +114,7 @@ import { RoomProvider } from "./liveblocks.config";
 
 ReactDOM.render(
   <React.StrictMode>
-    <RoomProvider id="react-whiteboard-app" initialPresence={{}}>
+    <RoomProvider id="react-whiteboard-app">
       <App />
     </RoomProvider>
   </React.StrictMode>,
@@ -136,7 +136,7 @@ for all users in the room.
 
 Initialize the storage with the `initialStorage` prop on the `RoomProvider`.
 
-```jsx highlight="6,16-20" file="src/index.js"
+```jsx highlight="6,17-19" file="src/index.js"
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
@@ -153,7 +153,6 @@ ReactDOM.render(
   <React.StrictMode>
     <RoomProvider
       id="react-whiteboard-app"
-      initialPresence={{}}
       initialStorage={{
         shapes: new LiveMap(),
       }}

--- a/guides/pages/how-to-create-a-collaborative-to-do-list-with-react-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-to-do-list-with-react-and-liveblocks.mdx
@@ -113,15 +113,11 @@ We can now import the `RoomProvider` directly from our `liveblocks.config.ts`
 file. Every component wrapped inside `RoomProvider` will have access to the
 React hooks we’ll be using to interact with this room.
 
-```tsx file="pages/index.tsx" highlight="1,5-7"
+```tsx file="pages/index.tsx" highlight="1,4"
 import { RoomProvider } from "@/liveblocks.config";
 
 export default function Page() {
-  return (
-    <RoomProvider id={"nextjs-todo-list"} initialPresence={{}}>
-      {/* ... */}
-    </RoomProvider>
-  );
+  return <RoomProvider id="nextjs-todo-list">{/* ... */}</RoomProvider>;
 }
 ```
 
@@ -140,9 +136,9 @@ import { RoomProvider } from "@/liveblocks.config";
 
 export default function Page() {
   return (
-    <RoomProvider id={"nextjs-todo-list"} initialPresence={{}}>
+    <RoomProvider id="nextjs-todo-list">
       <ClientSideSuspense fallback={<div>Loading...</div>}>
-        {() => <TodoList />}
+        <TodoList />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/guides/pages/how-to-use-liveblocks-presence-with-react.mdx
+++ b/guides/pages/how-to-use-liveblocks-presence-with-react.mdx
@@ -57,7 +57,7 @@ function App() {
 
 function Index() {
   return (
-    <RoomProvider id="my-room-id" initialPresence={{}}>
+    <RoomProvider id="my-room-id">
       <App />
     </RoomProvider>
   );

--- a/guides/pages/how-to-use-liveblocks-with-nextjs-app-directory.mdx
+++ b/guides/pages/how-to-use-liveblocks-with-nextjs-app-directory.mdx
@@ -19,7 +19,6 @@ export default function Room({ children }: { children: ReactNode }) {
   return (
     <RoomProvider
       id="my-room-name"
-      initialPresence={{}}
       initialStorage={{
         // ✅ This is a client component, so everything works!
         session: new LiveObject(),

--- a/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
@@ -51,7 +51,7 @@ describe("useMentionSuggestions", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -78,7 +78,7 @@ describe("useMentionSuggestions", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -117,7 +117,7 @@ describe("useMentionSuggestions", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -151,7 +151,7 @@ describe("useMentionSuggestions", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -205,7 +205,7 @@ describe("useMentionSuggestions", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -59,7 +59,7 @@ describe("RoomProvider", () => {
     const { RoomProvider } = createRoomContext(client);
 
     render(
-      <RoomProvider id="room" initialPresence={{}} autoConnect={false}>
+      <RoomProvider id="room" autoConnect={false}>
         <></>
       </RoomProvider>
     );
@@ -76,7 +76,7 @@ describe("RoomProvider", () => {
     const { RoomProvider } = createRoomContext(client);
 
     render(
-      <RoomProvider id="room" initialPresence={{}} autoConnect={true}>
+      <RoomProvider id="room" autoConnect={true}>
         <></>
       </RoomProvider>
     );

--- a/packages/liveblocks-react/src/__tests__/useCreateComment.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateComment.test.tsx
@@ -86,7 +86,7 @@ describe("useCreateComment", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -172,7 +172,7 @@ describe("useCreateComment", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -245,7 +245,7 @@ describe("useCreateComment", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),

--- a/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
@@ -88,7 +88,7 @@ describe("useCreateThread", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -143,7 +143,7 @@ describe("useCreateThread", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),

--- a/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
@@ -76,7 +76,7 @@ describe("useEditThreadMetadata", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -149,7 +149,7 @@ describe("useEditThreadMetadata", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),

--- a/packages/liveblocks-react/src/__tests__/useMarkThreadAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkThreadAsRead.test.tsx
@@ -96,7 +96,7 @@ describe("useMarkThreadAsRead", () => {
       {
         wrapper: ({ children }) => (
           <LiveblocksProvider>
-            <RoomProvider id="room-id" initialPresence={{}}>
+            <RoomProvider id="room-id">
               {children}
             </RoomProvider>
           </LiveblocksProvider>
@@ -169,7 +169,7 @@ describe("useMarkThreadAsRead", () => {
       {
         wrapper: ({ children }) => (
           <LiveblocksProvider>
-            <RoomProvider id="room-id" initialPresence={{}}>
+            <RoomProvider id="room-id">
               {children}
             </RoomProvider>
           </LiveblocksProvider>

--- a/packages/liveblocks-react/src/__tests__/useRoomInfo.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomInfo.test.tsx
@@ -57,7 +57,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -87,7 +87,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -115,7 +115,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -160,7 +160,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -206,7 +206,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -253,7 +253,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -284,7 +284,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -315,7 +315,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -356,7 +356,7 @@ describe("useRoomInfo", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -407,7 +407,7 @@ describe("useRoomInfoSuspense", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
           </RoomProvider>
         ),
@@ -442,7 +442,7 @@ describe("useRoomInfoSuspense", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <ErrorBoundary
               fallback={<div>There was an error while getting room info.</div>}
             >

--- a/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomNotificationSettings.test.tsx
@@ -71,7 +71,7 @@ describe("useRoomNotificationSettings", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -120,7 +120,7 @@ describe("useRoomNotificationSettings", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -192,7 +192,7 @@ describe("useRoomNotificationSettings: error", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -230,7 +230,7 @@ describe("useRoomNotificationSettings: error", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -288,7 +288,7 @@ describe("useRoomNotificationSettings: error", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -353,7 +353,7 @@ describe("useRoomNotificationSettings: error", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -412,7 +412,7 @@ describe("useRoomNotificationSettings suspense", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <Suspense>{children}</Suspense>
           </RoomProvider>
         ),
@@ -475,7 +475,7 @@ describe("useRoomNotificationSettingsSuspense: error", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <ErrorBoundary FallbackComponent={Fallback}>
               <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
             </ErrorBoundary>
@@ -538,7 +538,7 @@ describe("useRoomNotificationSettingsSuspense: error", () => {
       () => useRoomNotificationSettings(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <ErrorBoundary FallbackComponent={Fallback}>
               <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
             </ErrorBoundary>

--- a/packages/liveblocks-react/src/__tests__/useThreadSubscription.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreadSubscription.test.tsx
@@ -68,7 +68,7 @@ describe("useThreadSubscription", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -125,7 +125,7 @@ describe("useThreadSubscription", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -179,7 +179,7 @@ describe("useThreadSubscription", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -232,7 +232,7 @@ describe("useThreadSubscription", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -123,7 +123,7 @@ describe("useThreads", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -166,7 +166,7 @@ describe("useThreads", () => {
 
     const { result, unmount, rerender } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -223,7 +223,7 @@ describe("useThreads", () => {
       },
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -287,7 +287,7 @@ describe("useThreads", () => {
       () => useThreads({ query: { metadata: { resolved: true } } }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -361,7 +361,7 @@ describe("useThreads", () => {
         }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -414,7 +414,7 @@ describe("useThreads", () => {
       },
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -475,7 +475,7 @@ describe("useThreads", () => {
         useThreads({ query: { metadata: { resolved } } }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -564,7 +564,7 @@ describe("useThreads", () => {
       () => useThreads(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room1" initialPresence={{}}>
+          <RoomProvider id="room1">
             {children}
           </RoomProvider>
         ),
@@ -575,7 +575,7 @@ describe("useThreads", () => {
       () => useThreads(),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room2" initialPresence={{}}>
+          <RoomProvider id="room2">
             {children}
           </RoomProvider>
         ),
@@ -658,7 +658,7 @@ describe("useThreads", () => {
 
       return (
         <RoomIdDispatchContext.Provider value={setRoomId}>
-          <RoomProvider id={roomId} initialPresence={{}}>
+          <RoomProvider id={roomId}>
             {children}
           </RoomProvider>
         </RoomIdDispatchContext.Provider>
@@ -725,7 +725,7 @@ describe("useThreads", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -777,7 +777,7 @@ describe("useThreads", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -849,7 +849,7 @@ describe("useThreads", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -924,7 +924,7 @@ describe("useThreads", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -992,7 +992,7 @@ describe("useThreads", () => {
       () => useThreads({ query: { metadata: {} } }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -1059,7 +1059,7 @@ describe("useThreads", () => {
 
     const firstRenderResult = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1083,7 +1083,7 @@ describe("useThreads", () => {
     // Render the RoomProvider again and verify the threads are updated
     const secondRenderResult = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1134,7 +1134,7 @@ describe("useThreads", () => {
 
     const Room = () => {
       return (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <Threads />
         </RoomProvider>
       );
@@ -1221,7 +1221,7 @@ describe("useThreads", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1283,7 +1283,7 @@ describe("useThreads: error", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1339,7 +1339,7 @@ describe("useThreads: error", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1407,7 +1407,7 @@ describe("useThreads: error", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1480,7 +1480,7 @@ describe("useThreads: polling", () => {
 
     const Room = () => {
       return (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <Threads />
         </RoomProvider>
       );
@@ -1538,7 +1538,7 @@ describe("useThreads: polling", () => {
 
     const Room = () => {
       return (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <NoThreads />
         </RoomProvider>
       );
@@ -1594,7 +1594,7 @@ describe("WebSocket events", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1653,7 +1653,7 @@ describe("WebSocket events", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1710,7 +1710,7 @@ describe("WebSocket events", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1803,7 +1803,7 @@ describe("WebSocket events", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           {children}
         </RoomProvider>
       ),
@@ -1870,7 +1870,7 @@ describe("useThreadsSuspense", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
         </RoomProvider>
       ),
@@ -1916,7 +1916,7 @@ describe("useThreadsSuspense", () => {
 
     const { result, unmount, rerender } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
         </RoomProvider>
       ),
@@ -1956,7 +1956,7 @@ describe("useThreadsSuspense", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <ErrorBoundary
             fallback={<div>There was an error while getting threads.</div>}
           >
@@ -2033,7 +2033,7 @@ describe("useThreadsSuspense: error", () => {
 
     const { result, unmount } = renderHook(() => useThreads(), {
       wrapper: ({ children }) => (
-        <RoomProvider id="room-id" initialPresence={{}}>
+        <RoomProvider id="room-id">
           <ErrorBoundary FallbackComponent={Fallback}>
             <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
           </ErrorBoundary>

--- a/packages/liveblocks-react/src/__tests__/useUser.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useUser.test.tsx
@@ -55,7 +55,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -83,7 +83,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -111,7 +111,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -156,7 +156,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -202,7 +202,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -249,7 +249,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -280,7 +280,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -311,7 +311,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -350,7 +350,7 @@ describe("useUser", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             {children}
           </RoomProvider>
         ),
@@ -399,7 +399,7 @@ describe("useUserSuspense", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
           </RoomProvider>
         ),
@@ -434,7 +434,7 @@ describe("useUserSuspense", () => {
       }),
       {
         wrapper: ({ children }) => (
-          <RoomProvider id="room-id" initialPresence={{}}>
+          <RoomProvider id="room-id">
             <ErrorBoundary
               fallback={<div>There was an error while getting user.</div>}
             >

--- a/tutorial/react/authenticating-with-nextjs/secret-key/guide.mdx
+++ b/tutorial/react/authenticating-with-nextjs/secret-key/guide.mdx
@@ -48,10 +48,9 @@ Now we’ve defined the type, we can switch to [App.tsx][] and add an
 `intialStorage` value, that is used when the room’s storage is created. We can
 match the `Storage` type by creating a new [`LiveObject`][].
 
-```tsx highlight="4-6"
+```tsx highlight="3-5"
 <RoomProvider
   id={roomId}
-  initialPresence={{}}
   initialStorage={{
     person: new LiveObject({ name: "Marie", age: 30 }),
   }}

--- a/tutorial/react/authenticating-with-nextjs/secret-key/initial/App.tsx
+++ b/tutorial/react/authenticating-with-nextjs/secret-key/initial/App.tsx
@@ -7,7 +7,7 @@ export default function App() {
   const roomId = "{% ROOM_ID %}";
 
   return (
-    <RoomProvider id={roomId} initialPresence={{}}>
+    <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
         {() => <Room />}
       </ClientSideSuspense>

--- a/tutorial/react/authenticating-with-nextjs/secret-key/initial/App.tsx
+++ b/tutorial/react/authenticating-with-nextjs/secret-key/initial/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/authenticating-with-nextjs/secret-key/solved-diff/App.tsx
+++ b/tutorial/react/authenticating-with-nextjs/secret-key/solved-diff/App.tsx
@@ -9,13 +9,12 @@ export default function App() {
   return (
     <RoomProvider
       id={roomId}
-      initialPresence={{}}
       initialStorage={{
         person: new LiveObject({ name: "Marie", age: 30 }),
       }}
     >
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/broadcasting-events/initial/App.tsx
+++ b/tutorial/react/getting-started/broadcasting-events/initial/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId} initialPresence={{ cursor: null }}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/joining-a-room/guide.mdx
+++ b/tutorial/react/getting-started/joining-a-room/guide.mdx
@@ -40,7 +40,7 @@ this, pass `<Room>`, and include a loading `fallback`:
 return (
   <RoomProvider id={roomId}>
     <ClientSideSuspense fallback={<div>Loading…</div>}>
-      {() => <Room />}
+      <Room />
     </ClientSideSuspense>
   </RoomProvider>
 );

--- a/tutorial/react/getting-started/joining-a-room/guide.mdx
+++ b/tutorial/react/getting-started/joining-a-room/guide.mdx
@@ -21,7 +21,7 @@ Switch to [App.tsx][] and return a [`RoomProvider`][] component with the
 
 ```tsx modifyTutorialFile="/App.tsx"
 return (
-  <RoomProvider id={roomId} initialPresence={{}}>
+  <RoomProvider id={roomId}>
     <Room />
   </RoomProvider>
 );
@@ -38,7 +38,7 @@ this, pass `<Room>`, and include a loading `fallback`:
 
 ```tsx highlight="3-5" modifyTutorialFile="/App.tsx"
 return (
-  <RoomProvider id={roomId} initialPresence={{}}>
+  <RoomProvider id={roomId}>
     <ClientSideSuspense fallback={<div>Loading…</div>}>
       {() => <Room />}
     </ClientSideSuspense>

--- a/tutorial/react/getting-started/joining-a-room/solved-diff/App.tsx
+++ b/tutorial/react/getting-started/joining-a-room/solved-diff/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/joining-a-room/solved-diff/App.tsx
+++ b/tutorial/react/getting-started/joining-a-room/solved-diff/App.tsx
@@ -6,7 +6,7 @@ export default function App() {
   const roomId = "{% ROOM_ID %}";
 
   return (
-    <RoomProvider id={roomId} initialPresence={{}}>
+    <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
         {() => <Room />}
       </ClientSideSuspense>

--- a/tutorial/react/getting-started/live-cursors/initial/App.tsx
+++ b/tutorial/react/getting-started/live-cursors/initial/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId} initialPresence={{ cursor: null }}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/modifying-storage-data/initial/App.tsx
+++ b/tutorial/react/getting-started/modifying-storage-data/initial/App.tsx
@@ -9,13 +9,12 @@ export default function App() {
   return (
     <RoomProvider
       id={roomId}
-      initialPresence={{}}
       initialStorage={{
         person: new LiveObject({ name: "Marie", age: 30 }),
       }}
     >
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/nesting-data-types/initial/App.tsx
+++ b/tutorial/react/getting-started/nesting-data-types/initial/App.tsx
@@ -9,13 +9,12 @@ export default function App() {
   return (
     <RoomProvider
       id={roomId}
-      initialPresence={{}}
       initialStorage={{
         person: new LiveObject({ name: "Marie", age: 30 }),
       }}
     >
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/nesting-data-types/solved-diff/App.tsx
+++ b/tutorial/react/getting-started/nesting-data-types/solved-diff/App.tsx
@@ -9,13 +9,12 @@ export default function App() {
   return (
     <RoomProvider
       id={roomId}
-      initialPresence={{}}
       initialStorage={{
         people: new LiveList([new LiveObject({ name: "Marie", age: 30 })]),
       }}
     >
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/others/initial/App.tsx
+++ b/tutorial/react/getting-started/others/initial/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/others/initial/App.tsx
+++ b/tutorial/react/getting-started/others/initial/App.tsx
@@ -6,7 +6,7 @@ export default function App() {
   const roomId = "{% ROOM_ID %}";
 
   return (
-    <RoomProvider id={roomId} initialPresence={{}}>
+    <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
         {() => <Room />}
       </ClientSideSuspense>

--- a/tutorial/react/getting-started/presence/initial/App.tsx
+++ b/tutorial/react/getting-started/presence/initial/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/presence/initial/App.tsx
+++ b/tutorial/react/getting-started/presence/initial/App.tsx
@@ -6,7 +6,7 @@ export default function App() {
   const roomId = "{% ROOM_ID %}";
 
   return (
-    <RoomProvider id={roomId} initialPresence={{}}>
+    <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
         {() => <Room />}
       </ClientSideSuspense>

--- a/tutorial/react/getting-started/presence/solved-diff/App.tsx
+++ b/tutorial/react/getting-started/presence/solved-diff/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId} initialPresence={{ cursor: null }}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/storage/guide.mdx
+++ b/tutorial/react/getting-started/storage/guide.mdx
@@ -47,10 +47,9 @@ Now we’ve defined the type, we can switch to [App.tsx][] and add an
 `intialStorage` value, that is used when the room’s storage is created. We can
 match the `Storage` type by creating a new [`LiveObject`][].
 
-```tsx highlight="4-6" modifyTutorialFile="/App.tsx"
+```tsx highlight="3-5" modifyTutorialFile="/App.tsx"
 <RoomProvider
   id={roomId}
-  initialPresence={{}}
   initialStorage={{
     person: new LiveObject({ name: "Marie", age: 30 }),
   }}

--- a/tutorial/react/getting-started/storage/initial/App.tsx
+++ b/tutorial/react/getting-started/storage/initial/App.tsx
@@ -7,7 +7,7 @@ export default function App() {
   const roomId = "{% ROOM_ID %}";
 
   return (
-    <RoomProvider id={roomId} initialPresence={{}}>
+    <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
         {() => <Room />}
       </ClientSideSuspense>

--- a/tutorial/react/getting-started/storage/initial/App.tsx
+++ b/tutorial/react/getting-started/storage/initial/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/storage/solved-diff/App.tsx
+++ b/tutorial/react/getting-started/storage/solved-diff/App.tsx
@@ -9,13 +9,12 @@ export default function App() {
   return (
     <RoomProvider
       id={roomId}
-      initialPresence={{}}
       initialStorage={{
         person: new LiveObject({ name: "Marie", age: 30 }),
       }}
     >
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );

--- a/tutorial/react/getting-started/updating-presence/initial/App.tsx
+++ b/tutorial/react/getting-started/updating-presence/initial/App.tsx
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <RoomProvider id={roomId} initialPresence={{ cursor: null }}>
       <ClientSideSuspense fallback={<div>Loading…</div>}>
-        {() => <Room />}
+        <Room />
       </ClientSideSuspense>
     </RoomProvider>
   );


### PR DESCRIPTION
...also notices a few places were we're still using `<ClientSideSuspense>` with a function as children. All no longer needed, so a nice simplification of our examples. ✨🧹🧽✨
