### PR TITLE
chore(docs): fix typo in @liveblocks/react page

### DIFF
--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -203,8 +203,7 @@ application.
 
 ### LiveblocksProvider
 
-Sets up a client for connecting to Liveblocks, and is the recommended way to
-create to do this for React apps. You must define either `authEndpoint` or
+Sets up a client for connecting to Liveblocks, and is the recommended way to do this for React apps. You must define either `authEndpoint` or
 `publicApiKey`. Resolver functions should be placed inside here, and a number of
 other options are available, which correspond with those passed to
 [`createClient`][]. Unlike [`RoomProvider`][], `LiveblocksProvider` doesn’t call


### PR DESCRIPTION
- Documentation updated

There's a typo (**"to create to do this in React apps"**) in this image attached below 

![image](https://github.com/user-attachments/assets/3b2fb161-169c-47ce-a662-3f8d3ba89aab)

