### PR TITLE
CHANGELOG — WEEK 26

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -38,13 +38,51 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 - Fix improper `useSyncExternalStore` import which would break on React <18.
 
-## v2.0.5
+## v2.0.5 (2024-06-21)
 
 ### `@liveblocks/react`
 
 - Improved DX: `useDeleteThread` will now throw a client-side error if someone
   else than the thread owner tries to delete the thread. This will help you
   catch and handle this case more easily.
+
+## v2.0.4 (2024-06-20)
+
+### All packages
+
+- Improve TS error messages and error locations if custom `UserMeta` or
+  `ActivitiesData` types do not match their requirements
+
+### `@liveblocks/client`
+
+- Add missing type export for `CommentReaction`
+- Don’t attempt to write missing initialStorage keys if the current user has no
+  write access to storage. This will no longer throw, but issue a warning
+  message in the console.
+
+## v2.0.3 (2024-06-17)
+
+### `@liveblocks/client`
+
+- In `client.enterRoom()`, the options `initialPresence` and `initialStorage`
+  are now only mandatory if your custom type requires them to be.
+
+### `@liveblocks/react`
+
+- In `<RoomProvider>`, the props `initialPresence` and `initialStorage` are now
+  only mandatory if your custom type requires them to be.
+- Nesting `<LiveblocksProvider>`s will now throw to prevent incorrect usage.
+
+### `@liveblocks/react-ui`
+
+- Prevent the composer from splitting text being composed.
+- Handle parentheses around and within auto-links.
+- Count whitespace as empty to prevent posting empty comments.
+- Prevent clearing the composer if it's not handled. (via `onComposerSubmit`)
+
+### `@liveblocks/yjs`
+
+- Add missing type exports
 
 ## Documentation
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -23,6 +23,10 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
   else than the thread owner tries to delete the thread. This will help you
   catch and handle this case more easily.
 
