### PR TITLE
Infer readonly-ness in Yjs provider, rather than having the user set it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.2.1 (not released yet)
+
+### `@liveblocks/yjs`
+
+- Don’t attempt to write Yjs changes if the current user has no write access.
+
 ## v2.2.0
 
 We are making `resolved` a first-class citizen property on

--- a/docs/pages/api-reference/liveblocks-yjs.mdx
+++ b/docs/pages/api-reference/liveblocks-yjs.mdx
@@ -71,8 +71,15 @@ function Component() {
 There are a few options you can pass as a third argument into the
 LiveblocksYjsProvider:
 
-- autoloadSubdocs: `boolean` (default: `false`). This option will load subdocs
-  automatically.
+<PropertiesList title="Constructor options">
+  <PropertiesListItem
+    name="autoloadSubdocs"
+    type="boolean"
+    defaultValue="false"
+  >
+    This option will load subdocs automatically.
+  </PropertiesListItem>
+</PropertiesList>
 
 ```ts
 const yProvider = new LiveblocksYjsProvider(room, yDoc, {

--- a/docs/pages/api-reference/liveblocks-yjs.mdx
+++ b/docs/pages/api-reference/liveblocks-yjs.mdx
@@ -73,13 +73,10 @@ LiveblocksYjsProvider:
 
 - autoloadSubdocs: `boolean` (default: `false`). This option will load subdocs
   automatically.
-- readOnly: `boolean` (default: `false`). This option will make the provider
-  read-only, it will not send changes to the server.
 
 ```ts
 const yProvider = new LiveblocksYjsProvider(room, yDoc, {
   autoloadSubdocs: true, // default false
-  readOnly: true, // default false
 });
 ```
 

--- a/packages/liveblocks-yjs/src/index.ts
+++ b/packages/liveblocks-yjs/src/index.ts
@@ -18,7 +18,6 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 type ProviderOptions = {
   autoloadSubdocs?: boolean;
-  readOnly?: boolean;
 };
 
 export class LiveblocksYjsProvider<
@@ -75,18 +74,19 @@ export class LiveblocksYjsProvider<
           return;
         }
         const { stateVector, update, guid } = message;
+        const canWrite = this.room.getSelf()?.canWrite ?? true;
         // find the right doc and update
         if (guid !== undefined) {
           this.subdocHandlers.get(guid)?.handleServerUpdate({
             update,
             stateVector,
-            readOnly: this.options.readOnly ?? false,
+            readOnly: !canWrite,
           });
         } else {
           this.rootDocHandler.handleServerUpdate({
             update,
             stateVector,
-            readOnly: this.options.readOnly ?? false,
+            readOnly: !canWrite,
           });
         }
       })
@@ -130,8 +130,10 @@ export class LiveblocksYjsProvider<
   };
 
   private updateDoc = (update: string, guid?: string) => {
-    if (this.options.readOnly) return;
-    this.room.updateYDoc(update, guid);
+    const canWrite = this.room.getSelf()?.canWrite ?? true;
+    if (canWrite) {
+      this.room.updateYDoc(update, guid);
+    }
   };
 
   private fetchDoc = (vector: string, guid?: string) => {


### PR DESCRIPTION
This is a quick follow-up after #1820, where I think it's a bit nicer DX-wise if we automatically infer this property from the session rather than to ask the user to set it manually.