### PR TITLE
Fix code example in liveblocks-react.mdx

### DIFF
--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1858,13 +1858,13 @@ function App() {
       id="my-room-name"
       initialStorage={{
         // +++
-        people: new LiveMap([
+        people: new LiveMap([[
           "alicia",
           new LiveObject({
             name: "Alicia",
             pets: new LiveList(["Fido", "Felix"]),
           }),
-        ]),
+        ]]),
         // +++
       }}
     >


### PR DESCRIPTION
## For Maintainers
Discovered an issue in the code example in the `Nesting Data Structures` code example. It was missing a pair of brackets in the `LiveMap` type — took me a minute to figure out what was going on after copy/pasting this example into my own code base to try to understand how `LiveMap` worked.

### Description
tldr: Fixing one of the code examples. The `LiveMap` API expects an array of key-value pairs to be passed in, not just a single array.