### PR TITLE
Implement check that matches factory exports from top-level exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.2.0 (not published yet
+
+### `@liveblocks/react`
+
+- The `useClient()` hook is now also available for users of
+  `createRoomContext()` and/or `createLiveblocksContext()`
+
 ## v2.1.0
 
 ### `@liveblocks/client`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.2.0 (not published yet
+## v2.2.0 (not published yet)
 
 ### `@liveblocks/react`
 

--- a/packages/liveblocks-react/scripts/check-exports.ts
+++ b/packages/liveblocks-react/scripts/check-exports.ts
@@ -19,6 +19,19 @@ const ALLOW_DIFFERENT_JSDOCS = [
   "useUser",
 ];
 
+// These exports may exist at the top-level without a factory equivalent
+const ALLOW_NO_FACTORY = [
+  "ClientSideSuspense",
+  "createLiveblocksContext", // the factories themselves, obviously
+  "createRoomContext", // the factories themselves, obviously
+  "Json",
+  "JsonObject",
+  "MutationContext",
+  "shallow",
+  "UseThreadsOptions",
+  "useClient", // XXX Should we export this from the factory too, for consistency? 🤔
+];
+
 /**
  * Any exported symbols are by default expected to be exported from both
  * ./index and ./suspense subpaths.
@@ -122,6 +135,21 @@ function listExports(filePath: string): ExportedSymbol[] {
   return Array.from(iterExports(filePath));
 }
 
+function listFactoryExports(filePath: string): {
+  classic: string[];
+  suspense: string[];
+} {
+  const { createRoomContext, createLiveblocksContext } = require(filePath);
+  const factory1 = createRoomContext({} as any);
+  const factory2 = createLiveblocksContext({} as any);
+  const { suspense: suspense1, ...classic1 } = factory1;
+  const { suspense: suspense2, ...classic2 } = factory2;
+  return {
+    classic: [...Object.keys(classic1), ...Object.keys(classic2)],
+    suspense: [...Object.keys(suspense1), ...Object.keys(suspense2)],
+  };
+}
+
 function isPrivate(sym: ExportedSymbol): boolean {
   return /\@private/.test(sym.jsDoc);
 }
@@ -138,6 +166,7 @@ function warn(...args: unknown[]) {
 
 const classicExports = listExports("dist/index.d.mts");
 const suspenseExports = listExports("dist/suspense.d.mts");
+const factoryExports = listFactoryExports("../dist/index.mjs");
 
 function blue(text: string | number): string {
   return `\x1b[34m${text}\x1b[0m`;
@@ -186,50 +215,99 @@ function difference<T>(xs: T[], ys: T[]): T[] {
   return result;
 }
 
+function symmetricDifference<T>(xs: T[], ys: T[]): [T[], T[], T[]] {
+  return [difference(xs, ys), difference(ys, xs), intersection(xs, ys)];
+}
+
 // Warn about any symbols that aren't documented yet
 const classicNames = classicExports.map((e) => e.name);
 const suspenseNames = suspenseExports.map((e) => e.name);
 
-for (const name of difference(classicNames, suspenseNames)) {
-  if (CLASSIC_ONLY.includes(name)) {
-    // Skip known classic-only symbols
-    continue;
-  }
-
-  const sym = classicExports.find((x) => x.name === name)!;
-  if (isPrivate(sym)) {
-    // Skip check: @private-symbols are not required to have both exports
-    continue;
-  }
-
-  warn(
-    formatLocation(sym),
-    "Symbol",
-    blue(sym.name),
-    "has no suspense export",
-    "⚠️"
+{
+  let [missingInSuspense, missingInClassic] = symmetricDifference(
+    difference(classicNames, CLASSIC_ONLY),
+    difference(suspenseNames, SUSPENSE_ONLY)
   );
+
+  for (const name of missingInSuspense) {
+    const sym = classicExports.find((x) => x.name === name)!;
+    if (isPrivate(sym)) continue;
+    warn(
+      formatLocation(sym),
+      "Symbol",
+      blue(sym.name),
+      "has no suspense export",
+      "⚠️"
+    );
+  }
+
+  for (const name of missingInClassic) {
+    const sym = suspenseExports.find((x) => x.name === name)!;
+    if (isPrivate(sym)) continue;
+    warn(
+      formatLocation(sym),
+      "Symbol",
+      blue(sym.name),
+      "has no classic export",
+      "⚠️"
+    );
+  }
 }
 
-for (const name of difference(suspenseNames, classicNames)) {
-  if (SUSPENSE_ONLY.includes(name)) {
-    // Skip known suspense-only symbols
-    continue;
-  }
-
-  const sym = suspenseExports.find((x) => x.name === name)!;
-  if (isPrivate(sym)) {
-    // Skip check: @private-symbols are not required to have both exports
-    continue;
-  }
-
-  warn(
-    formatLocation(sym),
-    "Symbol",
-    blue(sym.name),
-    "has no classic export",
-    "⚠️"
+{
+  let [missingInFactory, missingAtToplevel] = symmetricDifference(
+    difference(classicNames, ALLOW_NO_FACTORY),
+    factoryExports.classic
   );
+
+  for (const name of missingInFactory) {
+    const sym = classicExports.find((x) => x.name === name)!;
+    if (isPrivate(sym)) continue;
+    warn(
+      formatLocation(sym),
+      "Symbol",
+      blue(sym.name),
+      "has classic top-level export, but isn't returned by factory",
+      "⚠️"
+    );
+  }
+
+  for (const name of missingAtToplevel) {
+    warn(
+      "Symbol",
+      blue(name),
+      "is returned by factory, but has no classic top-level export",
+      "⚠️"
+    );
+  }
+}
+
+{
+  let [missingInFactory, missingAtToplevel] = symmetricDifference(
+    difference(suspenseNames, ALLOW_NO_FACTORY),
+    factoryExports.suspense
+  );
+
+  for (const name of missingInFactory) {
+    const sym = suspenseExports.find((x) => x.name === name)!;
+    if (isPrivate(sym)) continue;
+    warn(
+      formatLocation(sym),
+      "Symbol",
+      blue(sym.name),
+      "has top-level suspense export, but isn't returned by factory (under { suspense } key)",
+      "⚠️"
+    );
+  }
+
+  for (const name of missingAtToplevel) {
+    warn(
+      "Symbol",
+      blue(name),
+      "is returned by factory under { suspense } key, but has no top-level suspense export",
+      "⚠️"
+    );
+  }
 }
 
 for (const name of intersection(suspenseNames, classicNames)) {

--- a/packages/liveblocks-react/scripts/check-exports.ts
+++ b/packages/liveblocks-react/scripts/check-exports.ts
@@ -29,7 +29,6 @@ const ALLOW_NO_FACTORY = [
   "MutationContext",
   "shallow",
   "UseThreadsOptions",
-  "useClient", // XXX Should we export this from the factory too, for consistency? 🤔
 ];
 
 /**

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -736,12 +736,15 @@ function useRoomInfoSuspense_withClient(client: OpaqueClient, roomId: string) {
 export function createSharedContext<U extends BaseUserMeta>(
   client: Client<U>
 ): SharedContextBundle<U> {
+  const useClient = () => client;
   return {
     classic: {
+      useClient,
       useUser: (userId: string) => useUser_withClient(client, userId),
       useRoomInfo: (roomId: string) => useRoomInfo_withClient(client, roomId),
     },
     suspense: {
+      useClient,
       useUser: (userId: string) => useUserSuspense_withClient(client, userId),
       useRoomInfo: (roomId: string) =>
         useRoomInfoSuspense_withClient(client, roomId),

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -15,6 +15,7 @@ import type {
 } from "@liveblocks/client";
 import type {
   BaseMetadata,
+  Client,
   CommentBody,
   CommentData,
   DRI,
@@ -345,6 +346,11 @@ export type ThreadSubscription =
 export type SharedContextBundle<U extends BaseUserMeta> = {
   classic: {
     /**
+     * Obtains a reference to the current Liveblocks client.
+     */
+    useClient(): Client<U>;
+
+    /**
      * Returns user info from a given user ID.
      *
      * @example
@@ -362,6 +368,11 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
   };
 
   suspense: {
+    /**
+     * Obtains a reference to the current Liveblocks client.
+     */
+    useClient(): Client<U>;
+
     /**
      * Returns user info from a given user ID.
      *


### PR DESCRIPTION
Adds check that ensures that any top-level export we add, must also…

✔️ exist in `./suspense` subpath export  
✔️ exist in factory's return value  
✔️ exist in factory's `{ suspense }` key

For example, just adding this to `src/index.ts`:

<img src="https://github.com/liveblocks/liveblocks/assets/83844/fca26f77-da04-4dce-9d2a-f457567dba17" width="430" />

Will lead to these errors:

![Screen Shot 2024-06-28 at 00 41 41@2x](https://github.com/liveblocks/liveblocks/assets/83844/431a50b3-3363-40be-9790-9063475a7286)
