### PR TITLE
Internal refactoring: rename `storage` event source to `storageBatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.1.0 (not published yet)
+
+### `@liveblocks/core`
+
+- Various internal refactorings
+
 ## v2.0.5
 
 ### `@liveblocks/react`

--- a/packages/liveblocks-core/src/__tests__/_utils.ts
+++ b/packages/liveblocks-core/src/__tests__/_utils.ts
@@ -468,10 +468,10 @@ export async function prepareStorageUpdateTest<
   const jsonUpdates: JsonStorageUpdate[][] = [];
   const refJsonUpdates: JsonStorageUpdate[][] = [];
 
-  subject.room.events.storage.subscribe((updates) =>
+  subject.room.events.storageBatch.subscribe((updates) =>
     jsonUpdates.push(updates.map(serializeUpdateToJson))
   );
-  ref.room.events.storage.subscribe((updates) =>
+  ref.room.events.storageBatch.subscribe((updates) =>
     refJsonUpdates.push(updates.map(serializeUpdateToJson))
   );
 

--- a/packages/liveblocks-core/src/__tests__/_waitUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_waitUtils.ts
@@ -81,7 +81,7 @@ export async function waitUntilSynchronized(room: OpaqueRoom): Promise<void> {
 
 export async function waitUntilStorageUpdate(room: OpaqueRoom): Promise<void> {
   await withTimeout(
-    room.events.storage.waitUntil(),
+    room.events.storageBatch.waitUntil(),
     1000,
     "Room never received a storage update within 1s"
   );

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -70,7 +70,7 @@ export async function prepareStorageImmutableTest<
   state = lsonToJson(subject.storage.root) as ToJson<S>;
   refState = lsonToJson(ref.storage.root) as ToJson<S>;
 
-  ref.room.events.storage.subscribe(() => {
+  ref.room.events.storageBatch.subscribe(() => {
     refState = lsonToJson(ref.storage.root) as ToJson<S>;
   });
 

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1498,7 +1498,9 @@ describe("room", () => {
 
       let receivedUpdates: StorageUpdate[] = [];
 
-      room.events.storage.subscribe((updates) => (receivedUpdates = updates));
+      room.events.storageBatch.subscribe(
+        (updates) => (receivedUpdates = updates)
+      );
 
       const immutableState = root.toImmutable() as {
         items: Array<{ names: Array<string> }>;

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -1139,7 +1139,7 @@ describe("LiveList", () => {
       );
 
       const callback = jest.fn();
-      room.events.storage.subscribe(callback);
+      room.events.storageBatch.subscribe(callback);
 
       const root = storage.root;
       const liveList = root.get("items");
@@ -1177,7 +1177,7 @@ describe("LiveList", () => {
       );
 
       const callback = jest.fn();
-      room.events.storage.subscribe(callback);
+      room.events.storageBatch.subscribe(callback);
 
       const root = storage.root;
       const liveList = root.get("items");
@@ -1494,7 +1494,7 @@ describe("LiveList", () => {
         const items = root.get("items");
 
         const callback = jest.fn();
-        room.events.storage.subscribe(callback);
+        room.events.storageBatch.subscribe(callback);
 
         applyRemoteOperations([
           {

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -103,7 +103,7 @@ function startSyncStream(room: OpaqueRoom): void {
     room.events.storageDidLoad.subscribeOnce(() => partialSyncStorage(room)),
 
     // Any time storage updates, send the new storage root
-    room.events.storage.subscribe(() => partialSyncStorage(room)),
+    room.events.storageBatch.subscribe(() => partialSyncStorage(room)),
 
     // Any time "me" or "others" updates, send the new values accordingly
     room.events.self.subscribe(() => partialSyncMe(room)),

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2848,6 +2848,7 @@ export function createRoom<
     self: eventHub.self.observable,
     myPresence: eventHub.myPresence.observable,
     error: eventHub.error.observable,
+    /** @deprecated */
     storage: eventHub.storageBatch.observable,
     storageBatch: eventHub.storageBatch.observable,
     history: eventHub.history.observable,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -666,6 +666,11 @@ export type Room<
     readonly myPresence: Observable<P>;
     readonly others: Observable<OthersEvent<P, U>>;
     readonly error: Observable<LiveblocksError>;
+    /**
+     * @deprecated Renamed to `storageBatch`. The `storage` event source will
+     * soon be replaced by another/incompatible API.
+     */
+    readonly storage: Observable<StorageUpdate[]>;
     readonly storageBatch: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
 
@@ -2837,6 +2842,7 @@ export function createRoom<
     self: eventHub.self.observable,
     myPresence: eventHub.myPresence.observable,
     error: eventHub.error.observable,
+    storage: eventHub.storageBatch.observable,
     storageBatch: eventHub.storageBatch.observable,
     history: eventHub.history.observable,
     storageDidLoad: eventHub.storageDidLoad.observable,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -657,6 +657,12 @@ export type Room<
    */
   getStorageSnapshot(): LiveObject<S> | null;
 
+  /**
+   * All possible room events, subscribable from a single place.
+   *
+   * @private These event sources are private for now, but will become public
+   * once they're stable.
+   */
   readonly events: {
     readonly status: Observable<Status>;
     readonly lostConnection: Observable<LostConnectionEvent>;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -666,7 +666,7 @@ export type Room<
     readonly myPresence: Observable<P>;
     readonly others: Observable<OthersEvent<P, U>>;
     readonly error: Observable<LiveblocksError>;
-    readonly storage: Observable<StorageUpdate[]>;
+    readonly storageBatch: Observable<StorageUpdate[]>;
     readonly history: Observable<HistoryEvent>;
 
     /**
@@ -1639,7 +1639,7 @@ export function createRoom<
     myPresence: makeEventSource<P>(),
     others: makeEventSource<OthersEvent<P, U>>(),
     error: makeEventSource<LiveblocksError>(),
-    storage: makeEventSource<StorageUpdate[]>(),
+    storageBatch: makeEventSource<StorageUpdate[]>(),
     history: makeEventSource<HistoryEvent>(),
     storageDidLoad: makeEventSource<void>(),
     storageStatus: makeEventSource<StorageStatus>(),
@@ -1917,7 +1917,7 @@ export function createRoom<
 
       if (storageUpdates !== undefined && storageUpdates.size > 0) {
         const updates = Array.from(storageUpdates.values());
-        eventHub.storage.notify(updates);
+        eventHub.storageBatch.notify(updates);
       }
       notifyStorageStatus();
     });
@@ -2837,7 +2837,7 @@ export function createRoom<
     self: eventHub.self.observable,
     myPresence: eventHub.myPresence.observable,
     error: eventHub.error.observable,
-    storage: eventHub.storage.observable,
+    storageBatch: eventHub.storageBatch.observable,
     history: eventHub.history.observable,
     storageDidLoad: eventHub.storageDidLoad.observable,
     storageStatus: eventHub.storageStatus.observable,
@@ -3054,7 +3054,7 @@ function makeClassicSubscribeFn<
     node: L,
     callback: (updates: StorageUpdate[]) => void
   ): () => void {
-    return events.storage.subscribe((updates) => {
+    return events.storageBatch.subscribe((updates) => {
       const relatedUpdates = updates.filter((update) =>
         isSameNodeOrChildOf(update.node, node)
       );
@@ -3068,7 +3068,7 @@ function makeClassicSubscribeFn<
     node: L,
     callback: (node: L) => void
   ): () => void {
-    return events.storage.subscribe((updates) => {
+    return events.storageBatch.subscribe((updates) => {
       for (const update of updates) {
         if (update.node._id === node._id) {
           callback(update.node as L);
@@ -3145,7 +3145,7 @@ function makeClassicSubscribeFn<
     if (second === undefined || typeof first === "function") {
       if (typeof first === "function") {
         const storageCallback = first;
-        return events.storage.subscribe(storageCallback);
+        return events.storageBatch.subscribe(storageCallback);
       } else {
         // istanbul ignore next
         throw new Error("Please specify a listener callback");


### PR DESCRIPTION
Doing this before publicly advertising/documenting this API, to indicate its lower-level nature. There isn't a higher-level API for `storage` events yet (like `room.subscribe(node, callback, { isDeep: true })` currently is), so this internal changes makes room for that.
