### PR TITLE
Refactor cache store (day 3)

### DIFF
--- a/e2e/next-sandbox/pages/inbox-notifications/index.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/index.tsx
@@ -1,7 +1,7 @@
-import { kInternal } from "@liveblocks/core";
 import {
   createLiveblocksContext,
   createRoomContext,
+  getUmbrellaStoreForClient,
   useClient,
 } from "@liveblocks/react";
 import {
@@ -176,7 +176,7 @@ function TopPart() {
 
 function usePendingUpdatesCount() {
   const client = useClient();
-  const store = client[kInternal].umbrellaStore;
+  const store = getUmbrellaStoreForClient(client);
   const getter = React.useCallback(
     () => store.get().optimisticUpdates.length,
     [store]

--- a/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
@@ -1,8 +1,8 @@
-import { kInternal } from "@liveblocks/core";
 import {
   ClientSideSuspense,
   createLiveblocksContext,
   createRoomContext,
+  getUmbrellaStoreForClient,
   useClient,
 } from "@liveblocks/react";
 import {
@@ -197,7 +197,7 @@ function TopPart() {
 
 function usePendingUpdatesCount() {
   const client = useClient();
-  const store = client[kInternal].umbrellaStore;
+  const store = getUmbrellaStoreForClient(client);
   const getter = React.useCallback(
     () => store.get().optimisticUpdates.length,
     [store]

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -41,7 +41,6 @@ import {
   makeCreateSocketDelegateForRoom,
 } from "./room";
 import type { OptionalPromise } from "./types/OptionalPromise";
-import { UmbrellaStore } from "./umbrella-store";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1_000;
@@ -140,7 +139,6 @@ export type EnterOptions<P extends JsonObject = DP, S extends LsonObject = DS> =
 export type PrivateClientApi<U extends BaseUserMeta, M extends BaseMetadata> = {
   readonly currentUserIdStore: Store<string | null>;
   readonly resolveMentionSuggestions: ClientOptions<U>["resolveMentionSuggestions"];
-  readonly umbrellaStore: UmbrellaStore<BaseMetadata>;
   readonly usersStore: BatchStore<U["info"] | undefined, string>;
   readonly roomsInfoStore: BatchStore<DRI | undefined, string>;
   readonly getRoomIds: () => string[];
@@ -607,8 +605,6 @@ export function createClient<U extends BaseUserMeta = DU>(
     currentUserIdStore,
   });
 
-  const umbrellaStore = new UmbrellaStore();
-
   const resolveUsers = clientOptions.resolveUsers;
   const warnIfNoResolveUsers = createDevelopmentWarning(
     () => !resolveUsers,
@@ -665,7 +661,6 @@ export function createClient<U extends BaseUserMeta = DU>(
       [kInternal]: {
         currentUserIdStore,
         resolveMentionSuggestions: clientOptions.resolveMentionSuggestions,
-        umbrellaStore,
         usersStore,
         roomsInfoStore,
         getRoomIds() {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -109,10 +109,11 @@ export { asPos, makePosition } from "./lib/position";
 export type { Resolve } from "./lib/Resolve";
 export { shallow } from "./lib/shallow";
 export { stringify } from "./lib/stringify";
-export type { Brand } from "./lib/utils";
+export type { Brand, DistributiveOmit } from "./lib/utils";
 export {
   b64decode,
   isPlainObject,
+  mapValues,
   memoizeOnSuccess,
   raise,
   tryParseJson,
@@ -154,7 +155,11 @@ export type {
   CommentUserReactionPlain,
 } from "./protocol/Comments";
 export type { QueryMetadata } from "./protocol/Comments";
-export type { ThreadData, ThreadDataPlain } from "./protocol/Comments";
+export type {
+  ThreadData,
+  ThreadDataPlain,
+  ThreadDataWithDeleteInfo,
+} from "./protocol/Comments";
 export type { ThreadDeleteInfo } from "./protocol/Comments";
 export type {
   ActivityData,
@@ -276,12 +281,4 @@ export type { DevTools };
 
 // Store
 export type { Store } from "./lib/create-store";
-export {
-  addReaction,
-  applyOptimisticUpdates,
-  deleteComment,
-  removeReaction,
-  UmbrellaStore,
-  type UmbrellaStoreState,
-  upsertComment,
-} from "./umbrella-store";
+export { createStore } from "./lib/create-store";

--- a/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
@@ -4,9 +4,10 @@ import {
   registerNestedElementResolver,
   removeClassNamesFromElement,
 } from "@lexical/utils";
-import { kInternal, shallow } from "@liveblocks/core";
+import { shallow } from "@liveblocks/core";
 import {
   CreateThreadError,
+  getUmbrellaStoreForClient,
   selectedThreads,
   useClient,
   useCommentsErrorListener,
@@ -101,7 +102,7 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
     }
   });
 
-  const store = client[kInternal].umbrellaStore;
+  const store = getUmbrellaStoreForClient(client);
 
   const threads = useSyncExternalStoreWithSelector(
     store.subscribe,

--- a/packages/liveblocks-react/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react/src/__tests__/_utils.tsx
@@ -4,8 +4,6 @@ import type {
   JsonObject,
 } from "@liveblocks/client";
 import { createClient, LiveList, LiveObject } from "@liveblocks/client";
-import type { UmbrellaStore } from "@liveblocks/core";
-import { kInternal } from "@liveblocks/core";
 import type { RenderHookResult, RenderOptions } from "@testing-library/react";
 import { render, renderHook } from "@testing-library/react";
 import type { ReactElement } from "react";
@@ -13,6 +11,7 @@ import * as React from "react";
 
 import { createLiveblocksContext } from "../liveblocks";
 import { createRoomContext } from "../room";
+import { UmbrellaStore } from "../umbrella-store";
 import { RoomProvider } from "./_liveblocks.config";
 import MockWebSocket from "./_MockWebSocket";
 
@@ -86,7 +85,7 @@ export function createContextsForTest<M extends BaseMetadata>(
   }
 
   const client = createClient(clientOptions);
-  const umbrellaStore = client[kInternal].umbrellaStore as UmbrellaStore<M>;
+  const umbrellaStore = new UmbrellaStore<M>();
 
   return {
     room: createRoomContext<JsonObject, never, never, never, M>(client),

--- a/packages/liveblocks-react/src/__tests__/_utils.tsx
+++ b/packages/liveblocks-react/src/__tests__/_utils.tsx
@@ -9,9 +9,8 @@ import { render, renderHook } from "@testing-library/react";
 import type { ReactElement } from "react";
 import * as React from "react";
 
-import { createLiveblocksContext } from "../liveblocks";
+import { createLiveblocksContext, getExtrasForClient } from "../liveblocks";
 import { createRoomContext } from "../room";
-import { UmbrellaStore } from "../umbrella-store";
 import { RoomProvider } from "./_liveblocks.config";
 import MockWebSocket from "./_MockWebSocket";
 
@@ -85,7 +84,7 @@ export function createContextsForTest<M extends BaseMetadata>(
   }
 
   const client = createClient(clientOptions);
-  const umbrellaStore = new UmbrellaStore<M>();
+  const { store: umbrellaStore } = getExtrasForClient<M>(client);
 
   return {
     room: createRoomContext<JsonObject, never, never, never, M>(client),

--- a/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectedThreads.test.ts
@@ -1,7 +1,7 @@
 import type { ThreadData } from "@liveblocks/core";
-import { UmbrellaStore } from "@liveblocks/core";
 
 import { selectedThreads } from "../comments/lib/selected-threads";
+import { UmbrellaStore } from "../umbrella-store";
 
 describe("selectedThreads", () => {
   it("should only return resolved threads from a list of threads", () => {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/_dummies.ts
@@ -1,9 +1,9 @@
-import { nanoid } from "../lib/nanoid";
 import type {
   BaseMetadata,
   CommentData,
   ThreadDataWithDeleteInfo,
-} from "../protocol/Comments";
+} from "@liveblocks/core";
+import { nanoid } from "@liveblocks/core";
 
 export function createThread(
   overrides: Partial<ThreadDataWithDeleteInfo<BaseMetadata>> = {}

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/addReaction.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/addReaction.test.ts
@@ -1,5 +1,5 @@
 import { addReaction } from "../../umbrella-store";
-import { createComment, createThread } from "../_dummies";
+import { createComment, createThread } from "./_dummies";
 
 describe("addReaction", () => {
   it("should add a new reaction to a comment", () => {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/applyThreadUpdates.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/applyThreadUpdates.test.tsx
@@ -2,7 +2,8 @@ import type {
   ThreadData,
   ThreadDataWithDeleteInfo,
   ThreadDeleteInfo,
-} from "../../protocol/Comments";
+} from "@liveblocks/core";
+
 import { applyThreadUpdates } from "../../umbrella-store";
 
 describe("applyThreadUpdates", () => {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/compareInboxNotifications.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/compareInboxNotifications.test.ts
@@ -1,4 +1,5 @@
-import type { InboxNotificationData } from "../../protocol/InboxNotifications";
+import type { InboxNotificationData } from "@liveblocks/core";
+
 import { compareInboxNotifications } from "../../umbrella-store";
 
 describe("compareInboxNotifications", () => {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/compareThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/compareThreads.test.ts
@@ -1,4 +1,5 @@
-import type { ThreadData } from "../../protocol/Comments";
+import type { ThreadData } from "@liveblocks/core";
+
 import { compareThreads } from "../../umbrella-store";
 
 describe("compareThreads", () => {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/deleteComment.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/deleteComment.test.ts
@@ -1,5 +1,5 @@
 import { deleteComment } from "../../umbrella-store";
-import { createComment, createThread } from "../_dummies";
+import { createComment, createThread } from "./_dummies";
 
 describe("deleteComment", () => {
   it("should mark a comment as deleted in a thread", () => {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/upsertComment.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/upsertComment.test.ts
@@ -1,5 +1,5 @@
 import { upsertComment } from "../../umbrella-store";
-import { createComment, createThread } from "../_dummies";
+import { createComment, createThread } from "./_dummies";
 
 describe("upsertComment", () => {
   it("should add a new comment to an empty thread", () => {

--- a/packages/liveblocks-react/src/comments/lib/select-notification-settings.ts
+++ b/packages/liveblocks-react/src/comments/lib/select-notification-settings.ts
@@ -1,10 +1,8 @@
-import {
-  applyOptimisticUpdates,
-  type BaseMetadata,
-  nn,
-  type RoomNotificationSettings,
-  type UmbrellaStoreState,
-} from "@liveblocks/core";
+import type { BaseMetadata, RoomNotificationSettings } from "@liveblocks/core";
+import { nn } from "@liveblocks/core";
+
+import type { UmbrellaStoreState } from "../../umbrella-store";
+import { applyOptimisticUpdates } from "../../umbrella-store";
 
 export function selectNotificationSettings<M extends BaseMetadata>(
   roomId: string,

--- a/packages/liveblocks-react/src/comments/lib/selected-inbox-notifications.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-inbox-notifications.ts
@@ -1,9 +1,7 @@
-import type {
-  BaseMetadata,
-  InboxNotificationData,
-  UmbrellaStoreState,
-} from "@liveblocks/core";
-import { applyOptimisticUpdates } from "@liveblocks/core";
+import type { BaseMetadata, InboxNotificationData } from "@liveblocks/core";
+
+import type { UmbrellaStoreState } from "../../umbrella-store";
+import { applyOptimisticUpdates } from "../../umbrella-store";
 
 export function selectedInboxNotifications<M extends BaseMetadata>(
   state: UmbrellaStoreState<M>

--- a/packages/liveblocks-react/src/comments/lib/selected-threads.ts
+++ b/packages/liveblocks-react/src/comments/lib/selected-threads.ts
@@ -1,11 +1,8 @@
-import {
-  applyOptimisticUpdates,
-  type BaseMetadata,
-  type ThreadData,
-  type UmbrellaStoreState,
-} from "@liveblocks/core";
+import type { BaseMetadata, ThreadData } from "@liveblocks/core";
 
 import type { UseThreadsOptions } from "../../types";
+import type { UmbrellaStoreState } from "../../umbrella-store";
+import { applyOptimisticUpdates } from "../../umbrella-store";
 
 export function selectedUserThreads<M extends BaseMetadata>(
   state: UmbrellaStoreState<M>,

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -89,3 +89,6 @@ export {
   useUnreadInboxNotificationsCount,
   useUser,
 } from "./liveblocks";
+
+// Private APIs (for use in react-lexical only)
+export { getUmbrellaStoreForClient } from "./liveblocks";

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -234,7 +234,7 @@ function getExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
   };
 }
 
-function makeExtrasForClient(client: OpaqueClient) {
+function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
   const store = new UmbrellaStore();
 
   let lastRequestedAt: Date | undefined;

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -11,9 +11,6 @@ import type {
   DM,
   DU,
   OpaqueClient,
-  PrivateClientApi,
-  UmbrellaStore,
-  UmbrellaStoreState,
 } from "@liveblocks/core";
 import {
   assert,
@@ -55,6 +52,8 @@ import type {
   UserAsyncSuccess,
   UseUserThreadsOptions,
 } from "./types";
+import type { UmbrellaStoreState } from "./umbrella-store";
+import { UmbrellaStore } from "./umbrella-store";
 
 /**
  * Raw access to the React context where the LiveblocksProvider stores the
@@ -235,11 +234,8 @@ function getExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
   };
 }
 
-function makeExtrasForClient<U extends BaseUserMeta, M extends BaseMetadata>(
-  client: OpaqueClient
-) {
-  const internals = client[kInternal] as PrivateClientApi<U, M>;
-  const store = internals.umbrellaStore;
+function makeExtrasForClient(client: OpaqueClient) {
+  const store = new UmbrellaStore();
 
   let lastRequestedAt: Date | undefined;
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -223,7 +223,11 @@ function getOrCreateContextBundle<
   return bundle as LiveblocksContextBundle<U, M>;
 }
 
-// Gets or creates a unique Umbrella store for each unique client instance
+/**
+ * Gets or creates a unique Umbrella store for each unique client instance.
+ *
+ * @private
+ */
 export function getUmbrellaStoreForClient<M extends BaseMetadata>(
   client: OpaqueClient
 ): UmbrellaStore<M> {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -75,6 +75,7 @@ import { useLatest } from "./lib/use-latest";
 import { use } from "./lib/use-polyfill";
 import {
   createSharedContext,
+  getUmbrellaStoreForClient,
   LiveblocksProviderWithClient,
   useClient,
   useClientOrNull,
@@ -102,12 +103,11 @@ import type {
   UseStorageStatusOptions,
   UseThreadsOptions,
 } from "./types";
-import type { UmbrellaStoreState } from "./umbrella-store";
+import type { UmbrellaStore, UmbrellaStoreState } from "./umbrella-store";
 import {
   addReaction,
   deleteComment,
   removeReaction,
-  UmbrellaStore,
   upsertComment,
 } from "./umbrella-store";
 import { useScrollToCommentOnLoadEffect } from "./use-scroll-to-comment-on-load-effect";
@@ -274,7 +274,7 @@ function getExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
 }
 
 function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
-  const store = new UmbrellaStore<M>();
+  const store = getUmbrellaStoreForClient(client);
 
   const DEFAULT_DEDUPING_INTERVAL = 2000; // 2 seconds
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -112,7 +112,7 @@ import { useScrollToCommentOnLoadEffect } from "./use-scroll-to-comment-on-load-
 
 const SMOOTH_DELAY = 1000;
 
-const noop = () => { };
+const noop = () => {};
 const identity: <T>(x: T) => T = (x) => x;
 
 const missing_unstable_batchedUpdates = (
@@ -124,8 +124,8 @@ const missing_unstable_batchedUpdates = (
     import { unstable_batchedUpdates } from "react-dom";  // or "react-native"
 
     <RoomProvider id=${JSON.stringify(
-    roomId
-  )} ... unstable_batchedUpdates={unstable_batchedUpdates}>
+      roomId
+    )} ... unstable_batchedUpdates={unstable_batchedUpdates}>
       ...
     </RoomProvider>
 
@@ -2228,8 +2228,8 @@ function useHistoryVersionData(versionId: string): HistoryVersionDataState {
             error instanceof Error
               ? error
               : new Error(
-                "An unknown error occurred while loading this version"
-              ),
+                  "An unknown error occurred while loading this version"
+                ),
         });
       }
     };

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -33,26 +33,20 @@ import type {
   StorageStatus,
   ThreadData,
   ToImmutable,
-  UmbrellaStore,
-  UmbrellaStoreState,
 } from "@liveblocks/core";
 import {
-  addReaction,
   CommentsApiError,
   console,
   createCommentId,
   createThreadId,
-  deleteComment,
   deprecateIf,
   errorIf,
   kInternal,
   makeEventSource,
   makePoller,
   NotificationsApiError,
-  removeReaction,
   ServerMsgCode,
   stringify,
-  upsertComment,
 } from "@liveblocks/core";
 import * as React from "react";
 import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
@@ -108,6 +102,14 @@ import type {
   UseStorageStatusOptions,
   UseThreadsOptions,
 } from "./types";
+import type { UmbrellaStoreState } from "./umbrella-store";
+import {
+  addReaction,
+  deleteComment,
+  removeReaction,
+  UmbrellaStore,
+  upsertComment,
+} from "./umbrella-store";
 import { useScrollToCommentOnLoadEffect } from "./use-scroll-to-comment-on-load-effect";
 
 const SMOOTH_DELAY = 1000;
@@ -272,7 +274,7 @@ function getExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
 }
 
 function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
-  const store = client[kInternal].umbrellaStore as unknown as UmbrellaStore<M>;
+  const store = new UmbrellaStore<M>();
 
   const DEFAULT_DEDUPING_INTERVAL = 2000; // 2 seconds
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1,27 +1,22 @@
-import type { AsyncResult } from "./lib/AsyncResult";
-import type { Store } from "./lib/create-store";
-import { createStore } from "./lib/create-store";
-import * as console from "./lib/fancy-console";
-import { nanoid } from "./lib/nanoid";
-import type { Resolve } from "./lib/Resolve";
-import type { DistributiveOmit } from "./lib/utils";
-import { mapValues } from "./lib/utils";
 import type {
+  AsyncResult,
   BaseMetadata,
   CommentData,
   CommentReaction,
   CommentUserReaction,
+  DistributiveOmit,
+  HistoryVersion,
+  InboxNotificationData,
+  InboxNotificationDeleteInfo,
+  Patchable,
+  Resolve,
+  RoomNotificationSettings,
+  Store,
   ThreadData,
   ThreadDataWithDeleteInfo,
   ThreadDeleteInfo,
-} from "./protocol/Comments";
-import type {
-  InboxNotificationData,
-  InboxNotificationDeleteInfo,
-} from "./protocol/InboxNotifications";
-import type { HistoryVersion } from "./protocol/VersionHistory";
-import type { Patchable } from "./types/Patchable";
-import type { RoomNotificationSettings } from "./types/RoomNotificationSettings";
+} from "@liveblocks/core";
+import { console, createStore, mapValues, nanoid } from "@liveblocks/core";
 
 type OptimisticUpdate<M extends BaseMetadata> =
   | CreateThreadOptimisticUpdate<M>

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -286,11 +286,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
   // ---------------------------------------------------------------------------------- }}}
 
-  /**
-   * Only call this method from unit tests.
-   *
-   * @private
-   */
+  /** @internal - Only call this method from unit tests. */
   public force_set(
     callback: (
       currentState: Readonly<UmbrellaStoreState<M>>

--- a/shared/jest-config/index.js
+++ b/shared/jest-config/index.js
@@ -10,7 +10,7 @@ module.exports = {
 
   preset: "ts-jest",
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
-  testPathIgnorePatterns: ["__tests__/_.*"],
+  testPathIgnorePatterns: ["__tests__/_.*", "__tests__/(.+/)*_.*"],
   roots: ["<rootDir>/src"],
 
   // Ensure `window.fetch` is polyfilled if it isn't available in the runtime


### PR DESCRIPTION
Full refactoring history:
- #1916
- #1920
- #1925 👈 This PR!

---

This PR moves UmbrellaStore from `core` → `react`.

Fixes LB-1254.
