### PR TITLE
`removed` array not emitted in Yjs awareness event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.5.1 (unreleased)
+
+### `@liveblocks/yjs`
+
+- Fix `LiveblocksProvider` `update`/`change` event not returning `removed`
+  users.
+
 ## 2.5.0
 
 ### `@liveblocks/react`

--- a/packages/liveblocks-yjs/src/awareness.ts
+++ b/packages/liveblocks-yjs/src/awareness.ts
@@ -61,7 +61,6 @@ export class Awareness<
         | { added: number[]; updated: number[]; removed: number[] }
         | undefined;
 
-      this.rebuildActorToClientMap(event.others);
       // When others are changed, we emit an event that contains arrays added/updated/removed.
       if (event.type === "leave") {
         const targetClientId = this.actorToClientMap.get(
@@ -85,6 +84,9 @@ export class Awareness<
             removed: [],
           };
         }
+      }
+      if (event.type === "reset") {
+        this.rebuildActorToClientMap(event.others);
       }
       if (updates !== undefined) {
         this.emit("change", [updates, "presence"]);


### PR DESCRIPTION
The `removed` array in the `update` event was always empty because `actorToClientMap` was updated before the removed user could be retrieved.

```tsx
yProvider.awareness.on("update", ({ added, updated, removed } => {
  // always an empty array `[]`
  console.log(removed);
});
```