### PR TITLE
Stop prettier breaking the formatting

### DIFF
--- a/docs/pages/platform/limits.mdx
+++ b/docs/pages/platform/limits.mdx
@@ -24,10 +24,8 @@ To prevent abuse of our platform, we apply the following limits to all accounts.
 
 #### Comments
 
-Comments is free up to <Limits.StarterMauMax /> monthly active users and
-
-<Limits.StarterMaxComments /> comments per month. You can get higher limits for
-an additional <Limits.ProStartingPriceComments />.
+{/* prettier-ignore */}
+Comments is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterMaxComments /> comments per month. You can get higher limits for an additional <Limits.ProStartingPriceComments />.
 
 | Comments                      | Included                      | <Limits.ProStartingPriceComments /> |
 | ----------------------------- | ----------------------------- | ----------------------------------- |
@@ -37,10 +35,8 @@ an additional <Limits.ProStartingPriceComments />.
 
 #### Notifications
 
-Notifications is free up to <Limits.StarterMauMax /> monthly active users and
-
-<Limits.StarterMaxNotifications /> notifications per month. You can get higher
-limits for an additional <Limits.ProStartingPriceNotifications />.
+{/* prettier-ignore */}
+Notifications is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterMaxNotifications /> notifications per month. You can get higher limits for an additional <Limits.ProStartingPriceNotifications />.
 
 | Notifications                 | Included                           | <Limits.ProStartingPriceNotifications /> |
 | ----------------------------- | ---------------------------------- | ---------------------------------------- |
@@ -50,10 +46,8 @@ limits for an additional <Limits.ProStartingPriceNotifications />.
 
 #### Text editor
 
-Text editor is free up to <Limits.StarterMauMax /> monthly active users and
-
-<Limits.StarterTotalTextEditorStored /> data stored. You can get higher limits
-for an additional <Limits.ProStartingPriceTextEditor />.
+{/* prettier-ignore */}
+Text editor is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterTotalTextEditorStored /> data stored. You can get higher limits for an additional <Limits.ProStartingPriceTextEditor />.
 
 | Text editor                   | Included                                | <Limits.ProStartingPriceTextEditor /> |
 | ----------------------------- | --------------------------------------- | ------------------------------------- |
@@ -63,10 +57,8 @@ for an additional <Limits.ProStartingPriceTextEditor />.
 
 #### Realtime APIs
 
-Realtime APIs is free up to <Limits.StarterMauMax /> monthly active users and
-
-<Limits.StarterTotalCustomAppStored /> data stored. You can get higher limits
-for an additional <Limits.ProStartingPriceCustomApp />.
+{/* prettier-ignore */}
+Realtime APIs is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterTotalCustomAppStored /> data stored. You can get higher limits for an additional <Limits.ProStartingPriceCustomApp />.
 
 | Realtime APIs                 | Included                               | <Limits.ProStartingPriceCustomApp /> |
 | ----------------------------- | -------------------------------------- | ------------------------------------ |


### PR DESCRIPTION
Prettier is not working correctly in these paragraphs, this prevents the problem happening.

**Before**
![CleanShot 2024-07-26 at 10 52 44@2x](https://github.com/user-attachments/assets/fc01cffc-4713-40dc-b617-b22d4566a28f)

**After**
![CleanShot 2024-07-26 at 10 56 44@2x](https://github.com/user-attachments/assets/cd2710d3-5565-4abe-9251-b16db26e2e8c)

