### PR TITLE
Only mark threads as read if the window is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Add support for custom links to the composer. (either by pasting URLs with
   plain text selected or by pasting existing links)
 - Preserve whitespace and empty lines in comments.
+- Take into account the window's focus state when marking threads as read once
+  they are visible.
 - Fix improper `useTransition` fallback which would break on React versions
   lower than 18.
 

--- a/packages/liveblocks-react-ui/src/components/Comment.tsx
+++ b/packages/liveblocks-react-ui/src/components/Comment.tsx
@@ -57,6 +57,7 @@ import { MENTION_CHARACTER } from "../slate/plugins/mentions";
 import { classNames } from "../utils/class-names";
 import { useRefs } from "../utils/use-refs";
 import { useVisibleCallback } from "../utils/use-visible";
+import { useWindowFocus } from "../utils/use-window-focus";
 import { Composer } from "./Composer";
 import { Avatar } from "./internal/Avatar";
 import { Button } from "./internal/Button";
@@ -336,12 +337,18 @@ function MarkThreadAsReadWhenVisibleHandler({
   ref: RefObject<HTMLElement>;
 }) {
   const markThreadAsRead = useMarkThreadAsRead();
+  const isWindowFocused = useWindowFocus();
 
-  useVisibleCallback(ref, () => {
-    if (threadId) {
+  useVisibleCallback(
+    ref,
+    () => {
       markThreadAsRead(threadId);
+    },
+    {
+      // The underlying IntersectionObserver is only enabled when the window is focused
+      enabled: isWindowFocused,
     }
-  });
+  );
 
   return null;
 }

--- a/packages/liveblocks-react-ui/src/components/Comment.tsx
+++ b/packages/liveblocks-react-ui/src/components/Comment.tsx
@@ -331,16 +331,16 @@ export const CommentNonInteractiveReaction = forwardRef<
 // and focus hooks "conditionally" by conditionally rendering this component.
 function MarkThreadAsReadWhenVisibleHandler({
   threadId,
-  ref,
+  commentRef,
 }: {
   threadId: string;
-  ref: RefObject<HTMLElement>;
+  commentRef: RefObject<HTMLElement>;
 }) {
   const markThreadAsRead = useMarkThreadAsRead();
   const isWindowFocused = useWindowFocus();
 
   useVisibleCallback(
-    ref,
+    commentRef,
     () => {
       markThreadAsRead(threadId);
     },
@@ -502,7 +502,7 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
       <TooltipProvider>
         {markThreadAsReadWhenVisible && (
           <MarkThreadAsReadWhenVisibleHandler
-            ref={ref}
+            commentRef={ref}
             threadId={markThreadAsReadWhenVisible}
           />
         )}

--- a/packages/liveblocks-react-ui/src/utils/use-window-focus.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-window-focus.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
+
+function subscribe(callback: () => void) {
+  window.addEventListener("blur", callback);
+  window.addEventListener("focus", callback);
+
+  return () => {
+    window.removeEventListener("blur", callback);
+    window.removeEventListener("focus", callback);
+  };
+}
+
+function getSnapshot() {
+  return document.hasFocus();
+}
+
+function getServerSnapshot() {
+  return true;
+}
+
+export function useWindowFocus() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
We mark threads as read (in the default `Thread` component) once their last comment becomes visible using the `IntersectionObserver` API. But @nvie noticed that this logic was triggered even if the window wasn't focused.