### PR TITLE
Fix `useSyncExternalStore` usage in `@liveblocks/react-ui`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   to build "Saving..." UIs.
 - Add missing JSDoc comments
 
+### `@liveblocks/react-ui`
+
+- Fix improper `useSyncExternalStore` import which would break on React <18.
+
 ## v2.0.5
 
 ### `@liveblocks/react`

--- a/packages/liveblocks-react-lexical/.eslintrc.js
+++ b/packages/liveblocks-react-lexical/.eslintrc.js
@@ -18,7 +18,41 @@ module.exports = {
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------
-    "no-restricted-syntax": ["error", ...commonRestrictedSyntax],
+    "no-restricted-syntax": [
+      "error",
+      ...commonRestrictedSyntax,
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='use']",
+        message: "use is only available on React >=19.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useSyncExternalStore']",
+        message:
+          "useSyncExternalStore is only available on React >=18. Import it from 'use-sync-external-store/shim/index.js' instead.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useId']",
+        message: "useId is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useTransition']",
+        message: "useTransition is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useDeferredValue']",
+        message: "useDeferredValue is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useInsertionEffect']",
+        message: "useInsertionEffect is only available on React >=18.",
+      },
+    ],
 
     // ----------------------------------------------------------------------
     // Overrides from default rule config used in all other projects!

