### PR TITLE
CHANGELOG — WEEK 33

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -26,13 +26,13 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ### `@liveblocks/react-lexical`
 
-- Fix a bug in `useEditorStatus` which prevented it from returning a correct
-  status when `LexicalPlugin` was rendered conditionally.
+- Fix a bug in [`useEditorStatus`](https://liveblocks.io/docs/api-reference/liveblocks-react-lexical#useEditorStatus) which prevented it from returning a correct status when `LexicalPlugin` was rendered conditionally.
 - Fix remote cursors not displaying user names.
 
 ### `@liveblocks/react-ui`
 
-- Improve event propagation in `Composer`.
+- Improve event propagation in [`Composer`](https://liveblocks.io/docs/api-reference/liveblocks-react-ui#Composer).
+
 
 ## Contributors
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,6 +15,12 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 33 (2024-08-16)
 
+## 2.5.1
+
+### `@liveblocks/yjs`
+
+- Fix `LiveblocksProvider` `update`/`change` event not returning `removed` users.
+
 ## v2.5.0
 
 ### `@liveblocks/react`
@@ -32,7 +38,6 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 ### `@liveblocks/react-ui`
 
 - Improve event propagation in [`Composer`](https://liveblocks.io/docs/api-reference/liveblocks-react-ui#Composer).
-
 
 ## Contributors
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -39,6 +39,10 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 - Improve event propagation in [`Composer`](https://liveblocks.io/docs/api-reference/liveblocks-react-ui#Composer).
 
+## `@liveblocks/codemod`
+
+- Prevent modifying files that weren’t changed by the codemods. 
+
 ## Contributors
 
 ctnicholas, nimeshnayaju, marcbouchenoire

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -13,6 +13,10 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 -->
 
+# Week 33 (2024-08-16)
+
+## Contributors
+
 # Week 32 (2024-08-09)
 
 ## Website

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -36,7 +36,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ## Contributors
 
-ctnicholas, nimeshnayaju, jrowny
+ctnicholas, nimeshnayaju, marcbouchenoire
 
 # Week 32 (2024-08-09)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,28 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 33 (2024-08-16)
 
+## 2.5.0
+
+### `@liveblocks/react`
+
+- Add
+  [`useIsInsideRoom`](https://liveblocks.io/docs/api-reference/liveblocks-react#useIsInsideRoom)
+  hook, useful for rendering different components inside and outside of
+  [`RoomProvider`](https://liveblocks.io/docs/api-reference/liveblocks-react#RoomProvider).
+
+### `@liveblocks/react-lexical`
+
+- Fix a bug in `useEditorStatus` which prevented it from returning a correct
+  status when `LexicalPlugin` was rendered conditionally.
+- Fix remote cursors not displaying user names.
+
+### `@liveblocks/react-ui`
+
+- Improve event propagation in `Composer`.
+
 ## Contributors
+
+ctnicholas, nimeshnayaju, jrowny
 
 # Week 32 (2024-08-09)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 33 (2024-08-16)
 
-## 2.5.0
+## v2.5.0
 
 ### `@liveblocks/react`
 


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-33/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 16th of August.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.