### PR TITLE
Use event source to dispatch provider status inside `useEditorStatus`

### DIFF
--- a/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
@@ -244,7 +244,7 @@ export const LiveblocksPlugin = ({
         }}
       />
 
-      {self && (
+      {info && (
         <CollaborationPlugin
           // Setting the key allows us to reset the internal Y.doc used by useYjsCollaboration
           // without implementing `reload` event


### PR DESCRIPTION
This PR updates `useEditorStatus` to use event source to notify when the provider status updated. The current implementation fails when `LexicalPlugin` is rendered conditionally because the hook expects `provider` to be available after the first render. This fixes [LB-1011](https://linear.app/liveblocks/issue/LB-1011/useeditorstatus-always-returns-not-loaded-if-liveblocksplugin-is).

This PR also fixes issue with [remote cursor names not displaying](https://linear.app/liveblocks/issue/LB-878/user-names-on-remote-cursors-are-not-displayed) by rendering `CollaborationPlugin` only after `useSelf` returns a defined value, which is not ideal as we have to wait till `useSelf` returns a defined value to render `CollaborationPlugin`. But, hopefully, we can invest more time to think deeper about the issues around awareness and see if forking `CollaborationPlugin` from `@lexical/react` is necessary. 