### PR TITLE
add mark thread as resolved/unresolved methods

### DIFF
--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -574,7 +574,8 @@ describe("client", () => {
   });
 
   test("should return a filtered list of threads when a query parameter is used for getThreads", async () => {
-    const query = "metadata['status']:'open' AND metadata['priority']:3";
+    const query =
+      "metadata['status']:'open' AND metadata['priority']:3 AND resolved:true";
     server.use(
       http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads`, (res) => {
         const url = new URL(res.request.url);

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -1250,10 +1250,10 @@ export class Liveblocks {
 
   /**
    * Mark a thread as resolved.
-   * @param params.roomId The room ID to update the thread in.
-   * @param params.threadId The thread ID to update.
-   * @param params.data.userId The user ID of the user who updated the thread.
-   * @returns The updated thread.
+   * @param params.roomId the room ID of the thread.
+   * @param params.threadId The thread ID to mark as resolved.
+   * @param params.data.userId The user ID of the user who marked the thread as resolved.
+   * @returns The thread marked as resolved.
    */
   public async markThreadAsResolved(params: {
     roomId: string;
@@ -1261,7 +1261,7 @@ export class Liveblocks {
     data: {
       userId: string;
     };
-  }): Promise<M> {
+  }): Promise<ThreadData<M>> {
     const { roomId, threadId } = params;
 
     const res = await this.post(
@@ -1274,15 +1274,15 @@ export class Liveblocks {
       throw new LiveblocksError(res.status, text);
     }
 
-    return (await res.json()) as M;
+    return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
   }
 
   /**
    * Mark a thread as unresolved.
-   * @param params.roomId The room ID to update the thread in.
-   * @param params.threadId The thread ID to update.
-   * @param params.data.userId The user ID of the user who updated the thread.
-   * @returns The updated thread.
+   * @param params.roomId the room ID of the thread.
+   * @param params.threadId The thread ID to mark as unresolved.
+   * @param params.data.userId The user ID of the user who marked the thread as unresolved.
+   * @returns The thread marked as unresolved.
    */
   public async markThreadAsUnresolved(params: {
     roomId: string;
@@ -1290,7 +1290,7 @@ export class Liveblocks {
     data: {
       userId: string;
     };
-  }): Promise<M> {
+  }): Promise<ThreadData<M>> {
     const { roomId, threadId } = params;
 
     const res = await this.post(
@@ -1303,7 +1303,7 @@ export class Liveblocks {
       throw new LiveblocksError(res.status, text);
     }
 
-    return (await res.json()) as M;
+    return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
   }
 
   /**

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -984,7 +984,7 @@ export class Liveblocks {
      * @example
      * ```
      * {
-     *   query: "metadata['organization']^'liveblocks:' AND metadata['status']:'open' AND metadata['pinned']:false AND metadata['priority']:3"
+     *   query: "metadata['organization']^'liveblocks:' AND metadata['status']:'open' AND metadata['pinned']:false AND metadata['priority']:3 AND resolved:true"
      * }
      * ```
      * @example
@@ -998,7 +998,8 @@ export class Liveblocks {
      *       organization: {
      *         startsWith: "liveblocks:"
      *       }
-     *     }
+     *     },
+     *     resolved: true
      *   }
      * }
      * ```
@@ -1007,6 +1008,7 @@ export class Liveblocks {
       | string
       | {
           metadata?: Partial<QueryMetadata<M>>;
+          resolved?: boolean;
         };
   }): Promise<{ data: ThreadData<M>[] }> {
     const { roomId } = params;
@@ -1244,6 +1246,64 @@ export class Liveblocks {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
     }
+  }
+
+  /**
+   * Mark a thread as resolved.
+   * @param params.roomId The room ID to update the thread in.
+   * @param params.threadId The thread ID to update.
+   * @param params.data.userId The user ID of the user who updated the thread.
+   * @returns The updated thread.
+   */
+  public async markThreadAsResolved(params: {
+    roomId: string;
+    threadId: string;
+    data: {
+      userId: string;
+    };
+  }): Promise<M> {
+    const { roomId, threadId } = params;
+
+    const res = await this.post(
+      url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-resolved`,
+      {}
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new LiveblocksError(res.status, text);
+    }
+
+    return (await res.json()) as M;
+  }
+
+  /**
+   * Mark a thread as unresolved.
+   * @param params.roomId The room ID to update the thread in.
+   * @param params.threadId The thread ID to update.
+   * @param params.data.userId The user ID of the user who updated the thread.
+   * @returns The updated thread.
+   */
+  public async markThreadAsUnresolved(params: {
+    roomId: string;
+    threadId: string;
+    data: {
+      userId: string;
+    };
+  }): Promise<M> {
+    const { roomId, threadId } = params;
+
+    const res = await this.post(
+      url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-unresolved`,
+      {}
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new LiveblocksError(res.status, text);
+    }
+
+    return (await res.json()) as M;
   }
 
   /**

--- a/packages/liveblocks-node/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/augmentation.test-d.ts
@@ -357,4 +357,40 @@ async () => {
     expectType<string>(reaction.userId);
     expectType<Date>(reaction.createdAt);
   }
+
+  // .markThreadAsResolved()
+  {
+    const thread = await client.markThreadAsResolved({
+      roomId: "my-room",
+      threadId: "th_xxx",
+      data: {
+        userId: "user-id",
+      },
+    });
+    expectType<"thread">(thread.type);
+    expectType<string>(thread.id);
+    expectType<string>(thread.roomId);
+    expectType<boolean>(thread.resolved);
+    expectType<Date>(thread.createdAt);
+    expectType<Date | undefined>(thread.updatedAt);
+    expectType<CommentData[]>(thread.comments);
+  }
+
+  // .markThreadAsUnresolved()
+  {
+    const thread = await client.markThreadAsUnresolved({
+      roomId: "my-room",
+      threadId: "th_xxx",
+      data: {
+        userId: "user-id",
+      },
+    });
+    expectType<"thread">(thread.type);
+    expectType<string>(thread.id);
+    expectType<string>(thread.roomId);
+    expectType<boolean>(thread.resolved);
+    expectType<Date>(thread.createdAt);
+    expectType<Date | undefined>(thread.updatedAt);
+    expectType<CommentData[]>(thread.comments);
+  }
 };

--- a/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
@@ -294,4 +294,38 @@ async () => {
     expectType<string>(reaction.userId);
     expectType<Date>(reaction.createdAt);
   }
+  // .markThreadAsResolved()
+  {
+    const thread = await client.markThreadAsResolved({
+      roomId: "my-room",
+      threadId: "th_xxx",
+      data: {
+        userId: "user-id",
+      },
+    });
+    expectType<"thread">(thread.type);
+    expectType<string>(thread.id);
+    expectType<string>(thread.roomId);
+    expectType<boolean>(thread.resolved);
+    expectType<Date>(thread.createdAt);
+    expectType<Date | undefined>(thread.updatedAt);
+    expectType<CommentData[]>(thread.comments);
+  }
+  // .markThreadAsUnresolved()
+  {
+    const thread = await client.markThreadAsUnresolved({
+      roomId: "my-room",
+      threadId: "th_xxx",
+      data: {
+        userId: "user-id",
+      },
+    });
+    expectType<"thread">(thread.type);
+    expectType<string>(thread.id);
+    expectType<string>(thread.roomId);
+    expectType<boolean>(thread.resolved);
+    expectType<Date>(thread.createdAt);
+    expectType<Date | undefined>(thread.updatedAt);
+    expectType<CommentData[]>(thread.comments);
+  }
 };


### PR DESCRIPTION
### Description

Add methods to liveblocks-node to call endpoints to mark a thread as resolved/unresolved.

#### Related issue(s)

https://linear.app/liveblocks/issue/LB-940/client-node-add-new-methods-use-new-endpoint
