### PR TITLE
Fix Yjs get started guides

### DIFF
--- a/docs/pages/get-started/yjs-blocknote-react.mdx
+++ b/docs/pages/get-started/yjs-blocknote-react.mdx
@@ -135,7 +135,7 @@ collaboration to your React application using the APIs from the
         // Set up Liveblocks Yjs provider
         useEffect(() => {
           const yDoc = new Y.Doc();
-          const yProvider = new LiveblocksProvider(room, yDoc);
+          const yProvider = new LiveblocksYjsProvider(room, yDoc);
           setDoc(yDoc);
           setProvider(yProvider);
 

--- a/docs/pages/get-started/yjs-codemirror-javascript.mdx
+++ b/docs/pages/get-started/yjs-codemirror-javascript.mdx
@@ -77,7 +77,7 @@ collaboration to your JavaScript application using the APIs from the
       // Set up Yjs document, shared text, and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("codemirror");
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       // Set up CodeMirror and extensions
       const state = EditorState.create({

--- a/docs/pages/get-started/yjs-codemirror-react.mdx
+++ b/docs/pages/get-started/yjs-codemirror-react.mdx
@@ -146,7 +146,7 @@ collaboration to your React application using the APIs from the
 
           // Create Yjs provider and document
           ydoc = new Y.Doc();
-          provider = new LiveblocksProvider(room as any, ydoc);
+          provider = new LiveblocksYjsProvider(room as any, ydoc);
           const ytext = ydoc.getText("codemirror");
           const undoManager = new Y.UndoManager(ytext);
 

--- a/docs/pages/get-started/yjs-codemirror-svelte.mdx
+++ b/docs/pages/get-started/yjs-codemirror-svelte.mdx
@@ -71,7 +71,7 @@ collaboration to your Svelte application using the APIs from the
         const yDoc = new Y.Doc();
         const yText = yDoc.getText("codemirror");
         const undoManager = new Y.UndoManager(yText);
-        const yProvider = new LiveblocksProvider(room, yDoc);
+        const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
         // Set up CodeMirror and extensions
         const state = EditorState.create({

--- a/docs/pages/get-started/yjs-codemirror-vuejs.mdx
+++ b/docs/pages/get-started/yjs-codemirror-vuejs.mdx
@@ -73,7 +73,7 @@ collaboration to your Vue.js application using the APIs from the
       // Set up Yjs document, shared text, and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("codemirror");
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       onMounted(() => {
         // Set up CodeMirror and extensions

--- a/docs/pages/get-started/yjs-monaco-javascript.mdx
+++ b/docs/pages/get-started/yjs-monaco-javascript.mdx
@@ -75,7 +75,7 @@ collaboration to your JavaScript application using the APIs from the
       // Set up Yjs document, shared text, and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("monaco");
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       // Set up the Monaco editor
       const parent = document.querySelector("#editor");

--- a/docs/pages/get-started/yjs-monaco-react.mdx
+++ b/docs/pages/get-started/yjs-monaco-react.mdx
@@ -140,7 +140,7 @@ collaboration to your React application using the APIs from the
           if (editorRef) {
             yDoc = new Y.Doc();
             const yText = yDoc.getText("monaco");
-            yProvider = new LiveblocksProvider(room, yDoc);
+            yProvider = new LiveblocksYjsProvider(room, yDoc);
 
             // Attach Yjs to Monaco
             binding = new MonacoBinding(

--- a/docs/pages/get-started/yjs-monaco-svelte.mdx
+++ b/docs/pages/get-started/yjs-monaco-svelte.mdx
@@ -68,7 +68,7 @@ collaboration to your Svelte application using the APIs from the
         // Set up Yjs document, shared text, and Liveblocks Yjs provider
         const yDoc = new Y.Doc();
         const yText = yDoc.getText("monaco");
-        const yProvider = new LiveblocksProvider(room, yDoc);
+        const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
         // Set up the Monaco editor
         const editor = monaco.editor.create(element, {

--- a/docs/pages/get-started/yjs-monaco-vuejs.mdx
+++ b/docs/pages/get-started/yjs-monaco-vuejs.mdx
@@ -71,7 +71,7 @@ collaboration to your Vue.js application using the APIs from the
       // Set up Yjs document, shared text, and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("monaco");
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       onMounted(() => {
         // Set up the Monaco editor

--- a/docs/pages/get-started/yjs-quill-javascript.mdx
+++ b/docs/pages/get-started/yjs-quill-javascript.mdx
@@ -76,7 +76,7 @@ collaboration to your JavaScript application using the APIs from the
       // Set up Yjs document, shared text, and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("quill");
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       // Attach cursors plugin
       Quill.register("modules/cursors", QuillCursors);

--- a/docs/pages/get-started/yjs-quill-react.mdx
+++ b/docs/pages/get-started/yjs-quill-react.mdx
@@ -137,7 +137,7 @@ collaboration to your React application using the APIs from the
         useEffect(() => {
           const yDoc = new Y.Doc();
           const yText = yDoc.getText("quill");
-          const yProvider = new LiveblocksProvider(room, yDoc);
+          const yProvider = new LiveblocksYjsProvider(room, yDoc);
           setText(yText);
           setProvider(yProvider);
 

--- a/docs/pages/get-started/yjs-quill-svelte.mdx
+++ b/docs/pages/get-started/yjs-quill-svelte.mdx
@@ -68,7 +68,7 @@ collaboration to your Svelte application using the APIs from the
         // Set up Yjs document, shared text, and Liveblocks Yjs provider
         const yDoc = new Y.Doc();
         const yText = yDoc.getText("quill");
-        const yProvider = new LiveblocksProvider(room, yDoc);
+        const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
         // Attach cursors plugin
         Quill.register("modules/cursors", QuillCursors);

--- a/docs/pages/get-started/yjs-quill-vuejs.mdx
+++ b/docs/pages/get-started/yjs-quill-vuejs.mdx
@@ -71,7 +71,7 @@ collaboration to your Vue.js application using the APIs from the
       // Set up Yjs document, shared text, and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
       const yText = yDoc.getText("quill");
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       // Attach cursors plugin
       Quill.register("modules/cursors", QuillCursors);

--- a/docs/pages/get-started/yjs-slate-react.mdx
+++ b/docs/pages/get-started/yjs-slate-react.mdx
@@ -133,7 +133,7 @@ collaboration to your React application using the APIs from the
         // Set up Liveblocks Yjs provider
         useEffect(() => {
           const yDoc = new Y.Doc();
-          const yProvider = new LiveblocksProvider(room, yDoc);
+          const yProvider = new LiveblocksYjsProvider(room, yDoc);
           const sharedDoc = yDoc.get("slate", Y.XmlText) as Y.XmlText;
           yProvider.on("sync", setConnected);
 

--- a/docs/pages/get-started/yjs-tiptap-javascript.mdx
+++ b/docs/pages/get-started/yjs-tiptap-javascript.mdx
@@ -21,7 +21,7 @@ collaboration to your JavaScript application using the APIs from the
       Every Liveblocks package should use the same version.
 
       ```bash
-      npm install @liveblocks/client @liveblocks/yjs yjs @tiptap/core @tiptap/pm @tiptap/starter-kit  @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor
+      npm install @liveblocks/client @liveblocks/yjs yjs @tiptap/core @tiptap/pm @tiptap/starter-kit @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor y-prosemirror
       ```
     </StepContent>
 
@@ -76,7 +76,7 @@ collaboration to your JavaScript application using the APIs from the
 
       // Set up Yjs document and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       // Set up the Tiptap editor
       const element = document.querySelector("editor");

--- a/docs/pages/get-started/yjs-tiptap-react.mdx
+++ b/docs/pages/get-started/yjs-tiptap-react.mdx
@@ -21,7 +21,7 @@ collaboration to your React application using the APIs from the
       Every Liveblocks package should use the same version.
 
       ```bash
-      npm install @liveblocks/client @liveblocks/react @liveblocks/yjs yjs @tiptap/react @tiptap/pm @tiptap/starter-kit @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor
+      npm install @liveblocks/client @liveblocks/react @liveblocks/yjs yjs @tiptap/react @tiptap/pm @tiptap/starter-kit @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor y-prosemirror
       ```
 
     </StepContent>
@@ -138,7 +138,7 @@ collaboration to your React application using the APIs from the
         // Set up Liveblocks Yjs provider
         useEffect(() => {
           const yDoc = new Y.Doc();
-          const yProvider = new LiveblocksProvider(room, yDoc);
+          const yProvider = new LiveblocksYjsProvider(room, yDoc);
           setDoc(yDoc);
           setProvider(yProvider);
 

--- a/docs/pages/get-started/yjs-tiptap-svelte.mdx
+++ b/docs/pages/get-started/yjs-tiptap-svelte.mdx
@@ -20,7 +20,7 @@ collaboration to your Svelte application using the APIs from the
       Every Liveblocks package should use the same version.
 
       ```bash
-      npm install @liveblocks/client @liveblocks/yjs yjs @tiptap/core @tiptap/pm @tiptap/starter-kit  @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor
+      npm install @liveblocks/client @liveblocks/yjs yjs @tiptap/core @tiptap/pm @tiptap/starter-kit @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor y-prosemirror
       ```
     </StepContent>
 
@@ -68,7 +68,7 @@ collaboration to your Svelte application using the APIs from the
 
         // Set up Yjs document and Liveblocks Yjs provider
         const yDoc = new Y.Doc();
-        const yProvider = new LiveblocksProvider(room, yDoc);
+        const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
         // Set up the Tiptap editor
         editor = new Editor({

--- a/docs/pages/get-started/yjs-tiptap-vuejs.mdx
+++ b/docs/pages/get-started/yjs-tiptap-vuejs.mdx
@@ -20,7 +20,7 @@ collaboration to your Vue.js application using the APIs from the
       Every Liveblocks package should use the same version.
 
       ```bash
-      npm install @liveblocks/client @liveblocks/yjs yjs @tiptap/vue-3 @tiptap/pm @tiptap/starter-kit  @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor
+      npm install @liveblocks/client @liveblocks/yjs yjs @tiptap/vue-3 @tiptap/pm @tiptap/starter-kit @tiptap/extension-collaboration @tiptap/extension-collaboration-cursor y-prosemirror
       ```
     </StepContent>
 
@@ -69,7 +69,7 @@ collaboration to your Vue.js application using the APIs from the
 
       // Set up Yjs document and Liveblocks Yjs provider
       const yDoc = new Y.Doc();
-      const yProvider = new LiveblocksProvider(room, yDoc);
+      const yProvider = new LiveblocksYjsProvider(room, yDoc);
 
       // Set up the Tiptap editor
       const editor = useEditor({

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks.mdx
@@ -139,11 +139,11 @@ We’ll also need another type for this tutorial. After creating the config file
 open it up and insert the following:
 
 ```tsx file="liveblocks.config.ts"
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 
 // ...
 
-export type TypedLiveblocksProvider = LiveblocksProvider<
+export type TypedLiveblocksProvider = LiveblocksYjsProvider<
   Presence,
   Storage,
   UserMeta,
@@ -207,7 +207,7 @@ import { EditorView, basicSetup } from "codemirror";
 import { EditorState } from "@codemirror/state";
 import { javascript } from "@codemirror/lang-javascript";
 import { useCallback, useEffect, useState } from "react";
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import { TypedLiveblocksProvider, useRoom } from "@/liveblocks.config";
 import styles from "./CollaborativeEditor.module.css";
 

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-codemirror-yjs-nextjs-and-liveblocks.mdx
@@ -234,7 +234,7 @@ export function CollaborativeEditor() {
 
     // Create Yjs provider and document
     ydoc = new Y.Doc();
-    provider = new LiveblocksProvider(room as any, ydoc);
+    provider = new LiveblocksYjsProvider(room as any, ydoc);
     const ytext = ydoc.getText("codemirror");
     const undoManager = new Y.UndoManager(ytext);
     setYUndoManager(undoManager);
@@ -355,7 +355,7 @@ export function CollaborativeEditor() {
 
     // Create Yjs provider and document
     ydoc = new Y.Doc();
-    provider = new LiveblocksProvider(room as any, ydoc);
+    provider = new LiveblocksYjsProvider(room as any, ydoc);
     const ytext = ydoc.getText("codemirror");
     const undoManager = new Y.UndoManager(ytext);
     setYUndoManager(undoManager);

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
@@ -137,11 +137,11 @@ We’ll also need another type for this tutorial. After creating the config file
 open it up and insert the following:
 
 ```tsx file="liveblocks.config.ts"
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 
 // ...
 
-export type TypedLiveblocksProvider = LiveblocksProvider<
+export type TypedLiveblocksProvider = LiveblocksYjsProvider<
   Presence,
   Storage,
   UserMeta,
@@ -200,7 +200,7 @@ Now that we’ve set up Liveblocks, we can start integrating Monaco and Yjs in t
 "use client";
 
 import * as Y from "yjs";
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import { TypedLiveblocksProvider, useRoom } from "@/liveblocks.config";
 import { useCallback, useEffect, useState } from "react";
 import styles from "./CollaborativeEditor.module.css";

--- a/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-code-editor-with-monaco-yjs-nextjs-and-liveblocks.mdx
@@ -224,7 +224,7 @@ export function CollaborativeEditor() {
     if (editorRef) {
       yDoc = new Y.Doc();
       const yText = yDoc.getText("monaco");
-      yProvider = new LiveblocksProvider(room, yDoc);
+      yProvider = new LiveblocksYjsProvider(room, yDoc);
       setProvider(yProvider);
 
       // Attach Yjs to Monaco

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
@@ -256,7 +256,7 @@ export default function Editor() {
               // Set up Liveblocks Yjs provider
               const doc = new Y.Doc();
               yjsDocMap.set(id, doc);
-              const provider = new LiveblocksProvider(room, doc) as Provider;
+              const provider = new LiveblocksYjsProvider(room, doc) as Provider;
               return provider;
             }}
             initialEditorState={initialEditorState}
@@ -349,7 +349,7 @@ export default function Editor() {
               // Set up Liveblocks Yjs provider
               const doc = new Y.Doc();
               yjsDocMap.set(id, doc);
-              const provider = new LiveblocksProvider(room, doc) as Provider;
+              const provider = new LiveblocksYjsProvider(room, doc) as Provider;
               return provider;
             }}
             initialEditorState={initialEditorState}

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-lexical-yjs-nextjs-and-liveblocks.mdx
@@ -194,7 +194,7 @@ Now that we set up Liveblocks, we can start integrating Lexical and Yjs in the
 ```tsx file="Editor.tsx"
 "use client";
 
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import * as Y from "yjs";
 import { useRoom } from "@/liveblocks.config";
 import styles from "./Editor.module.css";

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks.mdx
@@ -187,7 +187,7 @@ import Quill from "quill";
 import ReactQuill from "react-quill";
 import { QuillBinding } from "y-quill";
 import * as Y from "yjs";
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import { useRoom } from "@/liveblocks.config";
 import { useEffect, useRef, useState } from "react";
 import styles from "./Editor.module.css";

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-quill-yjs-nextjs-and-liveblocks.mdx
@@ -202,7 +202,7 @@ export function CollaborativeEditor() {
   useEffect(() => {
     const yDoc = new Y.Doc();
     const yText = yDoc.getText("quill");
-    const yProvider = new LiveblocksProvider(room, yDoc);
+    const yProvider = new LiveblocksYjsProvider(room, yDoc);
     setText(yText);
     setProvider(yProvider);
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
@@ -229,7 +229,7 @@ export default function CollaborativeEditor() {
   // Set up Liveblocks Yjs provider
   useEffect(() => {
     const yDoc = new Y.Doc();
-    const yProvider = new LiveblocksProvider(room, yDoc);
+    const yProvider = new LiveblocksYjsProvider(room, yDoc);
     const sharedDoc = yDoc.get("slate", Y.XmlText) as Y.XmlText;
     yProvider.on("sync", setConnected);
 

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-slate-yjs-nextjs-and-liveblocks.mdx
@@ -211,7 +211,7 @@ Now that we’ve set up Liveblocks, we can start integrating Slate and Yjs in th
 `Editor.tsx` file.
 
 ```tsx file="Editor.tsx"
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import { useEffect, useMemo, useState } from "react";
 import { createEditor, Editor, Transforms } from "slate";
 import { Editable, Slate, withReact } from "slate-react";

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
@@ -188,7 +188,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Collaboration from "@tiptap/extension-collaboration";
 import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
 import * as Y from "yjs";
-import LiveblocksProvider from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import { useRoom } from "@/liveblocks.config";
 import { useEffect, useState } from "react";
 import styles from "./CollaborativeEditor.module.css";

--- a/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
+++ b/guides/pages/how-to-create-a-collaborative-text-editor-with-tiptap-yjs-nextjs-and-liveblocks.mdx
@@ -202,7 +202,7 @@ export function CollaborativeEditor() {
   // Set up Liveblocks Yjs provider
   useEffect(() => {
     const yDoc = new Y.Doc();
-    const yProvider = new LiveblocksProvider(room, yDoc);
+    const yProvider = new LiveblocksYjsProvider(room, yDoc);
     setDoc(yDoc);
     setProvider(yProvider);
 

--- a/guides/pages/how-to-use-yjs-subdocuments.mdx
+++ b/guides/pages/how-to-use-yjs-subdocuments.mdx
@@ -51,12 +51,14 @@ example we’ll create a [`Y.Map`](https://docs.yjs.dev/api/shared-types/y.map) 
 store them in, making sure to lazy load any subdocuments.
 
 ```ts
-import { LiveblocksProvider } from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import * as Y from "yjs";
 
 // Create main document and connect, disabling auto-loading of subdocuments
 const yDoc = new Y.Doc();
-const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+const yProvider = new LiveblocksYjsProvider(room, doc, {
+  autoloadSubdocs: false,
+});
 
 // Create a Y.Map to hold subdocuments
 const subdocMap = yDoc.getMap("subdocs");
@@ -67,12 +69,14 @@ const subdocMap = yDoc.getMap("subdocs");
 To create a new subdocument, create a `new Y.Doc()`, and use this it any other.
 
 ```ts highlight="8-9,11-14,16-17"
-import { LiveblocksProvider } from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import * as Y from "yjs";
 
 // Create main document and connect, disabling auto-loading of subdocuments
 const yDoc = new Y.Doc();
-const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+const yProvider = new LiveblocksYjsProvider(room, doc, {
+  autoloadSubdocs: false,
+});
 
 // Create a Y.Map to hold subdocuments
 const subdocMap = yDoc.getMap("subdocs");
@@ -93,12 +97,14 @@ Make sure to keep track of its `guid`.
 To load the subdocument on _another client_, use its `guid`.
 
 ```ts highlight="8-9"
-import { LiveblocksProvider } from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import * as Y from "yjs";
 
 // Create main document and connect, disabling auto-loading of subdocuments
 const yDoc = new Y.Doc();
-const yProvider = new LiveblocksProvider(room, doc, { autoloadSubdocs: false });
+const yProvider = new LiveblocksYjsProvider(room, doc, {
+  autoloadSubdocs: false,
+});
 
 // From another client, load the subdoc using the GUID from `subdoc.guid` or `doc.getSubdocGuids`
 yProvider.loadSubdoc("c4a755...");
@@ -112,12 +118,12 @@ yProvider.loadSubdoc("c4a755...");
 To keep track of subdocument changes, you can use `Y.Doc.on("subdocs")`.
 
 ```ts highlight="10-13"
-import { LiveblocksProvider } from "@liveblocks/yjs";
+import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import * as Y from "yjs";
 
 // Create main document and connect, disabling auto-loading of subdocuments
 const yDoc = new Y.Doc();
-const yProvider = new LiveblocksProvider(room, yDoc, {
+const yProvider = new LiveblocksYjsProvider(room, yDoc, {
   autoloadSubdocs: false,
 });
 


### PR DESCRIPTION
- `LiveblocksProvider` → `LiveblocksYjsProvider`
- Missing `y-prosemirror` install for Tiptap