### PR TITLE
Add missing JSDocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add new hook `useStorageStatus()`, which returns the current storage status of
   the room, and will re-render your component whenever it changes. This can used
   to build "Saving..." UIs.
+- Add missing JSDoc comments
 
 ## v2.0.5
 

--- a/packages/liveblocks-core/src/lib/Json.ts
+++ b/packages/liveblocks-core/src/lib/Json.ts
@@ -11,6 +11,9 @@
 export type Json = JsonScalar | JsonArray | JsonObject;
 export type JsonScalar = string | number | boolean | null;
 export type JsonArray = Json[];
+/**
+ * Any valid JSON object.
+ */
 export type JsonObject = { [key: string]: Json | undefined };
 
 export function isJsonScalar(data: Json): data is JsonScalar {

--- a/packages/liveblocks-react/src/comments/errors.ts
+++ b/packages/liveblocks-react/src/comments/errors.ts
@@ -1,5 +1,8 @@
 import type { BaseMetadata, CommentBody, Patchable } from "@liveblocks/core";
 
+/**
+ * @private Internal API, do not rely on it.
+ */
 export class CreateThreadError<M extends BaseMetadata> extends Error {
   constructor(
     public cause: Error,

--- a/packages/liveblocks-react/src/comments/lib/selected-threads.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-threads.ts
@@ -7,6 +7,9 @@ import {
 
 import type { UseThreadsOptions } from "../../types";
 
+/**
+ * @private Do not rely on this internal API.
+ */
 export function selectedThreads<M extends BaseMetadata>(
   roomId: string,
   state: CacheState<M>,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -45,6 +45,12 @@ import type {
   UserStateSuccess,
 } from "./types";
 
+/**
+ * Raw access to the React context where the LiveblocksProvider stores the
+ * current client. Exposed for advanced use cases only.
+ *
+ * @private This is a private/advanced API. Do not rely on it.
+ */
 export const ClientContext = createContext<OpaqueClient | null>(null);
 
 const missingUserError = new Error(
@@ -841,6 +847,11 @@ export function LiveblocksProvider<U extends BaseUserMeta = DU>(
   );
 }
 
+/**
+ * Creates a LiveblocksProvider and a set of typed hooks. Note that any
+ * LiveblocksProvider created in this way takes no props, because it uses
+ * settings from the given client instead.
+ */
 export function createLiveblocksContext<
   U extends BaseUserMeta = DU,
   M extends BaseMetadata = DM,
@@ -848,10 +859,26 @@ export function createLiveblocksContext<
   return getOrCreateContextBundle<U, M>(client);
 }
 
+/**
+ * @beta
+ *
+ * Returns the inbox notifications for the current user.
+ *
+ * @example
+ * const { inboxNotifications, error, isLoading } = useInboxNotifications();
+ */
 function useInboxNotifications() {
   return useInboxNotifications_withClient(useClient());
 }
 
+/**
+ * @beta
+ *
+ * Returns the inbox notifications for the current user.
+ *
+ * @example
+ * const { inboxNotifications } = useInboxNotifications();
+ */
 function useInboxNotificationsSuspense() {
   return useInboxNotificationsSuspense_withClient(useClient());
 }
@@ -865,18 +892,52 @@ function useInboxNotificationThread<M extends BaseMetadata>(
   );
 }
 
+/**
+ * @beta
+ *
+ * Returns a function that marks all inbox notifications as read.
+ *
+ * @example
+ * const markAllInboxNotificationsAsRead = useMarkAllInboxNotificationsAsRead();
+ * markAllInboxNotificationsAsRead();
+ */
 function useMarkAllInboxNotificationsAsRead() {
   return useMarkAllInboxNotificationsAsRead_withClient(useClient());
 }
 
+/**
+ * @beta
+ *
+ * Returns a function that marks an inbox notification as read.
+ *
+ * @example
+ * const markInboxNotificationAsRead = useMarkInboxNotificationAsRead();
+ * markInboxNotificationAsRead("in_xxx");
+ */
 function useMarkInboxNotificationAsRead() {
   return useMarkInboxNotificationAsRead_withClient(useClient());
 }
 
+/**
+ * @beta
+ *
+ * Returns the number of unread inbox notifications for the current user.
+ *
+ * @example
+ * const { count, error, isLoading } = useUnreadInboxNotificationsCount();
+ */
 function useUnreadInboxNotificationsCount() {
   return useUnreadInboxNotificationsCount_withClient(useClient());
 }
 
+/**
+ * @beta
+ *
+ * Returns the number of unread inbox notifications for the current user.
+ *
+ * @example
+ * const { count } = useUnreadInboxNotificationsCount();
+ */
 function useUnreadInboxNotificationsCountSuspense() {
   return useUnreadInboxNotificationsCountSuspense_withClient(useClient());
 }
@@ -891,26 +952,60 @@ function useUserSuspense<U extends BaseUserMeta>(userId: string) {
   return useUserSuspense_withClient(client, userId);
 }
 
+/**
+ * Returns room info from a given room ID.
+ *
+ * @example
+ * const { info, error, isLoading } = useRoomInfo("room-id");
+ */
 function useRoomInfo(roomId: string) {
   return useRoomInfo_withClient(useClient(), roomId);
 }
 
+/**
+ * Returns room info from a given room ID.
+ *
+ * @example
+ * const { info } = useRoomInfo("room-id");
+ */
 function useRoomInfoSuspense(roomId: string) {
   return useRoomInfoSuspense_withClient(useClient(), roomId);
 }
 
-// TODO in 2.0 Copy/paste all the docstrings onto these global hooks :(
-const __1: LiveblocksContextBundle<DU, DM>["useInboxNotificationThread"] =
+type TypedBundle = LiveblocksContextBundle<DU, DM>;
+
+/**
+ * @beta
+ *
+ * Returns the thread associated with a `"thread"` inbox notification.
+ *
+ * @example
+ * const thread = useInboxNotificationThread("in_xxx");
+ */
+const _useInboxNotificationThread: TypedBundle["useInboxNotificationThread"] =
   useInboxNotificationThread;
-const __2: LiveblocksContextBundle<DU, DM>["useUser"] = useUser;
-const __3: LiveblocksContextBundle<DU, DM>["suspense"]["useUser"] =
-  useUserSuspense;
+
+/**
+ * Returns user info from a given user ID.
+ *
+ * @example
+ * const { user, error, isLoading } = useUser("user-id");
+ */
+const _useUser: TypedBundle["useUser"] = useUser;
+
+/**
+ * Returns user info from a given user ID.
+ *
+ * @example
+ * const { user } = useUser("user-id");
+ */
+const _useUserSuspense: TypedBundle["suspense"]["useUser"] = useUserSuspense;
 
 // eslint-disable-next-line simple-import-sort/exports
 export {
-  __1 as useInboxNotificationThread,
-  __2 as useUser,
-  __3 as useUserSuspense,
+  _useInboxNotificationThread as useInboxNotificationThread,
+  _useUser as useUser,
+  _useUserSuspense as useUserSuspense,
   useInboxNotifications,
   useInboxNotificationsSuspense,
   useMarkAllInboxNotificationsAsRead,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2710,8 +2710,13 @@ const _useEditThreadMetadata: TypedBundle["useEditThreadMetadata"] =
  * useEventListener is a React hook that allows you to respond to events broadcast
  * by other users in the room.
  *
+ * The `user` argument will indicate which `User` instance sent the message.
+ * This will be equal to one of the others in the room, but it can be `null`
+ * in case this event was broadcasted from the server.
+ *
  * @example
- * useEventListener(({ connectionId, event }) => {
+ * useEventListener(({ event, user, connectionId }) => {
+ * //                         ^^^^ Will be Client A
  *   if (event.type === "CUSTOM_EVENT") {
  *     // Do something
  *   }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2815,6 +2815,7 @@ const _useThreadsSuspense: TypedBundle["suspense"]["useThreads"] =
  */
 const _useOther: TypedBundle["useOther"] = useOther;
 
+// TODO This one is tricky, as it has overloads
 const _useOthers: TypedBundle["useOthers"] = useOthers;
 
 /**
@@ -2828,6 +2829,7 @@ const _useOthers: TypedBundle["useOthers"] = useOthers;
  */
 const _useOtherSuspense: TypedBundle["suspense"]["useOther"] = useOtherSuspense;
 
+// TODO This one is tricky, as it has overloads
 const _useOthersSuspense: TypedBundle["suspense"]["useOthers"] =
   useOthersSuspense;
 
@@ -2874,8 +2876,10 @@ const _useStorage: TypedBundle["useStorage"] = useStorage;
 const _useStorageSuspense: TypedBundle["suspense"]["useStorage"] =
   useStorageSuspense;
 
+// TODO This one is tricky, as it has overloads
 const _useSelf: TypedBundle["useSelf"] = useSelf;
 
+// TODO This one is tricky, as it has overloads
 const _useSelfSuspense: TypedBundle["suspense"]["useSelf"] = useSelfSuspense;
 
 /**

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2815,7 +2815,6 @@ const _useThreadsSuspense: TypedBundle["suspense"]["useThreads"] =
  */
 const _useOther: TypedBundle["useOther"] = useOther;
 
-// XXX This one is tricky, as it has overloads
 const _useOthers: TypedBundle["useOthers"] = useOthers;
 
 /**
@@ -2829,7 +2828,6 @@ const _useOthers: TypedBundle["useOthers"] = useOthers;
  */
 const _useOtherSuspense: TypedBundle["suspense"]["useOther"] = useOtherSuspense;
 
-// XXX This one is tricky, as it has overloads
 const _useOthersSuspense: TypedBundle["suspense"]["useOthers"] =
   useOthersSuspense;
 
@@ -2876,10 +2874,8 @@ const _useStorage: TypedBundle["useStorage"] = useStorage;
 const _useStorageSuspense: TypedBundle["suspense"]["useStorage"] =
   useStorageSuspense;
 
-// XXX This one is tricky, as it has overloads
 const _useSelf: TypedBundle["useSelf"] = useSelf;
 
-// XXX This one is tricky, as it has overloads
 const _useSelfSuspense: TypedBundle["suspense"]["useSelf"] = useSelfSuspense;
 
 /**

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2637,10 +2637,9 @@ const _useAddReaction: TypedBundle["useAddReaction"] = useAddReaction;
  * The first argument that gets passed into your callback will be
  * a "mutation context", which exposes the following:
  *
- *   - `root` - The mutable Storage root.
- *              You can normal mutation on Live structures with this, for
- *              example: root.get('layers').get('layer1').set('fill',
- *              'red')
+ *   - `storage` - The mutable Storage root.
+ *                 You can mutate any Live structures with this, for example:
+ *                 `storage.get('layers').get('layer1').set('fill', 'red')`
  *
  *   - `setMyPresence` - Call this with a new (partial) Presence value.
  *
@@ -2654,11 +2653,11 @@ const _useAddReaction: TypedBundle["useAddReaction"] = useAddReaction;
  * that gets passed into your callback will be a "mutation context".
  *
  * If you want get access to the immutable root somewhere in your mutation,
- * you can use `root.ToImmutable()`.
+ * you can use `storage.ToImmutable()`.
  *
  * @example
  * const fillLayers = useMutation(
- *   ({ root }, color: Color) => {
+ *   ({ storage }, color: Color) => {
  *     ...
  *   },
  *   [],
@@ -2667,7 +2666,7 @@ const _useAddReaction: TypedBundle["useAddReaction"] = useAddReaction;
  * fillLayers('red');
  *
  * const deleteLayers = useMutation(
- *   ({ root }) => {
+ *   ({ storage }) => {
  *     ...
  *   },
  *   [],

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -574,10 +574,9 @@ type RoomContextBundleCommon<
    * The first argument that gets passed into your callback will be
    * a "mutation context", which exposes the following:
    *
-   *   - `root` - The mutable Storage root.
-   *              You can normal mutation on Live structures with this, for
-   *              example: root.get('layers').get('layer1').set('fill',
-   *              'red')
+   *   - `storage` - The mutable Storage root.
+   *                 You can mutate any Live structures with this, for example:
+   *                 `storage.get('layers').get('layer1').set('fill', 'red')`
    *
    *   - `setMyPresence` - Call this with a new (partial) Presence value.
    *
@@ -591,11 +590,11 @@ type RoomContextBundleCommon<
    * that gets passed into your callback will be a "mutation context".
    *
    * If you want get access to the immutable root somewhere in your mutation,
-   * you can use `root.ToImmutable()`.
+   * you can use `storage.ToImmutable()`.
    *
    * @example
    * const fillLayers = useMutation(
-   *   ({ root }, color: Color) => {
+   *   ({ storage }, color: Color) => {
    *     ...
    *   },
    *   [],
@@ -604,7 +603,7 @@ type RoomContextBundleCommon<
    * fillLayers('red');
    *
    * const deleteLayers = useMutation(
-   *   ({ root }) => {
+   *   ({ storage }) => {
    *     ...
    *   },
    *   [],

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -490,8 +490,13 @@ type RoomContextBundleCommon<
    * useEventListener is a React hook that allows you to respond to events broadcast
    * by other users in the room.
    *
+   * The `user` argument will indicate which `User` instance sent the message.
+   * This will be equal to one of the others in the room, but it can be `null`
+   * in case this event was broadcasted from the server.
+   *
    * @example
-   * useEventListener(({ connectionId, event }) => {
+   * useEventListener(({ event, user, connectionId }) => {
+   * //                         ^^^^ Will be Client A
    *   if (event.type === "CUSTOM_EVENT") {
    *     // Do something
    *   }


### PR DESCRIPTION
Add back all the missing JSDocs that got lost in the 2.0 refactoring.

This PR copies them all back in. Note that currently they are duplicated, because there is no way to "share" them in TypeScript (for good reason). However, to avoid a massive maintenance burden, I'm working on a script to check that all of these exports (and their JSDoc strings) are in sync in all their various forms, so that CI will fail as a reminder if we update one but forget to publish a suspense version.

In fact, I've used that WIP script to find all of these, and ensure they're correct. However, I want to get this fix out for 2.1 before publishing the script, because that may take a bit longer to finish completely.

Fixes LB-730.
