### PR TITLE
Upgrade guide 2.2: Thread resolved as first-class citizen

### DIFF
--- a/docs/pages/platform/upgrading.mdx
+++ b/docs/pages/platform/upgrading.mdx
@@ -12,6 +12,12 @@ there are no breaking changes.
 <ListGrid>
   <DocsCard
     type="image"
+    title="Upgrading to 2.2"
+    href="/docs/platform/upgrading/2.2"
+    visual={<DocsCardGradientText>2.2</DocsCardGradientText>}
+  />
+  <DocsCard
+    type="image"
     title="Upgrading to 2.0"
     href="/docs/platform/upgrading/2.0"
     visual={<DocsCardGradientText>2.0</DocsCardGradientText>}

--- a/docs/pages/platform/upgrading/2.2.mdx
+++ b/docs/pages/platform/upgrading/2.2.mdx
@@ -51,5 +51,5 @@ property.
    `threadMarkedAsUnresolved` in your webhook endpoint.
 2. Upgrade all Liveblocks packages to 2.2. Run
    `npx create-liveblocks-app@latest upgrade` to do so.
-3. Update your back-end to use the new "mark thread as resolved/unresolved"
+3. Update your back end to use the new "mark thread as resolved/unresolved"
    endpoints.

--- a/docs/pages/platform/upgrading/2.2.mdx
+++ b/docs/pages/platform/upgrading/2.2.mdx
@@ -1,0 +1,49 @@
+---
+meta:
+  title: "Upgrading to 2.2"
+  parentTitle: "Upgrading"
+  description: "Guide to upgrade to Liveblocks version 2.2"
+---
+
+We are making Thread "resolved" a first-class citizen property. You don't have
+to use thread's metadata to set a thread as resolved anymore.
+
+## All breaking changes are for Comments and only if you use a metadata "resolved"
+
+If you are using Comments without using a metadata `resolved`, there are no
+breaking changes for you! However, if you are using a thread's metadata
+"resolved", and have logic based on the webhook event `threadMetadataUpdated`,
+keep reading.
+
+### Webhook events
+
+When you upgrade to 2.2, our React component will update the thread first-class
+citizen property instead of the metadata. When a thread is marked as resolved or
+unresolved, we will send the events `threadMarkedAsResolved` and
+`threadMarkedAsUnresolved` instead of `threadMetadataUpdated`.
+
+Before upgrading to 2.2, you should update you webhook endpoint to process those
+new events accordingly.
+
+### REST API update thread metadata endpoint
+
+If you use the REST endpoint
+[`update thread metadata`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-metadata)
+to update the metadata `resolved`, you should instead use the endpoints
+[`mark thread as resolved`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-resolved)
+and
+[`mark thread as unresolved`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-unresolved).
+
+Note that updating the metadata "resolved" automatically updates the first-class
+citizen property.
+
+### Migration plan
+
+Here is the plan to migrate the metadata `resolved` to the first-class citizen
+property.
+
+1. Support the new events `threadMarkedAsResolved` and
+   `threadMarkedAsUnresolved` in your webhook endpoint.
+2. Upgrade liveblocks packages to 2.2.
+3. Update your back-end to use the new "mark thread as resolved/unresolved"
+   endpoints.

--- a/docs/pages/platform/upgrading/2.2.mdx
+++ b/docs/pages/platform/upgrading/2.2.mdx
@@ -5,13 +5,14 @@ meta:
   description: "Guide to upgrade to Liveblocks version 2.2"
 ---
 
