### PR TITLE
docs: Update how-to-modify-liveblocks-storage-from-the-server.mdx

### DIFF
--- a/guides/pages/how-to-modify-liveblocks-storage-from-the-server.mdx
+++ b/guides/pages/how-to-modify-liveblocks-storage-from-the-server.mdx
@@ -146,7 +146,6 @@ export async function modifyStorage(
 
   // Leave when storage has been synchronized
   roomContext.leave(roomId);
-  resolve();
 }
 ```
 

--- a/guides/pages/how-to-modify-liveblocks-storage-from-the-server.mdx
+++ b/guides/pages/how-to-modify-liveblocks-storage-from-the-server.mdx
@@ -128,26 +128,25 @@ export async function modifyStorage(
   roomId: string,
   storageChanges: (root: LiveObject<Storage>) => void
 ) {
-  return new Promise(async (resolve) => {
-    const room = enterRoom(roomId);
-    const { root } = await room.getStorage();
+  const roomContext = enterRoom(roomId);
+  const { room } = roomContext;
+  const { root } = await room.getStorage();
 
-    // Make storage adjustments in a batch, so they all happen at once
-    room.batch(() => {
-      storageChanges(root);
-    });
-
-    // If storage changes are not synchronized, wait for them to finish
-    if (room.getStorageStatus() !== "synchronized") {
-      await room.events.storageStatus.waitUntil(
-        (status) => status === "synchronized"
-      );
-    }
-
-    // Leave when storage has been synchronized
-    serverClient.leave(roomId);
-    resolve();
+  // Make storage adjustments in a batch, so they all happen at once
+  room.batch(() => {
+    storageChanges(root);
   });
+
+  // If storage changes are not synchronized, wait for them to finish
+  if (room.getStorageStatus() !== "synchronized") {
+    await room.events.storageStatus.waitUntil(
+      (status) => status === "synchronized"
+    );
+  }
+
+  // Leave when storage has been synchronized
+  roomContext.leave(roomId);
+  resolve();
 }
 ```
 


### PR DESCRIPTION
Updating the code example in the modifying liveblocks from the server snippet.

Recently implemented this, and somethings were out of date:

- (Style change, nit) Removed the outer Promise since felt unnecessary + probably should just let any errors boil up
- Found through trial and error had to access the `room` property from an object that is returned from the `enterRoom` versus `enterRoom` doesn't seem to return just the `room` object anymore
