### PR TITLE
Add missing JSDocs for `useOthers` and `useSelf`

### DIFF
--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2820,8 +2820,8 @@ const _useThreadsSuspense: TypedBundle["suspense"]["useThreads"] =
 const _useOther: TypedBundle["useOther"] = useOther;
 
 /**
- * Returns an object that lets you get information about all the users
- * currently connected in the room.
+ * Returns an array with information about all the users currently connected in
+ * the room (except yourself).
  *
  * @example
  * const others = useOthers();
@@ -2880,8 +2880,8 @@ function _useOthers(...args: any[]) {
 const _useOtherSuspense: TypedBundle["suspense"]["useOther"] = useOtherSuspense;
 
 /**
- * Returns an object that lets you get information about all the users
- * currently connected in the room.
+ * Returns an array with information about all the users currently connected in
+ * the room (except yourself).
  *
  * @example
  * const others = useOthers();

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2819,8 +2819,54 @@ const _useThreadsSuspense: TypedBundle["suspense"]["useThreads"] =
  */
 const _useOther: TypedBundle["useOther"] = useOther;
 
-// TODO This one is tricky, as it has overloads
-const _useOthers: TypedBundle["useOthers"] = useOthers;
+/**
+ * Returns an object that lets you get information about all the users
+ * currently connected in the room.
+ *
+ * @example
+ * const others = useOthers();
+ *
+ * // Example to map all cursors in JSX
+ * return (
+ *   <>
+ *     {others.map((user) => {
+ *        if (user.presence.cursor == null) {
+ *          return null;
+ *        }
+ *        return <Cursor key={user.connectionId} cursor={user.presence.cursor} />
+ *      })}
+ *   </>
+ * )
+ */
+function _useOthers(): readonly User<DP, DU>[];
+/**
+ * Extract arbitrary data based on all the users currently connected in the
+ * room (except yourself).
+ *
+ * The selector function will get re-evaluated any time a user enters or
+ * leaves the room, as well as whenever their presence data changes.
+ *
+ * The component that uses this hook will automatically re-render if your
+ * selector function returns a different value from its previous run.
+ *
+ * By default `useOthers()` uses strict `===` to check for equality. Take
+ * extra care when returning a computed object or list, for example when you
+ * return the result of a .map() or .filter() call from the selector. In
+ * those cases, you'll probably want to use a `shallow` comparison check.
+ *
+ * @example
+ * const avatars = useOthers(users => users.map(u => u.info.avatar), shallow);
+ * const cursors = useOthers(users => users.map(u => u.presence.cursor), shallow);
+ * const someoneIsTyping = useOthers(users => users.some(u => u.presence.isTyping));
+ *
+ */
+function _useOthers<T>(
+  selector: (others: readonly User<DP, DU>[]) => T,
+  isEqual?: (prev: T, curr: T) => boolean
+): T;
+function _useOthers(...args: any[]) {
+  return useOthers(...(args as []));
+}
 
 /**
  * Given a connection ID (as obtained by using `useOthersConnectionIds`), you
@@ -2833,9 +2879,54 @@ const _useOthers: TypedBundle["useOthers"] = useOthers;
  */
 const _useOtherSuspense: TypedBundle["suspense"]["useOther"] = useOtherSuspense;
 
-// TODO This one is tricky, as it has overloads
-const _useOthersSuspense: TypedBundle["suspense"]["useOthers"] =
-  useOthersSuspense;
+/**
+ * Returns an object that lets you get information about all the users
+ * currently connected in the room.
+ *
+ * @example
+ * const others = useOthers();
+ *
+ * // Example to map all cursors in JSX
+ * return (
+ *   <>
+ *     {others.map((user) => {
+ *        if (user.presence.cursor == null) {
+ *          return null;
+ *        }
+ *        return <Cursor key={user.connectionId} cursor={user.presence.cursor} />
+ *      })}
+ *   </>
+ * )
+ */
+function _useOthersSuspense(): readonly User<DP, DU>[];
+/**
+ * Extract arbitrary data based on all the users currently connected in the
+ * room (except yourself).
+ *
+ * The selector function will get re-evaluated any time a user enters or
+ * leaves the room, as well as whenever their presence data changes.
+ *
+ * The component that uses this hook will automatically re-render if your
+ * selector function returns a different value from its previous run.
+ *
+ * By default `useOthers()` uses strict `===` to check for equality. Take
+ * extra care when returning a computed object or list, for example when you
+ * return the result of a .map() or .filter() call from the selector. In
+ * those cases, you'll probably want to use a `shallow` comparison check.
+ *
+ * @example
+ * const avatars = useOthers(users => users.map(u => u.info.avatar), shallow);
+ * const cursors = useOthers(users => users.map(u => u.presence.cursor), shallow);
+ * const someoneIsTyping = useOthers(users => users.some(u => u.presence.isTyping));
+ *
+ */
+function _useOthersSuspense<T>(
+  selector: (others: readonly User<DP, DU>[]) => T,
+  isEqual?: (prev: T, curr: T) => boolean
+): T;
+function _useOthersSuspense(...args: any[]) {
+  return useOthersSuspense(...(args as []));
+}
 
 /**
  * Extract arbitrary data from the Liveblocks Storage state, using an
@@ -2880,11 +2971,83 @@ const _useStorage: TypedBundle["useStorage"] = useStorage;
 const _useStorageSuspense: TypedBundle["suspense"]["useStorage"] =
   useStorageSuspense;
 
-// TODO This one is tricky, as it has overloads
-const _useSelf: TypedBundle["useSelf"] = useSelf;
+/**
+ * Gets the current user once it is connected to the room.
+ *
+ * @example
+ * const me = useSelf();
+ * const { x, y } = me.presence.cursor;
+ */
+function _useSelf(): User<DP, DU> | null;
+/**
+ * Extract arbitrary data based on the current user.
+ *
+ * The selector function will get re-evaluated any time your presence data
+ * changes.
+ *
+ * The component that uses this hook will automatically re-render if your
+ * selector function returns a different value from its previous run.
+ *
+ * By default `useSelf()` uses strict `===` to check for equality. Take extra
+ * care when returning a computed object or list, for example when you return
+ * the result of a .map() or .filter() call from the selector. In those
+ * cases, you'll probably want to use a `shallow` comparison check.
+ *
+ * Will return `null` while Liveblocks isn't connected to a room yet.
+ *
+ * @example
+ * const cursor = useSelf(me => me.presence.cursor);
+ * if (cursor !== null) {
+ *   const { x, y } = cursor;
+ * }
+ *
+ */
+function _useSelf<T>(
+  selector: (me: User<DP, DU>) => T,
+  isEqual?: (prev: T, curr: T) => boolean
+): T | null;
+function _useSelf(...args: any[]) {
+  return useSelf(...(args as []));
+}
 
