### PR TITLE
Refactor cache store internals (day 2)

### DIFF
--- a/packages/liveblocks-core/src/__tests__/umbrella-store/addReaction.test.ts
+++ b/packages/liveblocks-core/src/__tests__/umbrella-store/addReaction.test.ts
@@ -1,5 +1,5 @@
-import { addReaction } from "../umbrella-store";
-import { createComment, createThread } from "./_dummies";
+import { addReaction } from "../../umbrella-store";
+import { createComment, createThread } from "../_dummies";
 
 describe("addReaction", () => {
   it("should add a new reaction to a comment", () => {

--- a/packages/liveblocks-core/src/__tests__/umbrella-store/applyThreadUpdates.test.tsx
+++ b/packages/liveblocks-core/src/__tests__/umbrella-store/applyThreadUpdates.test.tsx
@@ -2,8 +2,8 @@ import type {
   ThreadData,
   ThreadDataWithDeleteInfo,
   ThreadDeleteInfo,
-} from "../protocol/Comments";
-import { applyThreadUpdates } from "../umbrella-store";
+} from "../../protocol/Comments";
+import { applyThreadUpdates } from "../../umbrella-store";
 
 describe("applyThreadUpdates", () => {
   const thread1: ThreadDataWithDeleteInfo = {

--- a/packages/liveblocks-core/src/__tests__/umbrella-store/compareInboxNotifications.test.ts
+++ b/packages/liveblocks-core/src/__tests__/umbrella-store/compareInboxNotifications.test.ts
@@ -1,5 +1,5 @@
-import type { InboxNotificationData } from "../protocol/InboxNotifications";
-import { compareInboxNotifications } from "../umbrella-store";
+import type { InboxNotificationData } from "../../protocol/InboxNotifications";
+import { compareInboxNotifications } from "../../umbrella-store";
 
 describe("compareInboxNotifications", () => {
   const inboxNotificationA: InboxNotificationData = {

--- a/packages/liveblocks-core/src/__tests__/umbrella-store/compareThreads.test.ts
+++ b/packages/liveblocks-core/src/__tests__/umbrella-store/compareThreads.test.ts
@@ -1,5 +1,5 @@
-import type { ThreadData } from "../protocol/Comments";
-import { compareThreads } from "../umbrella-store";
+import type { ThreadData } from "../../protocol/Comments";
+import { compareThreads } from "../../umbrella-store";
 
 describe("compareThreads", () => {
   const thread1: ThreadData = {

--- a/packages/liveblocks-core/src/__tests__/umbrella-store/deleteComment.test.ts
+++ b/packages/liveblocks-core/src/__tests__/umbrella-store/deleteComment.test.ts
@@ -1,5 +1,5 @@
-import { deleteComment } from "../umbrella-store";
-import { createComment, createThread } from "./_dummies";
+import { deleteComment } from "../../umbrella-store";
+import { createComment, createThread } from "../_dummies";
 
 describe("deleteComment", () => {
   it("should mark a comment as deleted in a thread", () => {

--- a/packages/liveblocks-core/src/__tests__/umbrella-store/upsertComment.test.ts
+++ b/packages/liveblocks-core/src/__tests__/umbrella-store/upsertComment.test.ts
@@ -1,5 +1,5 @@
-import { upsertComment } from "../umbrella-store";
-import { createComment, createThread } from "./_dummies";
+import { upsertComment } from "../../umbrella-store";
+import { createComment, createThread } from "../_dummies";
 
 describe("upsertComment", () => {
   it("should add a new comment to an empty thread", () => {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -280,7 +280,7 @@ export {
   applyOptimisticUpdates,
   deleteComment,
   removeReaction,
-  type UmbrellaStore,
+  UmbrellaStore,
   type UmbrellaStoreState,
   upsertComment,
 } from "./umbrella-store";

--- a/packages/liveblocks-core/src/lib/create-store.ts
+++ b/packages/liveblocks-core/src/lib/create-store.ts
@@ -5,12 +5,15 @@ export type Store<T> = {
   get: () => Readonly<T>;
   set: (callback: (currentState: Readonly<T>) => Readonly<T>) => void;
   subscribe: (callback: (state: Readonly<T>) => void) => () => void;
+  batch: (callback: () => void) => void;
 };
 
 /**
  * Create a store for an immutable state. Close to Zustand's vanilla store conceptually but with less features.
  */
 export function createStore<T>(initialState: T): Store<T> {
+  let notifyImmediately = true;
+  let dirty = false;
   let state = initialState;
   const subscribers = new Set<(state: T) => void>();
 
@@ -25,15 +28,47 @@ export function createStore<T>(initialState: T): Store<T> {
    * Update the current state and notify all the subscribers of the update.
    */
   function set(callback: (currentState: T) => T) {
-    const newState = callback(state);
-    if (state === newState) {
+    const oldState = state;
+    const newState = callback(oldState);
+
+    if (newState !== oldState) {
+      state = newState;
+      dirty = true;
+    }
+
+    if (notifyImmediately) {
+      notify();
+    }
+  }
+
+  function notify() {
+    if (!dirty) {
       return;
     }
 
-    state = newState;
-
+    dirty = false;
     for (const subscriber of subscribers) {
       subscriber(state);
+    }
+  }
+
+  /**
+   * While the callback is running, do not notify any subscribers. Keep
+   * collecting (potentially multiple) .set() updates to the store, and only
+   * notify subscribers at the end of the callback.
+   */
+  function batch(cb: () => void): void {
+    if (notifyImmediately === false) {
+      // Already in a batch, make this inner batch a no-op
+      return cb();
+    }
+
+    notifyImmediately = false;
+    try {
+      cb();
+    } finally {
+      notifyImmediately = true;
+      notify();
     }
   }
 
@@ -55,6 +90,7 @@ export function createStore<T>(initialState: T): Store<T> {
   return {
     get,
     set,
+    batch,
     subscribe,
   };
 }

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -593,12 +593,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public removeOptimisticUpdate(optimisticUpdateId: string): void {
-    return this._store.set((state) => ({
-      ...state,
-      optimisticUpdates: state.optimisticUpdates.filter(
-        (update) => update.id !== optimisticUpdateId
-      ),
-    }));
+    return this.replaceOptimisticUpdate(optimisticUpdateId, (state) => state);
   }
 
   public setQueryState(queryKey: string, queryState: QueryState): void {

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -524,6 +524,8 @@ export class UmbrellaStore<M extends BaseMetadata> {
         newInboxNotifications: inboxNotifications,
         deletedNotifications: deletedInboxNotifications,
       }),
+
+      // XXX Direct mutation of query state here (this should ideally only happen through setQueryOK()
       queries:
         queryKey !== undefined
           ? {
@@ -573,6 +575,8 @@ export class UmbrellaStore<M extends BaseMetadata> {
         ...state.notificationSettings,
         [roomId]: settings,
       },
+
+      // XXX Direct mutation of query state here (this should ideally only happen through setQueryOK()
       queries: {
         ...state.queries,
         [queryKey]: { isLoading: false, data: undefined },
@@ -596,7 +600,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this.replaceOptimisticUpdate(optimisticUpdateId, (state) => state);
   }
 
-  public setQueryState(queryKey: string, queryState: QueryState): void {
+  //
+  // Query State APIs
+  //
+
+  private setQueryState(queryKey: string, queryState: QueryState): void {
     this._store.set((state) => ({
       ...state,
       queries: {
@@ -604,6 +612,18 @@ export class UmbrellaStore<M extends BaseMetadata> {
         [queryKey]: queryState,
       },
     }));
+  }
+
+  public setQueryLoading(queryKey: string): void {
+    this.setQueryState(queryKey, { isLoading: true });
+  }
+
+  // public setQueryOK(queryKey: string): void {
+  //   this.setQueryState(queryKey, { isLoading: false, data: undefined });
+  // }
+
+  public setQueryError(queryKey: string, error: Error): void {
+    this.setQueryState(queryKey, { isLoading: false, error });
   }
 }
 

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -618,9 +618,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
     this.setQueryState(queryKey, { isLoading: true });
   }
 
-  // XXX Ideally, we should somehow call this one externally to keep the
-  // symmetry with the loading/error states in the same call sites, or make the
-  // other two ones private to retain that symmetry
   private setQueryOK(queryKey: string): void {
     this.setQueryState(queryKey, { isLoading: false, data: undefined });
   }

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -240,29 +240,15 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
   private setNotificationSettings(
     roomId: string,
-    settings: RoomNotificationSettings,
-    // XXX: This mode reflects the two modes of updating that CURRENTLY EXIST
-    // XXX: Note sure if this difference is relevant here, or if we could always assume upsert?
-    // XXX: I think we can, but will make that behavior change in a separate commit
-    mode: "only-update" | "upsert"
+    settings: RoomNotificationSettings
   ): void {
-    this._store.set((state) => {
-      // If the notification setting doesn't exist in the cache, we do not change anything
-      if (mode === "only-update") {
-        const existing = state.notificationSettings[roomId];
-        if (!existing) {
-          return state;
-        }
-      }
-
-      return {
-        ...state,
-        notificationSettings: {
-          ...state.notificationSettings,
-          [roomId]: settings,
-        },
-      };
-    });
+    this._store.set((state) => ({
+      ...state,
+      notificationSettings: {
+        ...state.notificationSettings,
+        [roomId]: settings,
+      },
+    }));
   }
 
   private setQueryState(queryKey: string, queryState: QueryState): void {

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -579,7 +579,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // Batch 1️⃣ + 2️⃣
     this._store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
-      this.setNotificationSettings(roomId, settings, "only-update"); // 2️⃣
+      this.setNotificationSettings(roomId, settings); // 2️⃣
     });
   }
 
@@ -591,7 +591,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // Batch 1️⃣ + 2️⃣
     this._store.batch(() => {
       this.setQueryOK(queryKey); // 1️⃣
-      this.setNotificationSettings(roomId, settings, "upsert"); // 2️⃣
+      this.setNotificationSettings(roomId, settings); // 2️⃣
     });
   }
 

--- a/packages/liveblocks-core/src/umbrella-store.ts
+++ b/packages/liveblocks-core/src/umbrella-store.ts
@@ -206,6 +206,12 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this._store.get();
   }
 
+  public subscribe(
+    callback: (state: Readonly<UmbrellaStoreState<M>>) => void
+  ): () => void {
+    return this._store.subscribe(callback);
+  }
+
   /**
    * Only call this method from unit tests.
    *
@@ -336,12 +342,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
         return { ...state, inboxNotifications: {} };
       }
     );
-  }
-
-  public subscribe(
-    callback: (state: Readonly<UmbrellaStoreState<M>>) => void
-  ): () => void {
-    return this._store.subscribe(callback);
   }
 
   /**

--- a/packages/liveblocks-react/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react/src/__tests__/_utils.tsx
@@ -4,6 +4,7 @@ import type {
   JsonObject,
 } from "@liveblocks/client";
 import { createClient, LiveList, LiveObject } from "@liveblocks/client";
+import { kInternal, UmbrellaStore } from "@liveblocks/core";
 import type { RenderHookResult, RenderOptions } from "@testing-library/react";
 import { render, renderHook } from "@testing-library/react";
 import type { ReactElement } from "react";
@@ -84,11 +85,13 @@ export function createContextsForTest<M extends BaseMetadata>(
   }
 
   const client = createClient(clientOptions);
+  const umbrellaStore = client[kInternal].umbrellaStore as UmbrellaStore<M>;
 
   return {
     room: createRoomContext<JsonObject, never, never, never, M>(client),
     liveblocks: createLiveblocksContext(client),
     client,
+    umbrellaStore,
   };
 }
 

--- a/packages/liveblocks-react/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react/src/__tests__/_utils.tsx
@@ -4,7 +4,8 @@ import type {
   JsonObject,
 } from "@liveblocks/client";
 import { createClient, LiveList, LiveObject } from "@liveblocks/client";
-import { kInternal, UmbrellaStore } from "@liveblocks/core";
+import type { UmbrellaStore } from "@liveblocks/core";
+import { kInternal } from "@liveblocks/core";
 import type { RenderHookResult, RenderOptions } from "@testing-library/react";
 import { render, renderHook } from "@testing-library/react";
 import type { ReactElement } from "react";

--- a/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
@@ -1,4 +1,5 @@
-import { ThreadData, UmbrellaStore } from "@liveblocks/core";
+import type { ThreadData } from "@liveblocks/core";
+import { UmbrellaStore } from "@liveblocks/core";
 
 import { selectedThreads } from "../comments/lib/selected-threads";
 

--- a/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
@@ -1,18 +1,9 @@
-import type { BaseMetadata, ThreadData, UmbrellaStore } from "@liveblocks/core";
-import { createClient, kInternal } from "@liveblocks/core";
+import { ThreadData, UmbrellaStore } from "@liveblocks/core";
 
 import { selectedThreads } from "../comments/lib/selected-threads";
-import MockWebSocket from "./_MockWebSocket";
 
 describe("selectedThreads", () => {
   it("should only return resolved threads from a list of threads", () => {
-    const client = createClient({
-      publicApiKey: "pk_xxx",
-      polyfills: {
-        WebSocket: MockWebSocket as any,
-      },
-    });
-
     const thread1: ThreadData = {
       type: "thread" as const,
       id: "th_1",
@@ -33,8 +24,7 @@ describe("selectedThreads", () => {
       resolved: false,
     };
 
-    const store = client[kInternal]
-      .umbrellaStore as unknown as UmbrellaStore<BaseMetadata>;
+    const store = new UmbrellaStore();
 
     store.updateThreadsAndNotifications([thread1, thread2], [], [], []);
 

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { kInternal, nanoid, wait } from "@liveblocks/core";
+import { nanoid, wait } from "@liveblocks/core";
 import {
   act,
   fireEvent,
@@ -263,11 +263,10 @@ describe("useInboxNotifications", () => {
 
     const {
       liveblocks: { LiveblocksProvider, useInboxNotifications },
-      client,
+      umbrellaStore,
     } = createContextsForTest();
 
-    const store = client[kInternal].umbrellaStore;
-    store.force_set((state) => ({
+    umbrellaStore.force_set((state) => ({
       ...state,
       inboxNotifications: {
         // Explicitly set the order to be reversed to test that the hook sorts the notifications

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { kInternal, nanoid, ServerMsgCode } from "@liveblocks/core";
+import { nanoid, ServerMsgCode } from "@liveblocks/core";
 import type { AST } from "@liveblocks/query-parser";
 import { QueryParser } from "@liveblocks/query-parser";
 import {
@@ -954,11 +954,10 @@ describe("useThreads", () => {
 
     const {
       room: { RoomProvider, useThreads },
-      client,
+      umbrellaStore,
     } = createContextsForTest();
 
-    const store = client[kInternal].umbrellaStore;
-    store.force_set((state) => ({
+    umbrellaStore.force_set((state) => ({
       ...state,
       threads: {
         [thread1.id]: thread1,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -322,9 +322,7 @@ function makeExtrasForClient<U extends BaseUserMeta, M extends BaseMetadata>(
    * delays. Will throw eventually only if all retries fail.
    */
   const waitUntilInboxNotificationsLoaded = memoizeOnSuccess(async () => {
-    store.setQueryState(INBOX_NOTIFICATIONS_QUERY, {
-      isLoading: true,
-    });
+    store.setQueryLoading(INBOX_NOTIFICATIONS_QUERY);
 
     try {
       await autoRetry(
@@ -334,10 +332,7 @@ function makeExtrasForClient<U extends BaseUserMeta, M extends BaseMetadata>(
       );
     } catch (err) {
       // Store the error in the cache as a side-effect, for non-Suspense
-      store.setQueryState(INBOX_NOTIFICATIONS_QUERY, {
-        isLoading: false,
-        error: err as Error,
-      });
+      store.setQueryError(INBOX_NOTIFICATIONS_QUERY, err as Error);
 
       // Rethrow it for Suspense, where this promise must fail
       throw err;
@@ -423,18 +418,12 @@ function makeExtrasForClient<U extends BaseUserMeta, M extends BaseMetadata>(
    * delays. Will throw eventually only if all retries fail.
    */
   const waitUntilUserThreadsLoaded = memoizeOnSuccess(async () => {
-    store.setQueryState(USER_THREADS_QUERY, {
-      isLoading: true,
-    });
-
+    store.setQueryLoading(USER_THREADS_QUERY);
     try {
       await autoRetry(() => fetchUserThreads(), 5, [5000, 5000, 10000, 15000]);
     } catch (err) {
       // Store the error in the cache as a side-effect, for non-Suspense
-      store.setQueryState(USER_THREADS_QUERY, {
-        isLoading: false,
-        error: err as Error,
-      });
+      store.setQueryError(USER_THREADS_QUERY, err as Error);
 
       // Rethrow it for Suspense, where this promise must fail
       throw err;

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -387,10 +387,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     // Store the promise of the request for the query so that we do not make another request for the same query
     requestsByQuery.set(queryKey, request);
 
-    store.setQueryState(queryKey, {
-      isLoading: true,
-    });
-
+    store.setQueryLoading(queryKey);
     try {
       const result = await request;
 
@@ -429,10 +426,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
       }, retryCount);
 
       // Set the query state to the error state
-      store.setQueryState(queryKey, {
-        isLoading: false,
-        error: err as Error,
-      });
+      store.setQueryError(queryKey, err as Error);
     }
     return;
   }
@@ -452,11 +446,10 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
 
       requestsByQuery.set(queryKey, request);
 
-      store.setQueryState(queryKey, {
-        isLoading: true,
-      });
+      store.setQueryLoading(queryKey);
 
       const settings = await request;
+
       store.updateRoomInboxNotificationSettings(room.id, settings, queryKey);
     } catch (err) {
       requestsByQuery.delete(queryKey);
@@ -467,10 +460,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
         });
       }, retryCount);
 
-      store.setQueryState(queryKey, {
-        isLoading: false,
-        error: err as Error,
-      });
+      store.setQueryError(queryKey, err as Error);
     }
     return;
   }


### PR DESCRIPTION
Results of the next refactoring steps, where I ended on day 2. The code is best reviewed commit-by-commit.

This PR introduces a `.batch()` method on the abstract `Store` class (a new sibling to `.get()`, `.set()`, and `.subscribe()`). This allows us to perform multiple successive `.set()` calls on the store without triggering multiple notifications to subscribers. Separating `.set()` calls from notifying allows us to better split and reuse individual cache mutations and enables more DRYing up of code.

More tomorrow, where I'll be focusing on moving the UmbrellaCache into `@liveblocks/react` (out of `@liveblocks/core`).

**One behavioral change:** Please note that the only behavioral change introduces here is in [this commit](https://github.com/liveblocks/liveblocks/commit/ecf7a0df6e7451a1a2cb9022878b8d76ca790953) (which we [discussed here](https://liveblocks.slack.com/archives/C02PZL7QAAW/p1725980167039189)).
