### PR TITLE
Add `hideResolvedThreadMarks` prop to LiveblocksPlugin

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -412,15 +412,6 @@ rendering until threads have loaded.
 </LexicalComposer>
 ```
 
-When a thread is resolved, its text mark is still highlighted in the editor.
-Finish up by hiding these resolved thread highlights using CSS.
-
-```css
-.lb-lexical-thread-mark[data-resolved] {
-  all: unset;
-}
-```
-
 #### Customization [#FloatingThreads-customization]
 
 The `FloatingThreads` component acts as a wrapper around each individual
@@ -658,15 +649,6 @@ rendering until threads have loaded.
 </LexicalComposer>
 ```
 
-When a thread is resolved, its text mark is still highlighted in the editor.
-Finish up by hiding these resolved thread highlights using CSS.
-
-```css
-.lb-lexical-thread-mark[data-resolved] {
-  all: unset;
-}
-```
-
 #### Customization [#AnchoredThreads-customization]
 
 The `AnchoredThreads` component acts as a wrapper around each [`Thread`][]. It
@@ -873,19 +855,6 @@ import "@liveblocks/react-lexical/styles.css";
 Adding dark mode and customizing your styles is part of `@liveblocks/react-ui`,
 learn how to do this under
 [styling and customization](/docs/api-reference/liveblocks-react-ui#Styling-and-customization).
-
-### Hiding resolved thread marks
-
-When a thread is created with the [`FloatingComposer`][], a thread mark is left
-in the editor, highlighting the selected text attached to the thread. However,
-after a thread is resolved, you may wish to hide this mark. To do so, select
-marks with the `data-resolved` attribute and reset their styles.
-
-```css
-.lb-lexical-thread-mark[data-resolved] {
-  all: unset;
-}
-```
 
 [`LiveblocksPlugin`]: #LiveblocksPlugin
 [`LexicalComposer`]: https://lexical.dev/docs/react/plugins

--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -412,6 +412,15 @@ rendering until threads have loaded.
 </LexicalComposer>
 ```
 
+When a thread is resolved, its text mark is still highlighted in the editor.
+Finish up by hiding these resolved thread highlights using CSS.
+
+```css
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}
+```
+
 #### Customization [#FloatingThreads-customization]
 
 The `FloatingThreads` component acts as a wrapper around each individual
@@ -649,6 +658,15 @@ rendering until threads have loaded.
 </LexicalComposer>
 ```
 
+When a thread is resolved, its text mark is still highlighted in the editor.
+Finish up by hiding these resolved thread highlights using CSS.
+
+```css
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}
+```
+
 #### Customization [#AnchoredThreads-customization]
 
 The `AnchoredThreads` component acts as a wrapper around each [`Thread`][]. It
@@ -855,6 +873,19 @@ import "@liveblocks/react-lexical/styles.css";
 Adding dark mode and customizing your styles is part of `@liveblocks/react-ui`,
 learn how to do this under
 [styling and customization](/docs/api-reference/liveblocks-react-ui#Styling-and-customization).
+
+### Hiding resolved thread marks
+
+When a thread is created with the [`FloatingComposer`][], a thread mark is left
+in the editor, highlighting the selected text attached to the thread. However,
+after a thread is resolved, you may wish to hide this mark. To do so, select
+marks with the `data-resolved` attribute and reset their styles.
+
+```css
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}
+```
 
 [`LiveblocksPlugin`]: #LiveblocksPlugin
 [`LexicalComposer`]: https://lexical.dev/docs/react/plugins

--- a/examples/nextjs-lexical/app/lexical/editor.tsx
+++ b/examples/nextjs-lexical/app/lexical/editor.tsx
@@ -37,7 +37,7 @@ export default function Editor() {
   return (
     <div className="relative min-h-screen flex flex-col">
       <LexicalComposer initialConfig={initialConfig}>
-        <LiveblocksPlugin>
+        <LiveblocksPlugin hideResolvedThreadMarks={true}>
           {status === "not-loaded" || status === "loading" ? (
             <Loading />
           ) : (
@@ -80,7 +80,7 @@ export default function Editor() {
 }
 
 function Threads() {
-  const { threads } = useThreads();
+  const { threads } = useThreads({ query: { resolved: false } }); // Only show unresolved threads
   const isMobile = useIsMobile();
 
   return isMobile ? (

--- a/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
@@ -91,6 +91,10 @@ export function useEditorStatus(): EditorStatus {
 
 export type LiveblocksPluginProps = {
   children?: React.ReactNode;
+  /**
+   * Whether to hide thread marks associated to resolved threads or not, defaults to false
+   */
+  hideResolvedThreadMarks?: boolean;
 };
 
 /**
@@ -128,6 +132,7 @@ export type LiveblocksPluginProps = {
  */
 export const LiveblocksPlugin = ({
   children,
+  hideResolvedThreadMarks = false,
 }: LiveblocksPluginProps): JSX.Element => {
   const client = useClient();
   const hasResolveMentionSuggestions =
@@ -261,7 +266,9 @@ export const LiveblocksPlugin = ({
       )}
 
       {hasResolveMentionSuggestions && <MentionPlugin />}
-      <CommentPluginProvider>{children}</CommentPluginProvider>
+      <CommentPluginProvider hideResolvedThreadMarks={hideResolvedThreadMarks}>
+        {children}
+      </CommentPluginProvider>
     </>
   );
 };


### PR DESCRIPTION
This pull request adds a new prop, `hideResolvedThreadMarks`, to the `LiveblocksPlugin` component in the `liveblocks-react-lexical` package. This prop controls whether resolved thread marks are hidden or not on the editor. The default value is `false`. The `CommentPluginProvider` component has also been updated to handle this prop and hide the thread marks associated with resolved threads if `hideResolvedThreadMarks` is set to `true`.