### PR TITLE
Add `data-resolved` attribute to annotations associated with resolved threads

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -412,6 +412,15 @@ rendering until threads have loaded.
 </LexicalComposer>
 ```
 
+When a thread is resolved, its text mark is still highlighted in the editor.
+Finish up by hiding these resolved thread highlights using CSS.
+
+```css
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}
+```
+
 #### Customization [#FloatingThreads-customization]
 
 The `FloatingThreads` component acts as a wrapper around each individual
@@ -649,6 +658,15 @@ rendering until threads have loaded.
 </LexicalComposer>
 ```
 
+When a thread is resolved, its text mark is still highlighted in the editor.
+Finish up by hiding these resolved thread highlights using CSS.
+
+```css
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}
+```
+
 #### Customization [#AnchoredThreads-customization]
 
 The `AnchoredThreads` component acts as a wrapper around each [`Thread`][]. It
@@ -855,6 +873,19 @@ import "@liveblocks/react-lexical/styles.css";
 Adding dark mode and customizing your styles is part of `@liveblocks/react-ui`,
 learn how to do this under
 [styling and customization](/docs/api-reference/liveblocks-react-ui#Styling-and-customization).
+
+### Hiding resolved thread marks
+
+When a thread is created with the [`FloatingComposer`][], a thread mark is left
+in the editor, highlighting the selected text attached to the thread. However,
+after a thread is resolved, you may wish to hide this mark. To do so, select
+marks with the `data-resolved` attribute and reset their styles.
+
+```css
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}
+```
 
 [`LiveblocksPlugin`]: #LiveblocksPlugin
 [`LexicalComposer`]: https://lexical.dev/docs/react/plugins

--- a/examples/nextjs-lexical/app/globals.css
+++ b/examples/nextjs-lexical/app/globals.css
@@ -130,3 +130,7 @@ li::marker {
   text-align: start !important;
   text-align-last: start !important;
 }
+
+.lb-lexical-thread-mark[data-resolved] {
+  all: unset;
+}

--- a/examples/nextjs-lexical/app/lexical/editor.tsx
+++ b/examples/nextjs-lexical/app/lexical/editor.tsx
@@ -80,7 +80,7 @@ export default function Editor() {
 }
 
 function Threads() {
-  const { threads } = useThreads();
+  const { threads } = useThreads({ query: { resolved: false } });
   const isMobile = useIsMobile();
 
   return isMobile ? (

--- a/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
@@ -74,7 +74,12 @@ export function AnchoredThreads({
   const Thread = components?.Thread ?? DefaultThread;
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const activeThreads = useActiveThreads();
+  const _activeThreads = useActiveThreads();
+  const activeThreads = useMemo(
+    () =>
+      _activeThreads.filter((id) => threads.some((thread) => thread.id === id)),
+    [_activeThreads, threads]
+  );
 
   const nodes = useThreadToNodes(); // A map of thread ids to a set of thread mark nodes associated with the thread
 


### PR DESCRIPTION
This pull request includes updates to the thread marks and resolved threads handling. The `data-resolved` attribute has been added to thread marks associated with resolved threads. 

Additionally, the handling of active threads has been improved to filter out threads that are not present in the current set of threads.