### PR TITLE
Fix: check on good element type for internal function in comment body

### DIFF
--- a/packages/liveblocks-core/src/comments/comment-body.ts
+++ b/packages/liveblocks-core/src/comments/comment-body.ts
@@ -136,7 +136,7 @@ export type StringifyCommentBodyOptions<U extends BaseUserMeta = DU> = {
 function isCommentBodyParagraph(
   element: CommentBodyElement
 ): element is CommentBodyParagraph {
-  return "type" in element && element.type === "mention";
+  return "type" in element && element.type === "paragraph";
 }
 
 function isCommentBodyText(


### PR DESCRIPTION
Small fix on the guard `isCommentBodyParagraph` to make it check on the good element type e.g `paragraph`

Thanks 🙏🏻 