### PR TITLE
Fix: version history documentation

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -1567,6 +1567,7 @@ specific verions. These components aid in displaying a list of those versions.
 
 Displays a version summary which includes the author and date.
 
+```tsx
 <HistoryVersionSummary
   onClick={() => {
     setSelectedVersionId(version.id);
@@ -1574,6 +1575,7 @@ Displays a version summary which includes the author and date.
   version={version}
   selected={version.id === selectedVersionId}
 />
+```
 
 ##### Props [#HistoryVersionSummary-props]
 


### PR DESCRIPTION
Small fix into the version history documentation to fix the `liveblocks.io` build