### PR TITLE
Ignore history merge mutations to MentionNode

### DIFF
--- a/packages/liveblocks-react-lexical/src/mentions/mention-plugin.tsx
+++ b/packages/liveblocks-react-lexical/src/mentions/mention-plugin.tsx
@@ -209,7 +209,14 @@ export function MentionPlugin() {
     return editor.registerMutationListener(
       MentionNode,
       (mutations, payload) => {
-        if (payload.updateTags.has("collaboration")) return;
+        // Ignore mutations to MentionNode (creation/updates/deletions) that are caused by collaboration (remote users) or history merge.
+        if (
+          payload.updateTags.has("collaboration") ||
+          payload.updateTags.has("history-merge")
+        ) {
+          return;
+        }
+
         $handleMutation(mutations, payload);
       }
     );


### PR DESCRIPTION
This pull request adds a check to ignore mutations to the MentionNode that are caused by history merge. This prevents unnecessary updates to the MentionNode and ensures that only relevant changes are processed. 

In Lexical, an update is tagged with `history-merge` if the change is merged with the previous entry of history stack so that the current change is not undoable as an atomic operation.

Notice in the recording that a document with 3 mentions makes 3 fetch requests to post the notifications every time the document is loaded. This PR should fix this issue.

https://github.com/user-attachments/assets/9fade6c2-3c7f-45bd-b760-c97a71deba11