--- a/packages/liveblocks-react-lexical/rollup.config.ts
+++ b/packages/liveblocks-react-lexical/rollup.config.ts
@@ -20,6 +20,11 @@ interface Pkg {
 
 const pkg = createRequire(import.meta.url)("./package.json") as Pkg;
 
+// Match dependencies exactly or with any subpath
+function createExternals(dependencies: string[]) {
+  return dependencies.map((dependency) => new RegExp(`^${dependency}(/.*)?$`));
+}
+
 function createMainConfig(format: "cjs" | "esm"): RollupOptions {
   const output: RollupOptions["output"] =
     format === "cjs"
@@ -42,17 +47,13 @@ function createMainConfig(format: "cjs" | "esm"): RollupOptions {
   return {
     input: ENTRIES,
     external: [
-      ...Object.keys(pkg.dependencies),
-      ...Object.keys(pkg.peerDependencies),
-      "@lexical/react/LexicalCollaborationPlugin",
-      "@lexical/react/LexicalComposerContext",
-      "react-dom",
+      ...createExternals([
+        ...Object.keys(pkg.dependencies),
+        ...Object.keys(pkg.peerDependencies),
+      ]),
 
-      // NOTE: These should ideally not have to be here, because
-      // use-sync-external-store is already declared as a production
-      // dependency. Figure this out later.
-      "use-sync-external-store/shim/index.js",
-      "use-sync-external-store/shim/with-selector.js",
+      // "react-dom" is an implicit peer dependency
+      "react-dom",
     ],
     output,
     treeshake: false,

--- a/packages/liveblocks-react-ui/.eslintrc.js
+++ b/packages/liveblocks-react-ui/.eslintrc.js
@@ -31,13 +31,13 @@ module.exports = {
         selector:
           "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useId']",
         message:
-          "useId is only available on React >=18. Import it from 'src/utils/use-id' instead.",
+          "useId is only available on React >=18. Import it from '/src/utils/use-id' instead.",
       },
       {
         selector:
           "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useTransition']",
         message:
-          "useTransition is only available on React >=18. Import it from 'src/utils/use-transition' instead.",
+          "useTransition is only available on React >=18. Import it from '/src/utils/use-transition' instead.",
       },
     ],
 

--- a/packages/liveblocks-react-ui/.eslintrc.js
+++ b/packages/liveblocks-react-ui/.eslintrc.js
@@ -23,6 +23,11 @@ module.exports = {
       ...commonRestrictedSyntax,
       {
         selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='use']",
+        message: "use is only available on React >=19.",
+      },
+      {
+        selector:
           "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useSyncExternalStore']",
         message:
           "useSyncExternalStore is only available on React >=18. Import it from 'use-sync-external-store/shim/index.js' instead.",
@@ -38,6 +43,16 @@ module.exports = {
           "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useTransition']",
         message:
           "useTransition is only available on React >=18. Import it from '/src/utils/use-transition' instead.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useDeferredValue']",
+        message: "useDeferredValue is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useInsertionEffect']",
+        message: "useInsertionEffect is only available on React >=18.",
       },
     ],
 

--- a/packages/liveblocks-react-ui/.eslintrc.js
+++ b/packages/liveblocks-react-ui/.eslintrc.js
@@ -18,7 +18,28 @@ module.exports = {
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------
-    "no-restricted-syntax": ["error", ...commonRestrictedSyntax],
+    "no-restricted-syntax": [
+      "error",
+      ...commonRestrictedSyntax,
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useSyncExternalStore']",
+        message:
+          "useSyncExternalStore is only available on React >=18. Import it from 'use-sync-external-store/shim/index.js' instead.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useId']",
+        message:
+          "useId is only available on React >=18. Import it from 'src/utils/use-id' instead.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useTransition']",
+        message:
+          "useTransition is only available on React >=18. Import it from 'src/utils/use-transition' instead.",
+      },
+    ],
 
     // ----------------------------------------------------------------------
     // Overrides from default rule config used in all other projects!

--- a/packages/liveblocks-react-ui/rollup.config.ts
+++ b/packages/liveblocks-react-ui/rollup.config.ts
@@ -20,6 +20,11 @@ interface Pkg {
 
 const pkg = createRequire(import.meta.url)("./package.json") as Pkg;
 
+// Match dependencies exactly or with any subpath
+function createExternals(dependencies: string[]) {
+  return dependencies.map((dependency) => new RegExp(`^${dependency}(/.*)?$`));
+}
+
 function createMainConfig(format: "cjs" | "esm"): RollupOptions {
   const output: RollupOptions["output"] =
     format === "cjs"
@@ -42,8 +47,12 @@ function createMainConfig(format: "cjs" | "esm"): RollupOptions {
   return {
     input: ENTRIES,
     external: [
-      ...Object.keys(pkg.dependencies),
-      ...Object.keys(pkg.peerDependencies),
+      ...createExternals([
+        ...Object.keys(pkg.dependencies),
+        ...Object.keys(pkg.peerDependencies),
+      ]),
+
+      // "react-dom" is an implicit peer dependency
       "react-dom",
     ],
     output,

--- a/packages/liveblocks-react-ui/src/shared.ts
+++ b/packages/liveblocks-react-ui/src/shared.ts
@@ -7,7 +7,8 @@ import {
   useRoom,
   useSelf,
 } from "@liveblocks/react";
-import React, { useContext, useSyncExternalStore } from "react";
+import React, { useContext } from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 
 const MENTION_SUGGESTIONS_DEBOUNCE = 500;
 

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -8,7 +8,23 @@ module.exports = {
     // -------------------------------
     // Custom syntax we want to forbid
     // -------------------------------
-    "no-restricted-syntax": ["error", ...commonRestrictedSyntax],
+    "no-restricted-syntax": [
+      "error",
+      ...commonRestrictedSyntax,
+      // TODO: Enable the following error once React 19 is released and our polyfill is ready
+      // {
+      //   selector:
+      //     "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='use']",
+      //   message:
+      //     "use is only available on React >=19. Import it from '/src/lib/use-polyfill' instead.",
+      // },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useSyncExternalStore']",
+        message:
+          "useSyncExternalStore is only available on React >=18. Import it from 'use-sync-external-store/shim/index.js' instead.",
+      },
+    ],
 
     // ----------------------------------------------------------------------
     // Overrides from default rule config used in all other projects!

--- a/packages/liveblocks-react/.eslintrc.js
+++ b/packages/liveblocks-react/.eslintrc.js
@@ -11,18 +11,36 @@ module.exports = {
     "no-restricted-syntax": [
       "error",
       ...commonRestrictedSyntax,
-      // TODO: Enable the following error once React 19 is released and our polyfill is ready
-      // {
-      //   selector:
-      //     "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='use']",
-      //   message:
-      //     "use is only available on React >=19. Import it from '/src/lib/use-polyfill' instead.",
-      // },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='use']",
+        message: "use is only available on React >=19.",
+      },
       {
         selector:
           "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useSyncExternalStore']",
         message:
           "useSyncExternalStore is only available on React >=18. Import it from 'use-sync-external-store/shim/index.js' instead.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useId']",
+        message: "useId is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useTransition']",
+        message: "useTransition is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useDeferredValue']",
+        message: "useDeferredValue is only available on React >=18.",
+      },
+      {
+        selector:
+          "ImportDeclaration[source.value='react'] ImportSpecifier[imported.name='useInsertionEffect']",
+        message: "useInsertionEffect is only available on React >=18.",
       },
     ],
 


### PR DESCRIPTION
This PR fixes a case where `useSyncExternalStore` was imported directly from `react` instead of its shim.
While I was there I also improved two things:
- improve how our Rollup configs list external imports (it currently does exact matching so it complains about subpaths)
- create a set of ESLint errors for React >=18 hooks whenever we have an alternative