### PR TITLE
Prevent codemod false positives

### DIFF
--- a/tools/liveblocks-codemod/src/transforms/live-list-constructor.ts
+++ b/tools/liveblocks-codemod/src/transforms/live-list-constructor.ts
@@ -9,6 +9,7 @@ export default function transformer(
 ) {
   const j = api.jscodeshift.withParser("tsx");
   const root = j(file.source);
+  let isDirty = false;
 
   const sources = ["@liveblocks/core", "@liveblocks/client"];
   const identifiersToChange = [];
@@ -43,9 +44,11 @@ export default function transformer(
             j.newExpression(path.node.callee, [j.arrayExpression([])])
           );
         }
+
+        isDirty = true;
       }
     });
   }
 
-  return root.toSource(options);
+  return isDirty ? root.toSource(options) : file.source;
 }

--- a/tools/liveblocks-codemod/src/transforms/remove-unneeded-type-params.ts
+++ b/tools/liveblocks-codemod/src/transforms/remove-unneeded-type-params.ts
@@ -9,6 +9,7 @@ export default function transformer(
 ) {
   const j = api.jscodeshift.withParser("tsx");
   const root = j(file.source);
+  let isDirty = false;
 
   /**
    * Matches: import { type User, User as U1 } from "@liveblocks/client";
@@ -58,7 +59,9 @@ export default function transformer(
       .replaceWith((path) =>
         j.tsTypeReference(path.node.typeName /* no typeParameters */)
       );
+
+    isDirty = true;
   }
 
-  return root.toSource(options);
+  return isDirty ? root.toSource(options) : file.source;
 }

--- a/tools/liveblocks-codemod/src/transforms/remove-yjs-default-export.ts
+++ b/tools/liveblocks-codemod/src/transforms/remove-yjs-default-export.ts
@@ -9,6 +9,7 @@ export default function transformer(
 ) {
   const j = api.jscodeshift.withParser("tsx");
   const root = j(file.source);
+  let isDirty = false;
   let liveblocksProviderName: string | null = null;
 
   /**
@@ -33,6 +34,8 @@ export default function transformer(
         j(path).replaceWith(
           j.importDeclaration(newSpecifiers, j.literal("@liveblocks/yjs"))
         );
+
+        isDirty = true;
       }
     }
   });
@@ -53,9 +56,11 @@ export default function transformer(
             path.node.arguments
           )
         );
+
+        isDirty = true;
       }
     });
   }
 
-  return root.toSource(options);
+  return isDirty ? root.toSource(options) : file.source;
 }

--- a/tools/liveblocks-codemod/src/transforms/room-info-to-room-data.ts
+++ b/tools/liveblocks-codemod/src/transforms/room-info-to-room-data.ts
@@ -9,6 +9,7 @@ export default function transformer(
 ) {
   const j = api.jscodeshift.withParser("tsx");
   const root = j(file.source);
+  let isDirty = false;
   let isRoomInfoImported = false;
 
   /**
@@ -22,8 +23,10 @@ export default function transformer(
           specifier.type === "ImportSpecifier" &&
           specifier.imported.name === "RoomInfo"
         ) {
-          isRoomInfoImported = true;
           specifier.imported.name = "RoomData";
+
+          isRoomInfoImported = true;
+          isDirty = true;
         }
       });
     }
@@ -44,7 +47,9 @@ export default function transformer(
       .replaceWith((path) =>
         j.tsTypeReference(j.identifier("RoomData"), path.node.typeParameters)
       );
+
+    isDirty = true;
   }
 
-  return root.toSource(options);
+  return isDirty ? root.toSource(options) : file.source;
 }


### PR DESCRIPTION
There are some cases where the `text → AST → text` process will result in different code even if the AST wasn't changed. Inspired by [this list of codemods](https://github.com/es-tooling/module-replacements-codemods/blob/main/codemods/has/index.js), this PR adds a dirty flag to all our codemods and uses it to return the unchanged input if the codemod didn't change the AST. 

**False positive example with the current version of `@liveblocks/codemod`:**
![false-positive](https://github.com/user-attachments/assets/a27f6b9f-c2be-4abd-b2a7-3873f3dc35b4)
