### PR TITLE
Re-enable CI for codemod test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        pkg: [
+        pkg:
+          [
             "@liveblocks/core",
             "@liveblocks/client",
             "@liveblocks/react",
@@ -20,8 +21,7 @@ jobs:
             "@liveblocks/react-ui",
             "@liveblocks/react-lexical",
             "@liveblocks/node-lexical",
-            # TODO: Re-enable once we figure out why it's breaking
-            # "@liveblocks/codemod",
+            "@liveblocks/codemod",
           ]
 
     steps:

--- a/packages/liveblocks-codemod/src/transforms/__tests__/live-list-constructor.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/live-list-constructor.test.ts
@@ -1,18 +1,19 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "live-list-constructor";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "live-list-constructor";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
-
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  }
 }

--- a/packages/liveblocks-codemod/src/transforms/__tests__/react-comments-to-react-ui.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/react-comments-to-react-ui.test.ts
@@ -1,18 +1,19 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "react-comments-to-react-ui";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "react-comments-to-react-ui";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
-
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  }
 }

--- a/packages/liveblocks-codemod/src/transforms/__tests__/remove-liveblocks-config-contexts.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/remove-liveblocks-config-contexts.test.ts
@@ -1,26 +1,27 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "remove-liveblocks-config-contexts";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "remove-liveblocks-config-contexts";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    const options = {} as { suspense?: boolean };
 
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  const options = {} as { suspense?: boolean };
+    if (fixture.includes("suspense")) {
+      options.suspense = true;
+    }
 
-  if (fixture.includes("suspense")) {
-    options.suspense = true;
+    defineTest(__dirname, fixtureDir, options, prefix, {
+      parser: "tsx",
+    });
   }
-
-  defineTest(__dirname, fixtureDir, options, prefix, {
-    parser: "tsx",
-  });
 }

--- a/packages/liveblocks-codemod/src/transforms/__tests__/remove-unneeded-type-params.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/remove-unneeded-type-params.test.ts
@@ -1,18 +1,19 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "remove-unneeded-type-params";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "remove-unneeded-type-params";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
-
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  }
 }

--- a/packages/liveblocks-codemod/src/transforms/__tests__/remove-yjs-default-export.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/remove-yjs-default-export.test.ts
@@ -1,18 +1,19 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "remove-yjs-default-export";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "remove-yjs-default-export";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
-
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  }
 }

--- a/packages/liveblocks-codemod/src/transforms/__tests__/room-info-to-room-data.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/room-info-to-room-data.test.ts
@@ -1,18 +1,19 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "room-info-to-room-data";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "room-info-to-room-data";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
-
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    defineTest(__dirname, fixtureDir, null, prefix, { parser: "tsx" });
+  }
 }

--- a/packages/liveblocks-codemod/src/transforms/__tests__/simplify-client-side-suspense-children.test.ts
+++ b/packages/liveblocks-codemod/src/transforms/__tests__/simplify-client-side-suspense-children.test.ts
@@ -1,26 +1,27 @@
 /* eslint-disable */
 
 // Based on https://github.com/vercel/next.js/blob/main/packages/next-codemod
+{
+  const defineTest = require("jscodeshift/dist/testUtils").defineTest;
+  const { readdirSync } = require("fs");
+  const { join } = require("path");
 
-const defineTest = require("jscodeshift/dist/testUtils").defineTest;
-const { readdirSync } = require("fs");
-const { join } = require("path");
+  const fixtureDir = "simplify-client-side-suspense-children";
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.tsx"))
+    .map((file) => file.replace(".input.tsx", ""));
 
-const fixtureDir = "simplify-client-side-suspense-children";
-const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
-const fixtures = readdirSync(fixtureDirPath)
-  .filter((file) => file.endsWith(".input.tsx"))
-  .map((file) => file.replace(".input.tsx", ""));
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    const options = {} as { suspense?: boolean };
 
-for (const fixture of fixtures) {
-  const prefix = `${fixtureDir}/${fixture}`;
-  const options = {} as { suspense?: boolean };
+    if (fixture.includes("suspense")) {
+      options.suspense = true;
+    }
 
-  if (fixture.includes("suspense")) {
-    options.suspense = true;
+    defineTest(__dirname, fixtureDir, options, prefix, {
+      parser: "tsx",
+    });
   }
-
-  defineTest(__dirname, fixtureDir, options, prefix, {
-    parser: "tsx",
-  });
 }

--- a/packages/liveblocks-codemod/src/transforms/remove-liveblocks-config-contexts.ts
+++ b/packages/liveblocks-codemod/src/transforms/remove-liveblocks-config-contexts.ts
@@ -4,7 +4,6 @@ import type {
   File,
   FileInfo,
   Options,
-  Program,
   TSTypeParameterInstantiation,
   VariableDeclarator,
 } from "jscodeshift";

--- a/packages/liveblocks-codemod/src/transforms/simplify-client-side-suspense-children.ts
+++ b/packages/liveblocks-codemod/src/transforms/simplify-client-side-suspense-children.ts
@@ -1,4 +1,4 @@
-import type { FileInfo, API } from "jscodeshift";
+import type { API, FileInfo } from "jscodeshift";
 
 export default function transform(
   file: FileInfo,

--- a/packages/liveblocks-codemod/src/transforms/simplify-client-side-suspense-children.ts
+++ b/packages/liveblocks-codemod/src/transforms/simplify-client-side-suspense-children.ts
@@ -1,9 +1,8 @@
-import type { FileInfo, API, Options } from "jscodeshift";
+import type { FileInfo, API } from "jscodeshift";
 
 export default function transform(
   file: FileInfo,
-  api: API,
-  options?: Options
+  api: API
 ): string | undefined {
   const j = api.jscodeshift;
   const root = j(file.source);


### PR DESCRIPTION
Re-enable CI tests for `liveblocks-codemod`. I found a lil' hack/workaround. Still not sure why those tests are failing on CI but not locally, but this seems to work.

Fixes LB-897.