### PR TITLE
`useIsInsideRoom` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2.4.1 (Not yet published)
 
+### `@liveblocks/react`
+
+- Add
+  [`useIsInsideRoom`](https://liveblocks.io/docs/api-reference/liveblocks-react#useIsInsideRoom)
+  hook, useful for rendering different components inside and outside of
+  [`RoomProvider`](https://liveblocks.io/docs/api-reference/liveblocks-react#RoomProvider).
+
 ### `@liveblocks/react-lexical`
 
 - Fix a bug in `useEditorStatus` which prevented the hook from returning correct

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1220,6 +1220,71 @@ import { useRoom } from "@liveblocks/react/suspense";
 const room = useRoom();
 ```
 
+### useIsInsideRoom [@badge=Both]
+
+Returns a boolean, `true` if the hook was called inside a
+[`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider) context, and
+`false` otherwise.
+
+```ts
+import { useisInsideRoom } from "@liveblocks/react/suspense";
+
+const isInsideRoom = useIsInsideRoom();
+```
+
+#### Displaying different components inside rooms
+
+`useIsInsideRoom` is helpful for rendering different components depending on
+whether they’re inside a room, or not. One example is a header component that
+only displays a live avatar stack when users are connected to the room.
+
+```tsx
+import { useIsInsideRoom, useOthers } from "@liveblocks/react/suspense";
+
+function Header() {
+  // +++
+  const isInsideRoom = useIsInsideRoom();
+  // +++
+
+  return (
+    <div>
+      // +++
+      {isInsideRoom ? <LiveAvatars /> : null}
+      // +++
+      <MyAvatar />
+    </div>
+  );
+}
+
+function LiveAvatars() {
+  const others = useOthers();
+  return others.map((other) => <img src={other.info.picture} />);
+}
+```
+
+Here’s how the example above would render in three different
+[`LiveblocksProvider`](/docs/api-reference/liveblocks-react#LiveblocksProvider)
+and [`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider)
+contexts.
+
+```tsx
+// 👥👤 Live avatar stack and your avatar
+<LiveblocksProvider /* ... */>
+  <RoomProvider /* ... */>
+    <Header />
+  </RoomProvider>
+</LiveblocksProvider>
+
+
+// 👤 Just your avatar
+<LiveblocksProvider /* ... */>
+  <Header />
+</LiveblocksProvider>
+
+// 👤 Just your avatar
+<Header />
+```
+
 ### useErrorListener [@badge=RoomProvider]
 
 Listen to potential room connection errors.

--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -27,6 +27,7 @@ export const {
   RoomProvider,
   useCanRedo,
   useCanUndo,
+  useInsideRoom,
   useMutation,
   useMyPresence,
   useOthers,

--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -27,7 +27,7 @@ export const {
   RoomProvider,
   useCanRedo,
   useCanUndo,
-  useInsideRoom,
+  useIsInsideRoom,
   useMutation,
   useMyPresence,
   useOthers,

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -9,7 +9,7 @@ import { createRoomContext } from "../room";
 import {
   useCanRedo,
   useCanUndo,
-  useInsideRoom,
+  useIsInsideRoom,
   useMutation,
   useMyPresence,
   useOthers,
@@ -103,19 +103,19 @@ describe("useRoom", () => {
   });
 });
 
-describe("useInsideRoom", () => {
-  test("useInsideRoom should return true inside a room", () => {
-    const { result } = renderHook(() => useInsideRoom());
-    const insideRoom = result.current;
-    expect(insideRoom).toBe(true);
+describe("useIsInsideRoom", () => {
+  test("useIsInsideRoom should return true inside a room", () => {
+    const { result } = renderHook(() => useIsInsideRoom());
+    const isInsideRoom = result.current;
+    expect(isInsideRoom).toBe(true);
   });
 
-  test("useInsideRoom should return false outside a room", () => {
-    const { result } = renderHook(() => useInsideRoom(), {
+  test("useIsInsideRoom should return false outside a room", () => {
+    const { result } = renderHook(() => useIsInsideRoom(), {
       wrapper: undefined, // Skip using RoomProvider wrapper
     });
-    const insideRoom = result.current;
-    expect(insideRoom).toBe(false);
+    const isInsideRoom = result.current;
+    expect(isInsideRoom).toBe(false);
   });
 });
 

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -9,6 +9,7 @@ import { createRoomContext } from "../room";
 import {
   useCanRedo,
   useCanUndo,
+  useInsideRoom,
   useMutation,
   useMyPresence,
   useOthers,
@@ -99,6 +100,22 @@ describe("useRoom", () => {
         },
       ])
     );
+  });
+});
+
+describe("useInsideRoom", () => {
+  test("useInsideRoom should return true inside a room", () => {
+    const { result } = renderHook(() => useInsideRoom());
+    const insideRoom = result.current;
+    expect(insideRoom).toBe(true);
+  });
+
+  test("useInsideRoom should return false outside a room", () => {
+    const { result } = renderHook(() => useInsideRoom(), {
+      wrapper: undefined, // Skip using RoomProvider wrapper
+    });
+    const insideRoom = result.current;
+    expect(insideRoom).toBe(false);
   });
 });
 

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -47,6 +47,7 @@ export {
   useErrorListener,
   useEventListener,
   useHistory,
+  useInRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMutation,
@@ -70,7 +71,6 @@ export { selectedThreads } from "./comments/lib/selected-threads";
 // Export the classic (non-Suspense) versions of our hooks
 // (This part differs from src/suspense.ts)
 export {
-  useInRoom,
   useOther,
   useOthers,
   useOthersConnectionIds,

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -47,7 +47,7 @@ export {
   useErrorListener,
   useEventListener,
   useHistory,
-  useInsideRoom,
+  useIsInsideRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMutation,

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -47,7 +47,7 @@ export {
   useErrorListener,
   useEventListener,
   useHistory,
-  useInRoom,
+  useInsideRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMutation,

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -70,6 +70,7 @@ export { selectedThreads } from "./comments/lib/selected-threads";
 // Export the classic (non-Suspense) versions of our hooks
 // (This part differs from src/suspense.ts)
 export {
+  useInRoom,
   useOther,
   useOthers,
   useOthersConnectionIds,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -50,7 +50,7 @@ import type {
   UserAsyncResult,
   UserAsyncSuccess,
 } from "./types";
-import { useInRoom } from "./room";
+import { useInsideRoom } from "./room";
 
 /**
  * Raw access to the React context where the LiveblocksProvider stores the
@@ -879,14 +879,14 @@ export function createSharedContext<U extends BaseUserMeta>(
       useClient,
       useUser: (userId: string) => useUser_withClient(client, userId),
       useRoomInfo: (roomId: string) => useRoomInfo_withClient(client, roomId),
-      useInRoom,
+      useInsideRoom,
     },
     suspense: {
       useClient,
       useUser: (userId: string) => useUserSuspense_withClient(client, userId),
       useRoomInfo: (roomId: string) =>
         useRoomInfoSuspense_withClient(client, roomId),
-      useInRoom,
+      useInsideRoom,
     },
   };
 }

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -40,6 +40,7 @@ import { selectedInboxNotifications } from "./comments/lib/selected-inbox-notifi
 import { autoRetry } from "./lib/retry-error";
 import { useInitial, useInitialUnlessFunction } from "./lib/use-initial";
 import { use } from "./lib/use-polyfill";
+import { useInsideRoom } from "./room";
 import type {
   InboxNotificationsState,
   LiveblocksContextBundle,
@@ -50,7 +51,6 @@ import type {
   UserAsyncResult,
   UserAsyncSuccess,
 } from "./types";
-import { useInsideRoom } from "./room";
 
 /**
  * Raw access to the React context where the LiveblocksProvider stores the

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -40,7 +40,7 @@ import { selectedInboxNotifications } from "./comments/lib/selected-inbox-notifi
 import { autoRetry } from "./lib/retry-error";
 import { useInitial, useInitialUnlessFunction } from "./lib/use-initial";
 import { use } from "./lib/use-polyfill";
-import { useInsideRoom } from "./room";
+import { useIsInsideRoom } from "./room";
 import type {
   InboxNotificationsState,
   LiveblocksContextBundle,
@@ -879,14 +879,14 @@ export function createSharedContext<U extends BaseUserMeta>(
       useClient,
       useUser: (userId: string) => useUser_withClient(client, userId),
       useRoomInfo: (roomId: string) => useRoomInfo_withClient(client, roomId),
-      useInsideRoom,
+      useIsInsideRoom,
     },
     suspense: {
       useClient,
       useUser: (userId: string) => useUserSuspense_withClient(client, userId),
       useRoomInfo: (roomId: string) =>
         useRoomInfoSuspense_withClient(client, roomId),
-      useInsideRoom,
+      useIsInsideRoom,
     },
   };
 }

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -50,6 +50,7 @@ import type {
   UserAsyncResult,
   UserAsyncSuccess,
 } from "./types";
+import { useInRoom } from "./room";
 
 /**
  * Raw access to the React context where the LiveblocksProvider stores the
@@ -878,12 +879,14 @@ export function createSharedContext<U extends BaseUserMeta>(
       useClient,
       useUser: (userId: string) => useUser_withClient(client, userId),
       useRoomInfo: (roomId: string) => useRoomInfo_withClient(client, roomId),
+      useInRoom,
     },
     suspense: {
       useClient,
       useUser: (userId: string) => useUserSuspense_withClient(client, userId),
       useRoomInfo: (roomId: string) =>
         useRoomInfoSuspense_withClient(client, roomId),
+      useInRoom,
     },
   };
 }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -930,9 +930,9 @@ function useRoom<
  * Returns whether the hook is called within a RoomProvider context.
  *
  * @example
- * const insideRoom = useInsideRoom();
+ * const isInsideRoom = useIsInsideRoom();
  */
-function useInsideRoom(): boolean {
+function useIsInsideRoom(): boolean {
   const room = useRoomOrNull();
   return room !== null;
 }
@@ -2829,9 +2829,9 @@ const _useRoom: TypedBundle["useRoom"] = useRoom;
  * Returns whether the hook is called within a RoomProvider context.
  *
  * @example
- * const insideRoom = useInsideRoom();
+ * const isInsideRoom = useIsInsideRoom();
  */
-const _useInsideRoom: TypedBundle["useInsideRoom"] = useInsideRoom;
+const _useIsInsideRoom: TypedBundle["useIsInsideRoom"] = useIsInsideRoom;
 
 /**
  * Returns a function that adds a reaction from a comment.
@@ -3301,7 +3301,7 @@ export {
   useErrorListener,
   _useEventListener as useEventListener,
   useHistory,
-  _useInsideRoom as useInsideRoom,
+  _useIsInsideRoom as useIsInsideRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMarkThreadAsResolved,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -928,6 +928,9 @@ function useRoom<
 
 /**
  * Returns whether the hook is called within a RoomProvider context.
+ *
+ * @example
+ * const inRoom = useInRoom();
  */
 function useInRoom(): boolean {
   const room = useRoomOrNull();
@@ -2823,6 +2826,14 @@ const _useOthersListener: TypedBundle["useOthersListener"] = useOthersListener;
 const _useRoom: TypedBundle["useRoom"] = useRoom;
 
 /**
+ * Returns whether the hook is called within a RoomProvider context.
+ *
+ * @example
+ * const inRoom = useInRoom();
+ */
+const _useInRoom: TypedBundle["useInRoom"] = useInRoom;
+
+/**
  * Returns a function that adds a reaction from a comment.
  *
  * @example
@@ -3290,7 +3301,7 @@ export {
   useErrorListener,
   _useEventListener as useEventListener,
   useHistory,
-  useInRoom,
+  _useInRoom as useInRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMarkThreadAsResolved,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -927,6 +927,14 @@ function useRoom<
 }
 
 /**
+ * Returns whether the hook is called within a RoomProvider context.
+ */
+function useInRoom(): boolean {
+  const room = useRoomOrNull();
+  return room !== null;
+}
+
+/**
  * Returns the current connection status for the Room, and triggers
  * a re-render whenever it changes. Can be used to render a status badge.
  */
@@ -3282,6 +3290,7 @@ export {
   useErrorListener,
   _useEventListener as useEventListener,
   useHistory,
+  useInRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMarkThreadAsResolved,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -930,9 +930,9 @@ function useRoom<
  * Returns whether the hook is called within a RoomProvider context.
  *
  * @example
- * const inRoom = useInRoom();
+ * const insideRoom = useInsideRoom();
  */
-function useInRoom(): boolean {
+function useInsideRoom(): boolean {
   const room = useRoomOrNull();
   return room !== null;
 }
@@ -2829,9 +2829,9 @@ const _useRoom: TypedBundle["useRoom"] = useRoom;
  * Returns whether the hook is called within a RoomProvider context.
  *
  * @example
- * const inRoom = useInRoom();
+ * const insideRoom = useInsideRoom();
  */
-const _useInRoom: TypedBundle["useInRoom"] = useInRoom;
+const _useInsideRoom: TypedBundle["useInsideRoom"] = useInsideRoom;
 
 /**
  * Returns a function that adds a reaction from a comment.
@@ -3301,7 +3301,7 @@ export {
   useErrorListener,
   _useEventListener as useEventListener,
   useHistory,
-  _useInRoom as useInRoom,
+  _useInsideRoom as useInsideRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMarkThreadAsResolved,

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -45,7 +45,7 @@ export {
   useErrorListener,
   useEventListener,
   useHistory,
-  useInsideRoom,
+  useIsInsideRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMutation,

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -45,6 +45,7 @@ export {
   useErrorListener,
   useEventListener,
   useHistory,
+  useInsideRoom,
   useLostConnectionListener,
   useMarkThreadAsRead,
   useMutation,

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -400,6 +400,11 @@ type RoomContextBundleCommon<
   useRoom(): Room<P, S, U, E, M>;
 
   /**
+   * Returns whether the hook is called within a RoomProvider context.
+   */
+  useInRoom(): boolean;
+
+  /**
    * Returns the current connection status for the Room, and triggers
    * a re-render whenever it changes. Can be used to render a status badge.
    */

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -343,6 +343,14 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * const { info, error, isLoading } = useRoomInfo("room-id");
      */
     useRoomInfo(roomId: string): RoomInfoAsyncResult;
+
+    /**
+     * Returns whether the hook is called within a RoomProvider context.
+     *
+     * @example
+     * const inRoom = useInRoom();
+     */
+    useInRoom(): boolean;
   };
 
   suspense: {
@@ -366,6 +374,14 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * const { info } = useRoomInfo("room-id");
      */
     useRoomInfo(roomId: string): RoomInfoAsyncSuccess;
+
+    /**
+     * Returns whether the hook is called within a RoomProvider context.
+     *
+     * @example
+     * const inRoom = useInRoom();
+     */
+    useInRoom(): boolean;
   };
 };
 
@@ -398,11 +414,6 @@ type RoomContextBundleCommon<
    * tree.
    */
   useRoom(): Room<P, S, U, E, M>;
-
-  /**
-   * Returns whether the hook is called within a RoomProvider context.
-   */
-  useInRoom(): boolean;
 
   /**
    * Returns the current connection status for the Room, and triggers

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -348,9 +348,9 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * Returns whether the hook is called within a RoomProvider context.
      *
      * @example
-     * const inRoom = useInRoom();
+     * const insideRoom = useInsideRoom();
      */
-    useInRoom(): boolean;
+    useInsideRoom(): boolean;
   };
 
   suspense: {
@@ -379,9 +379,9 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * Returns whether the hook is called within a RoomProvider context.
      *
      * @example
-     * const inRoom = useInRoom();
+     * const insideRoom = useInsideRoom();
      */
-    useInRoom(): boolean;
+    useInsideRoom(): boolean;
   };
 };
 

--- a/packages/liveblocks-react/src/types.ts
+++ b/packages/liveblocks-react/src/types.ts
@@ -348,9 +348,9 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * Returns whether the hook is called within a RoomProvider context.
      *
      * @example
-     * const insideRoom = useInsideRoom();
+     * const isInsideRoom = useIsInsideRoom();
      */
-    useInsideRoom(): boolean;
+    useIsInsideRoom(): boolean;
   };
 
   suspense: {
@@ -379,9 +379,9 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * Returns whether the hook is called within a RoomProvider context.
      *
      * @example
-     * const insideRoom = useInsideRoom();
+     * const isInsideRoom = useIsInsideRoom();
      */
-    useInsideRoom(): boolean;
+    useIsInsideRoom(): boolean;
   };
 };
 

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -269,16 +269,16 @@ declare global {
 
 // ---------------------------------------------------------
 
-// useInsideRoom()
+// useIsInsideRoom()
 {
-  const insideRoom = classic.useInsideRoom();
-  expectType<boolean>(insideRoom);
+  const isInsideRoom = classic.useIsInsideRoom();
+  expectType<boolean>(isInsideRoom);
 }
 
-// useInsideRoom() (suspense)
+// useIsInsideRoom() (suspense)
 {
-  const insideRoom = suspense.useInsideRoom();
-  expectType<boolean>(insideRoom);
+  const isInsideRoom = suspense.useIsInsideRoom();
+  expectType<boolean>(isInsideRoom);
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -269,16 +269,16 @@ declare global {
 
 // ---------------------------------------------------------
 
-// useInRoom()
+// useInsideRoom()
 {
-  const inRoom = classic.useInRoom();
-  expectType<true>(inRoom);
+  const insideRoom = classic.useInsideRoom();
+  expectType<boolean>(insideRoom);
 }
 
-// useInRoom() (suspense)
+// useInsideRoom() (suspense)
 {
-  const inRoom = suspense.useInRoom();
-  expectType<true>(inRoom);
+  const insideRoom = suspense.useInsideRoom();
+  expectType<boolean>(insideRoom);
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -269,6 +269,20 @@ declare global {
 
 // ---------------------------------------------------------
 
+// useInRoom()
+{
+  const inRoom = classic.useInRoom();
+  expectType<true>(inRoom);
+}
+
+// useInRoom() (suspense)
+{
+  const inRoom = suspense.useInRoom();
+  expectType<true>(inRoom);
+}
+
+// ---------------------------------------------------------
+
 // useStorageStatus()
 {
   expectType<"not-loaded" | "loading" | "synchronizing" | "synchronized">(

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -251,9 +251,9 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
 // The useRoom() hook
 expectType<Room<P, S, U, E, M>>(ctx.useRoom());
 
-// useInRoom()
-expectType<true>(ctx.useInRoom);
-expectType<false>(lbctx.useInRoom);
+// useInsideRoom()
+expectType<boolean>(ctx.useInsideRoom());
+expectType<boolean>(lbctx.useInsideRoom());
 
 // The presence hooks
 expectType<P>(ctx.useSelf()!.presence);

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -251,9 +251,9 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
 // The useRoom() hook
 expectType<Room<P, S, U, E, M>>(ctx.useRoom());
 
-// useInsideRoom()
-expectType<boolean>(ctx.useInsideRoom());
-expectType<boolean>(lbctx.useInsideRoom());
+// useIsInsideRoom()
+expectType<boolean>(ctx.useIsInsideRoom());
+expectType<boolean>(lbctx.useIsInsideRoom());
 
 // The presence hooks
 expectType<P>(ctx.useSelf()!.presence);

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -251,6 +251,10 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
 // The useRoom() hook
 expectType<Room<P, S, U, E, M>>(ctx.useRoom());
 
+// useInRoom()
+expectType<true>(ctx.useInRoom);
+expectType<false>(lbctx.useInRoom);
+
 // The presence hooks
 expectType<P>(ctx.useSelf()!.presence);
 expectType<readonly User<P, U>[]>(ctx.useOthers());

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -172,6 +172,20 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
+// useInRoom()
+{
+  const inRoom = classic.useInRoom();
+  expectType<true>(inRoom);
+}
+
+// useInRoom() (suspense)
+{
+  const inRoom = suspense.useRoom();
+  expectType<true>(inRoom);
+}
+
+// ---------------------------------------------------------
+
 // useStorageStatus()
 {
   expectType<"not-loaded" | "loading" | "synchronizing" | "synchronized">(

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -172,16 +172,16 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
-// useInRoom()
+// useInsideRoom()
 {
-  const inRoom = classic.useInRoom();
-  expectType<true>(inRoom);
+  const insideRoom = classic.useInsideRoom();
+  expectType<boolean>(insideRoom);
 }
 
-// useInRoom() (suspense)
+// useInsideRoom() (suspense)
 {
-  const inRoom = suspense.useRoom();
-  expectType<true>(inRoom);
+  const insideRoom = suspense.useInsideRoom();
+  expectType<boolean>(insideRoom);
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -172,16 +172,16 @@ import { expectAssignable, expectError, expectType } from "tsd";
 
 // ---------------------------------------------------------
 
-// useInsideRoom()
+// useIsInsideRoom()
 {
-  const insideRoom = classic.useInsideRoom();
-  expectType<boolean>(insideRoom);
+  const isInsideRoom = classic.useIsInsideRoom();
+  expectType<boolean>(isInsideRoom);
 }
 
-// useInsideRoom() (suspense)
+// useIsInsideRoom() (suspense)
 {
-  const insideRoom = suspense.useInsideRoom();
-  expectType<boolean>(insideRoom);
+  const isInsideRoom = suspense.useIsInsideRoom();
+  expectType<boolean>(isInsideRoom);
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
`useIsInsideRoom`: Returns `true` if the hook is inside `RoomProvider`, `false` otherwise.

```tsx
import { useIsInsideRoom } from "@liveblocks/react";

function Header() {
  const isInsideRoom = useIsInsideRoom();
  return isInsideRoom ? <LiveAvatars /> : <JustMyAvatar />;
}
```

This is not currently possible with `useRoom`, because it throws an error outside of `RoomProvider`.

LB-1123