+## Documentation
+
+- Updated the [interactive tutorial](https://liveblocks.io/docs/tutorial/react/getting-started/welcome) for Liveblocks 2.0.
+
 ## Contributors
 
 flowflorent

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -13,6 +13,10 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 -->
 
+# Week 26 (2024-06-28)
+
+## Contributors
+
 # Week 25 (2024-06-21)
 
 ## v2.0.2

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 # Week 26 (2024-06-28)
 
-## v2.1.0 (2024-06-27)
+## v2.1.0
 
 ### `@liveblocks/client`
 
@@ -38,7 +38,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 - Fix improper `useSyncExternalStore` import which would break on React <18.
 
-## v2.0.5 (2024-06-21)
+## v2.0.5
 
 ### `@liveblocks/react`
 
@@ -46,7 +46,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
   else than the thread owner tries to delete the thread. This will help you
   catch and handle this case more easily.
 
-## v2.0.4 (2024-06-20)
+## v2.0.4
 
 ### All packages
 
@@ -60,7 +60,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
   write access to storage. This will no longer throw, but issue a warning
   message in the console.
 
-## v2.0.3 (2024-06-17)
+## v2.0.3
 
 ### `@liveblocks/client`
 
@@ -88,13 +88,17 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 - Updated the [interactive tutorial](https://liveblocks.io/docs/tutorial/react/getting-started/welcome) for Liveblocks 2.0.
 
+## Website
+
+- New blog post: [Introducing Liveblocks collaboration kit for Figma](https://liveblocks.io/blog/introducing-liveblocks-collaboration-kit-for-figma).
+
 ## Processes
 
-- Versioning and publishing of public packages is now decoupled from versioning/publishing of our CLI tools
+- Versioning and publishing of public packages is now decoupled from versioning/publishing of our CLI tools.
 
 ## Contributors
 
-flowflorent, ctnicholas, nvie
+flowflorent, ctnicholas, nvie, stevenfabre, pierrelevaillant
 
 # Week 25 (2024-06-21)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -29,7 +29,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 ## Contributors
 
-flowflorent
+flowflorent, ctnicholas
 
 # Week 25 (2024-06-21)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,6 +15,29 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 # Week 26 (2024-06-28)
 
+## v2.1.0
+
+### `@liveblocks/client`
+
+- Various internal refactorings
+
+### `@liveblocks/react`
+
+- Add new hook
+  [`useStorageStatus`](https://liveblocks.io/docs/api-reference/liveblocks-react#useStorageStatus),
+  which returns the current storage status of the room, and will re-render your
+  component whenever it changes. This can used to build "Saving..." UIs.
+- Add
+  [`useDeleteThread`](https://liveblocks.io/docs/api-reference/liveblocks-react#useDeleteThread)
+  hook to delete a thread and its associated comments.
+- Fix: add missing JSDoc comments
+- Fix: improve some error messages and stack traces to contain more info
+- Refactorings to Suspense internals
+
+### `@liveblocks/react-ui`
+
+- Fix improper `useSyncExternalStore` import which would break on React <18.
+
 ## v2.0.5
 
 ### `@liveblocks/react`

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -56,7 +56,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 ### `@liveblocks/client`
 
 - Add missing type export for `CommentReaction`
-- Don’t attempt to write missing initialStorage keys if the current user has no
+- Don’t attempt to write missing `initialStorage` keys if the current user has no
   write access to storage. This will no longer throw, but issue a warning
   message in the console.
 
@@ -76,7 +76,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 ### `@liveblocks/react-ui`
 
 - Prevent the composer from splitting text being composed.
-- Handle parentheses around and within auto-links.
+- Handle parentheses around and within auto links.
 - Count whitespace as empty to prevent posting empty comments.
 - Prevent clearing the composer if it's not handled. (via `onComposerSubmit`)
 
@@ -98,7 +98,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 ## Contributors
 
-flowflorent, ctnicholas, nvie, stevenfabre, pierrelevaillant
+flowflorent, ctnicholas, nvie, stevenfabre, pierrelevaillant, marcbouchenoire
 
 # Week 25 (2024-06-21)
 
@@ -124,7 +124,7 @@ flowflorent, ctnicholas, nvie, stevenfabre, pierrelevaillant
 ### `@liveblocks/react-ui`
 
 - Prevent the composer from splitting text being composed.
-- Handle parentheses around and within auto-links.
+- Handle parentheses around and within auto links.
 - Count whitespace as empty to prevent posting empty comments.
 - Prevent clearing the composer if it's not handled. (via `onComposerSubmit`)
 
@@ -1076,7 +1076,7 @@ leave();
 
 ## `@liveblocks/react-comments`
 
-- Add support for auto-links. (e.g. `"www.liveblocks.io"`)
+- Add support for auto links. (e.g. `"www.liveblocks.io"`)
 
 # v1.3.2
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 # Week 26 (2024-06-28)
 
-## v2.1.0
+## v2.1.0 (2024-06-27)
 
 ### `@liveblocks/client`
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,17 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 # Week 26 (2024-06-28)
 
+## v2.0.5
+
+### `@liveblocks/react`
+
+- Improved DX: `useDeleteThread` will now throw a client-side error if someone
+  else than the thread owner tries to delete the thread. This will help you
+  catch and handle this case more easily.
+
 ## Contributors
+
+flowflorent
 
 # Week 25 (2024-06-21)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -88,9 +88,13 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre
 
 - Updated the [interactive tutorial](https://liveblocks.io/docs/tutorial/react/getting-started/welcome) for Liveblocks 2.0.
 
+## Processes
+
+- Versioning and publishing of public packages is now decoupled from versioning/publishing of our CLI tools
+
 ## Contributors
 
-flowflorent, ctnicholas
+flowflorent, ctnicholas, nvie
 
 # Week 25 (2024-06-21)
 


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-26/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 28th of June.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.