### PR TITLE
Re-mention new hook in 2.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### `@liveblocks/react`
 
+- Add
+  [`useDeleteThread`](https://liveblocks.io/docs/api-reference/liveblocks-react#useDeleteThread)
+  hook to delete a thread and its associated comments.
 - Add new hook `useStorageStatus()`, which returns the current storage status of
   the room, and will re-render your component whenever it changes. This can used
   to build "Saving..." UIs.


### PR DESCRIPTION
Last week, 2.0.4 was released which introduced a new hook. New features should land in a minor version, instead of in patch-level releases. We'll leave it be for now, but let's at least re-mention the addition of this hook in the 2.1 changelog, so people that skip reading all the patch level changelog entries will still see this one.
