### PR TITLE
Make URL paths static, so they're better searchable

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -109,6 +109,8 @@ export { asPos, makePosition } from "./lib/position";
 export type { Resolve } from "./lib/Resolve";
 export { shallow } from "./lib/shallow";
 export { stringify } from "./lib/stringify";
+export type { QueryParams, URLSafeString } from "./lib/url";
+export { url, urljoin } from "./lib/url";
 export type { Brand, DistributiveOmit } from "./lib/utils";
 export {
   b64decode,

--- a/packages/liveblocks-core/src/lib/url.ts
+++ b/packages/liveblocks-core/src/lib/url.ts
@@ -1,3 +1,5 @@
+import type { Brand } from "./utils";
+
 export type QueryParams =
   | Record<string, string | number | null | undefined>
   | URLSearchParams;
@@ -49,4 +51,23 @@ export function urljoin(
     ).toString();
   }
   return url.toString();
+}
+
+/**
+ * A string that is guaranteed to be URL safe (where all arguments are properly
+ * encoded), only obtainable as the result of using `url` template strings.
+ */
+export type URLSafeString = Brand<string, "URLSafeString">;
+
+/**
+ * Builds a URL where each "hole" in the template string will automatically be
+ * encodeURIComponent()-escaped, so it's impossible to build invalid URLs.
+ */
+export function url(
+  strings: TemplateStringsArray,
+  ...values: string[]
+): URLSafeString {
+  return strings.reduce(
+    (result, str, i) => result + encodeURIComponent(values[i - 1] ?? "") + str
+  ) as URLSafeString;
 }

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -60,7 +60,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }>;
 } {
   async function fetchJson<T>(
-    endpoint: string,
+    endpoint: `/v2/c/${string}`,
     options?: RequestInit,
     params?: QueryParams
   ): Promise<T> {
@@ -76,7 +76,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       currentUserIdStore.set(() => userId);
     }
 
-    const url = urljoin(baseUrl, `/v2/c${endpoint}`, params);
+    const url = urljoin(baseUrl, endpoint, params);
     const response = await fetcher(url.toString(), {
       ...options,
       headers: {
@@ -128,7 +128,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/inbox-notifications", undefined, {});
+    }>("/v2/c/inbox-notifications", undefined, {});
 
     return {
       threads: json.threads.map(convertToThreadData),
@@ -148,7 +148,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/inbox-notifications", undefined, {
+    }>("/v2/c/inbox-notifications", undefined, {
       since: options.since.toISOString(),
     });
 
@@ -170,13 +170,13 @@ export function createNotificationsApi<M extends BaseMetadata>({
   async function getUnreadInboxNotificationsCount() {
     const { count } = await fetchJson<{
       count: number;
-    }>("/inbox-notifications/count");
+    }>("/v2/c/inbox-notifications/count");
 
     return count;
   }
 
   async function markAllInboxNotificationsAsRead() {
-    await fetchJson("/inbox-notifications/read", {
+    await fetchJson("/v2/c/inbox-notifications/read", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -186,7 +186,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function markInboxNotificationsAsRead(inboxNotificationIds: string[]) {
-    await fetchJson("/inbox-notifications/read", {
+    await fetchJson("/v2/c/inbox-notifications/read", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -211,14 +211,14 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function deleteAllInboxNotifications() {
-    await fetchJson("/inbox-notifications", {
+    await fetchJson("/v2/c/inbox-notifications", {
       method: "DELETE",
     });
   }
 
   async function deleteInboxNotification(inboxNotificationId: string) {
     await fetchJson(
-      `/inbox-notifications/${encodeURIComponent(inboxNotificationId)}`,
+      `/v2/c/inbox-notifications/${encodeURIComponent(inboxNotificationId)}`,
       {
         method: "DELETE",
       }
@@ -240,7 +240,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/threads", undefined, {
+    }>("/v2/c/threads", undefined, {
       query,
     });
 
@@ -270,7 +270,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/threads", undefined, {
+    }>("/v2/c/threads", undefined, {
       since: options.since.toISOString(),
       query,
     });

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -13,7 +13,9 @@ import {
 } from "./convert-plain-data";
 import { Batch } from "./lib/batch";
 import type { Store } from "./lib/create-store";
-import { type QueryParams, urljoin } from "./lib/url";
+import { url, urljoin } from "./lib/url";
+import type { QueryParams, URLSafeString } from "./lib/url";
+import { raise } from "./lib/utils";
 import { TokenKind } from "./protocol/AuthToken";
 import type {
   BaseMetadata,
@@ -60,10 +62,14 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }>;
 } {
   async function fetchJson<T>(
-    endpoint: `/v2/c/${string}`,
+    endpoint: URLSafeString,
     options?: RequestInit,
     params?: QueryParams
   ): Promise<T> {
+    if (!endpoint.startsWith("/v2/c/")) {
+      raise("Expected a /v2/c/* endpoint");
+    }
+
     const authValue = await authManager.getAuthValue({
       requestedScope: "comments:read",
     });
@@ -128,7 +134,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/v2/c/inbox-notifications", undefined, {});
+    }>(url`/v2/c/inbox-notifications`, undefined, {});
 
     return {
       threads: json.threads.map(convertToThreadData),
@@ -148,7 +154,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/v2/c/inbox-notifications", undefined, {
+    }>(url`/v2/c/inbox-notifications`, undefined, {
       since: options.since.toISOString(),
     });
 
@@ -170,13 +176,13 @@ export function createNotificationsApi<M extends BaseMetadata>({
   async function getUnreadInboxNotificationsCount() {
     const { count } = await fetchJson<{
       count: number;
-    }>("/v2/c/inbox-notifications/count");
+    }>(url`/v2/c/inbox-notifications/count`);
 
     return count;
   }
 
   async function markAllInboxNotificationsAsRead() {
-    await fetchJson("/v2/c/inbox-notifications/read", {
+    await fetchJson(url`/v2/c/inbox-notifications/read`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -186,7 +192,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function markInboxNotificationsAsRead(inboxNotificationIds: string[]) {
-    await fetchJson("/v2/c/inbox-notifications/read", {
+    await fetchJson(url`/v2/c/inbox-notifications/read`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -211,18 +217,15 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function deleteAllInboxNotifications() {
-    await fetchJson("/v2/c/inbox-notifications", {
+    await fetchJson(url`/v2/c/inbox-notifications`, {
       method: "DELETE",
     });
   }
 
   async function deleteInboxNotification(inboxNotificationId: string) {
-    await fetchJson(
-      `/v2/c/inbox-notifications/${encodeURIComponent(inboxNotificationId)}`,
-      {
-        method: "DELETE",
-      }
-    );
+    await fetchJson(url`/v2/c/inbox-notifications/${inboxNotificationId}`, {
+      method: "DELETE",
+    });
   }
 
   async function getThreads(options: GetThreadsOptions<M>) {
@@ -240,7 +243,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/v2/c/threads", undefined, {
+    }>(url`/v2/c/threads`, undefined, {
       query,
     });
 
@@ -270,7 +273,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>("/v2/c/threads", undefined, {
+    }>(url`/v2/c/threads`, undefined, {
       since: options.since.toISOString(),
       query,
     });

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -13,8 +13,8 @@ import {
 } from "./convert-plain-data";
 import { Batch } from "./lib/batch";
 import type { Store } from "./lib/create-store";
-import { url, urljoin } from "./lib/url";
 import type { QueryParams, URLSafeString } from "./lib/url";
+import { url, urljoin } from "./lib/url";
 import { raise } from "./lib/utils";
 import { TokenKind } from "./protocol/AuthToken";
 import type {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -45,12 +45,13 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import { objectToQuery } from "./lib/objectToQuery";
 import { asPos } from "./lib/position";
-import type { QueryParams } from "./lib/url";
+import { QueryParams, url, URLSafeString } from "./lib/url";
 import { urljoin } from "./lib/url";
 import {
   compact,
   deepClone,
   memoizeOnSuccess,
+  raise,
   tryParseJson,
 } from "./lib/utils";
 import { canComment, canWriteStorage, TokenKind } from "./protocol/AuthToken";
@@ -1517,17 +1518,16 @@ export function createRoom<
   };
 
   async function fetchClientApi(
-    roomId: string,
-    endpoint: string,
+    endpoint: URLSafeString,
     authValue: AuthValue,
     options?: RequestInit,
     params?: QueryParams
   ) {
-    const url = urljoin(
-      config.baseUrl,
-      `/v2/c/rooms/${encodeURIComponent(roomId)}${endpoint}`,
-      params
-    );
+    if (!endpoint.startsWith("/v2/c/rooms/")) {
+      raise("Expected a /v2/c/rooms/* endpoint");
+    }
+
+    const url = urljoin(config.baseUrl, endpoint, params);
     const fetcher = config.polyfills?.fetch || /* istanbul ignore next */ fetch;
     return await fetcher(url, {
       ...options,
@@ -1539,7 +1539,7 @@ export function createRoom<
   }
 
   async function streamFetch(authValue: AuthValue, roomId: string) {
-    return fetchClientApi(roomId, "/storage", authValue, {
+    return fetchClientApi(url`/v2/c/rooms/${roomId}/storage`, authValue, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -1555,13 +1555,19 @@ export function createRoom<
       throw new Error("Not authorized");
     }
 
-    return fetchClientApi(config.roomId, endpoint, managedSocket.authValue, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    return fetchClientApi(
+      endpoint === "/send-message"
+        ? url`/v2/c/rooms/${config.roomId}/send-message`
+        : url`/v2/c/rooms/${config.roomId}/text-metadata`,
+      managedSocket.authValue,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }
+    );
   }
 
   async function createTextMention(userId: string, mentionId: string) {
@@ -1570,8 +1576,7 @@ export function createRoom<
     }
 
     return fetchClientApi(
-      config.roomId,
-      "/text-mentions",
+      url`/v2/c/rooms/${config.roomId}/text-mentions`,
       managedSocket.authValue,
       {
         method: "POST",
@@ -1592,8 +1597,7 @@ export function createRoom<
     }
 
     return fetchClientApi(
-      config.roomId,
-      `/text-mentions/${mentionId}`,
+      url`/v2/c/rooms/${config.roomId}/text-mentions/${mentionId}`,
       managedSocket.authValue,
       {
         method: "DELETE",
@@ -1603,30 +1607,21 @@ export function createRoom<
 
   async function reportTextEditor(type: "lexical", rootKey: string) {
     const authValue = await delegates.authenticate();
-    return fetchClientApi(config.roomId, "/text-metadata", authValue, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        type,
-        rootKey,
-      }),
-    });
+    return fetchClientApi(
+      url`/v2/c/rooms/${config.roomId}/text-metadata`,
+      authValue,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, rootKey }),
+      }
+    );
   }
 
   async function listTextVersions() {
     const authValue = await delegates.authenticate();
-    return fetchClientApi(config.roomId, "/versions/", authValue, {
-      method: "GET",
-    });
-  }
-
-  async function getTextVersion(versionId: string) {
-    const authValue = await delegates.authenticate();
     return fetchClientApi(
-      config.roomId,
-      `/y-version/${encodeURIComponent(versionId)}`,
+      url`/v2/c/rooms/${config.roomId}/versions`,
       authValue,
       {
         method: "GET",
@@ -1634,11 +1629,22 @@ export function createRoom<
     );
   }
 
+  async function getTextVersion(versionId: string) {
+    const authValue = await delegates.authenticate();
+    return fetchClientApi(
+      url`/v2/c/rooms/${config.roomId}/y-version/${versionId}`,
+      authValue,
+      { method: "GET" }
+    );
+  }
+
   async function createTextVersion() {
     const authValue = await delegates.authenticate();
-    return fetchClientApi(config.roomId, "/version", authValue, {
-      method: "POST",
-    });
+    return fetchClientApi(
+      url`/v2/c/rooms/${config.roomId}/version`,
+      authValue,
+      { method: "POST" }
+    );
   }
 
   function sendMessages(messages: ClientMsg<P, E>[]) {
@@ -2772,18 +2778,17 @@ export function createRoom<
   };
 
   async function fetchCommentsApi(
-    endpoint: string,
+    endpoint: URLSafeString,
     params?: QueryParams,
     options?: RequestInit
   ): Promise<Response> {
     // TODO: Use the right scope
     const authValue = await delegates.authenticate();
-
-    return fetchClientApi(config.roomId, endpoint, authValue, options, params);
+    return fetchClientApi(endpoint, authValue, options, params);
   }
 
   async function fetchCommentsJson<T>(
-    endpoint: string,
+    endpoint: URLSafeString,
     options?: RequestInit,
     params?: QueryParams
   ): Promise<T> {
@@ -2822,7 +2827,7 @@ export function createRoom<
 
   async function getThreadsSince(options: { since: Date }) {
     const response = await fetchCommentsApi(
-      "/threads",
+      url`/v2/c/rooms/${config.roomId}/threads`,
       {
         since: options?.since?.toISOString(),
       },
@@ -2882,15 +2887,9 @@ export function createRoom<
     }
 
     const response = await fetchCommentsApi(
-      "/threads",
-      {
-        query,
-      },
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
+      url`/v2/c/rooms/${config.roomId}/threads`,
+      { query },
+      { headers: { "Content-Type": "application/json" } }
     );
 
     if (response.ok) {
@@ -2926,7 +2925,7 @@ export function createRoom<
 
   async function getThread(threadId: string) {
     const response = await fetchCommentsApi(
-      `/thread-with-notification/${threadId}`
+      url`/v2/c/rooms/${config.roomId}/thread-with-notification/${threadId}`
     );
 
     if (response.ok) {
@@ -2963,28 +2962,32 @@ export function createRoom<
     metadata: M | undefined;
     body: CommentBody;
   }) {
-    const thread = await fetchCommentsJson<ThreadDataPlain<M>>("/threads", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        id: threadId,
-        comment: {
-          id: commentId,
-          body,
+    const thread = await fetchCommentsJson<ThreadDataPlain<M>>(
+      url`/v2/c/rooms/${config.roomId}/threads`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
         },
-        metadata,
-      }),
-    });
+        body: JSON.stringify({
+          id: threadId,
+          comment: {
+            id: commentId,
+            body,
+          },
+          metadata,
+        }),
+      }
+    );
 
     return convertToThreadData(thread);
   }
 
   async function deleteThread(threadId: string) {
-    await fetchCommentsJson(`/threads/${encodeURIComponent(threadId)}`, {
-      method: "DELETE",
-    });
+    await fetchCommentsJson(
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}`,
+      { method: "DELETE" }
+    );
   }
 
   async function editThreadMetadata({
@@ -2996,7 +2999,7 @@ export function createRoom<
     threadId: string;
   }) {
     return await fetchCommentsJson<M>(
-      `/threads/${encodeURIComponent(threadId)}/metadata`,
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/metadata`,
       {
         method: "POST",
         headers: {
@@ -3009,19 +3012,15 @@ export function createRoom<
 
   async function markThreadAsResolved(threadId: string) {
     await fetchCommentsJson(
-      `/threads/${encodeURIComponent(threadId)}/mark-as-resolved`,
-      {
-        method: "POST",
-      }
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/mark-as-resolved`,
+      { method: "POST" }
     );
   }
 
   async function markThreadAsUnresolved(threadId: string) {
     await fetchCommentsJson(
-      `/threads/${encodeURIComponent(threadId)}/mark-as-unresolved`,
-      {
-        method: "POST",
-      }
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/mark-as-unresolved`,
+      { method: "POST" }
     );
   }
 
@@ -3035,7 +3034,7 @@ export function createRoom<
     body: CommentBody;
   }) {
     const comment = await fetchCommentsJson<CommentDataPlain>(
-      `/threads/${encodeURIComponent(threadId)}/comments`,
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments`,
       {
         method: "POST",
         headers: {
@@ -3061,9 +3060,7 @@ export function createRoom<
     body: CommentBody;
   }) {
     const comment = await fetchCommentsJson<CommentDataPlain>(
-      `/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(
-        commentId
-      )}`,
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}`,
       {
         method: "POST",
         headers: {
@@ -3087,12 +3084,8 @@ export function createRoom<
     commentId: string;
   }) {
     await fetchCommentsJson(
-      `/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(
-        commentId
-      )}`,
-      {
-        method: "DELETE",
-      }
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}`,
+      { method: "DELETE" }
     );
   }
 
@@ -3106,9 +3099,7 @@ export function createRoom<
     emoji: string;
   }) {
     const reaction = await fetchCommentsJson<CommentUserReactionPlain>(
-      `/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(
-        commentId
-      )}/reactions`,
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}/reactions`,
       {
         method: "POST",
         headers: {
@@ -3131,26 +3122,17 @@ export function createRoom<
     emoji: string;
   }) {
     await fetchCommentsJson<CommentData>(
-      `/threads/${encodeURIComponent(threadId)}/comments/${encodeURIComponent(
-        commentId
-      )}/reactions/${encodeURIComponent(emoji)}`,
-      {
-        method: "DELETE",
-      }
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}/reactions/${emoji}`,
+      { method: "DELETE" }
     );
   }
 
   async function fetchNotificationsJson<T>(
-    endpoint: string,
+    endpoint: URLSafeString,
     options?: RequestInit
   ): Promise<T> {
     const authValue = await delegates.authenticate();
-    const response = await fetchClientApi(
-      config.roomId,
-      endpoint,
-      authValue,
-      options
-    );
+    const response = await fetchClientApi(endpoint, authValue, options);
 
     if (!response.ok) {
       if (response.status >= 400 && response.status < 600) {
@@ -3188,7 +3170,7 @@ export function createRoom<
 
   function getNotificationSettings(): Promise<RoomNotificationSettings> {
     return fetchNotificationsJson<RoomNotificationSettings>(
-      "/notification-settings"
+      url`/v2/c/rooms/${config.roomId}/notification-settings`
     );
   }
 
@@ -3196,7 +3178,7 @@ export function createRoom<
     settings: Partial<RoomNotificationSettings>
   ): Promise<RoomNotificationSettings> {
     return fetchNotificationsJson<RoomNotificationSettings>(
-      "/notification-settings",
+      url`/v2/c/rooms/${config.roomId}/notification-settings`,
       {
         method: "POST",
         body: JSON.stringify(settings),
@@ -3208,19 +3190,22 @@ export function createRoom<
   }
 
   // This method (and the following batch handling) isn't the same as the one in
-  // src/notifications.ts, this one is room-based: /v2/c/rooms/:roomId/inbox-notifications/read.
+  // src/notifications.ts, this one is room-based: /v2/c/rooms/<roomId>/inbox-notifications/read.
   //
   // The reason for this is that unlike the room-based Comments ones, the Notifications endpoints
   // don't work with a public key. Since `markThreadAsRead` needs to mark the related inbox notifications
   // as read, this room-based method is necessary to keep all Comments features working with a public key.
   async function markInboxNotificationsAsRead(inboxNotificationIds: string[]) {
-    await fetchNotificationsJson("/inbox-notifications/read", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ inboxNotificationIds }),
-    });
+    await fetchNotificationsJson(
+      url`/v2/c/rooms/${config.roomId}/inbox-notifications/read`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ inboxNotificationIds }),
+      }
+    );
   }
 
   const batchedMarkInboxNotificationsAsRead = new Batch<string, string>(

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -45,8 +45,8 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import { objectToQuery } from "./lib/objectToQuery";
 import { asPos } from "./lib/position";
-import { QueryParams, url, URLSafeString } from "./lib/url";
-import { urljoin } from "./lib/url";
+import type { QueryParams, URLSafeString } from "./lib/url";
+import { url, urljoin } from "./lib/url";
 import {
   compact,
   deepClone,

--- a/packages/liveblocks-node/src/Session.ts
+++ b/packages/liveblocks-node/src/Session.ts
@@ -1,12 +1,13 @@
-import type { IUserInfo, Json, JsonObject } from "@liveblocks/core";
+import type {
+  IUserInfo,
+  Json,
+  JsonObject,
+  URLSafeString,
+} from "@liveblocks/core";
+import { url } from "@liveblocks/core";
 
 import type { AuthResponse } from "./client";
-import {
-  assertNonEmpty,
-  normalizeStatusCode,
-  url,
-  type URLSafeString,
-} from "./utils";
+import { assertNonEmpty, normalizeStatusCode } from "./utils";
 
 // As defined in the source of truth in ApiScope in
 // https://github.com/liveblocks/liveblocks-cloudflare/blob/main/src/security.ts

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -27,10 +27,12 @@ import type {
   Patchable,
   PlainLsonObject,
   QueryMetadata,
+  QueryParams,
   RoomNotificationSettings,
   ThreadData,
   ThreadDataPlain,
   ToImmutable,
+  URLSafeString,
 } from "@liveblocks/core";
 import {
   convertToCommentData,
@@ -38,6 +40,8 @@ import {
   convertToInboxNotificationData,
   convertToThreadData,
   objectToQuery,
+  url,
+  urljoin,
 } from "@liveblocks/core";
 
 import { Session } from "./Session";
@@ -47,10 +51,6 @@ import {
   fetchPolyfill,
   getBaseUrl,
   normalizeStatusCode,
-  type QueryParams,
-  url,
-  urljoin,
-  type URLSafeString,
 } from "./utils";
 
 type ToSimplifiedJson<S extends LsonObject> = LsonObject extends S

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -1,5 +1,3 @@
-import type { Brand } from "@liveblocks/core";
-
 const DEFAULT_BASE_URL = "https://api.liveblocks.io";
 
 export function getBaseUrl(baseUrl?: string | undefined): string {
@@ -53,76 +51,4 @@ export function normalizeStatusCode(statusCode: number): number {
   } else {
     return 403; /* Forbidden */
   }
-}
-
-export type QueryParams =
-  | Record<string, string | number | null | undefined>
-  | URLSearchParams;
-
-/**
- * Safely but conveniently build a URLSearchParams instance from a given
- * dictionary of values. For example:
- *
- *   {
- *     "foo": "bar+qux/baz",
- *     "empty": "",
- *     "n": 42,
- *     "nope": undefined,
- *     "alsonope": null,
- *   }
- *
- * Will produce a value that will get serialized as
- * `foo=bar%2Bqux%2Fbaz&empty=&n=42`.
- *
- * Notice how the number is converted to its string representation
- * automatically and the `null`/`undefined` values simply don't end up in the
- * URL.
- */
-function toURLSearchParams(
-  params: Record<string, string | number | null | undefined>
-): URLSearchParams {
-  const result = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (value !== undefined && value !== null) {
-      result.set(key, value.toString());
-    }
-  }
-  return result;
-}
-
-/**
- * Concatenates a path to an existing URL.
- */
-export function urljoin(
-  baseUrl: string | URL,
-  path: string,
-  params?: QueryParams
-): string {
-  // First, sanitize by removing user/passwd/search/hash parts from the URL
-  const url = new URL(path, baseUrl);
-  if (params !== undefined) {
-    url.search = (
-      params instanceof URLSearchParams ? params : toURLSearchParams(params)
-    ).toString();
-  }
-  return url.toString();
-}
-
-/**
- * A string that is guaranteed to be URL safe (where all arguments are properly
- * encoded), only obtainable as the result of using `url` template strings.
- */
-export type URLSafeString = Brand<string, "URLSafeString">;
-
-/**
- * Builds a URL where each "hole" in the template string will automatically be
- * encodeURIComponent()-escaped, so it's impossible to build invalid URLs.
- */
-export function url(
-  strings: TemplateStringsArray,
-  ...values: string[]
-): URLSafeString {
-  return strings.reduce(
-    (result, str, i) => result + encodeURIComponent(values[i - 1] ?? "") + str
-  ) as URLSafeString;
 }

--- a/packages/liveblocks-react/src/__tests__/useDeleteAllInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteAllInboxNotifications.test.tsx
@@ -87,7 +87,9 @@ describe("useDeleteAllInboxNotifications", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     act(() => {
@@ -154,7 +156,9 @@ describe("useDeleteAllInboxNotifications", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     act(() => {
@@ -166,7 +170,9 @@ describe("useDeleteAllInboxNotifications", () => {
 
     await waitFor(() => {
       // The optimistic update is reverted because of the error response
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications);
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
     });
 
     unmount();
@@ -231,7 +237,9 @@ describe("useDeleteAllInboxNotifications", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications);
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
       expect(result.current.unreadInboxNotificationsCount).toEqual(2);
     });
 
@@ -246,7 +254,9 @@ describe("useDeleteAllInboxNotifications", () => {
 
     await waitFor(() => {
       // The optimistic update is reverted because of the error response
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications);
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
     });
 
     expect(result.current.unreadInboxNotificationsCount).toEqual(2);
@@ -324,7 +334,9 @@ describe("useDeleteAllInboxNotifications", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // We delete all notifications optimitiscally
@@ -418,7 +430,9 @@ describe("useDeleteAllInboxNotifications", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // We delete all notifications optimitiscally

--- a/packages/liveblocks-react/src/__tests__/useDeleteInboxNotification.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useDeleteInboxNotification.test.tsx
@@ -90,9 +90,11 @@ describe("useDeleteInboxNotification", () => {
       }
     );
 
-    await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
-    );
+    await waitFor(() => {
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
+    });
 
     act(() => {
       result.current.deleteInboxNotification(notification1.id);
@@ -167,7 +169,9 @@ describe("useDeleteInboxNotification", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // We delete the notification optimitiscally
@@ -179,7 +183,9 @@ describe("useDeleteInboxNotification", () => {
 
     await waitFor(() => {
       // The optimistic update is reverted because of the error response
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications);
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
     });
 
     unmount();
@@ -246,7 +252,9 @@ describe("useDeleteInboxNotification", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications);
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
       expect(result.current.unreadInboxNotificationsCount).toEqual(2);
     });
 
@@ -261,7 +269,9 @@ describe("useDeleteInboxNotification", () => {
 
     await waitFor(() => {
       // The optimistic update is reverted because of the error response
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications);
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
     });
 
     expect(result.current.unreadInboxNotificationsCount).toEqual(2);
@@ -343,7 +353,9 @@ describe("useDeleteInboxNotification", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // We delete the notification optimitiscally
@@ -440,7 +452,9 @@ describe("useDeleteInboxNotification", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // We delete the notification optimitiscally

--- a/packages/liveblocks-react/src/__tests__/useMarkAllInboxNotificationsAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkAllInboxNotificationsAsRead.test.tsx
@@ -81,9 +81,9 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
     );
 
     await waitFor(() => {
-      for (const ibn of inboxNotifications) {
-        expect(result.current.inboxNotifications).toContainEqual(ibn);
-      }
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      );
     });
 
     act(() => {
@@ -153,7 +153,9 @@ describe("useMarkAllInboxNotificationsAsRead", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     act(() => {

--- a/packages/liveblocks-react/src/__tests__/useMarkInboxNotificationAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkInboxNotificationAsRead.test.tsx
@@ -71,7 +71,9 @@ describe("useMarkInboxNotificationAsRead", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // Mark the first thread in our threads list as read
@@ -134,7 +136,9 @@ describe("useMarkInboxNotificationAsRead", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // Mark the first thread in our threads list as read

--- a/packages/liveblocks-react/src/__tests__/useMarkThreadAsRead.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkThreadAsRead.test.tsx
@@ -85,7 +85,9 @@ describe("useMarkThreadAsRead", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // Mark the first thread in our threads list as read
@@ -161,7 +163,9 @@ describe("useMarkThreadAsRead", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.inboxNotifications).toEqual(inboxNotifications)
+      expect(result.current.inboxNotifications).toEqual(
+        expect.arrayContaining(inboxNotifications)
+      )
     );
 
     // Mark the first thread in our threads list as read


### PR DESCRIPTION
Updates the client, making it more obvious what backend URLs are called exactly from the client, and requiring the use of URL-safe URL builder, making it unnecessary (and impossible to forget) to call `encodeURIComponent()` on all path arguments.

The other benefit is that all endpoint URL paths are now statically searchable, making it easier to see which paths are used where, and easier to find the backend endpoint implementation in the router.