### PR TITLE
Fix broken `useTransition` fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - The `useClient()` hook is now also available for users of
   `createRoomContext()` and/or `createLiveblocksContext()`
 
+### `@liveblocks/react-ui`
+
+- Fix improper `useTransition` fallback which would break on React versions
+  lower than 18.
+
 ## v2.1.0
 
 ### `@liveblocks/client`
@@ -26,7 +31,8 @@
 
 ### `@liveblocks/react-ui`
 
-- Fix improper `useSyncExternalStore` import which would break on React versions lower than 18.
+- Fix improper `useSyncExternalStore` import which would break on React versions
+  lower than 18.
 
 ## v2.0.5
 
@@ -46,8 +52,8 @@
 ### `@liveblocks/client`
 
 - Add missing type export for `CommentReaction`
-- Don’t attempt to write missing `initialStorage` keys if the current user has no
-  write access to storage. This will no longer throw, but issue a warning
+- Don’t attempt to write missing `initialStorage` keys if the current user has
+  no write access to storage. This will no longer throw, but issue a warning
   message in the console.
 
 ### `@liveblocks/react`

--- a/packages/liveblocks-react-ui/src/utils/use-transition.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-transition.ts
@@ -1,4 +1,5 @@
-import React from "react";
+import type { TransitionFunction } from "react";
+import React, { useCallback } from "react";
 
 // Prevent bundlers from importing `useTransition` directly
 // See https://github.com/radix-ui/primitives/pull/1028
@@ -8,8 +9,13 @@ const useReactTransition: typeof React.useTransition = (React as any)[
   "useTransition".toString()
 ];
 
-function useTransitionFallback(transition: () => void) {
-  return [false, transition] as ReturnType<typeof useReactTransition>;
+function useTransitionFallback() {
+  const startTransition = useCallback(
+    (callback: TransitionFunction) => callback(),
+    []
+  );
+
+  return [false, startTransition] as ReturnType<typeof useReactTransition>;
 }
 
 // React's `useTransition` is only available in React >=18.

--- a/packages/liveblocks-react-ui/src/utils/use-transition.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-transition.ts
@@ -9,13 +9,13 @@ const useReactTransition: typeof React.useTransition = (React as any)[
   "useTransition".toString()
 ];
 
-function useTransitionFallback() {
+function useTransitionFallback(): ReturnType<typeof useReactTransition> {
   const startTransition = useCallback(
     (callback: TransitionFunction) => callback(),
     []
   );
 
-  return [false, startTransition] as ReturnType<typeof useReactTransition>;
+  return [false, startTransition];
 }
 
 // React's `useTransition` is only available in React >=18.


### PR DESCRIPTION
We had a fallback in place for `useTransition` (like `useId`), but for some reason it wasn't the same signature as the official version so it was never going to work. 🤔