### PR TITLE
Fix resolved threads display on Lexical editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.7.1
+
+### `@liveblocks/react-lexical`
+
+- Fixed a bug where resolved threads remained visible in the editor and the
+  `AnchoredThreads` and `FloatingThreads` components.
+
 ## 2.7.0
 
 ### `@liveblocks/client`

--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -70,6 +70,13 @@ function Editor() {
 }
 ```
 
+<Banner title="Resolved threads">
+
+Annotations associated with resolved threads are hidden by default on the
+editor.
+
+</Banner>
+
 Learn more in our [get started guide](/docs/get-started/yjs-lexical-react).
 
 ### liveblocksConfig
@@ -327,6 +334,13 @@ function Editor() {
 
 Should be nested inside [`LiveblocksPlugin`][].
 
+<Banner title="Resolved threads">
+
+The `AnchoredThreads` component automatically excludes resolved threads from
+display. Any resolved threads passed in the threads list will not be shown.
+
+</Banner>
+
 #### Recommended usage [#FloatingThreads-recommended-usage]
 
 [`FloatingThreads`][] and [`AnchoredThreads`][] have been designed to work
@@ -563,6 +577,13 @@ function Editor() {
 ```
 
 Should be nested inside [`LiveblocksPlugin`][].
+
+<Banner title="Resolved threads">
+
+The `FloatingThreads` component automatically excludes resolved threads from
+display. Any resolved threads passed in the threads list will not be shown.
+
+</Banner>
 
 #### Recommended usage [#AnchoredThreads-recommended-usage]
 

--- a/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
@@ -80,6 +80,7 @@ export function AnchoredThreads({
 
   const getOrderedThreads = useCallback(() => {
     return threads
+      .filter((thread) => thread.resolved === false)
       .map((thread) => {
         const keys = nodes.get(thread.id);
         if (keys === undefined || keys.size === 0) return null;

--- a/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
@@ -114,6 +114,9 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
         selectThreads(store.getThreads(), {
           roomId,
           orderBy: "age",
+          query: {
+            resolved: false,
+          },
         }).map((thread) => thread.id),
       [roomId, store]
     ),
@@ -220,6 +223,9 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
         return selectThreads(store.getThreads(), {
           roomId,
           orderBy: "age",
+          query: {
+            resolved: false,
+          },
         }).some((thread) => thread.id === id);
       });
       setActiveThreads(threadIds);
@@ -239,7 +245,7 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
       unregisterUpdateListener();
       unsubscribeCache();
     };
-  }, [editor, client, room.id, store]);
+  }, [editor, client, roomId, store]);
 
   /**
    * When active threads change, we add a data-state attribute and set it to "active" for all HTML elements that are associated with the active threads.


### PR DESCRIPTION
This pull request includes a fix for the issue where resolved threads were still being displayed on the editor, `FloatingThreads` and `AnchoredThreads` components. 