### PR TITLE
Preserve whitespace and empty lines in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Preserve rich text when pasting into the composer.
 - Add support for custom links to the composer. (either by pasting URLs with
   plain text selected or by pasting existing links)
+- Preserve whitespace and empty lines in comments.
 - Fix improper `useTransition` fallback which would break on React versions
   lower than 18.
 

--- a/packages/liveblocks-react-ui/src/primitives/Comment/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Comment/index.tsx
@@ -81,7 +81,7 @@ const defaultBodyComponents: CommentBodyComponents = {
  * <Comment.Body body={comment.body} />
  */
 const CommentBody = forwardRef<HTMLDivElement, CommentBodyProps>(
-  ({ body, components, asChild, ...props }, forwardedRef) => {
+  ({ body, components, style, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
     const { Mention, Link } = useMemo(
       () => ({ ...defaultBodyComponents, ...components }),
@@ -93,12 +93,16 @@ const CommentBody = forwardRef<HTMLDivElement, CommentBodyProps>(
     }
 
     return (
-      <Component {...props} ref={forwardedRef}>
+      <Component
+        {...props}
+        style={{ whiteSpace: "break-spaces", ...style }}
+        ref={forwardedRef}
+      >
         {body.content.map((block, index) => {
           switch (block.type) {
             case "paragraph":
               return (
-                <p key={index}>
+                <p key={index} style={{ minHeight: "1lh" }}>
                   {block.children.map((inline, index) => {
                     if (isCommentBodyMention(inline)) {
                       return inline.id ? (


### PR DESCRIPTION
I noticed that whitespace and empty lines in comments were collapsed as it's CSS's default behavior.

I opted to do this inline (as opposed to doing it in the default styles we ship for the default components) so that the `Comment.Body` primitive benefits from this as well. To me it's not an opinionated visual decision but a fix that everyone should get.

https://github.com/liveblocks/liveblocks/assets/6959425/8d3d91a8-cb4b-42ab-b2dc-bc1622c95820

https://github.com/liveblocks/liveblocks/assets/6959425/afaf980d-1362-4804-96b3-1e9643de5474