-We are making Thread "resolved" a first-class citizen property. You don't have
-to use thread's metadata to set a thread as resolved anymore.
+We are making “resolved” a first-class citizen property on
+[Thread](/docs/api-reference/liveblocks-react-ui#Comments). You don’t have to
+use thread’s metadata to set a thread as resolved anymore.
 
 ## All breaking changes are for Comments and only if you use a metadata "resolved"
 
-If you are using Comments without using a metadata `resolved`, there are no
-breaking changes for you! However, if you are using a thread's metadata
+If you are using Comments without using the `resolved` metadata property, there
+are no breaking changes for you! However, if you are using a thread’s metadata
 "resolved", and have logic based on the webhook event `threadMetadataUpdated`,
 keep reading.
 
@@ -19,20 +20,24 @@ keep reading.
 
 When you upgrade to 2.2, our React component will update the thread first-class
 citizen property instead of the metadata. When a thread is marked as resolved or
-unresolved, we will send the events `threadMarkedAsResolved` and
-`threadMarkedAsUnresolved` instead of `threadMetadataUpdated`.
+unresolved, we will send the events
+[`threadMarkedAsResolved`](/docs/platform/webhooks#ThreadMarkedAsResolvedEvent)
+and
+[`threadMarkedAsUnresolved`](/docs/platform/webhooks#ThreadMarkedAsUnresolvedEvent)
+instead of
+[`threadMetadataUpdated`](/docs/platform/webhooks#ThreadMarkedAsUnresolvedEvent).
 
-Before upgrading to 2.2, you should update you webhook endpoint to process those
-new events accordingly.
+Before upgrading to 2.2, you should update your webhook endpoint to process
+those new events accordingly.
 
 ### REST API update thread metadata endpoint
 
 If you use the REST endpoint
-[`update thread metadata`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-metadata)
+[`Edit thread metadata`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-metadata)
 to update the metadata `resolved`, you should instead use the endpoints
-[`mark thread as resolved`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-resolved)
+[`Mark thread as resolved`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-resolved)
 and
-[`mark thread as unresolved`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-unresolved).
+[`Mark thread as unresolved`](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-unresolved).
 
 Note that updating the metadata "resolved" automatically updates the first-class
 citizen property.
@@ -44,6 +49,7 @@ property.
 
 1. Support the new events `threadMarkedAsResolved` and
    `threadMarkedAsUnresolved` in your webhook endpoint.
-2. Upgrade liveblocks packages to 2.2.
+2. Upgrade all Liveblocks packages to 2.2. Run
+   `npx create-liveblocks-app@latest upgrade` to do so.
 3. Update your back-end to use the new "mark thread as resolved/unresolved"
    endpoints.

--- a/docs/pages/platform/webhooks.mdx
+++ b/docs/pages/platform/webhooks.mdx
@@ -879,6 +879,68 @@ const threadMetadataUpdatedEvent = {
 };
 ```
 
+#### ThreadMarkedAsResolvedEvent
+
+An event is triggered when a thread is marked as resolved. This event is not
+throttled.
+
+```ts
+// Schema
+type ThreadMarkedAsResolvedEvent = {
+  type: "threadMarkedAsResolved";
+  data: {
+    projectId: string;
+    roomId: string;
+    threadId: string;
+    updatedAt: string;
+    updatedBy: string;
+  };
+};
+
+// Example
+const ThreadMarkedAsResolvedEvent = {
+  type: "threadMarkedAsResolved",
+  data: {
+    projectId: "my-project-id",
+    roomId: "my-room-id",
+    threadId: "my-thread-id",
+    updatedAt: "2021-10-06T01:45:56.558Z",
+    updatedBy: "my-user-id",
+  },
+};
+```
+
+#### ThreadMarkedAsUnresolvedEvent
+
+An event is triggered when a thread is marked as unresolved. This event is not
+throttled.
+
+```ts
+// Schema
+type ThreadMarkedAsUnresolvedEvent = {
+  type: "threadMarkedAsUnresolved";
+  data: {
+    projectId: string;
+    roomId: string;
+    threadId: string;
+    updatedAt: string;
+    updatedBy: string;
+  };
+};
+
+// Example
+const ThreadMarkedAsUnresolvedEvent = {
+  type: "threadMarkedAsUnresolved",
+  data: {
+    projectId: "my-project-id",
+    roomId: "my-room-id",
+    threadId: "my-thread-id",
+    updatedAt: "2021-10-06T01:45:56.558Z",
+    updatedBy: "my-user-id",
+  },
+};
+```
+
 #### NotificationEvent
 
 Notification events are designed to help you create notification emails for your

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -1368,7 +1368,7 @@
             },
             "in": "query",
             "name": "query",
-            "description": "Query to filter threads. You can filter by `metadata`, for example, `metadata[\"status\"]:\"open\" AND metadata[\"resolved\"]:true`. Learn more about [filtering threads with query language](/docs/guides/how-to-filter-threads-using-query-language)."
+            "description": "Query to filter threads. You can filter by `metadata` and `resolved`, for example, `metadata[\"status\"]:\"open\" AND metadata[\"resolved\"]:true AND resolved:true`. Learn more about [filtering threads with query language](/docs/guides/how-to-filter-threads-using-query-language)."
           }
         ],
         "operationId": "get-rooms-roomId-threads",
@@ -1772,6 +1772,100 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/rooms/{roomId}/threads/{threadId}/mark-as-resolved": {
+      "post": {
+        "summary": "Mark thread as resolved",
+        "x-badge": "Beta",
+        "tags": ["Comments"],
+        "description": "This endpoint marks a thread as resolved.",
+        "operationId": "post-rooms-roomId-threads-threadId-mark-as-resolved",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the room"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the thread"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. Returns the updated thread.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404-thread"
+          }
+        }
+      }
+    },
+    "/rooms/{roomId}/threads/{threadId}/mark-as-unresolved": {
+      "post": {
+        "summary": "Mark thread as unresolved",
+        "x-badge": "Beta",
+        "tags": ["Comments"],
+        "description": "This endpoint marks a thread as unresolved.",
+        "operationId": "post-rooms-roomId-threads-threadId-mark-as-unresolved",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the room"
+          },
+          {
+            "name": "threadId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the thread"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. Returns the updated thread.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404-thread"
           }
         }
       }
@@ -3106,6 +3200,9 @@
           },
           "metadata": {
             "type": "object"
+          },
+          "resolved": {
+            "type": "boolean"
           },
           "updatedAt": {
             "type": "string",

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -615,7 +615,8 @@
           { "title": "Upgrading to 1.5", "path": "/platform/upgrading/1.5" },
           { "title": "Upgrading to 1.9", "path": "/platform/upgrading/1.9" },
           { "title": "Upgrading to 1.10", "path": "/platform/upgrading/1.10" },
-          { "title": "Upgrading to 2.0", "path": "/platform/upgrading/2.0" }
+          { "title": "Upgrading to 2.0", "path": "/platform/upgrading/2.0" },
+          { "title": "Upgrading to 2.2", "path": "/platform/upgrading/2.2" }
         ]
       },
       {


### PR DESCRIPTION
### Description

This PR adds the documentation for the REST API endpoints `mark thread as resolved` and `mark thread as unresolved`.

It also adds an upgrade guide to 2.2 to help migrate from the thread metadata "resolved" to the first-class citizen property.