### PR TITLE
add option for read-only

### DIFF
--- a/docs/pages/api-reference/liveblocks-yjs.mdx
+++ b/docs/pages/api-reference/liveblocks-yjs.mdx
@@ -66,6 +66,23 @@ function Component() {
 }
 ```
 
+### LiveblocksYjsProvider Options [#LiveblocksYjsProvider.options]
+
+There are a few options you can pass as a third argument into the
+LiveblocksYjsProvider:
+
+- autoloadSubdocs: `boolean` (default: `false`). This option will load subdocs
+  automatically.
+- readOnly: `boolean` (default: `false`). This option will make the provider
+  read-only, it will not send changes to the server.
+
+```ts
+const yProvider = new LiveblocksYjsProvider(room, yDoc, {
+  autoloadSubdocs: true, // default false
+  readOnly: true, // default false
+});
+```
+
 ### LiveblocksYjsProvider.awareness [#LiveblocksYjsProvider.awareness]
 
 The [awareness](#Awareness) instance attached to the provider.

--- a/packages/liveblocks-yjs/src/doc.ts
+++ b/packages/liveblocks-yjs/src/doc.ts
@@ -38,26 +38,30 @@ export default class yDocHandler extends Observable<unknown> {
   public handleServerUpdate = ({
     update,
     stateVector,
+    readOnly,
   }: {
     update: string;
     stateVector: string | null;
+    readOnly: boolean;
   }): void => {
     // apply update from the server
     Y.applyUpdate(this.doc, Base64.toUint8Array(update), "backend");
     // if this update is the result of a fetch, the state vector is included
     if (stateVector) {
-      // Use server state to calculate a diff and send it
-      try {
-        const localUpdate = Y.encodeStateAsUpdate(
-          this.doc,
-          Base64.toUint8Array(stateVector)
-        );
-        this.updateRoomDoc(Base64.fromUint8Array(localUpdate));
-      } catch (e) {
-        // something went wrong encoding local state to send to the server
-        console.warn(e);
+      if (!readOnly) {
+        // Use server state to calculate a diff and send it
+        try {
+          const localUpdate = Y.encodeStateAsUpdate(
+            this.doc,
+            Base64.toUint8Array(stateVector)
+          );
+          this.updateRoomDoc(Base64.fromUint8Array(localUpdate));
+        } catch (e) {
+          // something went wrong encoding local state to send to the server
+          console.warn(e);
+        }
       }
-      // now that we've sent our local  and received from server, we're in sync
+      // now that we've sent our local and received from server, we're in sync
       // calling `syncDoc` again will sync up the documents
       this.synced = true;
     }

--- a/packages/liveblocks-yjs/src/index.ts
+++ b/packages/liveblocks-yjs/src/index.ts
@@ -17,13 +17,8 @@ import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
 detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 type ProviderOptions = {
-  autoloadSubdocs: boolean;
-  readOnly: boolean;
-};
-
-const DefaultOptions: ProviderOptions = {
-  autoloadSubdocs: false,
-  readOnly: false,
+  autoloadSubdocs?: boolean;
+  readOnly?: boolean;
 };
 
 export class LiveblocksYjsProvider<
@@ -47,7 +42,7 @@ export class LiveblocksYjsProvider<
   constructor(
     room: Room<P, S, U, E, M>,
     doc: Y.Doc,
-    options: ProviderOptions | undefined = DefaultOptions
+    options: ProviderOptions | undefined = {}
   ) {
     super();
     this.rootDoc = doc;
@@ -85,13 +80,13 @@ export class LiveblocksYjsProvider<
           this.subdocHandlers.get(guid)?.handleServerUpdate({
             update,
             stateVector,
-            readOnly: this.options.readOnly,
+            readOnly: this.options.readOnly ?? false,
           });
         } else {
           this.rootDocHandler.handleServerUpdate({
             update,
             stateVector,
-            readOnly: this.options.readOnly,
+            readOnly: this.options.readOnly ?? false,
           });
         }
       })

--- a/packages/liveblocks-yjs/src/index.ts
+++ b/packages/liveblocks-yjs/src/index.ts
@@ -18,10 +18,12 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 type ProviderOptions = {
   autoloadSubdocs: boolean;
+  readOnly: boolean;
 };
 
 const DefaultOptions: ProviderOptions = {
   autoloadSubdocs: false,
+  readOnly: false,
 };
 
 export class LiveblocksYjsProvider<
@@ -80,11 +82,17 @@ export class LiveblocksYjsProvider<
         const { stateVector, update, guid } = message;
         // find the right doc and update
         if (guid !== undefined) {
-          this.subdocHandlers
-            .get(guid)
-            ?.handleServerUpdate({ update, stateVector });
+          this.subdocHandlers.get(guid)?.handleServerUpdate({
+            update,
+            stateVector,
+            readOnly: this.options.readOnly,
+          });
         } else {
-          this.rootDocHandler.handleServerUpdate({ update, stateVector });
+          this.rootDocHandler.handleServerUpdate({
+            update,
+            stateVector,
+            readOnly: this.options.readOnly,
+          });
         }
       })
     );
@@ -127,6 +135,7 @@ export class LiveblocksYjsProvider<
   };
 
   private updateDoc = (update: string, guid?: string) => {
+    if (this.options.readOnly) return;
     this.room.updateYDoc(update, guid);
   };
 


### PR DESCRIPTION
Adds a read-only option to Yjs provider. When set to true, this will only ever fetch updates and never send them.