### PR TITLE
Implement `useStorageStatus()` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v2.1.0 (not published yet)
 
-### `@liveblocks/core`
+### `@liveblocks/client`
 
 - Various internal refactorings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Various internal refactorings
 
+### `@liveblocks/react`
+
+- Add new hook `useStorageStatus()`, which returns the current storage status of
+  the room, and will re-render your component whenever it changes. This can used
+  to build "Saving..." UIs.
+
 ## v2.0.5
 
 ### `@liveblocks/react`

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1267,27 +1267,6 @@ const status = useStatus();
 The possible value are: `initial`, `connecting`, `connected`, `reconnecting`, or
 `disconnected`.
 
-### useStorageStatus [@badge=RoomProvider]
-
-Returns the current storage status of the room, and will re-render your
-component whenever it changes.
-
-```ts
-import { useStorageStatus } from "@liveblocks/react";
-
-const status = useStatus();
-// "not-loaded" | "loading" | "synchronizing" | "synchronized"
-```
-
-👉 A [Suspense version][] of this hook is also available.
-
-```ts
-import { useStorageStatus } from "@liveblocks/react/suspense";
-
-const status = useStatus();
-// "synchronizing" | "synchronized"
-```
-
 ### useOthersListener [@badge=RoomProvider]
 
 Calls the given callback when an “others” event occurs. Possible event types

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1267,6 +1267,27 @@ const status = useStatus();
 The possible value are: `initial`, `connecting`, `connected`, `reconnecting`, or
 `disconnected`.
 
