### PR TITLE
Expose `isStorageReady` on mutation context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.1.0
+
+### `@liveblocks/react`
+
+- Add new `isStorageReady` property to `useMutation`'s first callback argument.
+  You can use this new property if you’re running into the
+  `Error: This mutation cannot be used until Storage has loaded` error. (For
+  example, to decide to make your mutation a no-op.)
+- Add new `isPresenceReady` property to `useMutation`'s first callback argument.
+
 ## v2.0.5
 
 ### `@liveblocks/react`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### `@liveblocks/react`
 
-- Add new `isStorageLoaded` property to `useMutation`'s first callback argument.
+- Add new `isStorageReady` property to `useMutation`'s first callback argument.
   You can use this new property if you’re running into the
   `Error: This mutation cannot be used until Storage has loaded` error. (For
   example, to decide to make your mutation a no-op.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
   You can use this new property if you’re running into the
   `Error: This mutation cannot be used until Storage has loaded` error. (For
   example, to decide to make your mutation a no-op.)
-- Add new `isPresenceReady` property to `useMutation`'s first callback argument.
 
 ## v2.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### `@liveblocks/react`
 
-- Add new `isStorageReady` property to `useMutation`'s first callback argument.
+- Add new `isStorageLoaded` property to `useMutation`'s first callback argument.
   You can use this new property if you’re running into the
   `Error: This mutation cannot be used until Storage has loaded` error. (For
   example, to decide to make your mutation a no-op.)

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -2058,14 +2058,14 @@ Both are equally fine, just a matter of preference.
 If Storage is modified inside a mutation before it has been initially loaded, an
 error will occur. It’s recommended to not call your mutation functions until
 Storage has loaded. If that is impractical, you can detect this situation using
-the `isStorageLoaded` boolean.
+the `isStorageReady` boolean.
 
 ```tsx
 const deleteCircle = useMutation(
   // Mutation context is passed as the first argument
-  ({ storage, isStorageLoaded }) => {
+  ({ storage, isStorageReady }) => {
     // No-op if storage has already loaded
-    if (!isStorageLoaded) return;
+    if (!isStorageReady) return;
 
     // Here, `storage` is guaranteed to be available
     storage.get("shapes").get("circle1").delete();

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -2053,6 +2053,27 @@ options:
 
 Both are equally fine, just a matter of preference.
 
+#### Waiting for Storage to load
+
+If Storage is modified inside a mutation before it has been initially loaded, an
+error will occur. It’s recommended to not call your mutation functions until
+Storage has loaded. If that is impractical, you can detect this situation using
+the `isStorageLoaded` boolean.
+
+```tsx
+const deleteCircle = useMutation(
+  // Mutation context is passed as the first argument
+  ({ storage, isStorageLoaded }) => {
+    // No-op if storage has already loaded
+    if (!isStorageLoaded) return;
+
+    // Here, `storage` is guaranteed to be available
+    storage.get("shapes").get("circle1").delete();
+  },
+  []
+);
+```
+
 #### With dependency arrays [#useMutation-dep-arrays]
 
 ```tsx

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -2053,27 +2053,6 @@ options:
 
 Both are equally fine, just a matter of preference.
 
-#### Waiting for Storage to load
-
-If Storage is modified inside a mutation before it has been initially loaded, an
-error will occur. It’s recommended to not call your mutation functions until
-Storage has loaded. If that is impractical, you can detect this situation using
-the `isStorageReady` boolean.
-
-```tsx
-const deleteCircle = useMutation(
-  // Mutation context is passed as the first argument
-  ({ storage, isStorageReady }) => {
-    // No-op if storage has already loaded
-    if (!isStorageReady) return;
-
-    // Here, `storage` is guaranteed to be available
-    storage.get("shapes").get("circle1").delete();
-  },
-  []
-);
-```
-
 #### With dependency arrays [#useMutation-dep-arrays]
 
 ```tsx
@@ -2160,6 +2139,27 @@ return <button onClick={deleteSelectedShapes} />;
 
 Mutations are automatically batched, so when using `useMutation` there’s no need
 to use `useBatch`, or call `room.batch()` manually.
+
+#### Waiting for Storage to load
+
+If Storage is modified inside a mutation before it has been initially loaded, an
+error will occur. It’s recommended to not call your mutation functions until
+Storage has loaded. If that is impractical, you can detect this situation using
+the `isStorageReady` boolean.
+
+```tsx
+const deleteCircle = useMutation(
+  // Mutation context is passed as the first argument
+  ({ storage, isStorageReady }) => {
+    // No-op if storage has already loaded
+    if (!isStorageReady) return;
+
+    // Here, `storage` is guaranteed to be available
+    storage.get("shapes").get("circle1").delete();
+  },
+  []
+);
+```
 
 #### ESLint rule [#useMutation-lint-rule] [@keywords=["exhaustive-deps", "additionalHooks", "eslint-plugin-react-hooks"]]
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -250,7 +250,7 @@ describe("useStorage", () => {
   test("unpacking storage before storage has loaded is possible", async () => {
     // Mutation 1 unpacks storage, but doesn't access it
     const { result: mut1 } = renderHook(() =>
-      useMutation(({ storage, isStorageReady }: any) => {
+      useMutation(({ storage, isStorageReady }) => {
         if (isStorageReady) {
           // Will never execute (= deliberate!)
           storage.get("obj").set("a", 42);
@@ -267,7 +267,7 @@ describe("useStorage", () => {
     act(() => mut1.current());
     act(() =>
       expect(() => mut2.current()).toThrow(
-        "This mutation cannot be used until storage has been loaded"
+        "This mutation cannot be used until Storage has loaded"
       )
     );
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -250,8 +250,8 @@ describe("useStorage", () => {
   test("unpacking storage before storage has loaded is possible", async () => {
     // Mutation 1 unpacks storage, but doesn't access it
     const { result: mut1 } = renderHook(() =>
-      useMutation(({ storage, isStorageReady }) => {
-        if (isStorageReady) {
+      useMutation(({ storage, isStorageLoaded }) => {
+        if (isStorageLoaded) {
           // Will never execute (= deliberate!)
           storage.get("obj").set("a", 42);
         }
@@ -267,7 +267,7 @@ describe("useStorage", () => {
     act(() => mut1.current());
     act(() =>
       expect(() => mut2.current()).toThrow(
-        "This mutation cannot be used until Storage has loaded. Hint: check `({ isStorageReady })` before accessing `storage`"
+        "This mutation cannot be used until Storage has loaded. Hint: check `({ isStorageLoaded })` before accessing `storage`"
       )
     );
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -267,7 +267,7 @@ describe("useStorage", () => {
     act(() => mut1.current());
     act(() =>
       expect(() => mut2.current()).toThrow(
-        "This mutation cannot be used until Storage has loaded"
+        "This mutation cannot be used until Storage has loaded (Hint: check `isStorageReady` before accessing `storage`)"
       )
     );
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -267,7 +267,7 @@ describe("useStorage", () => {
     act(() => mut1.current());
     act(() =>
       expect(() => mut2.current()).toThrow(
-        "This mutation cannot be used until Storage has loaded (Hint: check `isStorageReady` before accessing `storage`)"
+        "This mutation cannot be used until Storage has loaded. Hint: check `({ isStorageReady })` before accessing `storage`"
       )
     );
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -250,8 +250,8 @@ describe("useStorage", () => {
   test("unpacking storage before storage has loaded is possible", async () => {
     // Mutation 1 unpacks storage, but doesn't access it
     const { result: mut1 } = renderHook(() =>
-      useMutation(({ storage, isStorageLoaded }) => {
-        if (isStorageLoaded) {
+      useMutation(({ storage, isStorageReady }) => {
+        if (isStorageReady) {
           // Will never execute (= deliberate!)
           storage.get("obj").set("a", 42);
         }
@@ -267,7 +267,7 @@ describe("useStorage", () => {
     act(() => mut1.current());
     act(() =>
       expect(() => mut2.current()).toThrow(
-        "This mutation cannot be used until Storage has loaded. Hint: check `({ isStorageLoaded })` before accessing `storage`"
+        "This mutation cannot be used until Storage has loaded. Hint: check `({ isStorageReady })` before accessing `storage`"
       )
     );
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -166,8 +166,8 @@ function makeMutationContext<
   M extends BaseMetadata,
 >(room: Room<P, S, U, E, M>): MutationContext<P, S, U> {
   const cannotUseUntil = "This mutation cannot be used until";
-  const needsPresence = `${cannotUseUntil} connected to the Liveblocks room (Hint: check \`isPresenceReady\` before accessing \`self\` or \`others\`)`;
-  const needsStorage = `${cannotUseUntil} Storage has loaded (Hint: check \`isStorageReady\` before accessing \`storage\`)`;
+  const needsPresence = `${cannotUseUntil} connected to the Liveblocks room`;
+  const needsStorage = `${cannotUseUntil} Storage has loaded. Hint: check \`({ isStorageReady })\` before accessing \`storage\``;
 
   return {
     get isPresenceReady() {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -171,12 +171,10 @@ function makeMutationContext<
 
   return {
     get isPresenceReady() {
-      // XXX Replace by room.isPresenceLoaded() soon
       return room.getSelf() !== null;
     },
 
     get isStorageReady() {
-      // XXX Replace by room.isStorageLoaded() soon
       return room.getStorageSnapshot() !== null;
     },
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -170,10 +170,6 @@ function makeMutationContext<
   const needsStorage = `${cannotUseUntil} Storage has loaded. Hint: check \`({ isStorageReady })\` before accessing \`storage\``;
 
   return {
-    get isPresenceReady() {
-      return room.getSelf() !== null;
-    },
-
     get isStorageReady() {
       return room.getStorageSnapshot() !== null;
     },

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -167,10 +167,10 @@ function makeMutationContext<
 >(room: Room<P, S, U, E, M>): MutationContext<P, S, U> {
   const cannotUseUntil = "This mutation cannot be used until";
   const needsPresence = `${cannotUseUntil} connected to the Liveblocks room`;
-  const needsStorage = `${cannotUseUntil} Storage has loaded. Hint: check \`({ isStorageReady })\` before accessing \`storage\``;
+  const needsStorage = `${cannotUseUntil} Storage has loaded. Hint: check \`({ isStorageLoaded })\` before accessing \`storage\``;
 
   return {
-    get isStorageReady() {
+    get isStorageLoaded() {
       return room.getStorageSnapshot() !== null;
     },
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -166,8 +166,8 @@ function makeMutationContext<
   M extends BaseMetadata,
 >(room: Room<P, S, U, E, M>): MutationContext<P, S, U> {
   const cannotUseUntil = "This mutation cannot be used until";
-  const needsPresence = `${cannotUseUntil} connected to the Liveblocks room`;
-  const needsStorage = `${needsPresence} Storage has loaded`;
+  const needsPresence = `${cannotUseUntil} connected to the Liveblocks room (Hint: check \`isPresenceReady\` before accessing \`self\` or \`others\`)`;
+  const needsStorage = `${cannotUseUntil} Storage has loaded (Hint: check \`isStorageReady\` before accessing \`storage\`)`;
 
   return {
     get isPresenceReady() {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -167,10 +167,10 @@ function makeMutationContext<
 >(room: Room<P, S, U, E, M>): MutationContext<P, S, U> {
   const cannotUseUntil = "This mutation cannot be used until";
   const needsPresence = `${cannotUseUntil} connected to the Liveblocks room`;
-  const needsStorage = `${cannotUseUntil} Storage has loaded. Hint: check \`({ isStorageLoaded })\` before accessing \`storage\``;
+  const needsStorage = `${cannotUseUntil} Storage has loaded. Hint: check \`({ isStorageReady })\` before accessing \`storage\``;
 
   return {
-    get isStorageLoaded() {
+    get isStorageReady() {
       return room.getStorageSnapshot() !== null;
     },
 

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -310,7 +310,9 @@ export type MutationContext<
   S extends LsonObject,
   U extends BaseUserMeta,
 > = {
+  isStorageReady: boolean;
   storage: LiveObject<S>;
+  isPresenceReady: boolean;
   self: User<P, U>;
   others: readonly User<P, U>[];
   setMyPresence: (

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -312,7 +312,6 @@ export type MutationContext<
 > = {
   isStorageReady: boolean;
   storage: LiveObject<S>;
-  isPresenceReady: boolean;
   self: User<P, U>;
   others: readonly User<P, U>[];
   setMyPresence: (

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -310,7 +310,7 @@ export type MutationContext<
   S extends LsonObject,
   U extends BaseUserMeta,
 > = {
-  isStorageReady: boolean;
+  isStorageLoaded: boolean;
   storage: LiveObject<S>;
   self: User<P, U>;
   others: readonly User<P, U>[];

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -310,7 +310,7 @@ export type MutationContext<
   S extends LsonObject,
   U extends BaseUserMeta,
 > = {
-  isStorageLoaded: boolean;
+  isStorageReady: boolean;
   storage: LiveObject<S>;
   self: User<P, U>;
   others: readonly User<P, U>[];


### PR DESCRIPTION
This fixes a DX issue with `useMutation`.

## Problem

Currently, it's annoying to unpack `{ storage }` in a `useMutation(({ storage }) => ..., [])` call because it will throw immediately upon unpacking when Storage hasn't loaded at that point in time yet, leading to:

    Error: This mutation cannot be used until Storage has loaded

This could be happening if there is a button in the UI that is clicked before Storage has loaded, or if the mutation function gets called in a `useEffect(() => {}, [])` handler, for example.

The problem is that it's currently annoying and unclear to users how to properly avoid this error. For example, given this mutation…

```ts
const myMutation = useMutation(({ storage }) => {
  storage.doSomething();
}, []);
```

…really the only safe way around this is quite annoying:

```ts
// Ugh 😒
const room = useRoom();
const myMutation = useMutation((context) => {
  if (room.getStorageSnapshot() === null) {
    // Storage not ready yet, ignore
    return;
  }
  // Only unpack `storage` after it's loaded
  const { storage } = context;
  storage.doSomething();
}, [room]);
```

## ~Proposed Solution~ _We haven't decided yet!_

This PR makes two (backward-compatible) changes to this API, so the example above can now safely be written as:

```ts
// ✅ After this PR
const myMutation = useMutation(({ storage, isStorageReady }) => {
  // If storage not ready yet, ignore
  if (!isStorageReady) return;

  storage.doSomething();
}, []);
```

1. It no longer throws upon _unpacking_ `storage` (so we can keep all our examples the same), but yet it will throw when _accessing_ methods on the unpacked `storage`. Until storage has actually loaded, this object will be a stub that will throw errors when used.
1. It adds a `isStorageReady` boolean to the mutation context. You can check this boolean to determine if Storage has been loaded, which you can use to exit early. In the use cases of the early button click or `useEffect`, you can now conditionally allow it, rather than getting the error.
