### PR TITLE
Fix and improve `release.sh`

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -8,19 +8,22 @@ err () {
 }
 
 usage () {
-    err "usage: release.sh [-h] [-V <version>] <pkgdir> [<pkgdir>...]"
+    err "usage: release.sh [-h] [-V <version>] [-p] <pkgdir> [<pkgdir>...]"
     err
     err "Prepare a release by updating files in this repo."
-    err "Run this prior to publishing to NPM."
+    err "Run this prior to publishing to NPM (or elsewhere, e.g. DevTools)."
     err ""
     err "    -V   the new NPM version"
+    err "    -p   push the bump commit (no need if publish.sh is called afterwards)"
     err ""
 }
 
 VERSION=
-while getopts V:h flag; do
+PUSH_COMMIT="false"
+while getopts V:p:h flag; do
     case "$flag" in
         V) VERSION=$OPTARG;;
+        p) PUSH_COMMIT="true";;
         *) usage; exit 2;;
     esac
 done
@@ -82,6 +85,16 @@ commit_to_git () {
         git add "$@"
         if git is-dirty -i; then
             git commit -m "$msg"
+        fi
+        if [ "$PUSH_COMMIT" = "true" ]; then
+            echo "==> Pushing changes to GitHub"
+            if ! git push-current; then
+                echo "WARNING: Could not push this branch to GitHub!" >&2
+                echo "Please manually fix that now." >&2
+                exit 2
+            else
+                echo "Done!"
+            fi
         fi
     ) )
 }

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -8,22 +8,25 @@ err () {
 }
 
 usage () {
-    err "usage: release.sh [-h] [-V <version>] [-p] <pkgdir> [<pkgdir>...]"
+    err "usage: release.sh [-h] [-V <version>] [-p] [-m <message>] <pkgdir> [<pkgdir>...]"
     err
     err "Prepare a release by updating files in this repo."
     err "Run this prior to publishing to NPM (or elsewhere, e.g. DevTools)."
     err ""
     err "    -V   the new NPM version"
     err "    -p   push the bump commit (no need if publish.sh is called afterwards)"
+    err "    -m   improve the commit message by specifying what was bumped"
     err ""
 }
 
 VERSION=
 PUSH_COMMIT="false"
+COMMIT_MESSAGE="Bump to "
 while getopts V:p:h flag; do
     case "$flag" in
         V) VERSION=$OPTARG;;
         p) PUSH_COMMIT="true";;
+        m) COMMIT_MESSAGE=$OPTARG;;
         *) usage; exit 2;;
     esac
 done
@@ -110,4 +113,4 @@ done
 
 # Update package-lock.json with newly bumped versions
 npm install
-commit_to_git "Bump to $VERSION" "package-lock.json" "packages/" "tools/"
+commit_to_git "${COMMIT_MESSAGE}${VERSION}" "package-lock.json" "packages/" "tools/"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -22,7 +22,7 @@ usage () {
 VERSION=
 PUSH_COMMIT="false"
 COMMIT_MESSAGE="Bump to "
-while getopts V:p:h flag; do
+while getopts V:p:m:h flag; do
     case "$flag" in
         V) VERSION=$OPTARG;;
         p) PUSH_COMMIT="true";;

--- a/.github/workflows/publish-cli-tools.yml
+++ b/.github/workflows/publish-cli-tools.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           VERSION: ${{steps.version.outputs.value}}
         run:
-          ./.github/scripts/release.sh -V "$VERSION"
+          ./.github/scripts/release.sh -V "$VERSION" -m "Bump tools to "
           "tools/create-liveblocks-app" "tools/liveblocks-codemod"
 
       - name: Build all CLI tools

--- a/.github/workflows/publish-cli-tools.yml
+++ b/.github/workflows/publish-cli-tools.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           VERSION: ${{steps.version.outputs.value}}
         run:
-          ./.github/scripts/release.sh -V "$VERSION" -m "Bump tools to "
+          ./.github/scripts/release.sh -V "$VERSION" -m "Bump CLI tools to "
           "tools/create-liveblocks-app" "tools/liveblocks-codemod"
 
       - name: Build all CLI tools

--- a/.github/workflows/publish-devtools.yml
+++ b/.github/workflows/publish-devtools.yml
@@ -74,8 +74,8 @@ jobs:
         env:
           STRIPPED_VERSION: ${{steps.version.outputs.value}}
         run:
-          ./.github/scripts/release.sh -V -p "$STRIPPED_VERSION"
-          "tools/liveblocks-devtools"
+          ./.github/scripts/release.sh -V "$STRIPPED_VERSION" -p -m "Bump
+          DevTools to " "tools/liveblocks-devtools"
 
       - name: Build for Chromium
         run: npx --no turbo run build --filter=@liveblocks/devtools

--- a/.github/workflows/publish-devtools.yml
+++ b/.github/workflows/publish-devtools.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           STRIPPED_VERSION: ${{steps.version.outputs.value}}
         run:
-          ./.github/scripts/release.sh -V "$STRIPPED_VERSION"
+          ./.github/scripts/release.sh -V -p "$STRIPPED_VERSION"
           "tools/liveblocks-devtools"
 
       - name: Build for Chromium

--- a/package-lock.json
+++ b/package-lock.json
@@ -30652,7 +30652,7 @@
     },
     "tools/liveblocks-devtools": {
       "name": "@liveblocks/devtools",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "dependencies": {
         "@dagrejs/dagre": "^1.0.4",
         "@liveblocks/core": "*",

--- a/scripts/publish-lang-packages.sh
+++ b/scripts/publish-lang-packages.sh
@@ -312,7 +312,7 @@ build_version_everywhere "$VERSION"
 
 # Update package-lock.json with newly bumped versions
 npm install
-commit_to_git "Bump to $VERSION" "package-lock.json" "schema-lang/"
+commit_to_git "Bump language packages to $VERSION" "package-lock.json" "schema-lang/"
 
 echo "==> Rebuilding packages"
 turbo run build --force

--- a/tools/liveblocks-devtools/package.json
+++ b/tools/liveblocks-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liveblocks/devtools",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "private": true,
   "displayName": "Liveblocks DevTools",
   "description": "A browser extension that lets you inspect Liveblocks real-time collaborative experiences. Liveblocks is the all-in-one toolkit to build collaborative products like Figma, Notion, and more.",


### PR DESCRIPTION
This PR:
- bumps DevTools to 1.12.0 manually
- makes the DevTools publishing workflow push its commit
- improves bump commits (the packages remain as "Bump to 2.2.0" but all other bumps now specify their source: e.g. "Bump DevTools to 1.12.0")