### PR TITLE
Fix method name in update room node documentation

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -447,7 +447,7 @@ need only pass the properties you’re updating. Setting a property to `null` wi
 delete the property.
 
 ```ts
-const room = await liveblocks.createRoom("my-room-id", {
+const room = await liveblocks.updateRoom("my-room-id", {
   // Optional, update the default room permissions. `[]` for private, `["room:write"]` for public.
   defaultAccesses: [],
 


### PR DESCRIPTION
Hi @CTNicholas 👋🏻 

I found this one in the doc. I suppose we should display `updateRoom` and not `createRoom` right?

Thanks 🙏🏻 