### PR TITLE
Fix: webhook docs links

### DIFF
--- a/docs/pages/platform/webhooks.mdx
+++ b/docs/pages/platform/webhooks.mdx
@@ -953,7 +953,7 @@ This webhook event is triggered by both Liveblocks and custom notification
 
 ##### Thread notification
 
-When using [Comments](/docs/product/comments), an event is triggered 30 minutes
+When using [Comments](/docs/products/comments), an event is triggered 30 minutes
 after a user has been mentioned or replied to in a thread, and has not seen the
 thread. It will also be triggered if the user has subscribed to the thread and
 has not seen the thread. The event won’t be triggered if the user has seen the
@@ -994,7 +994,7 @@ const threadNotificationEvent = {
 
 ##### TextMention notification
 
-When using [Text editor](/docs/product/text-editor), an event is triggered 30
+When using [Text editor](/docs/products/text-editor), an event is triggered 30
 minutes after a user has been mentioned in a text and has not seen the text
 mention. This is the Liveblocks `textMention` notification kind.
 


### PR DESCRIPTION
Fixing links:
- `/docs/product/whatever` -> `/docs/products/whatever`

Thanks 🙏🏻 