### PR TITLE
Refactor cache store: expose getters to read data as async results

### DIFF
--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -14,10 +14,13 @@ describe("Umbrella Store", () => {
   it("getters returns the expected shapes", () => {
     const store = new UmbrellaStore();
 
+    // Sync getters
     expect(store.getThreads()).toEqual(empty);
-    expect(store.getInboxNotifications()).toEqual(empty);
     expect(store.getNotificationSettings()).toEqual(empty);
     expect(store.getVersions()).toEqual(empty);
+
+    // Sync async-results getters
+    expect(store.getInboxNotificationsAsync()).toEqual(empty);
   });
 
   it("calling getters multiple times should always return a stable result", () => {
@@ -25,10 +28,14 @@ describe("Umbrella Store", () => {
 
     // IMPORTANT! Strict equality expected!
     expect(store.getThreads()).toBe(store.getThreads());
-    expect(store.getInboxNotifications()).toBe(store.getInboxNotifications());
     expect(store.getNotificationSettings()).toBe(
       store.getNotificationSettings()
     );
     expect(store.getVersions()).toBe(store.getVersions());
+
+    // Sync async-results getter
+    expect(store.getInboxNotificationsAsync()).toBe(
+      store.getInboxNotificationsAsync()
+    );
   });
 });

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -10,17 +10,19 @@ const empty = {
   versionsByRoomId: {},
 } as const;
 
+const loading = { isLoading: true };
+
 describe("Umbrella Store", () => {
   it("getters returns the expected shapes", () => {
     const store = new UmbrellaStore();
 
     // Sync getters
     expect(store.getThreads()).toEqual(empty);
-    expect(store.getNotificationSettings()).toEqual(empty);
     expect(store.getVersions()).toEqual(empty);
 
     // Sync async-results getters
-    expect(store.getInboxNotificationsAsync()).toEqual(empty);
+    expect(store.getInboxNotificationsAsync()).toEqual(loading);
+    expect(store.getNotificationSettingsAsync("room-a")).toEqual(loading);
   });
 
   it("calling getters multiple times should always return a stable result", () => {
@@ -28,15 +30,16 @@ describe("Umbrella Store", () => {
 
     // IMPORTANT! Strict equality expected!
     expect(store.getThreads()).toBe(store.getThreads());
-    expect(store.getNotificationSettings()).toBe(
-      store.getNotificationSettings()
-    );
     expect(store.getVersions()).toBe(store.getVersions());
 
     // Sync async-results getter
     // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that
     expect(store.getInboxNotificationsAsync()).toBe(
       store.getInboxNotificationsAsync()
+    );
+    // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that
+    expect(store.getNotificationSettingsAsync("room-a")).toBe(
+      store.getNotificationSettingsAsync("room-a")
     );
   });
 });

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -34,6 +34,7 @@ describe("Umbrella Store", () => {
     expect(store.getVersions()).toBe(store.getVersions());
 
     // Sync async-results getter
+    // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that
     expect(store.getInboxNotificationsAsync()).toBe(
       store.getInboxNotificationsAsync()
     );

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -13,7 +13,7 @@ import { setupServer } from "msw/node";
 import React, { Suspense } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 
-import { INBOX_NOTIFICATIONS_QUERY, POLLING_INTERVAL } from "../liveblocks";
+import { POLLING_INTERVAL } from "../liveblocks";
 import { dummyThreadData, dummyThreadInboxNotificationData } from "./_dummies";
 import MockWebSocket from "./_MockWebSocket";
 import { mockGetInboxNotifications } from "./_restMocks";
@@ -274,7 +274,7 @@ describe("useInboxNotifications", () => {
         [newInboxNotification.id]: newInboxNotification,
       },
       queries: {
-        [INBOX_NOTIFICATIONS_QUERY]: { isLoading: false, data: undefined },
+        INBOX_NOTIFICATIONS: { isLoading: false, data: undefined },
       },
     }));
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -61,11 +61,8 @@ import { INBOX_NOTIFICATIONS_QUERY, UmbrellaStore } from "./umbrella-store";
 // NOTE: The reason we cannot inline them into the selectors is that the react-hooks/exchaustive-deps lint rule will think
 type GetInboxNotificationsType<M extends BaseMetadata = BaseMetadata> =
   ReturnType<UmbrellaStore<M>["getInboxNotifications"]>;
-export type GetThreadsType<M extends BaseMetadata = BaseMetadata> = ReturnType<
+type GetThreadsType<M extends BaseMetadata = BaseMetadata> = ReturnType<
   UmbrellaStore<M>["getThreads"]
->;
-export type GetNotificationSettingsType = ReturnType<
-  UmbrellaStore<BaseMetadata>["getNotificationSettings"]
 >;
 
 /**

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -427,7 +427,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     }
   }
 
-  // XXX Hmm. All of this is stuff that should be managed by the cache. Now we have caches in different places.
+  // TODO Hmm. All of this is stuff that should be managed by the cache. Now we have caches in different places.
   const userThreadsSubscribersByQuery = new Map<string, number>();
   const userThreadsRequestsByQuery = new Map<string, Promise<unknown>>();
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -106,7 +106,9 @@ export const USER_THREADS_QUERY = "USER_THREADS";
 function selectorFor_useInboxNotifications(
   state: ReturnType<UmbrellaStore<BaseMetadata>["getInboxNotifications"]>
 ): InboxNotificationsState {
-  // TODO Can we make this a static property, rather than a static key in a dynamic map?
+  // XXX Selectors like this should not be responsible for the wrapping back
+  // XXX into loading states. This data should be the _input_ to the selectors.
+  // XXX The _getters_ should get the AsyncResults instead.
   const query = state.queries[INBOX_NOTIFICATIONS_QUERY];
 
   if (query === undefined || query.isLoading) {
@@ -455,6 +457,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     }
   }
 
+  // XXX Hmm. All of this is stuff that should be managed by the cache. Now we have caches in different places.
   const userThreadsSubscribersByQuery = new Map<string, number>();
   const userThreadsRequestsByQuery = new Map<string, Promise<unknown>>();
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1456,6 +1456,8 @@ function useThreads<M extends BaseMetadata>(
 
   const selector = React.useCallback(
     (state: UmbrellaStoreState<M>): ThreadsState<M> => {
+      // TODO Don't make this the responsibility of the _selector_. It should be
+      // responsibility of the _getter_.
       const query = state.queries[queryKey];
       if (query === undefined || query.isLoading) {
         return {

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -176,6 +176,7 @@ export type InboxNotificationsStateError = {
   error: Error;
 };
 
+// TODO Think about ways to remove these types as global exports
 export type InboxNotificationsState =
   | InboxNotificationsStateLoading
   | InboxNotificationsStateSuccess
@@ -199,6 +200,7 @@ export type UnreadInboxNotificationsCountStateError = {
   error: Error;
 };
 
+// TODO Think about ways to remove these types as global exports
 export type UnreadInboxNotificationsCountState =
   | UnreadInboxNotificationsCountStateLoading
   | UnreadInboxNotificationsCountStateSuccess

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -159,6 +159,7 @@ type QueryState = AsyncResult<undefined>;
 const QUERY_STATE_LOADING = Object.freeze({ isLoading: true });
 const QUERY_STATE_OK = Object.freeze({ isLoading: false, data: undefined });
 
+// TODO Stop exporting this constant!
 export const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
 
 type InternalState<M extends BaseMetadata> = Readonly<{
@@ -182,7 +183,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
    * e.g. 'room-abc-{"color":"red"}'  - ok
    * e.g. 'room-abc-{}'               - loading
    */
-  // XXX Query state should not be exposed publicly by the store!
+  // TODO Query state should not be exposed publicly by the store!
   queries: Record<string, QueryState>;
 
   /**
@@ -277,7 +278,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public getInboxNotifications(): UmbrellaStoreState<M> {
-    // XXX Return only the stable reference to the inboxNotifications property
+    // TODO Now that we have getInboxNotificationsAsync, can we get rid of this method already?
     return this.get();
   }
 
@@ -297,12 +298,12 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }
 
     const inboxNotifications = this.get().inboxNotifications;
-    // XXX Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
+    // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return { inboxNotifications, isLoading: false };
   }
 
   public getNotificationSettings(): UmbrellaStoreState<M> {
-    // XXX Return only the stable reference to the notificationSettings property
+    // TODO Return only the stable reference to the notificationSettings property
     return this.get();
   }
 
@@ -325,27 +326,27 @@ export class UmbrellaStore<M extends BaseMetadata> {
    * @private Only used by the E2E test suite.
    */
   public _subscribeOptimisticUpdates(callback: () => void): () => void {
-    // XXX Make this actually only update when optimistic updates are changed
+    // TODO Make this actually only update when optimistic updates are changed
     return this.subscribe(callback);
   }
 
   public subscribeThreads(callback: () => void): () => void {
-    // XXX Make this actually only update when threads are invalidated
+    // TODO Make this actually only update when threads are invalidated
     return this.subscribe(callback);
   }
 
   public subscribeInboxNotifications(callback: () => void): () => void {
-    // XXX Make this actually only update when inbox notifications are invalidated
+    // TODO Make this actually only update when inbox notifications are invalidated
     return this.subscribe(callback);
   }
 
   public subscribeNotificationSettings(callback: () => void): () => void {
-    // XXX Make this actually only update when notification settings are invalidated
+    // TODO Make this actually only update when notification settings are invalidated
     return this.subscribe(callback);
   }
 
   public subscribeVersions(callback: () => void): () => void {
-    // XXX Make this actually only update when versions are invalidated
+    // TODO Make this actually only update when versions are invalidated
     return this.subscribe(callback);
   }
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -23,6 +23,7 @@ import {
   createStore,
   mapValues,
   nanoid,
+  nn,
 } from "@liveblocks/core";
 
 import { isMoreRecentlyUpdated } from "./lib/compare";
@@ -161,6 +162,11 @@ const QUERY_STATE_OK = Object.freeze({ isLoading: false, data: undefined });
 
 // TODO Stop exporting this constant!
 export const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
+
+// XXX Stop exporting this helper!
+export function makeNotificationSettingsQueryKey(roomId: string) {
+  return `${roomId}:NOTIFICATION_SETTINGS`;
+}
 
 type InternalState<M extends BaseMetadata> = Readonly<{
   queries: Record<string, QueryState>;
@@ -305,6 +311,27 @@ export class UmbrellaStore<M extends BaseMetadata> {
   public getNotificationSettings(): UmbrellaStoreState<M> {
     // TODO Return only the stable reference to the notificationSettings property
     return this.get();
+  }
+
+  public getNotificationSettingsAsync(
+    roomId: string
+  ): AsyncResultWithDataField<RoomNotificationSettings, "settings"> {
+    const state = this.get();
+
+    const query = state.queries[makeNotificationSettingsQueryKey(roomId)];
+
+    if (query === undefined || query.isLoading) {
+      return { isLoading: true };
+    }
+
+    if (query.error !== undefined) {
+      return { isLoading: false, error: query.error };
+    }
+
+    return {
+      isLoading: false,
+      settings: nn(state.notificationSettingsByRoomId[roomId]),
+    };
   }
 
   public getVersions(): UmbrellaStoreState<M> {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -262,7 +262,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     const rawState = this._store.get();
     if (this._prevState !== rawState || this._stateCached === null) {
       this._prevState = rawState;
-      this._stateCached = applyOptimisticUpdates(rawState);
+      this._stateCached = internalToExternalState(rawState);
     }
     return this._stateCached;
   }
@@ -836,7 +836,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 }
 
-function applyOptimisticUpdates<M extends BaseMetadata>(
+function internalToExternalState<M extends BaseMetadata>(
   state: InternalState<M>
 ): UmbrellaStoreState<M> {
   const output = {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -155,6 +155,9 @@ type UpdateNotificationSettingsOptimisticUpdate = {
 type QueryState = AsyncResult<undefined>;
 //                            ^^^^^^^^^ We don't store the actual query result in this status
 
+const QUERY_STATE_LOADING = Object.freeze({ isLoading: true });
+const QUERY_STATE_OK = Object.freeze({ isLoading: false, data: undefined });
+
 type InternalState<M extends BaseMetadata> = Readonly<{
   queries: Record<string, QueryState>;
   optimisticUpdates: readonly OptimisticUpdate<M>[];
@@ -821,11 +824,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
   //
 
   public setQueryLoading(queryKey: string): void {
-    this.setQueryState(queryKey, { isLoading: true });
+    this.setQueryState(queryKey, QUERY_STATE_LOADING);
   }
 
   private setQueryOK(queryKey: string): void {
-    this.setQueryState(queryKey, { isLoading: false, data: undefined });
+    this.setQueryState(queryKey, QUERY_STATE_OK);
   }
 
   public setQueryError(queryKey: string, error: Error): void {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -176,6 +176,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
    * e.g. 'room-abc-{"color":"red"}'  - ok
    * e.g. 'room-abc-{}'               - loading
    */
+  // XXX Query state should not be exposed publicly by the store!
   queries: Record<string, QueryState>;
 
   /**
@@ -268,12 +269,12 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public getInboxNotifications(): UmbrellaStoreState<M> {
-    // TODO Return only the stable reference to the inboxNotifications property
+    // XXX Return only the stable reference to the inboxNotifications property
     return this.get();
   }
 
   public getNotificationSettings(): UmbrellaStoreState<M> {
-    // TODO Return only the stable reference to the notificationSettings property
+    // XXX Return only the stable reference to the notificationSettings property
     return this.get();
   }
 
@@ -296,27 +297,27 @@ export class UmbrellaStore<M extends BaseMetadata> {
    * @private Only used by the E2E test suite.
    */
   public _subscribeOptimisticUpdates(callback: () => void): () => void {
-    // TODO Make this actually only update when optimistic updates are changed
+    // XXX Make this actually only update when optimistic updates are changed
     return this.subscribe(callback);
   }
 
   public subscribeThreads(callback: () => void): () => void {
-    // TODO Make this actually only update when threads are invalidated
+    // XXX Make this actually only update when threads are invalidated
     return this.subscribe(callback);
   }
 
   public subscribeInboxNotifications(callback: () => void): () => void {
-    // TODO Make this actually only update when inbox notifications are invalidated
+    // XXX Make this actually only update when inbox notifications are invalidated
     return this.subscribe(callback);
   }
 
   public subscribeNotificationSettings(callback: () => void): () => void {
-    // TODO Make this actually only update when notification settings are invalidated
+    // XXX Make this actually only update when notification settings are invalidated
     return this.subscribe(callback);
   }
 
   public subscribeVersions(callback: () => void): () => void {
-    // TODO Make this actually only update when versions are invalidated
+    // XXX Make this actually only update when versions are invalidated
     return this.subscribe(callback);
   }
 


### PR DESCRIPTION
Next refactoring baby steps from today, which we talked about on the call just now.

Biggest changes is how the selectors for the inbox notification hooks are no longer responsible for "recomputing/emulating" an async result from (1) the `store.get` synchronous read and (2) the query state, but instead the only way to read from the store is an async result in the first place, which gets rid of both the selector logic, and the need to expose the raw query state as an externally observable piece of state. It basically makes the query state an implementation detail.
