### PR TITLE
feat: add getInboxNotifications method to Liveblocks node client

### DIFF
--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -918,7 +918,7 @@ describe("client", () => {
     });
   });
 
-  test("getInboxNotifications works with a query", () => {
+  test("getInboxNotifications works with a query", async () => {
     const userId = "user1";
     const notifications = [
       {
@@ -946,7 +946,7 @@ describe("client", () => {
 
     const client = new Liveblocks({ secret: "sk_xxx" });
 
-    expect(
+    await expect(
       client.getInboxNotifications({
         userId,
         query: {
@@ -962,7 +962,7 @@ describe("client", () => {
     });
 
     // with a string query
-    expect(
+    await expect(
       client.getInboxNotifications({
         userId,
         query: "unread:true",

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -885,6 +885,74 @@ describe("client", () => {
     }
   });
 
+  test("should return the user's inbox notifications when getInboxNotifications receives a successful response", () => {
+    const userId = "user1";
+
+    const notifications = [
+      {
+        id: "notification1",
+        kind: "thread",
+        notifiedAt: new Date().toISOString(),
+        readAt: null,
+        threadId: "thread1",
+      },
+    ];
+
+    server.use(
+      http.get(
+        `${DEFAULT_BASE_URL}/v2/users/:userId/inbox-notifications`,
+        () => {
+          return HttpResponse.json(notifications, { status: 200 });
+        }
+      )
+    );
+
+    const client = new Liveblocks({ secret: "sk_xxx" });
+
+    return expect(client.getInboxNotifications({ userId })).resolves.toEqual({
+      data: notifications.map((notification) => ({
+        ...notification,
+        notifiedAt: new Date(notification.notifiedAt),
+        readAt: notification.readAt ? new Date(notification.readAt) : null,
+      })),
+    });
+  });
+
+  test("should throw a LiveblocksError when getInboxNotifications receives an error response", async () => {
+    const userId = "user1";
+
+    const error = {
+      error: "USER_NOT_FOUND",
+      message: "User not found",
+    };
+
+    server.use(
+      http.get(
+        `${DEFAULT_BASE_URL}/v2/users/:userId/inbox-notifications`,
+        () => {
+          return HttpResponse.json(error, { status: 404 });
+        }
+      )
+    );
+
+    const client = new Liveblocks({ secret: "sk_xxx" });
+
+    // This should throw a LiveblocksError
+    try {
+      // Attempt to get, which should fail and throw an error.
+      await client.getInboxNotifications({ userId });
+      // If it doesn't throw, fail the test.
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err instanceof LiveblocksError).toBe(true);
+      if (err instanceof LiveblocksError) {
+        expect(err.status).toBe(404);
+        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.name).toBe("LiveblocksError");
+      }
+    }
+  });
+
   test("should get user's room notification settings", async () => {
     const userId = "user1";
     const roomId = "room1";

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -1440,6 +1440,59 @@ export class Liveblocks {
   }
 
   /**
+   * Returns the inbox notifications for a user.
+   * @param params.userId The user ID to get the inbox notifications from.
+   * @param params.query The query to filter inbox notifications by. It is based on our query language and can filter by unread.
+   */
+  public async getInboxNotifications(params: {
+    userId: string;
+    /**
+     * The query to filter inbox notifications by. It is based on our query language.
+     *
+     * @example
+     * ```
+     * {
+     *  query: "unread:true"
+     * }
+     * ```
+     *
+     * @example
+     * ```
+     * {
+     *   query: {
+     *     unread: true
+     *   }
+     * }
+     * ```
+     *
+     */
+    query?: string | { unread: boolean };
+  }): Promise<{ data: InboxNotificationData[] }> {
+    const { userId } = params;
+
+    let query: string | undefined;
+
+    if (typeof params.query === "string") {
+      query = params.query;
+    } else if (typeof params.query === "object") {
+      query = objectToQuery(params.query);
+    }
+
+    const res = await this.get(url`/v2/users/${userId}/inbox-notifications`, {
+      query,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new LiveblocksError(res.status, text);
+    }
+
+    const data = (await res.json()) as InboxNotificationDataPlain[];
+    return {
+      data: data.map(convertToInboxNotificationData),
+    };
+  }
+
+  /**
    * Gets the user's room notification settings.
    * @param params.userId The user ID to get the room notifications from.
    * @param params.roomId The room ID to get the room notification settings from.

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -1486,7 +1486,10 @@ export class Liveblocks {
       throw new LiveblocksError(res.status, text);
     }
 
-    const data = (await res.json()) as InboxNotificationDataPlain[];
+    const { data } = (await res.json()) as {
+      data: InboxNotificationDataPlain[];
+    };
+
     return {
       data: data.map(convertToInboxNotificationData),
     };


### PR DESCRIPTION
#### Description

Adds `getInboxNotifications` with an `unread` query parameter.

```ts
  /**
   * Returns the inbox notifications for a user.
   * @param params.userId The user ID to get the inbox notifications from.
   * @param params.query The query to filter inbox notifications by. It is based on our query language and can filter by unread.
   */
  public async getInboxNotifications(params: {
    userId: string;
    /**
     * The query to filter inbox notifications by. It is based on our query language.
     *
     * @example
     * ```
     * {
     *  query: "unread:true"
     * }
     * ```
     *
     * @example
     * ```
     * {
     *   query: {
     *     unread: true
     *   }
     * }
     * ```
     *
     */
    query?: string | { unread: boolean };
  })
  ```