-// TODO This one is tricky, as it has overloads
-const _useSelfSuspense: TypedBundle["suspense"]["useSelf"] = useSelfSuspense;
+/**
+ * Gets the current user once it is connected to the room.
+ *
+ * @example
+ * const me = useSelf();
+ * const { x, y } = me.presence.cursor;
+ */
+function _useSelfSuspense(): User<DP, DU>;
+/**
+ * Extract arbitrary data based on the current user.
+ *
+ * The selector function will get re-evaluated any time your presence data
+ * changes.
+ *
+ * The component that uses this hook will automatically re-render if your
+ * selector function returns a different value from its previous run.
+ *
+ * By default `useSelf()` uses strict `===` to check for equality. Take extra
+ * care when returning a computed object or list, for example when you return
+ * the result of a .map() or .filter() call from the selector. In those
+ * cases, you'll probably want to use a `shallow` comparison check.
+ *
+ * Will return `null` while Liveblocks isn't connected to a room yet.
+ *
+ * @example
+ * const cursor = useSelf(me => me.presence.cursor);
+ * if (cursor !== null) {
+ *   const { x, y } = cursor;
+ * }
+ *
+ */
+function _useSelfSuspense<T>(
+  selector: (me: User<DP, DU>) => T,
+  isEqual?: (prev: T, curr: T) => boolean
+): T;
+function _useSelfSuspense(...args: any[]) {
+  return useSelfSuspense(...(args as []));
+}
 
 /**
  * Returns the mutable (!) Storage root. This hook exists for

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2976,7 +2976,9 @@ const _useStorageSuspense: TypedBundle["suspense"]["useStorage"] =
  *
  * @example
  * const me = useSelf();
- * const { x, y } = me.presence.cursor;
+ * if (me !== null) {
+ *   const { x, y } = me.presence.cursor;
+ * }
  */
 function _useSelf(): User<DP, DU> | null;
 /**
@@ -3032,13 +3034,9 @@ function _useSelfSuspense(): User<DP, DU>;
  * the result of a .map() or .filter() call from the selector. In those
  * cases, you'll probably want to use a `shallow` comparison check.
  *
- * Will return `null` while Liveblocks isn't connected to a room yet.
- *
  * @example
  * const cursor = useSelf(me => me.presence.cursor);
- * if (cursor !== null) {
- *   const { x, y } = cursor;
- * }
+ * const { x, y } = cursor;
  *
  */
 function _useSelfSuspense<T>(

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -624,8 +624,8 @@ type RoomContextBundleCommon<
   ): OmitFirstArg<F>;
 
   /**
-   * Returns an object that lets you get information about all the users
-   * currently connected in the room.
+   * Returns an array with information about all the users currently connected
+   * in the room (except yourself).
    *
    * @example
    * const others = useOthers();

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -895,7 +895,9 @@ export type RoomContextBundle<
        *
        * @example
        * const me = useSelf();
-       * const { x, y } = me.presence.cursor;
+       * if (me !== null) {
+       *   const { x, y } = me.presence.cursor;
+       * }
        */
       useSelf(): User<P, U> | null;
 
@@ -1006,13 +1008,9 @@ export type RoomContextBundle<
              * the result of a .map() or .filter() call from the selector. In those
              * cases, you'll probably want to use a `shallow` comparison check.
              *
-             * Will return `null` while Liveblocks isn't connected to a room yet.
-             *
              * @example
              * const cursor = useSelf(me => me.presence.cursor);
-             * if (cursor !== null) {
-             *   const { x, y } = cursor;
-             * }
+             * const { x, y } = cursor;
              *
              */
             useSelf<T>(


### PR DESCRIPTION
Unfortunately, I had to de-DRY (duplicate) the function signatures to get this to work with the overloading, but so be it. The DX is more important than our maintenance burden.
