### PR TITLE
Improve emoji picker keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Fix `resolved` query not being applied when filtering threads inside
   `useThreads` hook.
 
+### `@liveblocks/react-ui`
+
+- Improve keyboard navigation within emoji pickers.
+
 ## v2.2.2
 
 ### `@liveblocks/react-ui`

--- a/package-lock.json
+++ b/package-lock.json
@@ -22872,9 +22872,10 @@
       }
     },
     "node_modules/react-virtuoso": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.4.tgz",
-      "integrity": "sha512-aYD+ClOCtYxURuT/GK5GamcD7XFTtmagKakEDQ07EyCPBUFy7Oc6xC2I24zSGcY5rDj+QZf/R5Iiks9Ael8pCA==",
+      "version": "4.7.12",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.12.tgz",
+      "integrity": "sha512-q8yaykkVJGJbPNQH2Hgm82ik0LsbNGJpHMEjAGz5ibEsTVHKObs5WtEELAd1A99OKFHs091W1M+HN+1sasL08Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -27861,61 +27862,6 @@
         "react": "^16.14.0 || ^17 || ^18"
       }
     },
-    "packages/liveblocks-react-comments": {
-      "name": "@liveblocks/react-comments",
-      "version": "1.12.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.0.8",
-        "@liveblocks/client": "1.12.0",
-        "@liveblocks/core": "1.12.0",
-        "@liveblocks/react": "1.12.0",
-        "@radix-ui/react-dropdown-menu": "^2.0.6",
-        "@radix-ui/react-popover": "^1.0.7",
-        "@radix-ui/react-slot": "^1.0.2",
-        "@radix-ui/react-toggle": "^1.0.3",
-        "@radix-ui/react-tooltip": "^1.0.7",
-        "react-virtuoso": "^4.7.4",
-        "slate": "^0.102.0",
-        "slate-history": "^0.100.0",
-        "slate-react": "^0.102.0",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "devDependencies": {
-        "@liveblocks/eslint-config": "*",
-        "@liveblocks/jest-config": "*",
-        "@rollup/plugin-replace": "^5.0.5",
-        "@rollup/plugin-typescript": "^11.1.2",
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.1.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "emojibase": "^15.3.0",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
-        "postcss": "^8.4.31",
-        "postcss-advanced-variables": "^3.0.1",
-        "postcss-combine-duplicated-selectors": "^10.0.3",
-        "postcss-functions": "^4.0.2",
-        "postcss-import": "^15.1.0",
-        "postcss-lightningcss": "^1.0.0",
-        "postcss-nesting": "^12.0.1",
-        "postcss-reporter": "^7.0.5",
-        "postcss-sort-media-queries": "^5.2.0",
-        "rollup": "^3.28.0",
-        "rollup-plugin-dts": "^5.3.1",
-        "rollup-plugin-esbuild": "^5.0.0",
-        "rollup-plugin-preserve-directives": "^0.2.0",
-        "stylelint": "^15.10.2",
-        "stylelint-config-standard": "^34.0.0",
-        "stylelint-order": "^6.0.3",
-        "stylelint-plugin-logical-css": "^0.13.2"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17 || ^18"
-      }
-    },
     "packages/liveblocks-react-lexical": {
       "name": "@liveblocks/react-lexical",
       "version": "2.2.2",
@@ -28172,7 +28118,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toggle": "^1.0.3",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "react-virtuoso": "^4.7.4",
+        "react-virtuoso": "^4.7.12",
         "slate": "^0.102.0",
         "slate-history": "^0.100.0",
         "slate-hyperscript": "^0.100.0",
@@ -33716,7 +33662,7 @@
         "postcss-nesting": "^12.0.1",
         "postcss-reporter": "^7.0.5",
         "postcss-sort-media-queries": "^5.2.0",
-        "react-virtuoso": "^4.7.4",
+        "react-virtuoso": "^4.7.12",
         "rollup": "^3.28.0",
         "rollup-plugin-dts": "^5.3.1",
         "rollup-plugin-esbuild": "^5.0.0",
@@ -46463,9 +46409,9 @@
       }
     },
     "react-virtuoso": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.4.tgz",
