### PR TITLE
Refactor internals of Batch APIs to take only a single arg as input

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -143,8 +143,8 @@ export type PrivateClientApi<U extends BaseUserMeta, M extends BaseMetadata> = {
   readonly currentUserIdStore: Store<string | null>;
   readonly resolveMentionSuggestions: ClientOptions<U>["resolveMentionSuggestions"];
   readonly cacheStore: CacheStore<BaseMetadata>;
-  readonly usersStore: BatchStore<U["info"] | undefined, [string]>;
-  readonly roomsInfoStore: BatchStore<DRI | undefined, [string]>;
+  readonly usersStore: BatchStore<U["info"] | undefined, string>;
+  readonly roomsInfoStore: BatchStore<DRI | undefined, string>;
   readonly getRoomIds: () => string[];
 };
 
@@ -531,7 +531,7 @@ export function createClient<U extends BaseUserMeta = DU>(
   );
 
   const usersStore = createBatchStore(
-    async (batchedUserIds: [userId: string][]) => {
+    async (batchedUserIds: string[]) => {
       const userIds = batchedUserIds.flat();
       const users = await resolveUsers?.({ userIds });
 
@@ -549,7 +549,7 @@ export function createClient<U extends BaseUserMeta = DU>(
   );
 
   const roomsInfoStore = createBatchStore(
-    async (batchedRoomIds: [roomId: string][]) => {
+    async (batchedRoomIds: string[]) => {
       const roomIds = batchedRoomIds.flat();
       const roomsInfo = await resolveRoomsInfo?.({ roomIds });
 

--- a/packages/liveblocks-core/src/lib/__tests__/batch.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/batch.test.ts
@@ -26,7 +26,7 @@ describe("Batch", () => {
     await expect(b).resolves.toEqual("b");
 
     // Callback should be called only once for both "a" and "b".
-    expect(callback).toHaveBeenCalledWith([["a"], ["b"]]);
+    expect(callback).toHaveBeenCalledWith(["a", "b"]);
   });
 
   test("should batch asynchronous calls", async () => {
@@ -40,7 +40,7 @@ describe("Batch", () => {
     await expect(b).resolves.toEqual("b");
 
     // Callback should be called only once for both "a" and "b".
-    expect(callback).toHaveBeenCalledWith([["a"], ["b"]]);
+    expect(callback).toHaveBeenCalledWith(["a", "b"]);
   });
 
   test("should batch based on delay", async () => {
@@ -56,8 +56,8 @@ describe("Batch", () => {
 
     // Callback should be called twice, once for "a" and once for "b".
     expect(callback).toHaveBeenCalledTimes(2);
-    expect(callback).toHaveBeenNthCalledWith(1, [["a"]]);
-    expect(callback).toHaveBeenNthCalledWith(2, [["b"]]);
+    expect(callback).toHaveBeenNthCalledWith(1, ["a"]);
+    expect(callback).toHaveBeenNthCalledWith(2, ["b"]);
   });
 
   test("should batch based on size", async () => {
@@ -75,8 +75,8 @@ describe("Batch", () => {
 
     // Callback should be called twice, once for "a" and once for "b".
     expect(callback).toHaveBeenCalledTimes(2);
-    expect(callback).toHaveBeenNthCalledWith(1, [["a"]]);
-    expect(callback).toHaveBeenNthCalledWith(2, [["b"]]);
+    expect(callback).toHaveBeenNthCalledWith(1, ["a"]);
+    expect(callback).toHaveBeenNthCalledWith(2, ["b"]);
   });
 
   test("should reject batch errors", async () => {
@@ -155,7 +155,7 @@ describe("Batch", () => {
 
     // Callback should be called only once for ["a", "b"].
     expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith([["a"], ["b"]]);
+    expect(callback).toHaveBeenCalledWith(["a", "b"]);
   });
 
   test("should not deduplicate identical calls if they're not in the same batch", async () => {
@@ -173,7 +173,7 @@ describe("Batch", () => {
 
     // Callback should be called twice, once for ["a", "b"] and once for ["a"] again.
     expect(callback).toHaveBeenCalledTimes(2);
-    expect(callback).toHaveBeenNthCalledWith(1, [["a"], ["b"]]);
-    expect(callback).toHaveBeenNthCalledWith(2, [["a"]]);
+    expect(callback).toHaveBeenNthCalledWith(1, ["a", "b"]);
+    expect(callback).toHaveBeenNthCalledWith(2, ["a"]);
   });
 });

--- a/packages/liveblocks-core/src/lib/__tests__/batch.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/batch.test.ts
@@ -5,20 +5,19 @@ const SOME_TIME = 5;
 const ERROR_MESSAGE = "error";
 const ERROR = new Error(ERROR_MESSAGE);
 
-const synchronousCallback = (args: [string][]) => {
-  return args.map(([userId]) => userId);
+const synchronousCallback = (inputs: string[]) => {
+  return inputs.map((userId) => userId);
 };
 
-const asynchronousCallback = async (args: [string][]) => {
+const asynchronousCallback = async (inputs: string[]) => {
   await wait(SOME_TIME);
-
-  return args.map(([userId]) => userId);
+  return inputs.map((userId) => userId);
 };
 
 describe("Batch", () => {
   test("should batch synchronous calls", async () => {
     const callback = jest.fn(synchronousCallback);
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");
@@ -32,7 +31,7 @@ describe("Batch", () => {
 
   test("should batch asynchronous calls", async () => {
     const callback = jest.fn(asynchronousCallback);
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");
@@ -46,7 +45,7 @@ describe("Batch", () => {
 
   test("should batch based on delay", async () => {
     const callback = jest.fn(synchronousCallback);
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     await wait(SOME_TIME * 1.5);
@@ -63,7 +62,7 @@ describe("Batch", () => {
 
   test("should batch based on size", async () => {
     const callback = jest.fn(synchronousCallback);
-    const batch = new Batch<string, [string]>(callback, {
+    const batch = new Batch<string, string>(callback, {
       delay: SOME_TIME,
       size: 1,
     });
@@ -84,7 +83,7 @@ describe("Batch", () => {
     const callback = jest.fn(() => {
       throw ERROR;
     });
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");
@@ -98,7 +97,7 @@ describe("Batch", () => {
     const callback = jest.fn(() => {
       return Promise.reject(ERROR_MESSAGE);
     });
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");
@@ -112,7 +111,7 @@ describe("Batch", () => {
     const callback = jest.fn(() => {
       return ["a", ERROR];
     });
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");
@@ -124,7 +123,7 @@ describe("Batch", () => {
 
   test("should reject if callback doesn't return an array", async () => {
     const callback = jest.fn();
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     await expect(batch.get("a")).rejects.toEqual(
       new Error("Callback must return an array.")
@@ -133,7 +132,7 @@ describe("Batch", () => {
 
   test("should reject if callback doesn't return an array of the same length as batch", async () => {
     const callback = jest.fn(() => []);
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     await expect(batch.get("a")).rejects.toEqual(
       new Error(
@@ -144,7 +143,7 @@ describe("Batch", () => {
 
   test("should deduplicate identical calls", async () => {
     const callback = jest.fn(synchronousCallback);
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");
@@ -161,7 +160,7 @@ describe("Batch", () => {
 
   test("should not deduplicate identical calls if they're not in the same batch", async () => {
     const callback = jest.fn(synchronousCallback);
-    const batch = new Batch<string, [string]>(callback, { delay: SOME_TIME });
+    const batch = new Batch<string, string>(callback, { delay: SOME_TIME });
 
     const a = batch.get("a");
     const b = batch.get("b");

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -161,8 +161,8 @@ export function createNotificationsApi<M extends BaseMetadata>({
     });
   }
 
-  const batchedMarkInboxNotificationsAsRead = new Batch(
-    async (batchedInboxNotificationIds: [string][]) => {
+  const batchedMarkInboxNotificationsAsRead = new Batch<string, string>(
+    async (batchedInboxNotificationIds) => {
       const inboxNotificationIds = batchedInboxNotificationIds.flat();
 
       await markInboxNotificationsAsRead(inboxNotificationIds);

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3021,8 +3021,8 @@ export function createRoom<
     });
   }
 
-  const batchedMarkInboxNotificationsAsRead = new Batch(
-    async (batchedInboxNotificationIds: [string][]) => {
+  const batchedMarkInboxNotificationsAsRead = new Batch<string, string>(
+    async (batchedInboxNotificationIds) => {
       const inboxNotificationIds = batchedInboxNotificationIds.flat();
 
       await markInboxNotificationsAsRead(inboxNotificationIds);


### PR DESCRIPTION
The "multi-arg" batch API was a premature optimization we never used or needed, and this will make maintaining it going forward a bit easier. Look at the changed unit tests to see the difference of (internal) behavior. This only changes internal behavior. No public APIs are affected by this change.

Targeted to be included in #1809.
