### PR TITLE
Improve `useInboxNotificationThread` docs

### DIFF
--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -2492,6 +2492,15 @@ import { useInboxNotificationThread } from "@liveblocks/react/suspense";
 const thread = useInboxNotificationThread("in_xxx");
 ```
 
+<Banner type="info" title="No fetching and waterfalls">
+
+When `useInboxNotifications` returns `"thread"` inbox notifications, it also
+receives the associated threads and caches them behind the scenes. When you call
+`useInboxNotificationThread`, it simply returns the cached thread for the inbox
+notification ID you passed to it, without any fetching or waterfalls.
+
+</Banner>
+
 ### useRoomNotificationSettings [@badge=RoomProvider]
 
 Returns the user’s notification settings for the current room and a function to

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -2481,16 +2481,16 @@ markAllInboxNotificationsAsRead();
 
 Returns the thread associated with a `"thread"` inbox notification.
 
-It can **only** be called with IDs of `"thread"` inbox notifications, so we
-recommend only using it
-[when customizing the rendering](/docs/api-reference/liveblocks-react-ui#Rendering-notification-kinds-differently)
-or in other situations where you can guarantee the kind of the notification.
-
 ```tsx
 import { useInboxNotificationThread } from "@liveblocks/react/suspense";
 
 const thread = useInboxNotificationThread("in_xxx");
 ```
+
+It can **only** be called with IDs of `"thread"` inbox notifications, so we
+recommend only using it
+[when customizing the rendering](/docs/api-reference/liveblocks-react-ui#Rendering-notification-kinds-differently)
+or in other situations where you can guarantee the kind of the notification.
 
 <Banner type="info" title="No fetching and waterfalls">
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -2481,6 +2481,11 @@ markAllInboxNotificationsAsRead();
 
 Returns the thread associated with a `"thread"` inbox notification.
 
+It can **only** be called with IDs of `"thread"` inbox notifications, so we
+recommend only using it
+[when customizing the rendering](/docs/api-reference/liveblocks-react-ui#Rendering-notification-kinds-differently)
+or in other situations where you can guarantee the kind of the notification.
+
 ```tsx
 import { useInboxNotificationThread } from "@liveblocks/react/suspense";
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -981,6 +981,10 @@ type TypedBundle = LiveblocksContextBundle<DU, DM>;
 /**
  * Returns the thread associated with a `"thread"` inbox notification.
  *
+ * It can **only** be called with IDs of `"thread"` inbox notifications,
+ * so we recommend only using it when customizing the rendering or in other
+ * situations where you can guarantee the kind of the notification.
+ *
  * @example
  * const thread = useInboxNotificationThread("in_xxx");
  */

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -985,6 +985,11 @@ type TypedBundle = LiveblocksContextBundle<DU, DM>;
  * so we recommend only using it when customizing the rendering or in other
  * situations where you can guarantee the kind of the notification.
  *
+ * When `useInboxNotifications` returns `"thread"` inbox notifications,
+ * it also receives the associated threads and caches them behind the scenes.
+ * When you call `useInboxNotificationThread`, it simply returns the cached thread
+ * for the inbox notification ID you passed to it, without any fetching or waterfalls.
+ *
  * @example
  * const thread = useInboxNotificationThread("in_xxx");
  */

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -1120,6 +1120,11 @@ type LiveblocksContextBundleCommon<M extends BaseMetadata> = {
    * so we recommend only using it when customizing the rendering or in other
    * situations where you can guarantee the kind of the notification.
    *
+   * When `useInboxNotifications` returns `"thread"` inbox notifications,
+   * it also receives the associated threads and caches them behind the scenes.
+   * When you call `useInboxNotificationThread`, it simply returns the cached thread
+   * for the inbox notification ID you passed to it, without any fetching or waterfalls.
+   *
    * @example
    * const thread = useInboxNotificationThread("in_xxx");
    */

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -1116,6 +1116,10 @@ type LiveblocksContextBundleCommon<M extends BaseMetadata> = {
   /**
    * Returns the thread associated with a `"thread"` inbox notification.
    *
+   * It can **only** be called with IDs of `"thread"` inbox notifications,
+   * so we recommend only using it when customizing the rendering or in other
+   * situations where you can guarantee the kind of the notification.
+   *
    * @example
    * const thread = useInboxNotificationThread("in_xxx");
    */


### PR DESCRIPTION
After a few questions from users, these 2 missing aspects could be helpful to have in the docs.