-      "integrity": "sha512-aYD+ClOCtYxURuT/GK5GamcD7XFTtmagKakEDQ07EyCPBUFy7Oc6xC2I24zSGcY5rDj+QZf/R5Iiks9Ael8pCA==",
+      "version": "4.7.12",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.12.tgz",
+      "integrity": "sha512-q8yaykkVJGJbPNQH2Hgm82ik0LsbNGJpHMEjAGz5ibEsTVHKObs5WtEELAd1A99OKFHs091W1M+HN+1sasL08Q==",
       "requires": {}
     },
     "react-window": {

--- a/packages/liveblocks-react-ui/package.json
+++ b/packages/liveblocks-react-ui/package.json
@@ -71,7 +71,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toggle": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "react-virtuoso": "^4.7.4",
+    "react-virtuoso": "^4.7.12",
     "slate": "^0.102.0",
     "slate-history": "^0.100.0",
     "slate-hyperscript": "^0.100.0",

--- a/packages/liveblocks-react-ui/src/primitives/EmojiPicker/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/EmojiPicker/index.tsx
@@ -393,10 +393,13 @@ const placeholderRowAttributes: EmojiPickerContentEmojiRowAttributes = {
   categoryRowsCount: 0,
 };
 
+// About `data-testid={undefined}`: Virtuoso bakes test IDs into the components we pass
+// to it, so we manually remove them.
+
 const VirtuosoScroller = forwardRef<HTMLDivElement, ScrollerProps>(
   ({ children, ...props }, forwardedRef) => {
     return (
-      <div {...props} tabIndex={-1} data-test-id={undefined} ref={forwardedRef}>
+      <div {...props} tabIndex={-1} data-testid={undefined} ref={forwardedRef}>
         {children}
       </div>
     );
@@ -406,7 +409,7 @@ const VirtuosoScroller = forwardRef<HTMLDivElement, ScrollerProps>(
 const VirtuosoTopList = forwardRef<HTMLDivElement, TopItemListProps>(
   ({ children, ...props }, forwardedRef) => {
     return (
-      <div {...props} data-test-id={undefined} ref={forwardedRef}>
+      <div {...props} data-testid={undefined} ref={forwardedRef}>
         {children}
       </div>
     );
@@ -473,7 +476,7 @@ const EmojiPickerContent = forwardRef<HTMLDivElement, EmojiPickerContentProps>(
                 role="grid"
                 aria-colcount={columns}
                 {...props}
-                data-test-id={undefined}
+                data-testid={undefined}
                 ref={forwardedRef}
               >
                 {children}

--- a/packages/liveblocks-react-ui/src/primitives/EmojiPicker/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/EmojiPicker/index.tsx
@@ -11,6 +11,7 @@ import React, {
   useState,
 } from "react";
 import type {
+  CalculateViewLocationParams,
   GroupedVirtuosoHandle,
   ListProps as VirtuosoListProps,
   ScrollerProps,
@@ -23,6 +24,7 @@ import {
   cancelIdleCallback,
   requestIdleCallback,
 } from "../../utils/request-idle-callback";
+import { useLayoutEffect } from "../../utils/use-layout-effect";
 import { useTransition } from "../../utils/use-transition";
 import { visuallyHidden } from "../../utils/visually-hidden";
 import { Emoji as EmojiPrimitive } from "../internal/Emoji";
@@ -438,6 +440,10 @@ const EmojiPickerContent = forwardRef<HTMLDivElement, EmojiPickerContentProps>(
   ({ components, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
     const virtuosoRef = useRef<GroupedVirtuosoHandle>(null);
+    const placeholderContainerRef = useRef<HTMLDivElement>(null);
+    const rowScrollMarginTopRef = useRef<number>(0);
+    const rowScrollMarginBottomRef = useRef<number>(0);
+    const categoryHeaderHeightRef = useRef<number>(0);
     const {
       data,
       error,
@@ -492,31 +498,90 @@ const EmojiPickerContent = forwardRef<HTMLDivElement, EmojiPickerContentProps>(
       }
     }, [interaction, setInteraction]);
 
+    useLayoutEffect(() => {
+      if (!placeholderContainerRef.current) {
+        return;
+      }
+
+      const row = placeholderContainerRef.current.childNodes[0];
+      const categoryHeader = placeholderContainerRef.current.childNodes[1];
+
+      if (row instanceof HTMLElement) {
+        const style = window.getComputedStyle(row);
+
+        rowScrollMarginTopRef.current = parseFloat(style.scrollMarginTop);
+        rowScrollMarginBottomRef.current = parseFloat(style.scrollMarginBottom);
+      }
+
+      if (categoryHeader instanceof HTMLElement) {
+        categoryHeaderHeightRef.current = categoryHeader.offsetHeight;
+      }
+    }, []);
+
+    // Customize `scrollIntoView` behavior to take into account category headers and margins
+    const calculateViewLocation = useCallback(
+      ({
+        itemTop,
+        itemBottom,
+        viewportTop,
+        viewportBottom,
+        locationParams: { behavior, align, ...params },
+      }: CalculateViewLocationParams) => {
+        if (
+          itemTop -
+            (categoryHeaderHeightRef.current + rowScrollMarginTopRef.current) <
+          viewportTop
+        ) {
+          return {
+            ...params,
+            behavior,
+            align: align ?? "start",
+          };
+        }
+
+        if (itemBottom > viewportBottom) {
+          return {
+            ...params,
+            behavior,
+            align: align ?? "end",
+            offset: rowScrollMarginBottomRef.current,
+          };
+        }
+
+        return null;
+      },
+      []
+    );
+
     useEffect(() => {
       if (interaction === "keyboard") {
         virtuosoRef.current?.scrollIntoView({
           index: selectedRowIndex,
           behavior: "auto",
+          calculateViewLocation,
         });
       }
-    }, [interaction, selectedRowIndex]);
+    }, [interaction, selectedRowIndex, calculateViewLocation]);
 
     return (
       <Component {...props} ref={forwardedRef}>
-        {/* Virtualized rows are absolutely positioned so they won't make
-            the container automatically pick up their width. To achieve
-            an automatic width, we add a relative (but hidden) full row. */}
         <div
           style={{
             visibility: "hidden",
             height: 0,
           }}
+          ref={placeholderContainerRef}
         >
+          {/* Virtualized rows are absolutely positioned so they won't make
+            the container automatically pick up their width. To achieve
+            an automatic width, we add a relative (but hidden) full row. */}
           <Row attributes={placeholderRowAttributes}>
             {placeholderColumns.map((placeholder, index) => (
               <Emoji emoji={placeholder} key={index} />
             ))}
           </Row>
+          {/* We also add a hidden category header to get its computed height. */}
+          <CategoryHeader category="Category" />
         </div>
         {isLoading ? (
           <Loading />

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -323,7 +323,7 @@
 
   display: flex;
   flex-direction: column;
-  block-size: 350px;
+  block-size: 360px;
   color: var(--lb-foreground);
 }
 
@@ -416,11 +416,11 @@
 
 .lb-emoji-picker-row {
   display: flex;
-  padding-inline: $lb-emoji-picker-padding;
-  scroll-margin-block: $lb-emoji-picker-padding;
+  padding-inline: var(--lb-emoji-picker-padding);
+  scroll-margin-block-end: var(--lb-emoji-picker-padding);
 
   &:where([data-last]) {
-    padding-block-end: $lb-emoji-picker-padding;
+    padding-block-end: var(--lb-emoji-picker-padding);
   }
 }
 


### PR DESCRIPTION
While looking at LB-960, I remembered LB-227, and I discovered that it was also resulting in a bigger issue I missed before: the fact that it would be stuck to the bottom edge is just a nitpick but for the top edge it wasn't taking the sticky headers into account so pressing `↑` would do nothing visually half the time because the highlighted emoji was behind one of the sticky headers.

Fixes LB-227.

### Before

https://github.com/user-attachments/assets/ff514c9b-20c5-4ad2-ada3-d99a9d6d7ca8

Notice how navigating up only "works" half of the time.

### After

https://github.com/user-attachments/assets/b556a51e-3697-43df-bd16-48e949b0a62b