### PR TITLE
Fix shallow checks to reduce unnecessary re-rendering

### DIFF
--- a/packages/liveblocks-core/src/lib/shallow.ts
+++ b/packages/liveblocks-core/src/lib/shallow.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from "./utils";
+
 function shallowArray(xs: unknown[], ys: unknown[]): boolean {
   if (xs.length !== ys.length) {
     return false;
@@ -12,17 +14,10 @@ function shallowArray(xs: unknown[], ys: unknown[]): boolean {
   return true;
 }
 
-function shallowObj<T, U>(objA: T, objB: U): boolean {
+function shallowObj(objA: unknown, objB: unknown): boolean {
   // Only try to compare keys/values if these objects are both "pojos" (plain
   // old JavaScript objects)
-  if (
-    typeof objA !== "object" ||
-    objA === null ||
-    typeof objB !== "object" ||
-    objB === null ||
-    Object.prototype.toString.call(objA) !== "[object Object]" ||
-    Object.prototype.toString.call(objB) !== "[object Object]"
-  ) {
+  if (!isPlainObject(objA) || !isPlainObject(objB)) {
     return false;
   }
 
@@ -34,7 +29,7 @@ function shallowObj<T, U>(objA: T, objB: U): boolean {
   return keysA.every(
     (key) =>
       Object.prototype.hasOwnProperty.call(objB, key) &&
-      Object.is(objA[key as keyof T], objB[key as keyof U])
+      Object.is(objA[key], objB[key])
   );
 }
 

--- a/packages/liveblocks-react/src/lib/__tests__/shallow2.test.ts
+++ b/packages/liveblocks-react/src/lib/__tests__/shallow2.test.ts
@@ -1,0 +1,51 @@
+import { shallow } from "@liveblocks/core";
+
+import { shallow2 } from "../shallow2";
+
+const THING1 = { a: 1 };
+const THING2 = { a: 2 };
+const THING3 = { b: 3 };
+const THING4 = { b: 4 };
+const THINGS = [THING1, THING2, THING3, THING4];
+
+describe("two-level deep shallow equality checks", () => {
+  test("basic similarity with normal shallow", () => {
+    expect(shallow(THINGS, THINGS)).toBe(true);
+    expect(shallow2(THINGS, THINGS)).toBe(true);
+    expect(shallow(THINGS.slice(), THINGS.slice())).toBe(true);
+    expect(shallow2(THINGS.slice(), THINGS.slice())).toBe(true);
+  });
+
+  test("difference with with normal shallow", () => {
+    // Here, they would behave equal...
+    const x = { isLoading: false, myData: THINGS };
+    const y = { isLoading: false, myData: THINGS };
+    expect(shallow(x, y)).toBe(true);
+    expect(shallow2(x, y)).toBe(true);
+
+    // But here, there is the difference
+    const xx = { isLoading: false, myData: THINGS.slice() };
+    const yy = { isLoading: false, myData: THINGS.slice() };
+    expect(shallow(xx, yy)).toBe(false);
+    expect(shallow2(xx, yy)).toBe(true);
+  });
+
+  test("ordering of object keys should not matter", () => {
+    const x = { isLoading: false, myData: THINGS };
+    const y = { myData: THINGS, isLoading: false };
+    expect(shallow(x, y)).toBe(true);
+    expect(shallow2(x, y)).toBe(true);
+
+    const xx = { isLoading: false, myData: THINGS.slice() };
+    const yy = { myData: THINGS.slice(), isLoading: false };
+    expect(shallow(xx, yy)).toBe(false);
+    expect(shallow2(xx, yy)).toBe(true);
+  });
+
+  test("explicit-undefined matters", () => {
+    const x = { myData: THINGS, isLoading: undefined };
+    const y = { myData: THINGS };
+    expect(shallow(x, y)).toBe(false);
+    expect(shallow2(x, y)).toBe(false);
+  });
+});

--- a/packages/liveblocks-react/src/lib/shallow2.ts
+++ b/packages/liveblocks-react/src/lib/shallow2.ts
@@ -1,0 +1,25 @@
+import { isPlainObject, shallow } from "@liveblocks/core";
+
+/**
+ * Two-level deep shallow check.
+ * Useful for checking equality of { isLoading: false, myData: [ ... ] } like
+ * data structures, where you want to do a shallow comparison on the "data"
+ * key.
+ *
+ * NOTE: Works on objects only, not on arrays!
+ */
+export function shallow2(a: unknown, b: unknown): boolean {
+  if (!isPlainObject(a) || !isPlainObject(b)) {
+    return shallow(a, b);
+  }
+
+  const keysA = Object.keys(a);
+  if (keysA.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  return keysA.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(b, key) && shallow(a[key], b[key])
+  );
+}

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -37,6 +37,7 @@ import { useIsInsideRoom } from "./contexts";
 import { byFirstCreated, byMostRecentlyUpdated } from "./lib/compare";
 import { makeThreadsFilter } from "./lib/querying";
 import { autoRetry, retryError } from "./lib/retry-error";
+import { shallow2 } from "./lib/shallow2";
 import { useInitial, useInitialUnlessFunction } from "./lib/use-initial";
 import { use } from "./lib/use-polyfill";
 import type {
@@ -1193,7 +1194,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
     store.getThreads,
     store.getThreads,
     selector,
-    shallow
+    shallow2 // NOTE: Using 2-level-deep shallow check here, because the result of selectThreads() is not stable!
   );
 }
 
@@ -1262,7 +1263,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
     store.getThreads,
     store.getThreads,
     selector,
-    shallow
+    shallow2 // NOTE: Using 2-level-deep shallow check here, because the result of selectThreads() is not stable!
   );
 }
 


### PR DESCRIPTION
This PR adds a `shallow2` helper which is like `shallow`, except that it will perform a 2-level deep shallow test instead.

This is needed to avoid unnecessary re-renders of components where the selector returns values like this:

```tsx
return {
  isLoading: false,
  threads: selectThreads(...),
}
```

Those will never pass the `shallow()` test, because the `selectThreads()` helper is basically a filter that will thus never return a stable value, because it's a new array every time.

This is only needed for the hooks that currently do dynamic filtering in the selector, because most other hooks by now will already just return a stable result. This didn't use to be the case, but after last week's refactorings all pre-processing, filtering, and ordering is now happening on writes to the store, no longer on reads.
