### PR TITLE
Add Node.js resolved functions to docs

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1306,6 +1306,50 @@ const editedMetadata = await liveblocks.editThreadMetadata({
 console.log(editedMetadata);
 ```
 
+#### Liveblocks.markThreadAsResolved [#post-rooms-roomId-threads-threadId-mark-as-resolved]
+
+Marks a thread as resolved, which means it sets the `resolved` property on the
+specified thread to `true`. Takes a `userId`, which is the ID of the user that
+resolved the thread. Throws an error if the room or thread isn’t found. This is
+a wrapper around the
+[Mark Thread As Resolved API](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-resolved)
+and returns the same response.
+
+```ts
+const thread = await liveblocks.markThreadAsResolved({
+  roomId: "my-room-id",
+  threadId: "th_d75sF3...",
+  data: {
+    userId: "steven@example.com",
+  },
+});
+
+// { type: "thread", id: "th_d75sF3...", ... }
+console.log(thread);
+```
+
+#### Liveblocks.markThreadAsUnresolved [#post-rooms-roomId-threads-threadId-mark-as-unresolved]
+
+Marks a thread as unresolved, which means it sets the `resolved` property on the
+specified thread to `false`. Takes a `userId`, which is the ID of the user that
+unresolved the thread. Throws an error if the room or thread isn’t found. This
+is a wrapper around the
+[Mark Thread As Unresolved API](/docs/api-reference/rest-api-endpoints#post-rooms-roomId-threads-threadId-mark-as-unresolved)
+and returns the same response.
+
+```ts
+const thread = await liveblocks.markThreadAsUnresolved({
+  roomId: "my-room-id",
+  threadId: "th_d75sF3...",
+  data: {
+    userId: "steven@example.com",
+  },
+});
+
+// { type: "thread", id: "th_d75sF3...", ... }
+console.log(thread);
+```
+
 #### Liveblocks.deleteThread [#delete-rooms-roomId-threads-threadId]
 
 Deletes a thread. Throws an error if the room or thread isn’t found. This is a


### PR DESCRIPTION
Noticed these in [our package](https://github.com/liveblocks/liveblocks/blob/83e028c66947d65c0c95398bf35a72f7d24baf18/packages/liveblocks-node/src/client.ts#L1258), but they weren't documented.