### PR TITLE
Refactor cache store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.6.2 (not released yet)
+
+### `@liveblocks/core`
+
+- Refactor caching internals to prepare for upcoming features
+
 ## 2.6.1
 
 ### `@liveblocks/react-ui`

--- a/e2e/next-sandbox/pages/inbox-notifications/index.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/index.tsx
@@ -181,7 +181,13 @@ function usePendingUpdatesCount() {
     () => store.get().optimisticUpdates.length,
     [store]
   );
-  return React.useSyncExternalStore(store.subscribe, getter, getter);
+  return React.useSyncExternalStore(
+    // Here, store.subscribe is guaranteed to be bound, so it's fine
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    store.subscribe,
+    getter,
+    getter
+  );
 }
 
 function LeftSide() {

--- a/e2e/next-sandbox/pages/inbox-notifications/index.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/index.tsx
@@ -176,7 +176,7 @@ function TopPart() {
 
 function usePendingUpdatesCount() {
   const client = useClient();
-  const store = client[kInternal].cacheStore;
+  const store = client[kInternal].umbrellaStore;
   const getter = React.useCallback(
     () => store.get().optimisticUpdates.length,
     [store]

--- a/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
@@ -202,7 +202,12 @@ function usePendingUpdatesCount() {
     () => store.get().optimisticUpdates.length,
     [store]
   );
-  return React.useSyncExternalStore(store.subscribe, getter);
+  return React.useSyncExternalStore(
+    // Here, store.subscribe is guaranteed to be bound, so it's fine
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    store.subscribe,
+    getter
+  );
 }
 
 function LeftSide() {

--- a/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
@@ -197,7 +197,7 @@ function TopPart() {
 
 function usePendingUpdatesCount() {
   const client = useClient();
-  const store = client[kInternal].cacheStore;
+  const store = client[kInternal].umbrellaStore;
   const getter = React.useCallback(
     () => store.get().optimisticUpdates.length,
     [store]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ts-morph": "^22.0.0",
         "tsd": "^0.31.1",
         "tsup": "^8.1.0",
-        "turbo": "^2.0.6",
+        "turbo": "^2.1.1",
         "typescript": "<4.8"
       },
       "engines": {
@@ -26389,95 +26389,102 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.6.tgz",
-      "integrity": "sha512-/Ftmxd5Mq//a9yMonvmwENNUN65jOVTwhhBPQjEtNZutYT9YKyzydFGLyVM1nzhpLWahQSMamRc/RDBv5EapzA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.1.1.tgz",
+      "integrity": "sha512-u9gUDkmR9dFS8b5kAYqIETK4OnzsS4l2ragJ0+soSMHh6VEeNHjTfSjk1tKxCqLyziCrPogadxP680J+v6yGHw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.0.6",
-        "turbo-darwin-arm64": "2.0.6",
-        "turbo-linux-64": "2.0.6",
-        "turbo-linux-arm64": "2.0.6",
-        "turbo-windows-64": "2.0.6",
-        "turbo-windows-arm64": "2.0.6"
+        "turbo-darwin-64": "2.1.1",
+        "turbo-darwin-arm64": "2.1.1",
+        "turbo-linux-64": "2.1.1",
+        "turbo-linux-arm64": "2.1.1",
+        "turbo-windows-64": "2.1.1",
+        "turbo-windows-arm64": "2.1.1"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.6.tgz",
-      "integrity": "sha512-XpgBwWj3Ggmz/gQVqXdMKXHC1iFPMDiuwugLwSzE7Ih0O13JuNtYZKhQnopvbDQnFQCeRq2Vsm5OTWabg/oB/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.1.1.tgz",
+      "integrity": "sha512-aYNuJpZlCoi0Htd79fl/2DywpewGKijdXeOfg9KzNuPVKzSMYlAXuAlNGh0MKjiOcyqxQGL7Mq9LFhwA0VpDpQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.6.tgz",
-      "integrity": "sha512-RfeZYXIAkiA21E8lsvfptGTqz/256YD+eI1x37fedfvnHFWuIMFZGAOwJxtZc6QasQunDZ9TRRREbJNI68tkIw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.1.1.tgz",
+      "integrity": "sha512-tifJKD8yHY48rHXPMcM8o1jI/Jk2KCaXiNjTKvvy9Zsim61BZksNVLelIbrRoCGwAN6PUBZO2lGU5iL/TQJ5Pw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.6.tgz",
-      "integrity": "sha512-92UDa0xNQQbx0HdSp9ag3YSS3xPdavhc7q9q9mxIAcqyjjD6VElA4Y85m4F/DDGE5SolCrvBz2sQhVmkOd6Caw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.1.1.tgz",
+      "integrity": "sha512-Js6d/bSQe9DuV9c7ITXYpsU/ADzFHABdz1UIHa7Oqjj9VOEbFeA9WpAn0c+mdJrVD+IXJFbbDZUjN7VYssmtcg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.6.tgz",
-      "integrity": "sha512-eQKu6utCVUkIH2kqOzD8OS6E0ba6COjWm6PRDTNCHQRljZW503ycaTUIdMOiJrVg1MkEjDyOReUg8s8D18aJ4Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.1.1.tgz",
+      "integrity": "sha512-LidzTCq0yvQ+N8w8Qub9FmhQ/mmEIeoqFi7DSupekEV2EjvE9jw/zYc9Pk67X+g7dHVfgOnvVzmrjChdxpFePw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.6.tgz",
-      "integrity": "sha512-+9u4EPrpoeHYCQ46dRcou9kbkSoelhOelHNcbs2d86D6ruYD/oIAHK9qgYK8LeARRz0jxhZIA/dWYdYsxJJWkw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.1.1.tgz",
+      "integrity": "sha512-GKc9ZywKwy4xLDhwXd6H07yzl0TB52HjXMrFLyHGhCVnf/w0oq4sLJv2sjbvuarPjsyx4xnCBJ3m3oyL2XmFtA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.6.tgz",
-      "integrity": "sha512-rdrKL+p+EjtdDVg0wQ/7yTbzkIYrnb0Pw4IKcjsy3M0RqUM9UcEi67b94XOAyTa5a0GqJL1+tUj2ebsFGPgZbg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.1.1.tgz",
+      "integrity": "sha512-oFKkMj11KKUv3xSK9/fhAEQTxLUp1Ol1EOktwc32+SFtEU0uls7kosAz0b+qe8k3pJGEMFdDPdqoEjyJidbxtQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -48721,58 +48728,58 @@
       }
     },
     "turbo": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.6.tgz",
-      "integrity": "sha512-/Ftmxd5Mq//a9yMonvmwENNUN65jOVTwhhBPQjEtNZutYT9YKyzydFGLyVM1nzhpLWahQSMamRc/RDBv5EapzA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.1.1.tgz",
+      "integrity": "sha512-u9gUDkmR9dFS8b5kAYqIETK4OnzsS4l2ragJ0+soSMHh6VEeNHjTfSjk1tKxCqLyziCrPogadxP680J+v6yGHw==",
       "dev": true,
       "requires": {
-        "turbo-darwin-64": "2.0.6",
-        "turbo-darwin-arm64": "2.0.6",
-        "turbo-linux-64": "2.0.6",
-        "turbo-linux-arm64": "2.0.6",
-        "turbo-windows-64": "2.0.6",
-        "turbo-windows-arm64": "2.0.6"
+        "turbo-darwin-64": "2.1.1",
+        "turbo-darwin-arm64": "2.1.1",
+        "turbo-linux-64": "2.1.1",
+        "turbo-linux-arm64": "2.1.1",
+        "turbo-windows-64": "2.1.1",
+        "turbo-windows-arm64": "2.1.1"
       }
     },
     "turbo-darwin-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.6.tgz",
-      "integrity": "sha512-XpgBwWj3Ggmz/gQVqXdMKXHC1iFPMDiuwugLwSzE7Ih0O13JuNtYZKhQnopvbDQnFQCeRq2Vsm5OTWabg/oB/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.1.1.tgz",
+      "integrity": "sha512-aYNuJpZlCoi0Htd79fl/2DywpewGKijdXeOfg9KzNuPVKzSMYlAXuAlNGh0MKjiOcyqxQGL7Mq9LFhwA0VpDpQ==",
       "dev": true,
       "optional": true
     },
     "turbo-darwin-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.6.tgz",
-      "integrity": "sha512-RfeZYXIAkiA21E8lsvfptGTqz/256YD+eI1x37fedfvnHFWuIMFZGAOwJxtZc6QasQunDZ9TRRREbJNI68tkIw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.1.1.tgz",
+      "integrity": "sha512-tifJKD8yHY48rHXPMcM8o1jI/Jk2KCaXiNjTKvvy9Zsim61BZksNVLelIbrRoCGwAN6PUBZO2lGU5iL/TQJ5Pw==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.6.tgz",
-      "integrity": "sha512-92UDa0xNQQbx0HdSp9ag3YSS3xPdavhc7q9q9mxIAcqyjjD6VElA4Y85m4F/DDGE5SolCrvBz2sQhVmkOd6Caw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.1.1.tgz",
+      "integrity": "sha512-Js6d/bSQe9DuV9c7ITXYpsU/ADzFHABdz1UIHa7Oqjj9VOEbFeA9WpAn0c+mdJrVD+IXJFbbDZUjN7VYssmtcg==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.6.tgz",
-      "integrity": "sha512-eQKu6utCVUkIH2kqOzD8OS6E0ba6COjWm6PRDTNCHQRljZW503ycaTUIdMOiJrVg1MkEjDyOReUg8s8D18aJ4Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.1.1.tgz",
+      "integrity": "sha512-LidzTCq0yvQ+N8w8Qub9FmhQ/mmEIeoqFi7DSupekEV2EjvE9jw/zYc9Pk67X+g7dHVfgOnvVzmrjChdxpFePw==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.6.tgz",
-      "integrity": "sha512-+9u4EPrpoeHYCQ46dRcou9kbkSoelhOelHNcbs2d86D6ruYD/oIAHK9qgYK8LeARRz0jxhZIA/dWYdYsxJJWkw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.1.1.tgz",
+      "integrity": "sha512-GKc9ZywKwy4xLDhwXd6H07yzl0TB52HjXMrFLyHGhCVnf/w0oq4sLJv2sjbvuarPjsyx4xnCBJ3m3oyL2XmFtA==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.6.tgz",
-      "integrity": "sha512-rdrKL+p+EjtdDVg0wQ/7yTbzkIYrnb0Pw4IKcjsy3M0RqUM9UcEi67b94XOAyTa5a0GqJL1+tUj2ebsFGPgZbg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.1.1.tgz",
+      "integrity": "sha512-oFKkMj11KKUv3xSK9/fhAEQTxLUp1Ol1EOktwc32+SFtEU0uls7kosAz0b+qe8k3pJGEMFdDPdqoEjyJidbxtQ==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ts-morph": "^22.0.0",
     "tsd": "^0.31.1",
     "tsup": "^8.1.0",
-    "turbo": "^2.0.6",
+    "turbo": "^2.1.1",
     "typescript": "<4.8"
   },
   "engines": {

--- a/packages/liveblocks-core/src/__tests__/addReaction.test.ts
+++ b/packages/liveblocks-core/src/__tests__/addReaction.test.ts
@@ -1,4 +1,4 @@
-import { addReaction } from "../store";
+import { addReaction } from "../umbrella-store";
 import { createComment, createThread } from "./_dummies";
 
 describe("addReaction", () => {

--- a/packages/liveblocks-core/src/__tests__/applyThreadUpdates.test.tsx
+++ b/packages/liveblocks-core/src/__tests__/applyThreadUpdates.test.tsx
@@ -3,7 +3,7 @@ import type {
   ThreadDataWithDeleteInfo,
   ThreadDeleteInfo,
 } from "../protocol/Comments";
-import { applyThreadUpdates } from "../store";
+import { applyThreadUpdates } from "../umbrella-store";
 
 describe("applyThreadUpdates", () => {
   const thread1: ThreadDataWithDeleteInfo = {

--- a/packages/liveblocks-core/src/__tests__/compareInboxNotifications.test.ts
+++ b/packages/liveblocks-core/src/__tests__/compareInboxNotifications.test.ts
@@ -1,5 +1,5 @@
 import type { InboxNotificationData } from "../protocol/InboxNotifications";
-import { compareInboxNotifications } from "../store";
+import { compareInboxNotifications } from "../umbrella-store";
 
 describe("compareInboxNotifications", () => {
   const inboxNotificationA: InboxNotificationData = {

--- a/packages/liveblocks-core/src/__tests__/compareThreads.test.ts
+++ b/packages/liveblocks-core/src/__tests__/compareThreads.test.ts
@@ -1,5 +1,5 @@
 import type { ThreadData } from "../protocol/Comments";
-import { compareThreads } from "../store";
+import { compareThreads } from "../umbrella-store";
 
 describe("compareThreads", () => {
   const thread1: ThreadData = {

--- a/packages/liveblocks-core/src/__tests__/deleteComment.test.ts
+++ b/packages/liveblocks-core/src/__tests__/deleteComment.test.ts
@@ -1,4 +1,4 @@
-import { deleteComment } from "../store";
+import { deleteComment } from "../umbrella-store";
 import { createComment, createThread } from "./_dummies";
 
 describe("deleteComment", () => {

--- a/packages/liveblocks-core/src/__tests__/upsertComment.test.ts
+++ b/packages/liveblocks-core/src/__tests__/upsertComment.test.ts
@@ -1,4 +1,4 @@
-import { upsertComment } from "../store";
+import { upsertComment } from "../umbrella-store";
 import { createComment, createThread } from "./_dummies";
 
 describe("upsertComment", () => {

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -39,9 +39,9 @@ import {
   makeAuthDelegateForRoom,
   makeCreateSocketDelegateForRoom,
 } from "./room";
-import type { UmbrellaStore } from "./store";
-import { createUmbrellaStore } from "./store";
 import type { OptionalPromise } from "./types/OptionalPromise";
+import type { UmbrellaStore } from "./umbrella-store";
+import { createUmbrellaStore } from "./umbrella-store";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1_000;

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -39,8 +39,8 @@ import {
   makeAuthDelegateForRoom,
   makeCreateSocketDelegateForRoom,
 } from "./room";
-import type { CacheStore } from "./store";
-import { createClientStore } from "./store";
+import type { UmbrellaStore } from "./store";
+import { createUmbrellaStore } from "./store";
 import type { OptionalPromise } from "./types/OptionalPromise";
 
 const MIN_THROTTLE = 16;
@@ -140,7 +140,7 @@ export type EnterOptions<P extends JsonObject = DP, S extends LsonObject = DS> =
 export type PrivateClientApi<U extends BaseUserMeta, M extends BaseMetadata> = {
   readonly currentUserIdStore: Store<string | null>;
   readonly resolveMentionSuggestions: ClientOptions<U>["resolveMentionSuggestions"];
-  readonly cacheStore: CacheStore<BaseMetadata>;
+  readonly umbrellaStore: UmbrellaStore<BaseMetadata>;
   readonly usersStore: BatchStore<U["info"] | undefined, string>;
   readonly roomsInfoStore: BatchStore<DRI | undefined, string>;
   readonly getRoomIds: () => string[];
@@ -605,7 +605,7 @@ export function createClient<U extends BaseUserMeta = DU>(
     currentUserIdStore,
   });
 
-  const cacheStore = createClientStore();
+  const umbrellaStore = createUmbrellaStore();
 
   const resolveUsers = clientOptions.resolveUsers;
   const warnIfNoResolveUsers = createDevelopmentWarning(
@@ -663,7 +663,7 @@ export function createClient<U extends BaseUserMeta = DU>(
       [kInternal]: {
         currentUserIdStore,
         resolveMentionSuggestions: clientOptions.resolveMentionSuggestions,
-        cacheStore,
+        umbrellaStore,
         usersStore,
         roomsInfoStore,
         getRoomIds() {

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -40,8 +40,7 @@ import {
   makeCreateSocketDelegateForRoom,
 } from "./room";
 import type { OptionalPromise } from "./types/OptionalPromise";
-import type { UmbrellaStore } from "./umbrella-store";
-import { createUmbrellaStore } from "./umbrella-store";
+import { UmbrellaStore } from "./umbrella-store";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1_000;
@@ -605,7 +604,7 @@ export function createClient<U extends BaseUserMeta = DU>(
     currentUserIdStore,
   });
 
-  const umbrellaStore = createUmbrellaStore();
+  const umbrellaStore = new UmbrellaStore();
 
   const resolveUsers = clientOptions.resolveUsers;
   const warnIfNoResolveUsers = createDevelopmentWarning(

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -278,9 +278,9 @@ export type { Store } from "./lib/create-store";
 export {
   addReaction,
   applyOptimisticUpdates,
-  type CacheStore,
   deleteComment,
   removeReaction,
+  type UmbrellaStore,
   type UmbrellaStoreState,
   upsertComment,
 } from "./store";

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -283,4 +283,4 @@ export {
   type UmbrellaStore,
   type UmbrellaStoreState,
   upsertComment,
-} from "./store";
+} from "./umbrella-store";

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -278,9 +278,9 @@ export type { Store } from "./lib/create-store";
 export {
   addReaction,
   applyOptimisticUpdates,
-  type CacheState,
   type CacheStore,
   deleteComment,
   removeReaction,
+  type UmbrellaStoreState,
   upsertComment,
 } from "./store";

--- a/packages/liveblocks-core/src/lib/create-store.ts
+++ b/packages/liveblocks-core/src/lib/create-store.ts
@@ -1,3 +1,6 @@
+/**
+ * A Store is just a mini Zustand store.
+ */
 export type Store<T> = {
   get: () => T;
   set: (callback: (currentState: T) => T) => void;

--- a/packages/liveblocks-core/src/lib/create-store.ts
+++ b/packages/liveblocks-core/src/lib/create-store.ts
@@ -2,9 +2,9 @@
  * A Store is just a mini Zustand store.
  */
 export type Store<T> = {
-  get: () => T;
-  set: (callback: (currentState: T) => T) => void;
-  subscribe: (callback: (state: T) => void) => () => void;
+  get: () => Readonly<T>;
+  set: (callback: (currentState: Readonly<T>) => Readonly<T>) => void;
+  subscribe: (callback: (state: Readonly<T>) => void) => () => void;
 };
 
 /**

--- a/packages/liveblocks-core/src/lib/utils.ts
+++ b/packages/liveblocks-core/src/lib/utils.ts
@@ -3,6 +3,14 @@ import type { Json } from "./Json";
 declare const brand: unique symbol;
 export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };
 
+export type DistributiveOmit<T, K extends PropertyKey> = T extends any
+  ? Omit<T, K>
+  : never;
+
+// export type DistributivePick<T, K extends keyof T> = T extends any
+//   ? Pick<T, K>
+//   : never;
+
 /**
  * Throw an error, but as an expression instead of a statement.
  */

--- a/packages/liveblocks-core/src/store.ts
+++ b/packages/liveblocks-core/src/store.ts
@@ -151,11 +151,9 @@ type QueryState = AsyncResult<undefined>;
 
 export type CacheState<M extends BaseMetadata> = {
   /**
-   * Threads by ID.
-   */
-  threads: Record<string, ThreadDataWithDeleteInfo<M>>;
-  /**
    * Keep track of loading and error status of all the queries made by the client.
+   * e.g. 'room-abc-{"color":"red"}'  - ok
+   * e.g. 'room-abc-{}'               - loading
    */
   queries: Record<string, QueryState>;
   /**
@@ -163,12 +161,23 @@ export type CacheState<M extends BaseMetadata> = {
    * They are applied on top of the threads in selectors.
    */
   optimisticUpdates: OptimisticUpdate<M>[];
+
+  /**
+   * Threads by ID
+   * e.g. `th_${string}`
+   */
+  threads: Record<string, ThreadDataWithDeleteInfo<M>>;
   /**
    * Inbox notifications by ID.
+   * e.g. `in_${string}`
    */
   inboxNotifications: Record<string, InboxNotificationData>;
   /**
-   * Notification settings per room id
+   * Notification settings by room ID.
+   * e.g. { 'room-abc': { threads: "all" },
+   *        'room-def': { threads: "replies_and_mentions" },
+   *        'room-xyz': { threads: "none" },
+   *      }
    */
   notificationSettings: Record<string, RoomNotificationSettings>;
 };

--- a/packages/liveblocks-core/src/store.ts
+++ b/packages/liveblocks-core/src/store.ts
@@ -182,7 +182,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
   notificationSettings: Record<string, RoomNotificationSettings>;
 };
 
-export interface CacheStore<M extends BaseMetadata>
+export interface UmbrellaStore<M extends BaseMetadata>
   extends Store<UmbrellaStoreState<M>> {
   deleteThread(threadId: string): void;
   updateThreadAndNotification(
@@ -213,7 +213,9 @@ export interface CacheStore<M extends BaseMetadata>
  * Create internal immutable store for comments and notifications.
  * Keep all the state required to return data from our hooks.
  */
-export function createClientStore<M extends BaseMetadata>(): CacheStore<M> {
+export function createUmbrellaStore<
+  M extends BaseMetadata,
+>(): UmbrellaStore<M> {
   const store = createStore<UmbrellaStoreState<M>>({
     threads: {},
     queries: {},

--- a/packages/liveblocks-core/src/store.ts
+++ b/packages/liveblocks-core/src/store.ts
@@ -149,7 +149,7 @@ type UpdateNotificationSettingsOptimisticUpdate = {
 type QueryState = AsyncResult<undefined>;
 //                            ^^^^^^^^^ We don't store the actual query result in this status
 
-export type CacheState<M extends BaseMetadata> = {
+export type UmbrellaStoreState<M extends BaseMetadata> = {
   /**
    * Keep track of loading and error status of all the queries made by the client.
    * e.g. 'room-abc-{"color":"red"}'  - ok
@@ -183,7 +183,7 @@ export type CacheState<M extends BaseMetadata> = {
 };
 
 export interface CacheStore<M extends BaseMetadata>
-  extends Store<CacheState<M>> {
+  extends Store<UmbrellaStoreState<M>> {
   deleteThread(threadId: string): void;
   updateThreadAndNotification(
     thread: ThreadData<M>,
@@ -214,7 +214,7 @@ export interface CacheStore<M extends BaseMetadata>
  * Keep all the state required to return data from our hooks.
  */
 export function createClientStore<M extends BaseMetadata>(): CacheStore<M> {
-  const store = createStore<CacheState<M>>({
+  const store = createStore<UmbrellaStoreState<M>>({
     threads: {},
     queries: {},
     optimisticUpdates: [],
@@ -383,9 +383,9 @@ export function compareThreads<M extends BaseMetadata>(
 }
 
 export function applyOptimisticUpdates<M extends BaseMetadata>(
-  state: CacheState<M>
+  state: UmbrellaStoreState<M>
 ): Pick<
-  CacheState<M>,
+  UmbrellaStoreState<M>,
   "threads" | "inboxNotifications" | "notificationSettings"
 > {
   const result = {

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -196,15 +196,54 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // Auto-bind all of this class methods once here, so we can use stable
     // references to them (most important for use in useSyncExternalStore)
     this.get = this.get.bind(this);
-    this.set = this.set.bind(this);
     this.subscribe = this.subscribe.bind(this);
+
+    // Setters
+    this.force_set__call_from_unit_tests_only_plz =
+      this.force_set__call_from_unit_tests_only_plz.bind(this);
+    this.set_thr_ibn_and_optm = this.set_thr_ibn_and_optm.bind(this);
+    this.set_thr_and_optm = this.set_thr_and_optm.bind(this);
+    this.set_ibn_and_optm = this.set_ibn_and_optm.bind(this);
+    this.set_optm = this.set_optm.bind(this);
   }
 
   public get(): Readonly<UmbrellaStoreState<M>> {
     return this._store.get();
   }
 
-  public set(
+  public force_set__call_from_unit_tests_only_plz(
+    callback: (
+      currentState: Readonly<UmbrellaStoreState<M>>
+    ) => Readonly<UmbrellaStoreState<M>>
+  ): void {
+    return this._store.set(callback);
+  }
+
+  public set_thr_ibn_and_optm(
+    callback: (
+      currentState: Readonly<UmbrellaStoreState<M>>
+    ) => Readonly<UmbrellaStoreState<M>>
+  ): void {
+    return this._store.set(callback);
+  }
+
+  public set_thr_and_optm(
+    callback: (
+      currentState: Readonly<UmbrellaStoreState<M>>
+    ) => Readonly<UmbrellaStoreState<M>>
+  ): void {
+    return this._store.set(callback);
+  }
+
+  public set_ibn_and_optm(
+    callback: (
+      currentState: Readonly<UmbrellaStoreState<M>>
+    ) => Readonly<UmbrellaStoreState<M>>
+  ): void {
+    return this._store.set(callback);
+  }
+
+  public set_optm(
     callback: (
       currentState: Readonly<UmbrellaStoreState<M>>
     ) => Readonly<UmbrellaStoreState<M>>

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -376,7 +376,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     callback: (
       thread: Readonly<ThreadDataWithDeleteInfo<M>>
     ) => Readonly<ThreadDataWithDeleteInfo<M>>,
-    updatedAt?: Date // XXX We could look this up from the optimisticUpdate instead?
+    updatedAt?: Date // TODO We could look this up from the optimisticUpdate instead?
   ): void {
     return this.replaceOptimisticUpdate(
       optimisticUpdateId,

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -1,7 +1,6 @@
 import type { AsyncResult } from "./lib/AsyncResult";
 import type { Store } from "./lib/create-store";
 import { createStore } from "./lib/create-store";
-import { makeEventSource } from "./lib/EventSource";
 import * as console from "./lib/fancy-console";
 import type { Resolve } from "./lib/Resolve";
 import type {
@@ -203,10 +202,6 @@ export interface UmbrellaStore<M extends BaseMetadata>
   ): void;
   pushOptimisticUpdate(optimisticUpdate: OptimisticUpdate<M>): void;
   setQueryState(queryKey: string, queryState: QueryState): void;
-
-  optimisticUpdatesEventSource: ReturnType<
-    typeof makeEventSource<OptimisticUpdate<M>>
-  >;
 }
 
 /**
@@ -223,8 +218,6 @@ export function createUmbrellaStore<
     inboxNotifications: {},
     notificationSettings: {},
   });
-
-  const optimisticUpdatesEventSource = makeEventSource<OptimisticUpdate<M>>();
 
   return {
     ...store,
@@ -319,7 +312,6 @@ export function createUmbrellaStore<
     },
 
     pushOptimisticUpdate(optimisticUpdate: OptimisticUpdate<M>) {
-      optimisticUpdatesEventSource.notify(optimisticUpdate);
       store.set((state) => ({
         ...state,
         optimisticUpdates: [...state.optimisticUpdates, optimisticUpdate],
@@ -335,8 +327,6 @@ export function createUmbrellaStore<
         },
       }));
     },
-
-    optimisticUpdatesEventSource,
   };
 }
 

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -182,10 +182,10 @@ export type UmbrellaStoreState<M extends BaseMetadata> = Readonly<{
 }>;
 
 export class UmbrellaStore<M extends BaseMetadata> {
-  #store: Store<UmbrellaStoreState<M>>;
+  private _store: Store<UmbrellaStoreState<M>>;
 
   constructor() {
-    this.#store = createStore<UmbrellaStoreState<M>>({
+    this._store = createStore<UmbrellaStoreState<M>>({
       threads: {},
       queries: {},
       optimisticUpdates: [],
@@ -201,25 +201,25 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public get(): Readonly<UmbrellaStoreState<M>> {
-    return this.#store.get();
+    return this._store.get();
   }
 
   public set(
     callback: (
       currentState: Readonly<UmbrellaStoreState<M>>
     ) => Readonly<UmbrellaStoreState<M>>
-  ) {
-    return this.#store.set(callback);
+  ): void {
+    return this._store.set(callback);
   }
 
   public subscribe(
     callback: (state: Readonly<UmbrellaStoreState<M>>) => void
   ): () => void {
-    return this.#store.subscribe(callback);
+    return this._store.subscribe(callback);
   }
 
-  public deleteThread(threadId: string) {
-    this.#store.set((state) => {
+  public deleteThread(threadId: string): void {
+    this._store.set((state) => {
       return {
         ...state,
         threads: deleteKeyImmutable(state.threads, threadId),
@@ -238,7 +238,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     thread: ThreadData<M>,
     inboxNotification?: InboxNotificationData
   ): void {
-    this.#store.set((state) => {
+    this._store.set((state) => {
       const existingThread = state.threads[thread.id];
 
       return {
@@ -265,8 +265,8 @@ export class UmbrellaStore<M extends BaseMetadata> {
     deletedThreads: ThreadDeleteInfo[],
     deletedInboxNotifications: InboxNotificationDeleteInfo[],
     queryKey?: string
-  ) {
-    this.#store.set((state) => ({
+  ): void {
+    this._store.set((state) => ({
       ...state,
       threads: applyThreadUpdates(state.threads, {
         newThreads: threads,
@@ -290,8 +290,8 @@ export class UmbrellaStore<M extends BaseMetadata> {
     roomId: string,
     settings: RoomNotificationSettings,
     queryKey: string
-  ) {
-    this.#store.set((state) => ({
+  ): void {
+    this._store.set((state) => ({
       ...state,
       notificationSettings: {
         ...state.notificationSettings,
@@ -304,15 +304,15 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }));
   }
 
-  public pushOptimisticUpdate(optimisticUpdate: OptimisticUpdate<M>) {
-    this.#store.set((state) => ({
+  public pushOptimisticUpdate(optimisticUpdate: OptimisticUpdate<M>): void {
+    this._store.set((state) => ({
       ...state,
       optimisticUpdates: [...state.optimisticUpdates, optimisticUpdate],
     }));
   }
 
-  public setQueryState(queryKey: string, queryState: QueryState) {
-    this.#store.set((state) => ({
+  public setQueryState(queryKey: string, queryState: QueryState): void {
+    this._store.set((state) => ({
       ...state,
       queries: {
         ...state.queries,

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -149,7 +149,7 @@ type UpdateNotificationSettingsOptimisticUpdate = {
 type QueryState = AsyncResult<undefined>;
 //                            ^^^^^^^^^ We don't store the actual query result in this status
 
-export type UmbrellaStoreState<M extends BaseMetadata> = {
+export type UmbrellaStoreState<M extends BaseMetadata> = Readonly<{
   /**
    * Keep track of loading and error status of all the queries made by the client.
    * e.g. 'room-abc-{"color":"red"}'  - ok
@@ -180,7 +180,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
    *      }
    */
   notificationSettings: Record<string, RoomNotificationSettings>;
-};
+}>;
 
 export interface UmbrellaStore<M extends BaseMetadata>
   extends Store<UmbrellaStoreState<M>> {

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -2,7 +2,9 @@ import type { AsyncResult } from "./lib/AsyncResult";
 import type { Store } from "./lib/create-store";
 import { createStore } from "./lib/create-store";
 import * as console from "./lib/fancy-console";
+import { nanoid } from "./lib/nanoid";
 import type { Resolve } from "./lib/Resolve";
+import type { DistributiveOmit } from "./lib/utils";
 import type {
   BaseMetadata,
   CommentData,
@@ -334,11 +336,16 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }));
   }
 
-  public pushOptimisticUpdate(optimisticUpdate: OptimisticUpdate<M>): void {
+  public addOptimisticUpdate(
+    optimisticUpdate: DistributiveOmit<OptimisticUpdate<M>, "id">
+  ): string {
+    const id = nanoid();
+    const newUpdate: OptimisticUpdate<M> = { ...optimisticUpdate, id };
     this._store.set((state) => ({
       ...state,
-      optimisticUpdates: [...state.optimisticUpdates, optimisticUpdate],
+      optimisticUpdates: [...state.optimisticUpdates, newUpdate],
     }));
+    return id;
   }
 
   public removeOptimisticUpdate(optimisticUpdateId: string): void {

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -159,7 +159,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = Readonly<{
    * Optimistic updates that have not been acknowledged by the server yet.
    * They are applied on top of the threads in selectors.
    */
-  optimisticUpdates: OptimisticUpdate<M>[];
+  optimisticUpdates: readonly OptimisticUpdate<M>[];
 
   /**
    * Threads by ID
@@ -204,7 +204,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
     this.set_thr_ibn_and_optm = this.set_thr_ibn_and_optm.bind(this);
     this.set_thr_and_optm = this.set_thr_and_optm.bind(this);
     this.set_ibn_and_optm = this.set_ibn_and_optm.bind(this);
-    this.set_optm = this.set_optm.bind(this);
   }
 
   public get(): Readonly<UmbrellaStoreState<M>> {
@@ -236,14 +235,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public set_ibn_and_optm(
-    callback: (
-      currentState: Readonly<UmbrellaStoreState<M>>
-    ) => Readonly<UmbrellaStoreState<M>>
-  ): void {
-    return this._store.set(callback);
-  }
-
-  public set_optm(
     callback: (
       currentState: Readonly<UmbrellaStoreState<M>>
     ) => Readonly<UmbrellaStoreState<M>>
@@ -347,6 +338,15 @@ export class UmbrellaStore<M extends BaseMetadata> {
     this._store.set((state) => ({
       ...state,
       optimisticUpdates: [...state.optimisticUpdates, optimisticUpdate],
+    }));
+  }
+
+  public removeOptimisticUpdate(optimisticUpdateId: string): void {
+    return this._store.set((state) => ({
+      ...state,
+      optimisticUpdates: state.optimisticUpdates.filter(
+        (update) => update.id !== optimisticUpdateId
+      ),
     }));
   }
 

--- a/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
@@ -101,7 +101,7 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
     }
   });
 
-  const store = client[kInternal].cacheStore;
+  const store = client[kInternal].umbrellaStore;
 
   const threads = useSyncExternalStoreWithSelector(
     store.subscribe,

--- a/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
@@ -70,7 +70,7 @@ export function useEditorStatus(): EditorStatus {
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
-      if (provider === undefined) return () => { };
+      if (provider === undefined) return () => {};
       provider.on("status", onStoreChange);
       return () => {
         provider.off("status", onStoreChange);

--- a/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/useMentionSuggestions.test.tsx
@@ -1,6 +1,6 @@
 import type { ResolveMentionSuggestionsArgs } from "@liveblocks/core";
-import { renderHook, waitFor } from "@testing-library/react";
 import { nanoid } from "@liveblocks/core";
+import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 
 import { useMentionSuggestions } from "../shared";

--- a/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
@@ -1,4 +1,4 @@
-import type { BaseMetadata, CacheStore, ThreadData } from "@liveblocks/core";
+import type { BaseMetadata, ThreadData, UmbrellaStore } from "@liveblocks/core";
 import { createClient, kInternal } from "@liveblocks/core";
 
 import { selectedThreads } from "../comments/lib/selected-threads";
@@ -34,7 +34,7 @@ describe("selectedThreads", () => {
     };
 
     const store = client[kInternal]
-      .cacheStore as unknown as CacheStore<BaseMetadata>;
+      .umbrellaStore as unknown as UmbrellaStore<BaseMetadata>;
 
     store.updateThreadsAndNotifications([thread1, thread2], [], [], []);
 

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -266,7 +266,7 @@ describe("useInboxNotifications", () => {
       client,
     } = createContextsForTest();
 
-    const store = client[kInternal].cacheStore;
+    const store = client[kInternal].umbrellaStore;
     store.set((state) => ({
       ...state,
       inboxNotifications: {

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -267,7 +267,7 @@ describe("useInboxNotifications", () => {
     } = createContextsForTest();
 
     const store = client[kInternal].umbrellaStore;
-    store.force_set__call_from_unit_tests_only_plz((state) => ({
+    store.force_set((state) => ({
       ...state,
       inboxNotifications: {
         // Explicitly set the order to be reversed to test that the hook sorts the notifications

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -267,7 +267,7 @@ describe("useInboxNotifications", () => {
     } = createContextsForTest();
 
     const store = client[kInternal].umbrellaStore;
-    store.set((state) => ({
+    store.force_set__call_from_unit_tests_only_plz((state) => ({
       ...state,
       inboxNotifications: {
         // Explicitly set the order to be reversed to test that the hook sorts the notifications

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -957,7 +957,7 @@ describe("useThreads", () => {
       client,
     } = createContextsForTest();
 
-    const store = client[kInternal].cacheStore;
+    const store = client[kInternal].umbrellaStore;
     store.set((state) => ({
       ...state,
       threads: {

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -958,7 +958,7 @@ describe("useThreads", () => {
     } = createContextsForTest();
 
     const store = client[kInternal].umbrellaStore;
-    store.force_set__call_from_unit_tests_only_plz((state) => ({
+    store.force_set((state) => ({
       ...state,
       threads: {
         [thread1.id]: thread1,

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -958,7 +958,7 @@ describe("useThreads", () => {
     } = createContextsForTest();
 
     const store = client[kInternal].umbrellaStore;
-    store.set((state) => ({
+    store.force_set__call_from_unit_tests_only_plz((state) => ({
       ...state,
       threads: {
         [thread1.id]: thread1,

--- a/packages/liveblocks-react/src/comments/lib/select-notification-settings.ts
+++ b/packages/liveblocks-react/src/comments/lib/select-notification-settings.ts
@@ -1,14 +1,14 @@
 import {
   applyOptimisticUpdates,
   type BaseMetadata,
-  type CacheState,
   nn,
   type RoomNotificationSettings,
+  type UmbrellaStoreState,
 } from "@liveblocks/core";
 
 export function selectNotificationSettings<M extends BaseMetadata>(
   roomId: string,
-  state: CacheState<M>
+  state: UmbrellaStoreState<M>
 ): RoomNotificationSettings {
   const { notificationSettings } = applyOptimisticUpdates(state);
   return nn(notificationSettings[roomId]);

--- a/packages/liveblocks-react/src/comments/lib/selected-inbox-notifications.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-inbox-notifications.ts
@@ -1,12 +1,12 @@
 import type {
   BaseMetadata,
-  CacheState,
   InboxNotificationData,
+  UmbrellaStoreState,
 } from "@liveblocks/core";
 import { applyOptimisticUpdates } from "@liveblocks/core";
 
 export function selectedInboxNotifications<M extends BaseMetadata>(
-  state: CacheState<M>
+  state: UmbrellaStoreState<M>
 ): InboxNotificationData[] {
   const result = applyOptimisticUpdates(state);
 

--- a/packages/liveblocks-react/src/comments/lib/selected-threads.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-threads.ts
@@ -1,14 +1,14 @@
 import {
   applyOptimisticUpdates,
   type BaseMetadata,
-  type CacheState,
   type ThreadData,
+  type UmbrellaStoreState,
 } from "@liveblocks/core";
 
 import type { UseThreadsOptions } from "../../types";
 
 export function selectedUserThreads<M extends BaseMetadata>(
-  state: CacheState<M>
+  state: UmbrellaStoreState<M>
 ) {
   const result = applyOptimisticUpdates(state);
 
@@ -37,7 +37,7 @@ export function selectedUserThreads<M extends BaseMetadata>(
  */
 export function selectedThreads<M extends BaseMetadata>(
   roomId: string,
-  state: CacheState<M>,
+  state: UmbrellaStoreState<M>,
   options: UseThreadsOptions<M>
 ): ThreadData<M>[] {
   // Here, result contains copies of 3 out of the 5 caches with all optimistic

--- a/packages/liveblocks-react/src/comments/lib/selected-threads.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-threads.ts
@@ -40,6 +40,8 @@ export function selectedThreads<M extends BaseMetadata>(
   state: CacheState<M>,
   options: UseThreadsOptions<M>
 ): ThreadData<M>[] {
+  // Here, result contains copies of 3 out of the 5 caches with all optimistic
+  // updates mixed in
   const result = applyOptimisticUpdates(state);
 
   // Filter threads to only include the non-deleted threads from the specified room and that match the specified filter options

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -725,7 +725,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
 
       client.markInboxNotificationAsRead(inboxNotificationId).then(
         () => {
-          store.set((state) => {
+          store.set_ibn_and_optm((state) => {
             const existingNotification =
               state.inboxNotifications[inboxNotificationId];
 
@@ -733,6 +733,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
             if (existingNotification === undefined) {
               return {
                 ...state,
+                inboxNotifications: state.inboxNotifications,
                 optimisticUpdates: state.optimisticUpdates.filter(
                   (update) => update.id !== optimisticUpdateId
                 ),
@@ -756,7 +757,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
         },
         () => {
           // TODO: Broadcast errors to client
-          store.set((state) => ({
+          store.set_optm((state) => ({
             ...state,
             optimisticUpdates: state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -782,7 +783,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
 
     client.markAllInboxNotificationsAsRead().then(
       () => {
-        store.set((state) => ({
+        store.set_ibn_and_optm((state) => ({
           ...state,
           inboxNotifications: Object.fromEntries(
             Array.from(Object.entries(state.inboxNotifications)).map(
@@ -799,7 +800,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
       },
       () => {
         // TODO: Broadcast errors to client
-        store.set((state) => ({
+        store.set_optm((state) => ({
           ...state,
           optimisticUpdates: state.optimisticUpdates.filter(
             (update) => update.id !== optimisticUpdateId
@@ -826,7 +827,7 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
 
       client.deleteInboxNotification(inboxNotificationId).then(
         () => {
-          store.set((state) => {
+          store.set_ibn_and_optm((state) => {
             const existingNotification =
               state.inboxNotifications[inboxNotificationId];
 
@@ -854,7 +855,7 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
         },
         () => {
           // TODO: Broadcast errors to client
-          store.set((state) => ({
+          store.set_optm((state) => ({
             ...state,
             optimisticUpdates: state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -880,7 +881,7 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
 
     client.deleteAllInboxNotifications().then(
       () => {
-        store.set((state) => ({
+        store.set_ibn_and_optm((state) => ({
           ...state,
           inboxNotifications: {},
           optimisticUpdates: state.optimisticUpdates.filter(
@@ -890,7 +891,7 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
       },
       () => {
         // TODO: Broadcast errors to client
-        store.set((state) => ({
+        store.set_optm((state) => ({
           ...state,
           optimisticUpdates: state.optimisticUpdates.filter(
             (update) => update.id !== optimisticUpdateId

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -7,12 +7,12 @@ import type {
 import type {
   AsyncResult,
   BaseRoomInfo,
-  CacheStore,
   ClientOptions,
   DM,
   DU,
   OpaqueClient,
   PrivateClientApi,
+  UmbrellaStore,
   UmbrellaStoreState,
 } from "@liveblocks/core";
 import {
@@ -255,7 +255,7 @@ function getExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
   }
 
   return extras as unknown as Omit<typeof extras, "store"> & {
-    store: CacheStore<M>;
+    store: UmbrellaStore<M>;
   };
 }
 
@@ -263,7 +263,7 @@ function makeExtrasForClient<U extends BaseUserMeta, M extends BaseMetadata>(
   client: OpaqueClient
 ) {
   const internals = client[kInternal] as PrivateClientApi<U, M>;
-  const store = internals.cacheStore;
+  const store = internals.umbrellaStore;
 
   let lastRequestedAt: Date | undefined;
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -21,7 +21,6 @@ import {
   kInternal,
   makePoller,
   memoizeOnSuccess,
-  nanoid,
   raise,
   shallow,
 } from "@liveblocks/core";
@@ -714,11 +713,9 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
     (inboxNotificationId: string) => {
       const { store } = getExtrasForClient(client);
 
-      const optimisticUpdateId = nanoid();
       const readAt = new Date();
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "mark-inbox-notification-as-read",
-        id: optimisticUpdateId,
         inboxNotificationId,
         readAt,
       });
@@ -768,11 +765,9 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
 function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
   return useCallback(() => {
     const { store } = getExtrasForClient(client);
-    const optimisticUpdateId = nanoid();
     const readAt = new Date();
-    store.pushOptimisticUpdate({
+    const optimisticUpdateId = store.addOptimisticUpdate({
       type: "mark-all-inbox-notifications-as-read",
-      id: optimisticUpdateId,
       readAt,
     });
 
@@ -806,11 +801,9 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
     (inboxNotificationId: string) => {
       const { store } = getExtrasForClient(client);
 
-      const optimisticUpdateId = nanoid();
       const deletedAt = new Date();
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "delete-inbox-notification",
-        id: optimisticUpdateId,
         inboxNotificationId,
         deletedAt,
       });
@@ -856,11 +849,9 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
 function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
   return useCallback(() => {
     const { store } = getExtrasForClient(client);
-    const optimisticUpdateId = nanoid();
     const deletedAt = new Date();
-    store.pushOptimisticUpdate({
+    const optimisticUpdateId = store.addOptimisticUpdate({
       type: "delete-all-inbox-notifications",
-      id: optimisticUpdateId,
       deletedAt,
     });
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -722,35 +722,12 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
 
       client.markInboxNotificationAsRead(inboxNotificationId).then(
         () => {
-          store.set_ibn_and_optm((state) => {
-            const existingNotification =
-              state.inboxNotifications[inboxNotificationId];
-
-            // If existing notification has been deleted, we return the existing state
-            if (existingNotification === undefined) {
-              return {
-                ...state,
-                inboxNotifications: state.inboxNotifications,
-                optimisticUpdates: state.optimisticUpdates.filter(
-                  (update) => update.id !== optimisticUpdateId
-                ),
-              };
-            }
-
-            return {
-              ...state,
-              inboxNotifications: {
-                ...state.inboxNotifications,
-                [inboxNotificationId]: {
-                  ...existingNotification,
-                  readAt,
-                },
-              },
-              optimisticUpdates: state.optimisticUpdates.filter(
-                (update) => update.id !== optimisticUpdateId
-              ),
-            };
-          });
+          // Replace the optimistic update by the real thing
+          store.updateInboxNotification(
+            inboxNotificationId,
+            optimisticUpdateId,
+            (inboxNotification) => ({ ...inboxNotification, readAt })
+          );
         },
         () => {
           // TODO: Broadcast errors to client
@@ -773,20 +750,11 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
 
     client.markAllInboxNotificationsAsRead().then(
       () => {
-        store.set_ibn_and_optm((state) => ({
-          ...state,
-          inboxNotifications: Object.fromEntries(
-            Array.from(Object.entries(state.inboxNotifications)).map(
-              ([id, inboxNotification]) => [
-                id,
-                { ...inboxNotification, readAt },
-              ]
-            )
-          ),
-          optimisticUpdates: state.optimisticUpdates.filter(
-            (update) => update.id !== optimisticUpdateId
-          ),
-        }));
+        // Replace the optimistic update by the real thing
+        store.updateAllInboxNotifications(
+          optimisticUpdateId,
+          (inboxNotification) => ({ ...inboxNotification, readAt })
+        );
       },
       () => {
         // TODO: Broadcast errors to client
@@ -810,31 +778,11 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
 
       client.deleteInboxNotification(inboxNotificationId).then(
         () => {
-          store.set_ibn_and_optm((state) => {
-            const existingNotification =
-              state.inboxNotifications[inboxNotificationId];
-
-            // If existing notification has been deleted, we return the existing state
-            if (existingNotification === undefined) {
-              return {
-                ...state,
-                optimisticUpdates: state.optimisticUpdates.filter(
-                  (update) => update.id !== optimisticUpdateId
-                ),
-              };
-            }
-
-            const { [inboxNotificationId]: _, ...inboxNotifications } =
-              state.inboxNotifications;
-
-            return {
-              ...state,
-              inboxNotifications,
-              optimisticUpdates: state.optimisticUpdates.filter(
-                (update) => update.id !== optimisticUpdateId
-              ),
-            };
-          });
+          // Replace the optimistic update by the real thing
+          store.deleteInboxNotification(
+            inboxNotificationId,
+            optimisticUpdateId
+          );
         },
         () => {
           // TODO: Broadcast errors to client
@@ -857,13 +805,8 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
 
     client.deleteAllInboxNotifications().then(
       () => {
-        store.set_ibn_and_optm((state) => ({
-          ...state,
-          inboxNotifications: {},
-          optimisticUpdates: state.optimisticUpdates.filter(
-            (update) => update.id !== optimisticUpdateId
-          ),
-        }));
+        // Replace the optimistic update by the real thing
+        store.deleteAllInboxNotifications(optimisticUpdateId);
       },
       () => {
         // TODO: Broadcast errors to client

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -757,12 +757,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
         },
         () => {
           // TODO: Broadcast errors to client
-          store.set_optm((state) => ({
-            ...state,
-            optimisticUpdates: state.optimisticUpdates.filter(
-              (update) => update.id !== optimisticUpdateId
-            ),
-          }));
+          store.removeOptimisticUpdate(optimisticUpdateId);
         }
       );
     },
@@ -800,12 +795,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
       },
       () => {
         // TODO: Broadcast errors to client
-        store.set_optm((state) => ({
-          ...state,
-          optimisticUpdates: state.optimisticUpdates.filter(
-            (update) => update.id !== optimisticUpdateId
-          ),
-        }));
+        store.removeOptimisticUpdate(optimisticUpdateId);
       }
     );
   }, [client]);
@@ -855,12 +845,7 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
         },
         () => {
           // TODO: Broadcast errors to client
-          store.set_optm((state) => ({
-            ...state,
-            optimisticUpdates: state.optimisticUpdates.filter(
-              (update) => update.id !== optimisticUpdateId
-            ),
-          }));
+          store.removeOptimisticUpdate(optimisticUpdateId);
         }
       );
     },
@@ -891,12 +876,7 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
       },
       () => {
         // TODO: Broadcast errors to client
-        store.set_optm((state) => ({
-          ...state,
-          optimisticUpdates: state.optimisticUpdates.filter(
-            (update) => update.id !== optimisticUpdateId
-          ),
-        }));
+        store.removeOptimisticUpdate(optimisticUpdateId);
       }
     );
   }, [client]);

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -7,13 +7,13 @@ import type {
 import type {
   AsyncResult,
   BaseRoomInfo,
-  CacheState,
   CacheStore,
   ClientOptions,
   DM,
   DU,
   OpaqueClient,
   PrivateClientApi,
+  UmbrellaStoreState,
 } from "@liveblocks/core";
 import {
   assert,
@@ -87,7 +87,7 @@ export const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
 export const USER_THREADS_QUERY = "USER_THREADS";
 
 function selectorFor_useInboxNotifications(
-  state: CacheState<BaseMetadata>
+  state: UmbrellaStoreState<BaseMetadata>
 ): InboxNotificationsState {
   const query = state.queries[INBOX_NOTIFICATIONS_QUERY];
 
@@ -111,7 +111,7 @@ function selectorFor_useInboxNotifications(
 }
 
 function selectorFor_useUserThreads<M extends BaseMetadata>(
-  state: CacheState<M>
+  state: UmbrellaStoreState<M>
 ): ThreadsState<M> {
   const query = state.queries[USER_THREADS_QUERY];
 
@@ -135,7 +135,9 @@ function selectorFor_useUserThreads<M extends BaseMetadata>(
   };
 }
 
-function selectUnreadInboxNotificationsCount(state: CacheState<BaseMetadata>) {
+function selectUnreadInboxNotificationsCount(
+  state: UmbrellaStoreState<BaseMetadata>
+) {
   let count = 0;
 
   for (const notification of selectedInboxNotifications(state)) {
@@ -151,7 +153,7 @@ function selectUnreadInboxNotificationsCount(state: CacheState<BaseMetadata>) {
 }
 
 function selectorFor_useUnreadInboxNotificationsCount(
-  state: CacheState<BaseMetadata>
+  state: UmbrellaStoreState<BaseMetadata>
 ): UnreadInboxNotificationsCountState {
   const query = state.queries[INBOX_NOTIFICATIONS_QUERY];
 
@@ -906,7 +908,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
   const { store } = getExtrasForClient<M>(client);
 
   const selector = useCallback(
-    (state: CacheState<M>) => {
+    (state: UmbrellaStoreState<M>) => {
       const inboxNotification =
         state.inboxNotifications[inboxNotificationId] ??
         raise(`Inbox notification with ID "${inboxNotificationId}" not found`);

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -483,7 +483,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     optimisticUpdateId: string,
     createPublicError: (error: Error) => CommentsError<M>
   ) {
-    store.set((state) => ({
+    store.set_optm((state) => ({
       ...state,
       optimisticUpdates: state.optimisticUpdates.filter(
         (update) => update.id !== optimisticUpdateId
@@ -1529,7 +1529,7 @@ function useCreateThread<M extends BaseMetadata>(): (
 
       room.createThread({ threadId, commentId, body, metadata }).then(
         (thread) => {
-          store.set((state) => ({
+          store.set_thr_and_optm((state) => ({
             ...state,
             threads: {
               ...state.threads,
@@ -1588,7 +1588,7 @@ function useDeleteThread(): (threadId: string) => void {
 
       room.deleteThread(threadId).then(
         () => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             if (existingThread === undefined) {
               return state;
@@ -1648,7 +1648,7 @@ function useEditThreadMetadata<M extends BaseMetadata>() {
 
       room.editThreadMetadata({ metadata, threadId }).then(
         (metadata) => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -1747,7 +1747,7 @@ function useCreateComment(): (options: CreateCommentOptions) => CommentData {
 
       room.createComment({ threadId, commentId, body }).then(
         (newComment) => {
-          store.set((state) => {
+          store.set_thr_ibn_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -1859,7 +1859,7 @@ function useEditComment(): (options: EditCommentOptions) => void {
 
       room.editComment({ threadId, commentId, body }).then(
         (editedComment) => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -1930,7 +1930,7 @@ function useDeleteComment() {
 
       room.deleteComment({ threadId, commentId }).then(
         () => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -1996,7 +1996,7 @@ function useAddReaction<M extends BaseMetadata>() {
 
       room.addReaction({ threadId, commentId, emoji }).then(
         (addedReaction) => {
-          store.set((state): UmbrellaStoreState<M> => {
+          store.set_thr_and_optm((state): UmbrellaStoreState<M> => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -2072,7 +2072,7 @@ function useRemoveReaction() {
 
       room.removeReaction({ threadId, commentId, emoji }).then(
         () => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -2155,7 +2155,7 @@ function useMarkThreadAsRead() {
 
       room.markInboxNotificationAsRead(inboxNotification.id).then(
         () => {
-          store.set((state) => ({
+          store.set_ibn_and_optm((state) => ({
             ...state,
             inboxNotifications: {
               ...state.inboxNotifications,
@@ -2211,7 +2211,7 @@ function useMarkThreadAsResolved() {
 
       room.markThreadAsResolved(threadId).then(
         () => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -2297,7 +2297,7 @@ function useMarkThreadAsUnresolved() {
 
       room.markThreadAsUnresolved(threadId).then(
         () => {
-          store.set((state) => {
+          store.set_thr_and_optm((state) => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -2482,7 +2482,7 @@ function useUpdateRoomNotificationSettings() {
 
       room.updateNotificationSettings(settings).then(
         (settings) => {
-          store.set((state) => ({
+          store.set_ibn_and_optm((state) => ({
             ...state,
             notificationSettings: {
               [room.id]: settings,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -818,7 +818,7 @@ function RoomProviderInner<
       // If thread deleted event is received, we remove the thread from the local cache
       // no need for more processing
       if (message.type === ServerMsgCode.THREAD_DELETED) {
-        store.hardDeleteThread(message.threadId);
+        store.deleteThread(message.threadId, null);
         return;
       }
 
@@ -827,7 +827,7 @@ function RoomProviderInner<
 
       // If no thread info was returned (i.e., 404), we remove the thread and relevant inbox notifications from local cache.
       if (!info.thread) {
-        store.hardDeleteThread(message.threadId);
+        store.deleteThread(message.threadId, null);
         return;
       }
       const { thread, inboxNotification } = info;
@@ -1569,7 +1569,7 @@ function useDeleteThread(): (threadId: string) => void {
       room.deleteThread(threadId).then(
         () => {
           // Replace the optimistic update by the real thing
-          store.softDeleteThread(threadId, optimisticUpdateId);
+          store.deleteThread(threadId, optimisticUpdateId);
         },
         (err: Error) =>
           onMutationFailure(

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -47,7 +47,6 @@ import {
   kInternal,
   makeEventSource,
   makePoller,
-  nanoid,
   NotificationsApiError,
   removeReaction,
   ServerMsgCode,
@@ -1512,13 +1511,10 @@ function useCreateThread<M extends BaseMetadata>(): (
         resolved: false,
       };
 
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "create-thread",
         thread: newThread,
-        id: optimisticUpdateId,
         roomId: room.id,
       });
 
@@ -1561,8 +1557,6 @@ function useDeleteThread(): (threadId: string) => void {
   const room = useRoom();
   return React.useCallback(
     (threadId: string): void => {
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient(client);
 
       const thread = store.get().threads[threadId];
@@ -1573,9 +1567,8 @@ function useDeleteThread(): (threadId: string) => void {
         throw new Error("Only the thread creator can delete the thread");
       }
 
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "delete-thread",
-        id: optimisticUpdateId,
         roomId: room.id,
         threadId,
         deletedAt: new Date(),
@@ -1630,13 +1623,10 @@ function useEditThreadMetadata<M extends BaseMetadata>() {
       const metadata = options.metadata;
       const updatedAt = new Date();
 
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "edit-thread-metadata",
         metadata,
-        id: optimisticUpdateId,
         threadId,
         updatedAt,
       });
@@ -1731,13 +1721,10 @@ function useCreateComment(): (options: CreateCommentOptions) => CommentData {
         reactions: [],
       };
 
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "create-comment",
         comment,
-        id: optimisticUpdateId,
       });
 
       room.createComment({ threadId, commentId, body }).then(
@@ -1820,7 +1807,6 @@ function useEditComment(): (options: EditCommentOptions) => void {
   return React.useCallback(
     ({ threadId, commentId, body }: EditCommentOptions): void => {
       const editedAt = new Date();
-      const optimisticUpdateId = nanoid();
 
       const { store, onMutationFailure } = getExtrasForClient(client);
       const thread = store.get().threads[threadId];
@@ -1842,14 +1828,13 @@ function useEditComment(): (options: EditCommentOptions) => void {
         return;
       }
 
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "edit-comment",
         comment: {
           ...comment,
           editedAt,
           body,
         },
-        id: optimisticUpdateId,
       });
 
       room.editComment({ threadId, commentId, body }).then(
@@ -1911,15 +1896,13 @@ function useDeleteComment() {
     ({ threadId, commentId }: DeleteCommentOptions): void => {
       const deletedAt = new Date();
 
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "delete-comment",
         threadId,
         commentId,
         deletedAt,
-        id: optimisticUpdateId,
         roomId: room.id,
       });
 
@@ -1974,10 +1957,9 @@ function useAddReaction<M extends BaseMetadata>() {
       const createdAt = new Date();
       const userId = getCurrentUserId(room);
 
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient<M>(client);
-      store.pushOptimisticUpdate({
+
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "add-reaction",
         threadId,
         commentId,
@@ -1986,7 +1968,6 @@ function useAddReaction<M extends BaseMetadata>() {
           userId,
           createdAt,
         },
-        id: optimisticUpdateId,
       });
 
       room.addReaction({ threadId, commentId, emoji }).then(
@@ -2052,17 +2033,15 @@ function useRemoveReaction() {
       const userId = getCurrentUserId(room);
 
       const removedAt = new Date();
-      const optimisticUpdateId = nanoid();
 
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "remove-reaction",
         threadId,
         commentId,
         emoji,
         userId,
         removedAt,
-        id: optimisticUpdateId,
       });
 
       room.removeReaction({ threadId, commentId, emoji }).then(
@@ -2138,12 +2117,10 @@ function useMarkThreadAsRead() {
 
       if (!inboxNotification) return;
 
-      const optimisticUpdateId = nanoid();
       const now = new Date();
 
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "mark-inbox-notification-as-read",
-        id: optimisticUpdateId,
         inboxNotificationId: inboxNotification.id,
         readAt: now,
       });
@@ -2193,13 +2170,11 @@ function useMarkThreadAsResolved() {
   const room = useRoom();
   return React.useCallback(
     (threadId: string) => {
-      const optimisticUpdateId = nanoid();
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "mark-thread-as-resolved",
-        id: optimisticUpdateId,
         threadId,
         updatedAt,
       });
@@ -2279,13 +2254,11 @@ function useMarkThreadAsUnresolved() {
   const room = useRoom();
   return React.useCallback(
     (threadId: string) => {
-      const optimisticUpdateId = nanoid();
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "mark-thread-as-unresolved",
-        id: optimisticUpdateId,
         threadId,
         updatedAt,
       });
@@ -2465,11 +2438,8 @@ function useUpdateRoomNotificationSettings() {
   const room = useRoom();
   return React.useCallback(
     (settings: Partial<RoomNotificationSettings>) => {
-      const optimisticUpdateId = nanoid();
-
       const { store, onMutationFailure } = getExtrasForClient(client);
-      store.pushOptimisticUpdate({
-        id: optimisticUpdateId,
+      const optimisticUpdateId = store.addOptimisticUpdate({
         type: "update-notification-settings",
         roomId: room.id,
         settings,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1421,6 +1421,8 @@ function useThreads<M extends BaseMetadata>(
   const { scrollOnLoad = true } = options;
   const client = useClient();
   const room = useRoom();
+
+  // e.g. 'room-abc-{"color":"red","xyz":123}'
   const queryKey = React.useMemo(
     () => generateQueryKey(room.id, options.query),
     [room, options]
@@ -2779,6 +2781,11 @@ export function createRoomContext<
   return getOrCreateRoomContextBundle<P, S, U, E, M>(client);
 }
 
+/**
+ * Example:
+ * generateQueryKey('room-abc', { xyz: 123, abc: "red" })
+ * → 'room-abc-{"color":"red","xyz":123}'
+ */
 export function generateQueryKey(
   roomId: string,
   options: UseThreadsOptions<BaseMetadata>["query"]

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -483,12 +483,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     optimisticUpdateId: string,
     createPublicError: (error: Error) => CommentsError<M>
   ) {
-    store.set_optm((state) => ({
-      ...state,
-      optimisticUpdates: state.optimisticUpdates.filter(
-        (update) => update.id !== optimisticUpdateId
-      ),
-    }));
+    store.removeOptimisticUpdate(optimisticUpdateId);
 
     if (innerError instanceof CommentsApiError) {
       const error = handleApiError(innerError);

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -16,7 +16,6 @@ import type {
 } from "@liveblocks/client";
 import { shallow } from "@liveblocks/client";
 import type {
-  CacheState,
   CacheStore,
   CommentData,
   CommentsEventServerMsg,
@@ -34,6 +33,7 @@ import type {
   StorageStatus,
   ThreadData,
   ToImmutable,
+  UmbrellaStoreState,
 } from "@liveblocks/core";
 import {
   addReaction,
@@ -1437,7 +1437,7 @@ function useThreads<M extends BaseMetadata>(
   }, [room, queryKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const selector = React.useCallback(
-    (state: CacheState<M>): ThreadsState<M> => {
+    (state: UmbrellaStoreState<M>): ThreadsState<M> => {
       const query = state.queries[queryKey];
       if (query === undefined || query.isLoading) {
         return {
@@ -1996,7 +1996,7 @@ function useAddReaction<M extends BaseMetadata>() {
 
       room.addReaction({ threadId, commentId, emoji }).then(
         (addedReaction) => {
-          store.set((state): CacheState<M> => {
+          store.set((state): UmbrellaStoreState<M> => {
             const existingThread = state.threads[threadId];
             const updatedOptimisticUpdates = state.optimisticUpdates.filter(
               (update) => update.id !== optimisticUpdateId
@@ -2369,7 +2369,7 @@ function useThreadSubscription(threadId: string): ThreadSubscription {
   const { store } = getExtrasForClient(client);
 
   const selector = React.useCallback(
-    (state: CacheState<BaseMetadata>): ThreadSubscription => {
+    (state: UmbrellaStoreState<BaseMetadata>): ThreadSubscription => {
       const inboxNotification = selectedInboxNotifications(state).find(
         (inboxNotification) =>
           inboxNotification.kind === "thread" &&
@@ -2424,7 +2424,9 @@ function useRoomNotificationSettings(): [
   const updateRoomNotificationSettings = useUpdateRoomNotificationSettings();
 
   const selector = React.useCallback(
-    (state: CacheState<BaseMetadata>): RoomNotificationSettingsState => {
+    (
+      state: UmbrellaStoreState<BaseMetadata>
+    ): RoomNotificationSettingsState => {
       const query = state.queries[makeNotificationSettingsQueryKey(room.id)];
 
       if (query === undefined || query.isLoading) {
@@ -2659,7 +2661,7 @@ function useThreadsSuspense<M extends BaseMetadata>(
   }
 
   const selector = React.useCallback(
-    (state: CacheState<M>): ThreadsStateSuccess<M> => {
+    (state: UmbrellaStoreState<M>): ThreadsStateSuccess<M> => {
       return {
         threads: selectedThreads(room.id, state, options),
         isLoading: false,
@@ -2713,7 +2715,9 @@ function useRoomNotificationSettingsSuspense(): [
   }
 
   const selector = React.useCallback(
-    (state: CacheState<BaseMetadata>): RoomNotificationSettingsStateSuccess => {
+    (
+      state: UmbrellaStoreState<BaseMetadata>
+    ): RoomNotificationSettingsStateSuccess => {
       return {
         isLoading: false,
         settings: selectNotificationSettings(room.id, state),

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -16,7 +16,6 @@ import type {
 } from "@liveblocks/client";
 import { shallow } from "@liveblocks/client";
 import type {
-  CacheStore,
   CommentData,
   CommentsEventServerMsg,
   DE,
@@ -33,6 +32,7 @@ import type {
   StorageStatus,
   ThreadData,
   ToImmutable,
+  UmbrellaStore,
   UmbrellaStoreState,
 } from "@liveblocks/core";
 import {
@@ -264,12 +264,12 @@ function getExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
   }
 
   return extras as unknown as Omit<typeof extras, "store"> & {
-    store: CacheStore<M>;
+    store: UmbrellaStore<M>;
   };
 }
 
 function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
-  const store = client[kInternal].cacheStore as unknown as CacheStore<M>;
+  const store = client[kInternal].umbrellaStore as unknown as UmbrellaStore<M>;
 
   const DEFAULT_DEDUPING_INTERVAL = 2000; // 2 seconds
 


### PR DESCRIPTION
This PR starts refactoring the "cache store". Last week, we learned that the thing called the "cache store" is actually a store for multiple Liveblocks-specific concepts, like a cache for threads, inbox notifications, etc, as well as a query state cache, and a store for optimistic updates.

I'm starting the refactoring efforts small with some non-behavioral changes:

- `CacheState` → `UmbrellaStoreState` (the purpose is to not expose this directly soon)
- `CacheStore` → `UmbrellaStore` (the purpose is to make this a black box)
- Make `UmbrellaStore` a class
- Refactor all "setters" on the `UmbrellaStore` into a collection of public methods, so that call sites aren't responsible for knowing about, and updating the internal data structures in a integrity-safe way. How the internal cache data is maintained should be (and remain) a private implementation detail, which we can go refactor further later.

### About the `UmbrellaStore` ☂️🏪

For lack of a better name, Marc and I talked about a few alternatives last week and found "umbrella store" to be the least worst of the alternatives, mainly because it's not as generic as "cache store", and "umbrella" should not associate to any existing concepts, and at the same time associate roughly to "multiple things under one roof". There is, and will be, only one umbrella store, so we can also talk about _the_ umbrella store.

If a better name pops up, we can change it again later.

### Almost all pure refactorings…

These are almost all safe/pure refactorings, not changing any behavior. However, there is one small behavioral change introduced here, which is this commit: https://github.com/liveblocks/liveblocks/pull/1916/commits/4029f69e8d8ac136365dce3113dbcdbdd3fb3b4f (we made hard and soft deletions consistent for threads).