### PR TITLE
Fix: avoid unneeded re-renders if inbox notifications haven't changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `useClient()` hook is now also available for users of
   `createRoomContext()` and/or `createLiveblocksContext()`
+- Fix: avoid unnecessary re-renders if inbox notifications haven't changed
 
 ## v2.1.0
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -16,7 +16,13 @@ import type {
   PrivateClientApi,
   ThreadDeleteInfo,
 } from "@liveblocks/core";
-import { createClient, kInternal, makePoller, raise } from "@liveblocks/core";
+import {
+  createClient,
+  kInternal,
+  makePoller,
+  raise,
+  shallow,
+} from "@liveblocks/core";
 import { nanoid } from "nanoid";
 import type { PropsWithChildren } from "react";
 import React, {
@@ -386,7 +392,8 @@ function useInboxNotifications_withClient(client: OpaqueClient) {
     store.subscribe,
     store.get,
     store.get,
-    selectorFor_useInboxNotifications
+    selectorFor_useInboxNotifications,
+    shallow
   );
 }
 
@@ -412,7 +419,8 @@ function useInboxNotificationsSuspense_withClient(client: OpaqueClient) {
     store.subscribe,
     store.get,
     store.get,
-    selectorFor_useInboxNotificationsSuspense
+    selectorFor_useInboxNotificationsSuspense,
+    shallow
   );
 }
 
@@ -425,7 +433,8 @@ function useUnreadInboxNotificationsCount_withClient(client: OpaqueClient) {
     store.subscribe,
     store.get,
     store.get,
-    selectorFor_useUnreadInboxNotificationsCount
+    selectorFor_useUnreadInboxNotificationsCount,
+    shallow
   );
 }
 
@@ -449,7 +458,8 @@ function useUnreadInboxNotificationsCountSuspense_withClient(
     store.subscribe,
     store.get,
     store.get,
-    selectorFor_useUnreadInboxNotificationsCountSuspense
+    selectorFor_useUnreadInboxNotificationsCountSuspense,
+    shallow
   );
 }
 


### PR DESCRIPTION
Ensures that selector returns the same instance as the previous render if data has not changed. Why? Calling one of these `selectorFor_*` functions will return a new object instance on every call, making them never equal to the previous value, even if the data or loading state itself is identical.
