### PR TITLE
Various `textMention` notification fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### `@liveblocks/react-ui`
 
+- Fix missing avatar in `textMention` inbox notifications.
+- Fix `textMention` usage (and its props type) when customizing rendering via
+  `kinds` on `InboxNotification`.
 - Fix broken CSS selector in default styles.
 
 ## v2.2.1

--- a/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
@@ -681,8 +681,11 @@ export const InboxNotification = Object.assign(
         }
 
         case "textMention": {
+          const ResolvedInboxNotificationTextMention =
+            kinds?.textMention ?? InboxNotificationTextMention;
+
           return (
-            <InboxNotificationTextMention
+            <ResolvedInboxNotificationTextMention
               inboxNotification={inboxNotification}
               {...props}
               ref={forwardedRef}

--- a/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
@@ -67,7 +67,7 @@ type InboxNotificationKinds<KS extends KDAD = KDAD> = {
   [K in KS]: ComponentTypeWithRef<"a", InboxNotificationCustomKindProps<K>>;
 } & {
   thread: ComponentTypeWithRef<"a", InboxNotificationThreadKindProps>;
-  textMention: ComponentTypeWithRef<"a", InboxNotificationTextMentionProps>;
+  textMention: ComponentTypeWithRef<"a", InboxNotificationTextMentionKindProps>;
 };
 
 interface InboxNotificationSharedProps {

--- a/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
@@ -553,7 +553,7 @@ const InboxNotificationTextMention = forwardRef<
     return (
       <InboxNotificationLayout
         inboxNotification={inboxNotification}
-        aside={<InboxNotificationIcon />}
+        aside={<InboxNotificationAvatar userId={inboxNotification.createdBy} />}
         title={$.INBOX_NOTIFICATION_TEXT_MENTION(
           <User
             key={inboxNotification.createdBy}


### PR DESCRIPTION
Someone reported that the `showRoomName` prop didn't work on `textMention` notifications, which led me to fix a few other issues.

- We weren't using the provided (via `kinds`) components for `textMention` notifications, that's why the `showRoomName` prop didn't work
- We were using an empty icon but we have the mention's creator ID so we can show their avatar like thread notifications
- A type issue