### PR TITLE
Improve error messages and stack traces to contain more info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   the room, and will re-render your component whenever it changes. This can used
   to build "Saving..." UIs.
 - Add missing JSDoc comments
+- Improve some error messages and stack traces to contain more info
 
 ## v2.0.5
 

--- a/packages/liveblocks-react/src/__tests__/useRoomInfo.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useRoomInfo.test.tsx
@@ -69,7 +69,7 @@ describe("useRoomInfo", () => {
     expect(result.current.roomInfo).toEqual({
       isLoading: false,
       error: new Error(
-        "resolveRoomsInfo didn't return anything for this room ID."
+        "resolveRoomsInfo didn't return anything for room 'abc'"
       ),
     });
 
@@ -313,7 +313,7 @@ describe("useRoomInfo", () => {
     expect(result.current.roomInfo).toEqual({
       isLoading: false,
       error: new Error(
-        "resolveRoomsInfo didn't return anything for this room ID."
+        "resolveRoomsInfo didn't return anything for room 'abc'"
       ),
     });
 
@@ -353,7 +353,7 @@ describe("useRoomInfo", () => {
     expect(result.current.roomInfoAbc).toEqual({
       isLoading: false,
       error: new Error(
-        "resolveRoomsInfo didn't return anything for this room ID."
+        "resolveRoomsInfo didn't return anything for room 'abc'"
       ),
     });
 

--- a/packages/liveblocks-react/src/__tests__/useUser.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useUser.test.tsx
@@ -66,7 +66,7 @@ describe("useUser", () => {
 
     expect(result.current.user).toEqual({
       isLoading: false,
-      error: new Error("resolveUsers didn't return anything for this user ID."),
+      error: new Error("resolveUsers didn't return anything for user 'abc'"),
     });
 
     unmount();
@@ -308,7 +308,7 @@ describe("useUser", () => {
 
     expect(result.current.user).toEqual({
       isLoading: false,
-      error: new Error("resolveUsers didn't return anything for this user ID."),
+      error: new Error("resolveUsers didn't return anything for user 'abc'"),
     });
 
     unmount();
@@ -346,7 +346,7 @@ describe("useUser", () => {
 
     expect(result.current.userAbc).toEqual({
       isLoading: false,
-      error: new Error("resolveUsers didn't return anything for this user ID."),
+      error: new Error("resolveUsers didn't return anything for user 'abc'"),
     });
 
     expect(result.current.user123).toEqual({

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -53,12 +53,15 @@ import type {
  */
 export const ClientContext = createContext<OpaqueClient | null>(null);
 
-const missingUserError = new Error(
-  "resolveUsers didn't return anything for this user ID."
-);
-const missingRoomInfoError = new Error(
-  "resolveRoomsInfo didn't return anything for this room ID."
-);
+function missingUserError(userId: string) {
+  return new Error(`resolveUsers didn't return anything for user '${userId}'`);
+}
+
+function missingRoomInfoError(roomId: string) {
+  return new Error(
+    `resolveRoomsInfo didn't return anything for room '${roomId}'`
+  );
+}
 
 const _extras = new WeakMap<
   OpaqueClient,
@@ -616,7 +619,7 @@ function useUser_withClient<U extends BaseUserMeta>(
         // Return an error if `undefined` was returned by `resolveUsers` for this user ID
         error:
           !state.isLoading && !state.data && !state.error
-            ? missingUserError
+            ? missingUserError(userId)
             : state.error,
       } as UserState<U["info"]>)
     : { isLoading: true };
@@ -644,7 +647,7 @@ function useUserSuspense_withClient<U extends BaseUserMeta>(
 
   // Throw an error if `undefined` was returned by `resolveUsers` for this user ID
   if (!userState.data) {
-    throw missingUserError;
+    throw missingUserError(userId);
   }
 
   const state = useSyncExternalStore(
@@ -688,7 +691,7 @@ function useRoomInfo_withClient(
         // Return an error if `undefined` was returned by `resolveRoomsInfo` for this room ID
         error:
           !state.isLoading && !state.data && !state.error
-            ? missingRoomInfoError
+            ? missingRoomInfoError(roomId)
             : state.error,
       } as RoomInfoState)
     : { isLoading: true };
@@ -713,7 +716,7 @@ function useRoomInfoSuspense_withClient(client: OpaqueClient, roomId: string) {
 
   // Throw an error if `undefined` was returned by `resolveRoomsInfo` for this room ID
   if (!roomInfoState.data) {
-    throw missingRoomInfoError;
+    throw missingRoomInfoError(roomId);
   }
 
   const state = useSyncExternalStore(


### PR DESCRIPTION
Small fix to make these two errors have better stack traces and repeat the user ID and/or room ID in the error message. Both of these improvements should improve the DX when you run into these.
