### PR TITLE
Refactor cache store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### `@liveblocks/react`
 
+- Fix a bug where under some conditions threads could end up without comments.
 - Fix a bug where notifications associated to deleted threads would not be
   deleted.
 - Fix a bug where subsequent optimistic updates to the same inbox notification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### `@liveblocks/react`
 
+- Fix a bug where notifications associated to deleted threads would not be
+  deleted.
 - Fix a bug where subsequent optimistic updates to the same inbox notification
   could sometimes not get applied correctly.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.7.2 (not released yet)
+## 2.7.2
 
 ### `@liveblocks/react`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.7.2 (not released yet)
+
+### `@liveblocks/react`
+
+- Fix a bug where subsequent optimistic updates to the same inbox notification
+  could sometimes not get applied correctly.
+
 ## 2.7.1
 
 ### `@liveblocks/react-lexical`

--- a/e2e/next-sandbox/pages/index.tsx
+++ b/e2e/next-sandbox/pages/index.tsx
@@ -77,18 +77,6 @@ export default function Home() {
               </Link>
             </li>
           </ul>
-          <ul>
-            <li>
-              <Link href="/inbox-notifications?room=e2e-inbox-notif-del&user=12">
-                <a>Deletions (as user 12)</a>
-              </Link>
-            </li>
-            <li>
-              <Link href="/inbox-notifications?room=e2e-inbox-notif-del&user=7">
-                <a>Deletions (as user 7)</a>
-              </Link>
-            </li>
-          </ul>
         </li>
 
         <li>

--- a/e2e/next-sandbox/pages/index.tsx
+++ b/e2e/next-sandbox/pages/index.tsx
@@ -77,6 +77,18 @@ export default function Home() {
               </Link>
             </li>
           </ul>
+          <ul>
+            <li>
+              <Link href="/inbox-notifications?room=e2e-inbox-notif-del&user=12">
+                <a>Deletions (as user 12)</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/inbox-notifications?room=e2e-inbox-notif-del&user=7">
+                <a>Deletions (as user 7)</a>
+              </Link>
+            </li>
+          </ul>
         </li>
 
         <li>

--- a/e2e/next-sandbox/test/inbox-notifications/index.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/index.test.ts
@@ -55,6 +55,7 @@ test.describe("Inbox notifications", () => {
       await newThreadComposer.press("Enter");
 
       // Await confirmation for the thread creation from the server
+      await sleep(100);
       await waitForJson(page1, "#isSynced", true);
 
       const replyComposer = page1

--- a/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
@@ -55,6 +55,7 @@ test.describe("Inbox notifications", () => {
       await newThreadComposer.press("Enter");
 
       // Await confirmation for the thread creation from the server
+      await sleep(100);
       await waitForJson(page1, "#isSynced", true);
 
       const replyComposer = page1

--- a/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
+++ b/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
@@ -122,7 +122,7 @@ function remove<T>(array: T[], item: T) {
 export async function waitForSocketToBeConnected() {
   await waitFor(() => expect(MockWebSocket.instances.length).toBe(1));
 
-  const socket = MockWebSocket.instances[0];
+  const socket = MockWebSocket.instances[0]!;
   expect(socket.callbacks.open).toEqual([expect.any(Function)]); // Got open callback
   expect(socket.callbacks.message).toEqual([expect.any(Function)]); // Got ROOM_STATE message callback
 
@@ -173,7 +173,7 @@ export async function websocketSimulator() {
   }
 
   function simulateAbnormalClose() {
-    socket.callbacks.close[0]({
+    socket.callbacks.close[0]!({
       reason: "",
       wasClean: false,
       code: WebSocketErrorCodes.CLOSE_ABNORMAL,

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/addReaction.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/addReaction.test.ts
@@ -18,11 +18,11 @@ describe("addReaction", () => {
 
     const updatedThread = applyAddReaction(thread, comment.id, reaction);
 
-    expect(updatedThread.comments[0].reactions).toHaveLength(1);
-    expect(updatedThread.comments[0].reactions[0].emoji).toEqual(
+    expect(updatedThread.comments[0]?.reactions).toHaveLength(1);
+    expect(updatedThread.comments[0]?.reactions[0]?.emoji).toEqual(
       reaction.emoji
     );
-    expect(updatedThread.comments[0].reactions[0].users[0].id).toEqual(
+    expect(updatedThread.comments[0]?.reactions[0]?.users[0]?.id).toEqual(
       reaction.userId
     );
     expect(updatedThread.updatedAt).toEqual(reaction.createdAt);
@@ -53,15 +53,15 @@ describe("addReaction", () => {
 
     const updatedThread = applyAddReaction(thread, comment.id, newReaction);
 
-    expect(updatedThread.comments[0].reactions).toHaveLength(2);
-    expect(updatedThread.comments[0].reactions[0].emoji).toEqual("👍");
-    expect(updatedThread.comments[0].reactions[0].users[0].id).toEqual(
+    expect(updatedThread.comments[0]?.reactions).toHaveLength(2);
+    expect(updatedThread.comments[0]?.reactions[0]?.emoji).toEqual("👍");
+    expect(updatedThread.comments[0]?.reactions[0]?.users[0]?.id).toEqual(
       "user_1"
     );
-    expect(updatedThread.comments[0].reactions[1].emoji).toEqual(
+    expect(updatedThread.comments[0]?.reactions[1]?.emoji).toEqual(
       newReaction.emoji
     );
-    expect(updatedThread.comments[0].reactions[1].users[0].id).toEqual(
+    expect(updatedThread.comments[0]?.reactions[1]?.users[0]?.id).toEqual(
       newReaction.userId
     );
     expect(updatedThread.updatedAt).toEqual(newReaction.createdAt);
@@ -90,7 +90,7 @@ describe("addReaction", () => {
 
     const updatedThread = applyAddReaction(thread, comment.id, reaction);
 
-    expect(updatedThread.comments[0].reactions[0].users).toHaveLength(1); // No additional user should be added
+    expect(updatedThread.comments[0]?.reactions[0]?.users).toHaveLength(1); // No additional user should be added
   });
 
   it("should add a new user to an existing reaction", () => {
@@ -115,8 +115,8 @@ describe("addReaction", () => {
     };
     const updatedThread = applyAddReaction(thread, comment.id, reaction);
 
-    expect(updatedThread.comments[0].reactions[0].users).toHaveLength(2);
-    expect(updatedThread.comments[0].reactions[0].users[1].id).toEqual(
+    expect(updatedThread.comments[0]?.reactions[0]?.users).toHaveLength(2);
+    expect(updatedThread.comments[0]?.reactions[0]?.users[1]?.id).toEqual(
       "user_2"
     );
   });

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/deleteComment.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/deleteComment.test.ts
@@ -88,7 +88,7 @@ describe("deleteComment", () => {
       new Date("2024-01-03")
     );
 
-    expect(updatedThread.comments[0].deletedAt).toEqual(comment.deletedAt); // Ensure the original deletion time is preserved
+    expect(updatedThread.comments[0]?.deletedAt).toEqual(comment.deletedAt); // Ensure the original deletion time is preserved
     expect(updatedThread.updatedAt).toEqual(thread.updatedAt); // The thread's updatedAt should not change
   });
 

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -18,11 +18,11 @@ describe("Umbrella Store", () => {
 
     // Sync getters
     expect(store.getThreads()).toEqual(empty);
-    expect(store.getVersions()).toEqual(empty);
 
     // Sync async-results getters
     expect(store.getInboxNotificationsAsync()).toEqual(loading);
     expect(store.getNotificationSettingsAsync("room-a")).toEqual(loading);
+    expect(store.getVersionsAsync("room-a")).toEqual(loading);
   });
 
   it("calling getters multiple times should always return a stable result", () => {
@@ -30,7 +30,6 @@ describe("Umbrella Store", () => {
 
     // IMPORTANT! Strict equality expected!
     expect(store.getThreads()).toBe(store.getThreads());
-    expect(store.getVersions()).toBe(store.getVersions());
 
     // Sync async-results getter
     // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that
@@ -40,6 +39,10 @@ describe("Umbrella Store", () => {
     // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that
     expect(store.getNotificationSettingsAsync("room-a")).toBe(
       store.getNotificationSettingsAsync("room-a")
+    );
+    // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that
+    expect(store.getVersionsAsync("room-a")).toBe(
+      store.getVersionsAsync("room-a")
     );
   });
 });

--- a/packages/liveblocks-react/src/__tests__/useCreateComment.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateComment.test.tsx
@@ -98,11 +98,11 @@ describe("useCreateComment", () => {
       })
     );
 
-    expect(result.current.threads![0].comments[1]).toEqual(comment);
+    expect(result.current.threads?.[0]?.comments[1]).toEqual(comment);
 
     // We're using the createdDate overriden by the server to ensure the optimistic update have been properly deleted
     await waitFor(() =>
-      expect(result.current.threads![0].comments[1].createdAt).toEqual(
+      expect(result.current.threads?.[0]?.comments[1]?.createdAt).toEqual(
         fakeCreatedAt
       )
     );
@@ -261,7 +261,7 @@ describe("useCreateComment", () => {
       })
     );
 
-    expect(result.current.threads![0].comments[1]).toEqual(comment);
+    expect(result.current.threads?.[0]?.comments[1]).toEqual(comment);
 
     // Wait for optimistic update to be rolled back
     await waitFor(() =>

--- a/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
@@ -100,11 +100,11 @@ describe("useCreateThread", () => {
       })
     );
 
-    expect(result.current.threads![0]).toEqual(thread);
+    expect(result.current.threads?.[0]).toEqual(thread);
 
     // We're using the createdDate overriden by the server to ensure the optimistic update have been properly deleted
     await waitFor(() =>
-      expect(result.current.threads![0].createdAt).toEqual(fakeCreatedAt)
+      expect(result.current.threads?.[0]?.createdAt).toEqual(fakeCreatedAt)
     );
 
     unmount();

--- a/packages/liveblocks-react/src/__tests__/useDeleteAllInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteAllInboxNotifications.test.tsx
@@ -33,12 +33,12 @@ describe("useDeleteAllInboxNotifications", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[1].id,
+        threadId: threads?.[1]?.id,
         readAt: null,
       }),
     ];
@@ -105,12 +105,12 @@ describe("useDeleteAllInboxNotifications", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[1].id,
+        threadId: threads?.[1]?.id,
         readAt: null,
       }),
     ];
@@ -178,13 +178,13 @@ describe("useDeleteAllInboxNotifications", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
         notifiedAt: new Date(2024, 3, 6),
       }),
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[1].id,
+        threadId: threads?.[1]?.id,
         readAt: null,
         notifiedAt: new Date(2024, 3, 5),
       }),
@@ -288,7 +288,7 @@ describe("useDeleteAllInboxNotifications", () => {
         )
       ),
       mockDeleteAllInboxNotifications((_req, res, ctx) => res(ctx.status(204))),
-      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
+      mockDeleteThread({ threadId: threads[0]!.id }, async (_req, res, ctx) => {
         hasCalledDeleteThread = true;
         return res(ctx.status(204));
       })

--- a/packages/liveblocks-react/src/__tests__/useDeleteInboxNotification.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteInboxNotification.test.tsx
@@ -307,7 +307,7 @@ describe("useDeleteInboxNotification", () => {
         { inboxNotificationId: notification1.id },
         (_req, res, ctx) => res(ctx.status(500))
       ),
-      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
+      mockDeleteThread({ threadId: threads[0]!.id }, async (_req, res, ctx) => {
         hasCalledDeleteThread = true;
         return res(ctx.status(204));
       })

--- a/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteThread.test.tsx
@@ -59,7 +59,7 @@ describe("useDeleteThread", () => {
           })
         );
       }),
-      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
+      mockDeleteThread({ threadId: threads[0]!.id }, async (_req, res, ctx) => {
         hasCalledDeleteThread = true;
         return res(ctx.status(204));
       })
@@ -86,7 +86,7 @@ describe("useDeleteThread", () => {
     await waitFor(() => expect(result.current.threads).toEqual(threads));
 
     act(() => {
-      result.current.deleteThread(threads[0].id);
+      result.current.deleteThread(threads[0]!.id);
     });
 
     await waitFor(() => expect(result.current.threads).toEqual([]));
@@ -150,7 +150,7 @@ describe("useDeleteThread", () => {
 
     act(() => {
       try {
-        result.current.deleteThread(threads[0].id);
+        result.current.deleteThread(threads[0]!.id);
       } catch (error) {
         errorMessage = (error as Error).message;
       }
@@ -183,7 +183,7 @@ describe("useDeleteThread", () => {
           })
         )
       ),
-      mockDeleteThread({ threadId: threads[0].id }, async (_req, res, ctx) => {
+      mockDeleteThread({ threadId: threads[0]!.id }, async (_req, res, ctx) => {
         return res(ctx.status(500));
       })
     );
@@ -209,7 +209,7 @@ describe("useDeleteThread", () => {
     await waitFor(() => expect(result.current.threads).toEqual(threads));
 
     act(() => {
-      result.current.deleteThread(threads[0].id);
+      result.current.deleteThread(threads[0]!.id);
     });
 
     expect(result.current.threads).toEqual([]);

--- a/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useEditThreadMetadata.test.tsx
@@ -162,7 +162,7 @@ describe("useEditThreadMetadata", () => {
     );
 
     expect(result.current.threads).toBeDefined();
-    expect(result.current.threads![0].metadata).toEqual({
+    expect(result.current.threads?.[0]?.metadata).toEqual({
       pinned: null,
       color: "yellow",
     });
@@ -172,7 +172,7 @@ describe("useEditThreadMetadata", () => {
     await waitFor(() => expect(hasCalledEditThreadMetadata).toEqual(true));
 
     await waitFor(() => {
-      expect(result.current.threads![0].metadata).toEqual({
+      expect(result.current.threads?.[0]?.metadata).toEqual({
         color: "yellow",
       });
     });

--- a/packages/liveblocks-react/src/__tests__/useInboxNotificationThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotificationThread.test.tsx
@@ -36,7 +36,7 @@ describe("useInboxNotificationThread", () => {
     const threads = [dummyThreadData({ roomId })];
     const inboxNotification = dummyThreadInboxNotificationData({
       roomId,
-      threadId: threads[0].id,
+      threadId: threads[0]!.id,
     });
     const inboxNotifications = [inboxNotification];
 
@@ -106,7 +106,7 @@ describe("useInboxNotificationThread", () => {
     const threads = [dummyThreadData({ roomId })];
     const inboxNotification = dummyThreadInboxNotificationData({
       roomId,
-      threadId: threads[0].id,
+      threadId: threads[0]!.id,
     });
     const customInboxNotification = dummyCustomInboxNoficationData();
     const inboxNotifications = [inboxNotification, customInboxNotification];
@@ -183,7 +183,7 @@ describe("useInboxNotificationThread", () => {
           <LiveblocksProvider>{children}</LiveblocksProvider>
         ),
       })
-    ).toThrow(`Thread with ID "${threads[0].id}" not found`);
+    ).toThrow(`Thread with ID "${threads[0]!.id}" not found`);
 
     // Use the hook with a custom notification should throw
     expect(() =>

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -268,6 +268,10 @@ describe("useInboxNotifications", () => {
 
     umbrellaStore.force_set((state) => ({
       ...state,
+      rawThreadsById: {
+        [thread1.id]: thread1,
+        [thread2.id]: thread2,
+      },
       inboxNotificationsById: {
         // Explicitly set the order to be reversed to test that the hook sorts the notifications
         [oldInboxNotification.id]: oldInboxNotification,

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -39,7 +39,7 @@ describe("useInboxNotifications", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
 
     server.use(
@@ -86,7 +86,7 @@ describe("useInboxNotifications", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
 
     server.use(
@@ -138,7 +138,7 @@ describe("useInboxNotifications", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
 
     server.use(
@@ -370,7 +370,7 @@ describe("useInboxNotifications - Suspense", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
 
     server.use(
@@ -437,7 +437,7 @@ describe("useInboxNotifications: polling", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
     let getInboxNotificationsReqCount = 0;
 
@@ -569,7 +569,7 @@ describe("useInboxNotificationsSuspense: error", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
 
     let n = 0;

--- a/packages/liveblocks-react/src/__tests__/useMarkAllInboxNotificationsAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkAllInboxNotificationsAsRead.test.tsx
@@ -80,9 +80,11 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
       }
     );
 
-    await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
-    );
+    await waitFor(() => {
+      for (const ibn of inboxNotifications) {
+        expect(result.current.inboxNotifications).toContainEqual(ibn);
+      }
+    });
 
     act(() => {
       result.current.markAllInboxNotificationsAsRead();

--- a/packages/liveblocks-react/src/__tests__/useMarkAllInboxNotificationsAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkAllInboxNotificationsAsRead.test.tsx
@@ -27,12 +27,12 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[1].id,
+        threadId: threads?.[1]?.id,
         readAt: null,
       }),
     ];
@@ -88,8 +88,8 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
       result.current.markAllInboxNotificationsAsRead();
     });
 
-    expect(result.current.inboxNotifications![0].readAt).not.toBe(null);
-    expect(result.current.inboxNotifications![1].readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[0]?.readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[1]?.readAt).not.toBe(null);
 
     unmount();
   });
@@ -100,13 +100,13 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
         notifiedAt: new Date(2024, 3, 6),
       }),
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[1].id,
+        threadId: threads?.[1]?.id,
         readAt: null,
         notifiedAt: new Date(2024, 3, 5),
       }),
@@ -159,13 +159,13 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
     });
 
     // We mark the notifications as read optimitiscally
-    expect(result.current.inboxNotifications![0].readAt).not.toBe(null);
-    expect(result.current.inboxNotifications![1].readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[0]?.readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[1]?.readAt).not.toBe(null);
 
     await waitFor(() => {
       // The readAt field should have been updated in the inbox notifications cache
-      expect(result.current.inboxNotifications![0].readAt).toEqual(null);
-      expect(result.current.inboxNotifications![1].readAt).toEqual(null);
+      expect(result.current.inboxNotifications?.[0]?.readAt).toEqual(null);
+      expect(result.current.inboxNotifications?.[1]?.readAt).toEqual(null);
     });
 
     unmount();

--- a/packages/liveblocks-react/src/__tests__/useMarkInboxNotificationAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkInboxNotificationAsRead.test.tsx
@@ -27,7 +27,7 @@ describe("useMarkInboxNotificationAsRead", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
     ];
@@ -76,10 +76,10 @@ describe("useMarkInboxNotificationAsRead", () => {
 
     // Mark the first thread in our threads list as read
     act(() => {
-      result.current.markInboxNotificationAsRead(inboxNotifications[0].id);
+      result.current.markInboxNotificationAsRead(inboxNotifications[0]!.id);
     });
 
-    expect(result.current.inboxNotifications![0].readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[0]?.readAt).not.toBe(null);
 
     unmount();
   });
@@ -90,7 +90,7 @@ describe("useMarkInboxNotificationAsRead", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
     ];
@@ -139,15 +139,15 @@ describe("useMarkInboxNotificationAsRead", () => {
 
     // Mark the first thread in our threads list as read
     act(() => {
-      result.current.markInboxNotificationAsRead(inboxNotifications[0].id);
+      result.current.markInboxNotificationAsRead(inboxNotifications[0]!.id);
     });
 
     // We mark the notification as read optimitiscally
-    expect(result.current.inboxNotifications![0].readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[0]?.readAt).not.toBe(null);
 
     await waitFor(() => {
       // The readAt field should have been updated in the inbox notification cache
-      expect(result.current.inboxNotifications![0].readAt).toEqual(null);
+      expect(result.current.inboxNotifications?.[0]?.readAt).toEqual(null);
     });
 
     unmount();

--- a/packages/liveblocks-react/src/__tests__/useMarkThreadAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkThreadAsRead.test.tsx
@@ -28,7 +28,7 @@ describe("useMarkThreadAsRead", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
     ];
@@ -90,10 +90,10 @@ describe("useMarkThreadAsRead", () => {
 
     // Mark the first thread in our threads list as read
     act(() => {
-      result.current.markThreadAsRead(threads[0].id);
+      result.current.markThreadAsRead(threads[0]!.id);
     });
 
-    expect(result.current.inboxNotifications![0].readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[0]?.readAt).not.toBe(null);
 
     unmount();
   });
@@ -104,7 +104,7 @@ describe("useMarkThreadAsRead", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: null,
       }),
     ];
@@ -166,15 +166,15 @@ describe("useMarkThreadAsRead", () => {
 
     // Mark the first thread in our threads list as read
     act(() => {
-      result.current.markThreadAsRead(threads[0].id);
+      result.current.markThreadAsRead(threads[0]!.id);
     });
 
     // We mark the notification as read optimitiscally
-    expect(result.current.inboxNotifications![0].readAt).not.toBe(null);
+    expect(result.current.inboxNotifications?.[0]?.readAt).not.toBe(null);
 
     await waitFor(() => {
       // The readAt field should have been updated in the inbox notification cache
-      expect(result.current.inboxNotifications![0].readAt).toEqual(null);
+      expect(result.current.inboxNotifications?.[0]?.readAt).toEqual(null);
     });
 
     unmount();

--- a/packages/liveblocks-react/src/__tests__/useThreadSubscription.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreadSubscription.test.tsx
@@ -28,7 +28,7 @@ describe("useThreadSubscription", () => {
     const roomId = nanoid();
     const threads = [dummyThreadData({ roomId })];
     const inboxNotifications = [
-      dummyThreadInboxNotificationData({ roomId, threadId: threads[0].id }),
+      dummyThreadInboxNotificationData({ roomId, threadId: threads[0]!.id }),
     ];
 
     server.use(
@@ -54,7 +54,7 @@ describe("useThreadSubscription", () => {
     const { result, unmount } = renderHook(
       () => ({
         threads: useThreads(),
-        subscription: useThreadSubscription(threads[0].id),
+        subscription: useThreadSubscription(threads[0]!.id),
       }),
       {
         wrapper: ({ children }) => (
@@ -87,7 +87,7 @@ describe("useThreadSubscription", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
         readAt: new Date(),
       }),
     ];
@@ -115,7 +115,7 @@ describe("useThreadSubscription", () => {
     const { result, unmount } = renderHook(
       () => ({
         threads: useThreads(),
-        subscription: useThreadSubscription(threads[0].id),
+        subscription: useThreadSubscription(threads[0]!.id),
       }),
       {
         wrapper: ({ children }) => (
@@ -136,7 +136,7 @@ describe("useThreadSubscription", () => {
 
     expect(result.current.subscription).toEqual({
       status: "subscribed",
-      unreadSince: inboxNotifications[0].readAt,
+      unreadSince: inboxNotifications[0]!.readAt,
     });
 
     unmount();
@@ -169,7 +169,7 @@ describe("useThreadSubscription", () => {
     const { result, unmount } = renderHook(
       () => ({
         threads: useThreads(),
-        subscription: useThreadSubscription(threads[0].id),
+        subscription: useThreadSubscription(threads[0]!.id),
       }),
       {
         wrapper: ({ children }) => (
@@ -199,7 +199,7 @@ describe("useThreadSubscription", () => {
     const inboxNotifications = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threads[0].id,
+        threadId: threads[0]!.id,
       }),
     ];
 
@@ -226,7 +226,7 @@ describe("useThreadSubscription", () => {
     const { result, unmount, rerender } = renderHook(
       () => ({
         threads: useThreads(),
-        subscription: useThreadSubscription(threads[0].id),
+        subscription: useThreadSubscription(threads[0]!.id),
       }),
       {
         wrapper: ({ children }) => (

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1789,7 +1789,7 @@ describe("WebSocket events", () => {
     sim.simulateIncomingMessage({
       type: ServerMsgCode.COMMENT_CREATED,
       threadId: newThread.id,
-      commentId: newThread.comments[0].id,
+      commentId: newThread.comments[0]!.id,
     });
 
     await waitFor(() =>
@@ -1848,7 +1848,7 @@ describe("WebSocket events", () => {
     sim.simulateIncomingMessage({
       type: ServerMsgCode.COMMENT_DELETED,
       threadId: newThread.id,
-      commentId: newThread.comments[0].id,
+      commentId: newThread.comments[0]!.id,
     });
 
     await waitFor(() =>

--- a/packages/liveblocks-react/src/__tests__/useUnreadInboxNotificationsCount.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useUnreadInboxNotificationsCount.test.tsx
@@ -31,7 +31,7 @@ describe("useUnreadInboxNotificationsCount", () => {
     const threads = [dummyThreadData({ roomId })];
     const inboxNotification = dummyThreadInboxNotificationData({
       roomId,
-      threadId: threads[0].id,
+      threadId: threads[0]!.id,
       readAt: null,
     });
     const inboxNotifications = [inboxNotification];
@@ -86,7 +86,7 @@ describe("useUnreadInboxNotificationsCount - Suspense", () => {
     const threads = [dummyThreadData({ roomId })];
     const inboxNotification = dummyThreadInboxNotificationData({
       roomId,
-      threadId: threads[0].id,
+      threadId: threads[0]!.id,
       readAt: null,
     });
     const inboxNotifications = [inboxNotification];

--- a/packages/liveblocks-react/src/lib/retry-error.ts
+++ b/packages/liveblocks-react/src/lib/retry-error.ts
@@ -37,7 +37,7 @@ export async function autoRetry<T>(
   maxTries: number,
   backoff: number[]
 ): Promise<T> {
-  const fallbackBackoff = backoff.length > 0 ? backoff[backoff.length - 1] : 0;
+  const fallbackBackoff = backoff.length > 0 ? backoff[backoff.length - 1]! : 0;
 
   let attempt = 0;
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -370,27 +370,25 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
    * component to mount starts the polling. The last component to unmount stops
    * the polling.
    */
-  function useEnableInboxNotificationsPolling() {
-    useEffect(() => {
-      // Increment
-      pollerSubscribers++;
-      poller.start(POLLING_INTERVAL);
+  function startPolling() {
+    // Increment
+    pollerSubscribers++;
+    poller.start(POLLING_INTERVAL);
 
-      return () => {
-        // Decrement
-        if (pollerSubscribers <= 0) {
-          console.warn(
-            `Internal unexpected behavior. Cannot decrease subscriber count for query "${INBOX_NOTIFICATIONS_QUERY}"`
-          );
-          return;
-        }
+    return () => {
+      // Decrement
+      if (pollerSubscribers <= 0) {
+        console.warn(
+          `Internal unexpected behavior. Cannot decrease subscriber count for query "${INBOX_NOTIFICATIONS_QUERY}"`
+        );
+        return;
+      }
 
-        pollerSubscribers--;
-        if (pollerSubscribers <= 0) {
-          poller.stop();
-        }
-      };
-    }, []);
+      pollerSubscribers--;
+      if (pollerSubscribers <= 0) {
+        poller.stop();
+      }
+    };
   }
 
   const userThreadsPoller = makePoller(refreshUserThreads);
@@ -521,7 +519,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
 
   return {
     store,
-    useEnableInboxNotificationsPolling,
+    startPolling,
     waitUntilInboxNotificationsLoaded,
     loadInboxNotifications,
     incrementUserThreadsQuerySubscribers,
@@ -605,7 +603,7 @@ function makeLiveblocksContextBundle<
 }
 
 function useInboxNotifications_withClient(client: OpaqueClient) {
-  const { loadInboxNotifications, store, useEnableInboxNotificationsPolling } =
+  const { loadInboxNotifications, store, startPolling } =
     getExtrasForClient(client);
 
   // Trigger initial loading of inbox notifications if it hasn't started
@@ -614,7 +612,8 @@ function useInboxNotifications_withClient(client: OpaqueClient) {
     loadInboxNotifications();
   }, [loadInboxNotifications]);
 
-  useEnableInboxNotificationsPolling();
+  useEffect(startPolling, []);
+
   return useSyncExternalStoreWithSelector(
     store.subscribeInboxNotifications,
     store.getInboxNotificationsAsync,
@@ -639,7 +638,7 @@ function useInboxNotificationsSuspense_withClient(client: OpaqueClient) {
 }
 
 function useUnreadInboxNotificationsCount_withClient(client: OpaqueClient) {
-  const { store, loadInboxNotifications, useEnableInboxNotificationsPolling } =
+  const { store, loadInboxNotifications, startPolling } =
     getExtrasForClient(client);
 
   // Trigger initial loading of inbox notifications if it hasn't started
@@ -648,7 +647,8 @@ function useUnreadInboxNotificationsCount_withClient(client: OpaqueClient) {
     loadInboxNotifications();
   }, [loadInboxNotifications]);
 
-  useEnableInboxNotificationsPolling();
+  useEffect(startPolling, []);
+
   return useSyncExternalStoreWithSelector(
     store.subscribeInboxNotifications,
     store.getInboxNotificationsAsync,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -608,11 +608,8 @@ function useInboxNotifications_withClient(client: OpaqueClient) {
 
   // Trigger initial loading of inbox notifications if it hasn't started
   // already, but don't await its promise.
-  useEffect(() => {
-    loadInboxNotifications();
-  }, [loadInboxNotifications]);
-
-  useEffect(startPolling, []);
+  useEffect(loadInboxNotifications, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(startPolling, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return useSyncExternalStoreWithSelector(
     store.subscribeInboxNotifications,
@@ -643,11 +640,8 @@ function useUnreadInboxNotificationsCount_withClient(client: OpaqueClient) {
 
   // Trigger initial loading of inbox notifications if it hasn't started
   // already, but don't await its promise.
-  useEffect(() => {
-    loadInboxNotifications();
-  }, [loadInboxNotifications]);
-
-  useEffect(startPolling, []);
+  useEffect(loadInboxNotifications, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(startPolling, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return useSyncExternalStoreWithSelector(
     store.subscribeInboxNotifications,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -608,8 +608,8 @@ function useInboxNotifications_withClient(client: OpaqueClient) {
 
   // Trigger initial loading of inbox notifications if it hasn't started
   // already, but don't await its promise.
-  useEffect(loadInboxNotifications, []); // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(startPolling, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(loadInboxNotifications, [loadInboxNotifications]);
+  useEffect(startPolling, [startPolling]);
 
   return useSyncExternalStoreWithSelector(
     store.subscribeInboxNotifications,
@@ -640,8 +640,8 @@ function useUnreadInboxNotificationsCount_withClient(client: OpaqueClient) {
 
   // Trigger initial loading of inbox notifications if it hasn't started
   // already, but don't await its promise.
-  useEffect(loadInboxNotifications, []); // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(startPolling, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(loadInboxNotifications, [loadInboxNotifications]);
+  useEffect(startPolling, [startPolling]);
 
   return useSyncExternalStoreWithSelector(
     store.subscribeInboxNotifications,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1266,7 +1266,7 @@ function useOthersMapped<P extends JsonObject, U extends BaseUserMeta, T>(
         a.length === b.length &&
         a.every((atuple, index) => {
           // We know btuple always exist because we checked the array length on the previous line
-          const btuple = b[index];
+          const btuple = b[index]!;
           return atuple[0] === btuple[0] && eq(atuple[1], btuple[1]);
         })
       );

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1167,11 +1167,17 @@ function internalToExternalState<M extends BaseMetadata>(
       (thread): thread is ThreadData<M> => !thread.deletedAt
     );
 
+  // TODO Maybe consider also removing these from the inboxNotificationsById registry?
   const cleanedNotifications =
     // Sort so that the most recent notifications are first
-    Object.values(computed.inboxNotificationsById).sort(
-      (a, b) => b.notifiedAt.getTime() - a.notifiedAt.getTime()
-    );
+    Object.values(computed.inboxNotificationsById)
+      .filter((ibn) =>
+        ibn.kind === "thread"
+          ? computed.threadsById[ibn.threadId] &&
+            computed.threadsById[ibn.threadId]?.deletedAt === undefined
+          : true
+      )
+      .sort((a, b) => b.notifiedAt.getTime() - a.notifiedAt.getTime());
 
   return {
     inboxNotifications: cleanedNotifications,

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1106,8 +1106,7 @@ function internalToExternalState<M extends BaseMetadata>(
       }
       case "mark-inbox-notification-as-read": {
         const ibn =
-          // XXX Should this not be _output_ instead of _state_?
-          state.inboxNotificationsById[optimisticUpdate.inboxNotificationId];
+          computed.inboxNotificationsById[optimisticUpdate.inboxNotificationId];
 
         // If the inbox notification doesn't exist in the cache, we do not apply the update
         if (ibn === undefined) {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1401,13 +1401,13 @@ export function applyDeleteComment<M extends BaseMetadata>(
       : comment
   );
 
-  // If all comments have been deleted, we mark the thread as deleted
-  if (!updatedComments.some((comment) => comment.deletedAt === undefined)) {
+  // If all comments have been deleted (or there are no comments in the first
+  // place), we mark the thread as deleted.
+  if (updatedComments.every((comment) => comment.deletedAt !== undefined)) {
     return {
       ...thread,
       deletedAt,
       updatedAt: deletedAt,
-      comments: [],
     };
   }
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1062,7 +1062,7 @@ function internalToExternalState<M extends BaseMetadata>(
         }
 
         output.threads[optimisticUpdate.threadId] = {
-          ...output.threads[optimisticUpdate.threadId],
+          ...thread,
           deletedAt: optimisticUpdate.deletedAt,
           updatedAt: optimisticUpdate.deletedAt,
           comments: [],
@@ -1102,16 +1102,32 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "mark-inbox-notification-as-read": {
+        const ibn =
+          // XXX Should this not be _output_ instead of _state_?
+          state.inboxNotificationsById[optimisticUpdate.inboxNotificationId];
+
+        // If the inbox notification doesn't exist in the cache, we do not apply the update
+        if (ibn === undefined) {
+          break;
+        }
+
         output.inboxNotifications[optimisticUpdate.inboxNotificationId] = {
-          ...state.inboxNotificationsById[optimisticUpdate.inboxNotificationId],
+          ...ibn,
           readAt: optimisticUpdate.readAt,
         };
         break;
       }
       case "mark-all-inbox-notifications-as-read": {
         for (const id in output.inboxNotifications) {
+          const ibn = output.inboxNotifications[id];
+
+          // If the inbox notification doesn't exist in the cache, we do not apply the update
+          if (ibn === undefined) {
+            break;
+          }
+
           output.inboxNotifications[id] = {
-            ...output.inboxNotifications[id],
+            ...ibn,
             readAt: optimisticUpdate.readAt,
           };
         }
@@ -1129,9 +1145,17 @@ function internalToExternalState<M extends BaseMetadata>(
         output.inboxNotifications = {};
         break;
       }
+
       case "update-notification-settings": {
+        const settings = output.notificationSettings[optimisticUpdate.roomId];
+
+        // If the inbox notification doesn't exist in the cache, we do not apply the update
+        if (settings === undefined) {
+          break;
+        }
+
         output.notificationSettings[optimisticUpdate.roomId] = {
-          ...output.notificationSettings[optimisticUpdate.roomId],
+          ...settings,
           ...optimisticUpdate.settings,
         };
       }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -914,19 +914,20 @@ function internalToExternalState<M extends BaseMetadata>(
   state: InternalState<M>
 ): UmbrellaStoreState<M> {
   const computed = {
-    threads: { ...state.rawThreadsById },
-    inboxNotifications: { ...state.inboxNotificationsById },
-    notificationSettings: { ...state.notificationSettingsByRoomId },
+    threadsById: { ...state.rawThreadsById },
+    inboxNotificationsById: { ...state.inboxNotificationsById },
+    notificationSettingsByRoomId: { ...state.notificationSettingsByRoomId },
   };
 
   for (const optimisticUpdate of state.optimisticUpdates) {
     switch (optimisticUpdate.type) {
       case "create-thread": {
-        computed.threads[optimisticUpdate.thread.id] = optimisticUpdate.thread;
+        computed.threadsById[optimisticUpdate.thread.id] =
+          optimisticUpdate.thread;
         break;
       }
       case "edit-thread-metadata": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
@@ -945,7 +946,7 @@ function internalToExternalState<M extends BaseMetadata>(
           break;
         }
 
-        computed.threads[thread.id] = {
+        computed.threadsById[thread.id] = {
           ...thread,
           updatedAt: optimisticUpdate.updatedAt,
           metadata: {
@@ -957,7 +958,7 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "mark-thread-as-resolved": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
@@ -968,7 +969,7 @@ function internalToExternalState<M extends BaseMetadata>(
           break;
         }
 
-        computed.threads[thread.id] = {
+        computed.threadsById[thread.id] = {
           ...thread,
           resolved: true,
         };
@@ -976,7 +977,7 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "mark-thread-as-unresolved": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
@@ -987,7 +988,7 @@ function internalToExternalState<M extends BaseMetadata>(
           break;
         }
 
-        computed.threads[thread.id] = {
+        computed.threadsById[thread.id] = {
           ...thread,
           resolved: false,
         };
@@ -995,19 +996,19 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "create-comment": {
-        const thread = computed.threads[optimisticUpdate.comment.threadId];
+        const thread = computed.threadsById[optimisticUpdate.comment.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
         }
 
-        computed.threads[thread.id] = applyUpsertComment(
+        computed.threadsById[thread.id] = applyUpsertComment(
           thread,
           optimisticUpdate.comment
         );
 
         const inboxNotification = Object.values(
-          computed.inboxNotifications
+          computed.inboxNotificationsById
         ).find(
           (notification) =>
             notification.kind === "thread" &&
@@ -1018,7 +1019,7 @@ function internalToExternalState<M extends BaseMetadata>(
           break;
         }
 
-        computed.inboxNotifications[inboxNotification.id] = {
+        computed.inboxNotificationsById[inboxNotification.id] = {
           ...inboxNotification,
           notifiedAt: optimisticUpdate.comment.createdAt,
           readAt: optimisticUpdate.comment.createdAt,
@@ -1027,13 +1028,13 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "edit-comment": {
-        const thread = computed.threads[optimisticUpdate.comment.threadId];
+        const thread = computed.threadsById[optimisticUpdate.comment.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
         }
 
-        computed.threads[thread.id] = applyUpsertComment(
+        computed.threadsById[thread.id] = applyUpsertComment(
           thread,
           optimisticUpdate.comment
         );
@@ -1041,13 +1042,13 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "delete-comment": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
         }
 
-        computed.threads[thread.id] = applyDeleteComment(
+        computed.threadsById[thread.id] = applyDeleteComment(
           thread,
           optimisticUpdate.commentId,
           optimisticUpdate.deletedAt
@@ -1057,13 +1058,13 @@ function internalToExternalState<M extends BaseMetadata>(
       }
 
       case "delete-thread": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
         }
 
-        computed.threads[optimisticUpdate.threadId] = {
+        computed.threadsById[optimisticUpdate.threadId] = {
           ...thread,
           deletedAt: optimisticUpdate.deletedAt,
           updatedAt: optimisticUpdate.deletedAt,
@@ -1072,13 +1073,13 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "add-reaction": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
         }
 
-        computed.threads[thread.id] = applyAddReaction(
+        computed.threadsById[thread.id] = applyAddReaction(
           thread,
           optimisticUpdate.commentId,
           optimisticUpdate.reaction
@@ -1087,13 +1088,13 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "remove-reaction": {
-        const thread = computed.threads[optimisticUpdate.threadId];
+        const thread = computed.threadsById[optimisticUpdate.threadId];
         // If the thread doesn't exist in the cache, we do not apply the update
         if (thread === undefined) {
           break;
         }
 
-        computed.threads[thread.id] = applyRemoveReaction(
+        computed.threadsById[thread.id] = applyRemoveReaction(
           thread,
           optimisticUpdate.commentId,
           optimisticUpdate.emoji,
@@ -1113,22 +1114,23 @@ function internalToExternalState<M extends BaseMetadata>(
           break;
         }
 
-        computed.inboxNotifications[optimisticUpdate.inboxNotificationId] = {
-          ...ibn,
-          readAt: optimisticUpdate.readAt,
-        };
+        computed.inboxNotificationsById[optimisticUpdate.inboxNotificationId] =
+          {
+            ...ibn,
+            readAt: optimisticUpdate.readAt,
+          };
         break;
       }
       case "mark-all-inbox-notifications-as-read": {
-        for (const id in computed.inboxNotifications) {
-          const ibn = computed.inboxNotifications[id];
+        for (const id in computed.inboxNotificationsById) {
+          const ibn = computed.inboxNotificationsById[id];
 
           // If the inbox notification doesn't exist in the cache, we do not apply the update
           if (ibn === undefined) {
             break;
           }
 
-          computed.inboxNotifications[id] = {
+          computed.inboxNotificationsById[id] = {
             ...ibn,
             readAt: optimisticUpdate.readAt,
           };
@@ -1139,24 +1141,25 @@ function internalToExternalState<M extends BaseMetadata>(
         const {
           [optimisticUpdate.inboxNotificationId]: _,
           ...inboxNotifications
-        } = computed.inboxNotifications;
-        computed.inboxNotifications = inboxNotifications;
+        } = computed.inboxNotificationsById;
+        computed.inboxNotificationsById = inboxNotifications;
         break;
       }
       case "delete-all-inbox-notifications": {
-        computed.inboxNotifications = {};
+        computed.inboxNotificationsById = {};
         break;
       }
 
       case "update-notification-settings": {
-        const settings = computed.notificationSettings[optimisticUpdate.roomId];
+        const settings =
+          computed.notificationSettingsByRoomId[optimisticUpdate.roomId];
 
         // If the inbox notification doesn't exist in the cache, we do not apply the update
         if (settings === undefined) {
           break;
         }
 
-        computed.notificationSettings[optimisticUpdate.roomId] = {
+        computed.notificationSettingsByRoomId[optimisticUpdate.roomId] = {
           ...settings,
           ...optimisticUpdate.settings,
         };
@@ -1166,23 +1169,23 @@ function internalToExternalState<M extends BaseMetadata>(
 
   const cleanedThreads =
     // Don't expose any soft-deleted threads
-    Object.values(computed.threads).filter(
+    Object.values(computed.threadsById).filter(
       (thread): thread is ThreadData<M> => !thread.deletedAt
     );
 
   const cleanedNotifications =
     // Sort so that the most recent notifications are first
-    Object.values(computed.inboxNotifications).sort(
+    Object.values(computed.inboxNotificationsById).sort(
       (a, b) => b.notifiedAt.getTime() - a.notifiedAt.getTime()
     );
 
   return {
     inboxNotifications: cleanedNotifications,
-    inboxNotificationsById: computed.inboxNotifications,
-    notificationSettingsByRoomId: computed.notificationSettings,
+    inboxNotificationsById: computed.inboxNotificationsById,
+    notificationSettingsByRoomId: computed.notificationSettingsByRoomId,
     queries: state.queries,
     threads: cleanedThreads,
-    threadsById: computed.threads,
+    threadsById: computed.threadsById,
     versionsByRoomId: state.versionsByRoomId,
   };
 }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1163,9 +1163,13 @@ function internalToExternalState<M extends BaseMetadata>(
 
   const cleanedThreads =
     // Don't expose any soft-deleted threads
-    Object.values(computed.threadsById).filter(
-      (thread): thread is ThreadData<M> => !thread.deletedAt
-    );
+    Object.values(computed.threadsById)
+      .filter((thread): thread is ThreadData<M> => !thread.deletedAt)
+
+      .filter((thread) =>
+        // Only keep a thread if there is at least one non-deleted comment
+        thread.comments.some((c) => c.deletedAt === undefined)
+      );
 
   // TODO Maybe consider also removing these from the inboxNotificationsById registry?
   const cleanedNotifications =

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1114,10 +1114,7 @@ function internalToExternalState<M extends BaseMetadata>(
         }
 
         computed.inboxNotificationsById[optimisticUpdate.inboxNotificationId] =
-          {
-            ...ibn,
-            readAt: optimisticUpdate.readAt,
-          };
+          { ...ibn, readAt: optimisticUpdate.readAt };
         break;
       }
       case "mark-all-inbox-notifications-as-read": {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1138,11 +1138,9 @@ function internalToExternalState<M extends BaseMetadata>(
         break;
       }
       case "delete-inbox-notification": {
-        const {
-          [optimisticUpdate.inboxNotificationId]: _,
-          ...inboxNotifications
-        } = computed.inboxNotificationsById;
-        computed.inboxNotificationsById = inboxNotifications;
+        delete computed.inboxNotificationsById[
+          optimisticUpdate.inboxNotificationId
+        ];
         break;
       }
       case "delete-all-inbox-notifications": {

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -334,17 +334,17 @@ declare global {
 // useOthers()
 {
   const others = classic.useOthers();
-  expectType<number>(others[13].presence.cursor.x);
-  expectType<number>(others[42].presence.cursor.y);
-  expectType<boolean>(others[0].canWrite);
+  expectType<number>(others[13]!.presence.cursor.x);
+  expectType<number>(others[42]!.presence.cursor.y);
+  expectType<boolean>(others[0]!.canWrite);
 }
 
 // useOthers() (suspense)
 {
   const others = suspense.useOthers();
-  expectType<number>(others[13].presence.cursor.x);
-  expectType<number>(others[42].presence.cursor.y);
-  expectType<boolean>(others[0].canWrite);
+  expectType<number>(others[13]!.presence.cursor.x);
+  expectType<number>(others[42]!.presence.cursor.y);
+  expectType<boolean>(others[0]!.canWrite);
 }
 
 // useOthers(selector)
@@ -399,11 +399,11 @@ declare global {
       expectType<number>(mut.self.info.age);
       expectError(mut.self.info.nonexisting);
 
-      expectType<number>(mut.others[0].presence.cursor.x);
-      expectError(mut.others[0].presence.nonexisting);
-      expectType<string>(mut.others[0].info.name);
-      expectType<number>(mut.others[0].info.age);
-      expectError(mut.others[0].info.nonexisting);
+      expectType<number>(mut.others[0]!.presence.cursor.x);
+      expectError(mut.others[0]!.presence.nonexisting);
+      expectType<string>(mut.others[0]!.info.name);
+      expectType<number>(mut.others[0]!.info.age);
+      expectError(mut.others[0]!.info.nonexisting);
 
       expectType<string | undefined>(mut.storage.get("animals").get(0));
       expectType<number | undefined>(mut.storage.get("scores").get("one"));
@@ -427,11 +427,11 @@ declare global {
       expectType<number>(mut.self.info.age);
       expectError(mut.self.info.nonexisting);
 
-      expectType<number>(mut.others[0].presence.cursor.x);
-      expectError(mut.others[0].presence.nonexisting);
-      expectType<string>(mut.others[0].info.name);
-      expectType<number>(mut.others[0].info.age);
-      expectError(mut.others[0].info.nonexisting);
+      expectType<number>(mut.others[0]!.presence.cursor.x);
+      expectError(mut.others[0]!.presence.nonexisting);
+      expectType<string>(mut.others[0]!.info.name);
+      expectType<number>(mut.others[0]!.info.age);
+      expectError(mut.others[0]!.info.nonexisting);
 
       expectType<string | undefined>(mut.storage.get("animals").get(0));
       expectType<number | undefined>(mut.storage.get("scores").get("one"));
@@ -545,9 +545,9 @@ declare global {
   expectType<"thread">(thread.type);
   expectType<string>(thread.id);
   expectType<string>(thread.roomId);
-  expectType<"comment">(thread.comments[0].type);
-  expectType<string>(thread.comments[0].id);
-  expectType<string>(thread.comments[0].threadId);
+  expectType<"comment">(thread.comments[0]!.type);
+  expectType<string>(thread.comments[0]!.id);
+  expectType<string>(thread.comments[0]!.threadId);
 
   expectType<"red" | "blue">(thread.metadata.color);
   expectError(thread.metadata.nonexisting);
@@ -579,9 +579,9 @@ declare global {
   expectType<"thread">(thread.type);
   expectType<string>(thread.id);
   expectType<string>(thread.roomId);
-  expectType<"comment">(thread.comments[0].type);
-  expectType<string>(thread.comments[0].id);
-  expectType<string>(thread.comments[0].threadId);
+  expectType<"comment">(thread.comments[0]!.type);
+  expectType<string>(thread.comments[0]!.id);
+  expectType<string>(thread.comments[0]!.threadId);
 
   expectType<"red" | "blue">(thread.metadata.color);
   expectError(thread.metadata.nonexisting);

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -258,8 +258,8 @@ expectType<boolean>(lbctx.useIsInsideRoom());
 // The presence hooks
 expectType<P>(ctx.useSelf()!.presence);
 expectType<readonly User<P, U>[]>(ctx.useOthers());
-expectType<P>(ctx.useOthers()[0].presence);
-expectType<P>(ctx.useOthersMapped((u) => u.presence)[0][1]);
+expectType<P>(ctx.useOthers()[0]!.presence);
+expectType<P>(ctx.useOthersMapped((u) => u.presence)[0]![1]);
 expectType<readonly number[]>(ctx.useOthersConnectionIds());
 expectType<P>(ctx.useOther(123, (o) => o.presence));
 expectType<P>(ctx.useMyPresence()[0]);
@@ -267,8 +267,8 @@ expectType<P>(ctx.useMyPresence()[0]);
 // The presence hooks (suspense versions)
 expectType<P>(ctx.suspense.useSelf().presence);
 expectType<readonly User<P, U>[]>(ctx.suspense.useOthers());
-expectType<P>(ctx.suspense.useOthers()[0].presence);
-expectType<P>(ctx.suspense.useOthersMapped((u) => u.presence)[0][1]);
+expectType<P>(ctx.suspense.useOthers()[0]!.presence);
+expectType<P>(ctx.suspense.useOthersMapped((u) => u.presence)[0]![1]);
 expectType<readonly number[]>(ctx.suspense.useOthersConnectionIds());
 expectType<P>(ctx.suspense.useOther(123, (o) => o.presence));
 expectType<P>(ctx.suspense.useMyPresence()[0]);
@@ -395,11 +395,11 @@ ctx.useErrorListener((err) => {
       expectType<number>(mut.self.info.age);
       expectError(mut.self.info.nonexisting);
 
-      expectType<number>(mut.others[0].presence.cursor.x);
-      expectError(mut.others[0].presence.nonexisting);
-      expectType<string>(mut.others[0].info.name);
-      expectType<number>(mut.others[0].info.age);
-      expectError(mut.others[0].info.nonexisting);
+      expectType<number>(mut.others[0]!.presence.cursor.x);
+      expectError(mut.others[0]!.presence.nonexisting);
+      expectType<string>(mut.others[0]!.info.name);
+      expectType<number>(mut.others[0]!.info.age);
+      expectError(mut.others[0]!.info.nonexisting);
 
       expectType<string | undefined>(mut.storage.get("animals").get(0));
       expectType<number | undefined>(mut.storage.get("scores").get("one"));
@@ -423,11 +423,11 @@ ctx.useErrorListener((err) => {
       expectType<number>(mut.self.info.age);
       expectError(mut.self.info.nonexisting);
 
-      expectType<number>(mut.others[0].presence.cursor.x);
-      expectError(mut.others[0].presence.nonexisting);
-      expectType<string>(mut.others[0].info.name);
-      expectType<number>(mut.others[0].info.age);
-      expectError(mut.others[0].info.nonexisting);
+      expectType<number>(mut.others[0]!.presence.cursor.x);
+      expectError(mut.others[0]!.presence.nonexisting);
+      expectType<string>(mut.others[0]!.info.name);
+      expectType<number>(mut.others[0]!.info.age);
+      expectError(mut.others[0]!.info.nonexisting);
 
       expectType<string | undefined>(mut.storage.get("animals").get(0));
       expectType<number | undefined>(mut.storage.get("scores").get("one"));
@@ -549,9 +549,9 @@ ctx.useErrorListener((err) => {
     expectType<"thread">(thread1.type);
     expectType<string>(thread1.id);
     expectType<string>(thread1.roomId);
-    expectType<"comment">(thread1.comments[0].type);
-    expectType<string>(thread1.comments[0].id);
-    expectType<string>(thread1.comments[0].threadId);
+    expectType<"comment">(thread1.comments[0]!.type);
+    expectType<string>(thread1.comments[0]!.id);
+    expectType<string>(thread1.comments[0]!.threadId);
 
     expectType<string | number | boolean | undefined>(thread1.metadata.color);
 
@@ -593,9 +593,9 @@ ctx.useErrorListener((err) => {
     expectType<"thread">(thread.type);
     expectType<string>(thread.id);
     expectType<string>(thread.roomId);
-    expectType<"comment">(thread.comments[0].type);
-    expectType<string>(thread.comments[0].id);
-    expectType<string>(thread.comments[0].threadId);
+    expectType<"comment">(thread.comments[0]!.type);
+    expectType<string>(thread.comments[0]!.id);
+    expectType<string>(thread.comments[0]!.threadId);
 
     expectType<"red" | "blue">(thread.metadata.color);
   }
@@ -619,9 +619,9 @@ ctx.useErrorListener((err) => {
     expectType<"thread">(thread1.type);
     expectType<string>(thread1.id);
     expectType<string>(thread1.roomId);
-    expectType<"comment">(thread1.comments[0].type);
-    expectType<string>(thread1.comments[0].id);
-    expectType<string>(thread1.comments[0].threadId);
+    expectType<"comment">(thread1.comments[0]!.type);
+    expectType<string>(thread1.comments[0]!.id);
+    expectType<string>(thread1.comments[0]!.threadId);
 
     expectType<string | number | boolean | undefined>(thread1.metadata.color);
 
@@ -662,9 +662,9 @@ ctx.useErrorListener((err) => {
     expectType<"thread">(thread.type);
     expectType<string>(thread.id);
     expectType<string>(thread.roomId);
-    expectType<"comment">(thread.comments[0].type);
-    expectType<string>(thread.comments[0].id);
-    expectType<string>(thread.comments[0].threadId);
+    expectType<"comment">(thread.comments[0]!.type);
+    expectType<string>(thread.comments[0]!.id);
+    expectType<string>(thread.comments[0]!.threadId);
 
     expectType<"red" | "blue">(thread.metadata.color);
   }

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -235,15 +235,15 @@ import { expectAssignable, expectError, expectType } from "tsd";
 // useOthers()
 {
   const others = classic.useOthers();
-  expectType<Json | undefined>(others[13].presence.cursor);
-  expectType<boolean>(others[0].canWrite);
+  expectType<Json | undefined>(others[13]!.presence.cursor);
+  expectType<boolean>(others[0]!.canWrite);
 }
 
 // useOthers() (suspense)
 {
   const others = suspense.useOthers();
-  expectType<Json | undefined>(others[13].presence.cursor);
-  expectType<boolean>(others[0].canWrite);
+  expectType<Json | undefined>(others[13]!.presence.cursor);
+  expectType<boolean>(others[0]!.canWrite);
 }
 
 // useOthers(selector)
@@ -298,11 +298,11 @@ import { expectAssignable, expectError, expectType } from "tsd";
       expectType<Json | undefined>(mut.self.info!.age);
       expectType<Json | undefined>(mut.self.info!.nonexisting);
 
-      expectType<Json | undefined>(mut.others[0].presence.cursor);
-      expectType<Json | undefined>(mut.others[0].presence.nonexisting);
-      expectType<string | undefined>(mut.others[0].info!.name);
-      expectType<Json | undefined>(mut.others[0].info!.age);
-      expectType<Json | undefined>(mut.others[0].info!.nonexisting);
+      expectType<Json | undefined>(mut.others[0]!.presence.cursor);
+      expectType<Json | undefined>(mut.others[0]!.presence.nonexisting);
+      expectType<string | undefined>(mut.others[0]!.info!.name);
+      expectType<Json | undefined>(mut.others[0]!.info!.age);
+      expectType<Json | undefined>(mut.others[0]!.info!.nonexisting);
 
       expectType<Lson | undefined>(mut.storage.get("animals"));
       expectType<Lson | undefined>(mut.storage.get("nonexisting"));
@@ -324,11 +324,11 @@ import { expectAssignable, expectError, expectType } from "tsd";
       expectType<Json | undefined>(mut.self.info!.age);
       expectType<Json | undefined>(mut.self.info!.nonexisting);
 
-      expectType<Json | undefined>(mut.others[0].presence.cursor);
-      expectType<Json | undefined>(mut.others[0].presence.nonexisting);
-      expectType<string | undefined>(mut.others[0].info!.name);
-      expectType<Json | undefined>(mut.others[0].info!.age);
-      expectType<Json | undefined>(mut.others[0].info!.nonexisting);
+      expectType<Json | undefined>(mut.others[0]!.presence.cursor);
+      expectType<Json | undefined>(mut.others[0]!.presence.nonexisting);
+      expectType<string | undefined>(mut.others[0]!.info!.name);
+      expectType<Json | undefined>(mut.others[0]!.info!.age);
+      expectType<Json | undefined>(mut.others[0]!.info!.nonexisting);
 
       expectType<Lson | undefined>(mut.storage.get("animals"));
       expectType<Lson | undefined>(mut.storage.get("nonexisting"));
@@ -423,9 +423,9 @@ import { expectAssignable, expectError, expectType } from "tsd";
   expectType<"thread">(thread1.type);
   expectType<string>(thread1.id);
   expectType<string>(thread1.roomId);
-  expectType<"comment">(thread1.comments[0].type);
-  expectType<string>(thread1.comments[0].id);
-  expectType<string>(thread1.comments[0].threadId);
+  expectType<"comment">(thread1.comments[0]!.type);
+  expectType<string>(thread1.comments[0]!.id);
+  expectType<string>(thread1.comments[0]!.threadId);
 
   expectType<string | number | boolean | undefined>(thread1.metadata.color);
 
@@ -459,9 +459,9 @@ import { expectAssignable, expectError, expectType } from "tsd";
   expectType<"thread">(thread1.type);
   expectType<string>(thread1.id);
   expectType<string>(thread1.roomId);
-  expectType<"comment">(thread1.comments[0].type);
-  expectType<string>(thread1.comments[0].id);
-  expectType<string>(thread1.comments[0].threadId);
+  expectType<"comment">(thread1.comments[0]!.type);
+  expectType<string>(thread1.comments[0]!.id);
+  expectType<string>(thread1.comments[0]!.threadId);
 
   expectType<string | number | boolean | undefined>(thread1.metadata.foo);
 

--- a/packages/liveblocks-react/tsconfig.json
+++ b/packages/liveblocks-react/tsconfig.json
@@ -11,10 +11,7 @@
     // Transform JSX syntax from input *.tsx files into React.createElement()
     // calls in the *.js build output.
     // NOTE: We can change this to `react-jsx` once we stop supporting React 16.
-    "jsx": "react",
-
-    // TODO: Try to get rid of these overrides
-    "noUncheckedIndexedAccess": false // OVERWRITTEN to relax a bit
+    "jsx": "react"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Continuation of #1939. Now also adopting this pattern for `useHistoryVersions()`.

Stop disabling the TSConfig setting `noUncheckedIndexedAccess`, making TS stricter, which is a good idea when building a library.

Also fixes three bugs:
- Fix a bug where under some conditions threads could end up without comments
- Fix a bug where notifications associated to deleted threads would not be deleted
- Fix a bug where subsequent optimistic updates to the same inbox notification could sometimes not get applied correctly