+### useStorageStatus [@badge=RoomProvider]
+
+Returns the current storage status of the room, and will re-render your
+component whenever it changes.
+
+```ts
+import { useStorageStatus } from "@liveblocks/react";
+
+const status = useStatus();
+// "not-loaded" | "loading" | "synchronizing" | "synchronized"
+```
+
+👉 A [Suspense version][] of this hook is also available.
+
+```ts
+import { useStorageStatus } from "@liveblocks/react/suspense";
+
+const status = useStatus();
+// "synchronizing" | "synchronized"
+```
+
 ### useOthersListener [@badge=RoomProvider]
 
 Calls the given callback when an “others” event occurs. Possible event types

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -32,8 +32,8 @@ export {
   useCanUndo,
   useCreateComment,
   useCreateThread,
-  useDeleteThread,
   useDeleteComment,
+  useDeleteThread,
   useEditComment,
   useEditThreadMetadata,
   useErrorListener,
@@ -68,6 +68,7 @@ export {
   useOthersMapped,
   useSelf,
   useStorage,
+  useStorageStatus,
   useThreads,
 } from "./room";
 export {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2488,6 +2488,8 @@ export {
   useStatus,
   _useStorage as useStorage,
   _useStorageRoot as useStorageRoot,
+  useStorageStatus,
+  useStorageStatusSuspense,
   _useStorageSuspense as useStorageSuspense,
   _useThreads as useThreads,
   _useThreadsSuspense as useThreadsSuspense,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -32,6 +32,7 @@ import type {
   PrivateRoomApi,
   RoomEventMessage,
   RoomNotificationSettings,
+  StorageStatus,
   ThreadData,
   ToImmutable,
 } from "@liveblocks/core";
@@ -94,6 +95,7 @@ import type {
   RoomNotificationSettingsState,
   RoomNotificationSettingsStateSuccess,
   RoomProviderProps,
+  StorageStatusSuccess,
   ThreadsState,
   ThreadsStateSuccess,
   ThreadSubscription,
@@ -552,6 +554,7 @@ function makeRoomContextBundle<
 
     useRoom,
     useStatus,
+    useStorageStatus,
 
     useBatch,
     useBroadcastEvent,
@@ -603,6 +606,7 @@ function makeRoomContextBundle<
 
       useRoom,
       useStatus,
+      useStorageStatus: useStorageStatusSuspense,
 
       useBatch,
       useBroadcastEvent,
@@ -909,6 +913,14 @@ function useStatus(): Status {
   const subscribe = room.events.status.subscribe;
   const getSnapshot = room.getStatus;
   const getServerSnapshot = room.getStatus;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+function useStorageStatus(): StorageStatus {
+  const room = useRoom();
+  const subscribe = room.events.storageStatus.subscribe;
+  const getSnapshot = room.getStorageStatus;
+  const getServerSnapshot = room.getStorageStatus;
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
@@ -2234,6 +2246,15 @@ function useStorageSuspense<S extends LsonObject, T>(
     selector,
     isEqual as (prev: T | null, curr: T | null) => boolean
   ) as T;
+}
+
+function useStorageStatusSuspense(): StorageStatusSuccess {
+  useSuspendUntilStorageLoaded();
+  const room = useRoom();
+  const subscribe = room.events.storageStatus.subscribe;
+  const getSnapshot = room.getStorageStatus as () => StorageStatusSuccess;
+  const getServerSnapshot = room.getStorageStatus as () => StorageStatusSuccess;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 function useThreadsSuspense<M extends BaseMetadata>(

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -30,8 +30,8 @@ export {
   useCanUndo,
   useCreateComment,
   useCreateThread,
-  useDeleteThread,
   useDeleteComment,
+  useDeleteThread,
   useEditComment,
   useEditThreadMetadata,
   useErrorListener,
@@ -63,6 +63,7 @@ export {
   useOthersMappedSuspense as useOthersMapped,
   useSelfSuspense as useSelf,
   useStorageSuspense as useStorage,
+  useStorageStatusSuspense as useStorageStatus,
   useThreadsSuspense as useThreads,
 } from "./room";
 export {

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -25,9 +25,15 @@ import type {
   QueryMetadata,
   Resolve,
   RoomEventMessage,
+  StorageStatus,
   ThreadData,
   ToImmutable,
 } from "@liveblocks/core";
+
+export type StorageStatusSuccess = Exclude<
+  StorageStatus,
+  "not-loaded" | "loading"
+>;
 
 export type UseThreadsOptions<M extends BaseMetadata> = {
   /**
@@ -850,6 +856,13 @@ export type RoomContextBundle<
   RoomContextBundleCommon<P, S, U, E, M> &
     SharedContextBundle<U>["classic"] & {
       /**
+       * Returns the current storage status for the Room, and triggers
+       * a re-render whenever it changes. Can be used to render a "Saving..."
+       * indicator.
+       */
+      useStorageStatus(): StorageStatus;
+
+      /**
        * Extract arbitrary data from the Liveblocks Storage state, using an
        * arbitrary selector function.
        *
@@ -935,6 +948,13 @@ export type RoomContextBundle<
       suspense: Resolve<
         RoomContextBundleCommon<P, S, U, E, M> &
           SharedContextBundle<U>["suspense"] & {
+            /**
+             * Returns the current storage status for the Room, and triggers
+             * a re-render whenever it changes. Can be used to render a "Saving..."
+             * indicator.
+             */
+            useStorageStatus(): StorageStatusSuccess;
+
             /**
              * Extract arbitrary data from the Liveblocks Storage state, using an
              * arbitrary selector function.

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -269,6 +269,16 @@ declare global {
 
 // ---------------------------------------------------------
 
+// useStorageStatus()
+{
+  expectType<"not-loaded" | "loading" | "synchronizing" | "synchronized">(
+    classic.useStorageStatus()
+  );
+  expectType<"synchronizing" | "synchronized">(suspense.useStorageStatus());
+}
+
+// ---------------------------------------------------------
+
 // useSelf()
 {
   const me = classic.useSelf();

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -293,6 +293,17 @@ expectType<[root: LiveObject<MyStorage> | null]>(ctx.suspense.useStorageRoot());
 //                                             as it's used as a building
 //                                             block. This is NOT a bug.
 
+// The useStorageStatus() hook
+{
+  // Classic
+  expectType<"not-loaded" | "loading" | "synchronizing" | "synchronized">(
+    ctx.useStorageStatus()
+  );
+
+  // Suspense
+  expectType<"synchronizing" | "synchronized">(ctx.suspense.useStorageStatus());
+}
+
 // The useOthersListener() hook
 ctx.useOthersListener((event) => {
   expectType<readonly User<P, U>[]>(event.others);

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -172,6 +172,16 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
+// useStorageStatus()
+{
+  expectType<"not-loaded" | "loading" | "synchronizing" | "synchronized">(
+    classic.useStorageStatus()
+  );
+  expectType<"synchronizing" | "synchronized">(suspense.useStorageStatus());
+}
+
+// ---------------------------------------------------------
+
 // useSelf()
 {
   const me = classic.useSelf();


### PR DESCRIPTION
Note:

```tsx
import { useStorageStatus } from "@liveblocks/react";
const status = useStorageStatus();
//    ^? "not-loaded" | "loading" | "synchronizing" | "synchronized"
```

vs the suspending version:

```tsx
import { useStorageStatus } from "@liveblocks/react/suspense";
const status = useStorageStatus();
//    ^? "synchronizing" | "synchronized"
```

Fixes LB-932.