### PR TITLE
Use `actions/upload-artifact@v4`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run Playwright tests
         run: npm run test -- --filter @liveblocks/next-sandbox
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-report


### PR DESCRIPTION
We currently use `actions/upload-artifact@v2` but `v1`, `v2`, and `v3` are all [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

Given our simple usage of it, we're not affected by the breaking changes of `v3` and `v4`.