### PR TITLE
Fix resolved threads not being filtered correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### `@liveblocks/react`
 
 - Various refactorings to Suspense internals
+- Fix `resolved` query not being applied when filtering threads inside
+  `useThreads` hook.
 
 ## v2.2.2
 

--- a/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
@@ -5,46 +5,43 @@ import { selectedThreads } from "../comments/lib/selected-threads";
 import MockWebSocket from "./_MockWebSocket";
 
 describe("selectedThreads", () => {
-  it.failing(
-    "should only return resolved threads from a list of threads",
-    () => {
-      const client = createClient({
-        publicApiKey: "pk_xxx",
-        polyfills: {
-          WebSocket: MockWebSocket as any,
-        },
-      });
+  it("should only return resolved threads from a list of threads", () => {
+    const client = createClient({
+      publicApiKey: "pk_xxx",
+      polyfills: {
+        WebSocket: MockWebSocket as any,
+      },
+    });
 
-      const thread1: ThreadData = {
-        type: "thread" as const,
-        id: "th_1",
-        createdAt: new Date("2024-01-01"),
-        roomId: "room_1",
-        comments: [],
-        metadata: {},
-        resolved: false,
-      };
+    const thread1: ThreadData = {
+      type: "thread" as const,
+      id: "th_1",
+      createdAt: new Date("2024-01-01"),
+      roomId: "room_1",
+      comments: [],
+      metadata: {},
+      resolved: false,
+    };
 
-      const thread2: ThreadData = {
-        type: "thread" as const,
-        id: "th_2",
-        createdAt: new Date("2024-01-02"),
-        roomId: "room_1",
-        comments: [],
-        metadata: {},
-        resolved: false,
-      };
+    const thread2: ThreadData = {
+      type: "thread" as const,
+      id: "th_2",
+      createdAt: new Date("2024-01-02"),
+      roomId: "room_1",
+      comments: [],
+      metadata: {},
+      resolved: false,
+    };
 
-      const store = client[kInternal]
-        .cacheStore as unknown as CacheStore<BaseMetadata>;
+    const store = client[kInternal]
+      .cacheStore as unknown as CacheStore<BaseMetadata>;
 
-      store.updateThreadsAndNotifications([thread1, thread2], [], [], []);
+    store.updateThreadsAndNotifications([thread1, thread2], [], [], []);
 
-      const resolvedThreads = selectedThreads("room_1", store.get(), {
-        query: { resolved: true },
-      });
+    const resolvedThreads = selectedThreads("room_1", store.get(), {
+      query: { resolved: true },
+    });
 
-      expect(resolvedThreads).toEqual([]);
-    }
-  );
+    expect(resolvedThreads).toEqual([]);
+  });
 });

--- a/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
@@ -1,0 +1,50 @@
+import type { BaseMetadata, CacheStore, ThreadData } from "@liveblocks/core";
+import { createClient, kInternal } from "@liveblocks/core";
+
+import { selectedThreads } from "../comments/lib/selected-threads";
+import MockWebSocket from "./_MockWebSocket";
+
+describe("selectedThreads", () => {
+  it.failing(
+    "should only return resolved threads from a list of threads",
+    () => {
+      const client = createClient({
+        publicApiKey: "pk_xxx",
+        polyfills: {
+          WebSocket: MockWebSocket as any,
+        },
+      });
+
+      const thread1: ThreadData = {
+        type: "thread" as const,
+        id: "th_1",
+        createdAt: new Date("2024-01-01"),
+        roomId: "room_1",
+        comments: [],
+        metadata: {},
+        resolved: false,
+      };
+
+      const thread2: ThreadData = {
+        type: "thread" as const,
+        id: "th_2",
+        createdAt: new Date("2024-01-02"),
+        roomId: "room_1",
+        comments: [],
+        metadata: {},
+        resolved: false,
+      };
+
+      const store = client[kInternal]
+        .cacheStore as unknown as CacheStore<BaseMetadata>;
+
+      store.updateThreadsAndNotifications([thread1, thread2], [], [], []);
+
+      const resolvedThreads = selectedThreads("room_1", store.get(), {
+        query: { resolved: true },
+      });
+
+      expect(resolvedThreads).toEqual([]);
+    }
+  );
+});

--- a/packages/liveblocks-react/src/comments/lib/selected-threads.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-threads.ts
@@ -30,6 +30,11 @@ export function selectedThreads<M extends BaseMetadata>(
       const query = options.query;
       if (!query) return true;
 
+      // If the query includes 'resolved' filter and the thread's 'resolved' value does not match the query's 'resolved' value, exclude the thread
+      if (query.resolved !== undefined && thread.resolved !== query.resolved) {
+        return false;
+      }
+
       for (const key in query.metadata) {
         const metadataValue = thread.metadata[key];
         const filterValue = query.metadata[key];


### PR DESCRIPTION
The selectedThreads function was not correctly filtering threads based on the 'resolved' query parameter. This pull request fixes the bug by adding a check for the 'resolved' value in the query and excluding threads that do not match. Additionally, a failing test was added to demonstrate the bug and then removed after the fix was implemented.