### PR TITLE
DRY up AsyncResult types

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -83,7 +83,12 @@ export {
 } from "./immutable";
 export { kInternal } from "./internal";
 export { assert, assertNever, nn } from "./lib/assert";
-export type { AsyncResult, AsyncResultWithDataField } from "./lib/AsyncResult";
+export type {
+  AsyncError,
+  AsyncLoading,
+  AsyncResult,
+  AsyncSuccess,
+} from "./lib/AsyncResult";
 export {
   createCommentId,
   createInboxNotificationId,

--- a/packages/liveblocks-core/src/lib/AsyncResult.ts
+++ b/packages/liveblocks-core/src/lib/AsyncResult.ts
@@ -2,29 +2,33 @@ type RenameDataField<T, TFieldName extends string> = T extends any
   ? { [K in keyof T as K extends "data" ? TFieldName : K]: T[K] }
   : never;
 
-export type AsyncResult<T> =
-  // loading
-  | {
-      readonly isLoading: true;
-      readonly data?: never;
-      readonly error?: never;
-    }
+export type AsyncLoading<F extends string = "data"> = RenameDataField<
+  {
+    readonly isLoading: true;
+    readonly data?: never;
+    readonly error?: never;
+  },
+  F
+>;
 
-  // success
-  | {
-      readonly isLoading: false;
-      readonly data: T;
-      readonly error?: never;
-    }
+export type AsyncSuccess<T, F extends string = "data"> = RenameDataField<
+  {
+    readonly isLoading: false;
+    readonly data: T;
+    readonly error?: never;
+  },
+  F
+>;
+export type AsyncError<F extends string = "data"> = RenameDataField<
+  {
+    readonly isLoading: false;
+    readonly data?: never;
+    readonly error: Error;
+  },
+  F
+>;
 
-  // error
-  | {
-      readonly isLoading: false;
-      readonly data?: never;
-      readonly error: Error;
-    };
-
-export type AsyncResultWithDataField<
-  T,
-  TDataField extends string,
-> = RenameDataField<AsyncResult<T>, TDataField>;
+export type AsyncResult<T, F extends string = "data"> =
+  | AsyncLoading<F>
+  | AsyncSuccess<T, F>
+  | AsyncError<F>;

--- a/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateThread.test.tsx
@@ -37,6 +37,9 @@ describe("useCreateThread", () => {
           ctx.json({
             data: [],
             inboxNotifications: [],
+            meta: {
+              requestedAt: new Date(),
+            },
           })
         );
       }),
@@ -77,7 +80,7 @@ describe("useCreateThread", () => {
 
     const { result, unmount } = renderHook(
       () => ({
-        threads: useThreads().threads,
+        threadData: useThreads(),
         createThread: useCreateThread(),
       }),
       {
@@ -87,9 +90,14 @@ describe("useCreateThread", () => {
       }
     );
 
-    expect(result.current.threads).toBeUndefined();
+    expect(result.current.threadData).toEqual({ isLoading: true });
 
-    await waitFor(() => expect(result.current.threads).toEqual([]));
+    await waitFor(() =>
+      expect(result.current.threadData).toEqual({
+        isLoading: false,
+        threads: [],
+      })
+    );
 
     const thread = await act(() =>
       result.current.createThread({
@@ -100,11 +108,13 @@ describe("useCreateThread", () => {
       })
     );
 
-    expect(result.current.threads?.[0]).toEqual(thread);
+    expect(result.current.threadData.threads?.[0]).toEqual(thread);
 
     // We're using the createdDate overriden by the server to ensure the optimistic update have been properly deleted
     await waitFor(() =>
-      expect(result.current.threads?.[0]?.createdAt).toEqual(fakeCreatedAt)
+      expect(result.current.threadData.threads?.[0]?.createdAt).toEqual(
+        fakeCreatedAt
+      )
     );
 
     unmount();
@@ -119,6 +129,9 @@ describe("useCreateThread", () => {
           ctx.json({
             data: [],
             inboxNotifications: [],
+            meta: {
+              requestedAt: new Date(),
+            },
           })
         );
       }),
@@ -133,7 +146,7 @@ describe("useCreateThread", () => {
 
     const { result, unmount } = renderHook(
       () => ({
-        threads: useThreads().threads,
+        threadsData: useThreads(),
         createThread: useCreateThread(),
       }),
       {
@@ -143,9 +156,14 @@ describe("useCreateThread", () => {
       }
     );
 
-    expect(result.current.threads).toBeUndefined();
+    expect(result.current.threadsData).toEqual({ isLoading: true });
 
-    await waitFor(() => expect(result.current.threads).toEqual([]));
+    await waitFor(() =>
+      expect(result.current.threadsData).toEqual({
+        isLoading: false,
+        threads: [],
+      })
+    );
 
     const thread = await act(() =>
       result.current.createThread({
@@ -156,10 +174,10 @@ describe("useCreateThread", () => {
       })
     );
 
-    expect(result.current.threads).toEqual([thread]);
+    expect(result.current.threadsData.threads).toEqual([thread]);
 
     // Wait for optimistic update to be rolled back
-    await waitFor(() => expect(result.current.threads).toEqual([]));
+    await waitFor(() => expect(result.current.threadsData.threads).toEqual([]));
 
     unmount();
   });

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -913,7 +913,6 @@ describe("useThreads", () => {
 
     await waitFor(() =>
       expect(result.current).toEqual({
-        threads: [],
         isLoading: false,
         error: expect.any(Error),
       })
@@ -1476,7 +1475,6 @@ describe("useThreads: error", () => {
     await waitFor(() => expect(getThreadsReqCount).toBe(1));
 
     expect(result.current).toEqual({
-      threads: [],
       isLoading: false,
       error: expect.any(Error),
     });
@@ -1531,7 +1529,6 @@ describe("useThreads: error", () => {
     await waitFor(() => expect(getThreadsReqCount).toBe(1));
 
     expect(result.current).toEqual({
-      threads: [],
       isLoading: false,
       error: expect.any(Error),
     });
@@ -1599,7 +1596,6 @@ describe("useThreads: error", () => {
     await waitFor(() => expect(getThreadsReqCount).toBe(1));
 
     expect(result.current).toEqual({
-      threads: [],
       isLoading: false,
       error: expect.any(Error),
     });

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -7,7 +7,6 @@ import type {
 } from "@liveblocks/client";
 import type {
   AsyncResult,
-  AsyncResultWithDataField,
   BaseRoomInfo,
   DM,
   DU,
@@ -121,11 +120,8 @@ function selectUnreadInboxNotificationsCount(
 }
 
 function selectorFor_useUnreadInboxNotificationsCount(
-  result: AsyncResultWithDataField<
-    InboxNotificationData[],
-    "inboxNotifications"
-  >
-): AsyncResultWithDataField<number, "count"> {
+  result: AsyncResult<InboxNotificationData[], "inboxNotifications">
+): AsyncResult<number, "count"> {
   if (!result.inboxNotifications) {
     // Can be loading or error states
     return result;

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -1124,17 +1124,11 @@ function useUserThreads_experimental<M extends BaseMetadata>(
       const query = state.queries[queryKey];
 
       if (query === undefined || query.isLoading) {
-        return {
-          isLoading: true,
-        };
+        return { isLoading: true };
       }
 
       if (query.error !== undefined) {
-        return {
-          threads: [],
-          error: query.error,
-          isLoading: false,
-        };
+        return query;
       }
 
       return {

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -47,8 +47,8 @@ import type {
   RoomInfoAsyncSuccess,
   SharedContextBundle,
   ThreadsQuery,
-  ThreadsState,
-  ThreadsStateSuccess,
+  ThreadsAsyncResult,
+  ThreadsAsyncSuccess,
   UserAsyncResult,
   UserAsyncSuccess,
   UseUserThreadsOptions,
@@ -1103,7 +1103,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
       metadata: {},
     },
   }
-): ThreadsState<M> {
+): ThreadsAsyncResult<M> {
   const queryKey = React.useMemo(
     () => makeUserThreadsQueryKey(options.query),
     [options]
@@ -1120,7 +1120,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
   }, [queryKey, incrementUserThreadsQuerySubscribers, getUserThreads, options]);
 
   const selector = useCallback(
-    (state: GetThreadsType<M>): ThreadsState<M> => {
+    (state: GetThreadsType<M>): ThreadsAsyncResult<M> => {
       const query = state.queries[queryKey];
 
       if (query === undefined || query.isLoading) {
@@ -1173,7 +1173,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
       metadata: {},
     },
   }
-): ThreadsStateSuccess<M> {
+): ThreadsAsyncSuccess<M> {
   const queryKey = React.useMemo(
     () => makeUserThreadsQueryKey(options.query),
     [options]
@@ -1199,7 +1199,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
   }
 
   const selector = useCallback(
-    (state: GetThreadsType<M>): ThreadsStateSuccess<M> => {
+    (state: GetThreadsType<M>): ThreadsAsyncSuccess<M> => {
       return {
         threads: selectThreads(state, {
           roomId: null, // Do _not_ filter by roomId

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -1135,7 +1135,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
       // "Map" the success state, by selecting the threads and returning only those parts externally
       return { isLoading: false, threads };
     },
-    [queryKey, options]
+    [options]
   );
 
   return useSyncExternalStoreWithSelector(

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -62,8 +62,8 @@ import { INBOX_NOTIFICATIONS_QUERY, UmbrellaStore } from "./umbrella-store";
 // NOTE: The reason we cannot inline them into the selectors is that the react-hooks/exchaustive-deps lint rule will think
 type GetInboxNotificationsType<M extends BaseMetadata = BaseMetadata> =
   ReturnType<UmbrellaStore<M>["getInboxNotifications"]>;
-type GetThreadsType<M extends BaseMetadata = BaseMetadata> = ReturnType<
-  UmbrellaStore<M>["getThreads"]
+type GetUserThreadsType<M extends BaseMetadata = BaseMetadata> = ReturnType<
+  UmbrellaStore<M>["getUserThreads"]
 >;
 
 /**
@@ -1122,7 +1122,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
   }, [queryKey, incrementUserThreadsQuerySubscribers, getUserThreads, options]);
 
   const selector = useCallback(
-    (state: GetThreadsType<M>): ThreadsAsyncResult<M> => {
+    (state: GetUserThreadsType<M>): ThreadsAsyncResult<M> => {
       const query = state.queries[queryKey];
 
       if (query === undefined || query.isLoading) {
@@ -1146,9 +1146,9 @@ function useUserThreads_experimental<M extends BaseMetadata>(
   );
 
   return useSyncExternalStoreWithSelector(
-    store.subscribeThreads,
-    store.getThreads,
-    store.getThreads,
+    store.subscribeUserThreads,
+    store.getUserThreads,
+    store.getUserThreads,
     selector,
     shallow2 // NOTE: Using 2-level-deep shallow check here, because the result of selectThreads() is not stable!
   );
@@ -1190,7 +1190,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
     return incrementUserThreadsQuerySubscribers(queryKey);
   }, [client, queryKey]);
 
-  const query = store.getThreads().queries[queryKey];
+  const query = store.getUserThreads().queries[queryKey];
 
   if (query === undefined || query.isLoading) {
     throw getUserThreads(queryKey, options);
@@ -1201,7 +1201,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
   }
 
   const selector = useCallback(
-    (state: GetThreadsType<M>): ThreadsAsyncSuccess<M> => {
+    (state: GetUserThreadsType<M>): ThreadsAsyncSuccess<M> => {
       return {
         threads: selectThreads(state, {
           roomId: null, // Do _not_ filter by roomId
@@ -1215,9 +1215,9 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
   );
 
   return useSyncExternalStoreWithSelector(
-    store.subscribeThreads,
-    store.getThreads,
-    store.getThreads,
+    store.subscribeUserThreads,
+    store.getUserThreads,
+    store.getUserThreads,
     selector,
     shallow2 // NOTE: Using 2-level-deep shallow check here, because the result of selectThreads() is not stable!
   );

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -42,13 +42,15 @@ import { shallow2 } from "./lib/shallow2";
 import { useInitial, useInitialUnlessFunction } from "./lib/use-initial";
 import { use } from "./lib/use-polyfill";
 import type {
+  InboxNotificationsAsyncResult,
   LiveblocksContextBundle,
   RoomInfoAsyncResult,
   RoomInfoAsyncSuccess,
   SharedContextBundle,
-  ThreadsQuery,
   ThreadsAsyncResult,
   ThreadsAsyncSuccess,
+  ThreadsQuery,
+  UnreadInboxNotificationsCountAsyncResult,
   UserAsyncResult,
   UserAsyncSuccess,
   UseUserThreadsOptions,
@@ -120,8 +122,8 @@ function selectUnreadInboxNotificationsCount(
 }
 
 function selectorFor_useUnreadInboxNotificationsCount(
-  result: AsyncResult<InboxNotificationData[], "inboxNotifications">
-): AsyncResult<number, "count"> {
+  result: InboxNotificationsAsyncResult
+): UnreadInboxNotificationsCountAsyncResult {
   if (!result.inboxNotifications) {
     // Can be loading or error states
     return result;

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1455,14 +1455,17 @@ function useThreads<M extends BaseMetadata>(
         };
       }
 
+      if (query.error) {
+        return query;
+      }
+
       return {
+        isLoading: false,
         threads: selectThreads(state, {
           roomId: room.id,
           query: options.query,
           orderBy: "age",
         }),
-        isLoading: false,
-        error: query.error,
       };
     },
     [room, queryKey] // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -72,18 +72,18 @@ import type {
   DeleteCommentOptions,
   EditCommentOptions,
   EditThreadMetadataOptions,
-  HistoryVersionDataState,
-  HistoryVersionsState,
-  HistoryVersionsStateSuccess,
+  HistoryVersionDataAsyncResult,
+  HistoryVersionsAsyncResult,
+  HistoryVersionsAsyncSuccess,
   MutationContext,
   OmitFirstArg,
   RoomContextBundle,
-  RoomNotificationSettingsState,
-  RoomNotificationSettingsStateSuccess,
+  RoomNotificationSettingsAsyncResult,
+  RoomNotificationSettingsAsyncSuccess,
   RoomProviderProps,
   StorageStatusSuccess,
-  ThreadsState,
-  ThreadsStateSuccess,
+  ThreadsAsyncResult,
+  ThreadsAsyncSuccess,
   ThreadSubscription,
   UseStorageStatusOptions,
   UseThreadsOptions,
@@ -1425,7 +1425,7 @@ function useThreads<M extends BaseMetadata>(
   options: UseThreadsOptions<M> = {
     query: { metadata: {} },
   }
-): ThreadsState<M> {
+): ThreadsAsyncResult<M> {
   const { scrollOnLoad = true } = options;
   const client = useClient();
   const room = useRoom();
@@ -1445,7 +1445,7 @@ function useThreads<M extends BaseMetadata>(
   }, [room, queryKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const selector = React.useCallback(
-    (state: UmbrellaStoreState<M>): ThreadsState<M> => {
+    (state: UmbrellaStoreState<M>): ThreadsAsyncResult<M> => {
       // TODO Don't make this the responsibility of the _selector_. It should be
       // responsibility of the _getter_.
       const query = state.queries[queryKey];
@@ -2136,7 +2136,7 @@ function useThreadSubscription(threadId: string): ThreadSubscription {
  * const [{ settings }, updateSettings] = useRoomNotificationSettings();
  */
 function useRoomNotificationSettings(): [
-  RoomNotificationSettingsState,
+  RoomNotificationSettingsAsyncResult,
   (settings: Partial<RoomNotificationSettings>) => void,
 ] {
   const updateRoomNotificationSettings = useUpdateRoomNotificationSettings();
@@ -2175,7 +2175,7 @@ function useRoomNotificationSettings(): [
  * const [{ settings }, updateSettings] = useRoomNotificationSettings();
  */
 function useRoomNotificationSettingsSuspense(): [
-  RoomNotificationSettingsStateSuccess,
+  RoomNotificationSettingsAsyncSuccess,
   (settings: Partial<RoomNotificationSettings>) => void,
 ] {
   const updateRoomNotificationSettings = useUpdateRoomNotificationSettings();
@@ -2215,8 +2215,10 @@ function useRoomNotificationSettingsSuspense(): [
  * @example
  * const {data} = useHistoryVersionData(versionId);
  */
-function useHistoryVersionData(versionId: string): HistoryVersionDataState {
-  const [state, setState] = React.useState<HistoryVersionDataState>({
+function useHistoryVersionData(
+  versionId: string
+): HistoryVersionDataAsyncResult {
+  const [state, setState] = React.useState<HistoryVersionDataAsyncResult>({
     isLoading: true,
   });
   const room = useRoom();
@@ -2254,7 +2256,7 @@ function useHistoryVersionData(versionId: string): HistoryVersionDataState {
  * @example
  * const { versions, error, isLoading } = useHistoryVersions();
  */
-function useHistoryVersions(): HistoryVersionsState {
+function useHistoryVersions(): HistoryVersionsAsyncResult {
   const client = useClient();
   const room = useRoom();
 
@@ -2286,7 +2288,7 @@ function useHistoryVersions(): HistoryVersionsState {
  * @example
  * const { versions } = useHistoryVersions();
  */
-function useHistoryVersionsSuspense(): HistoryVersionsStateSuccess {
+function useHistoryVersionsSuspense(): HistoryVersionsAsyncSuccess {
   const client = useClient();
   const room = useRoom();
 
@@ -2489,7 +2491,7 @@ function useThreadsSuspense<M extends BaseMetadata>(
   options: UseThreadsOptions<M> = {
     query: { metadata: {} },
   }
-): ThreadsStateSuccess<M> {
+): ThreadsAsyncSuccess<M> {
   const { scrollOnLoad = true } = options;
 
   const client = useClient();
@@ -2513,7 +2515,7 @@ function useThreadsSuspense<M extends BaseMetadata>(
   }
 
   const selector = React.useCallback(
-    (state: ReturnType<typeof store.getThreads>): ThreadsStateSuccess<M> => {
+    (state: ReturnType<typeof store.getThreads>): ThreadsAsyncSuccess<M> => {
       return {
         threads: selectThreads(state, {
           roomId: room.id,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -74,7 +74,7 @@ import type {
   EditThreadMetadataOptions,
   HistoryVersionDataState,
   HistoryVersionsState,
-  HistoryVersionsStateResolved,
+  HistoryVersionsStateSuccess,
   MutationContext,
   OmitFirstArg,
   RoomContextBundle,
@@ -2283,7 +2283,7 @@ function useHistoryVersions(): HistoryVersionsState {
  * @example
  * const { versions } = useHistoryVersions();
  */
-function useHistoryVersionsSuspense(): HistoryVersionsStateResolved {
+function useHistoryVersionsSuspense(): HistoryVersionsStateSuccess {
   const client = useClient();
   const room = useRoom();
 

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -163,22 +163,7 @@ export type RoomNotificationSettingsStateError = AsyncError<"settings">;
 export type RoomNotificationSettingsStateSuccess = AsyncSuccess<RoomNotificationSettings, "settings">; // prettier-ignore
 export type RoomNotificationSettingsState = AsyncResult<RoomNotificationSettings, "settings">; // prettier-ignore
 
-export type HistoryVersionDataStateLoading = AsyncLoading;
-export type HistoryVersionDataStateError = AsyncError;
-
-// XXX Refactor this type away! We should NOT have data & error state simultaneously!
-// XXX Re-express this as AsyncSuccess<Uint8Array>
-export type HistoryVersionDataStateResolved = {
-  isLoading: false;
-  data: Uint8Array;
-  error?: Error;
-};
-
-export type HistoryVersionDataState =
-  | HistoryVersionDataStateLoading
-  // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
-  | HistoryVersionDataStateResolved
-  | HistoryVersionDataStateError;
+export type HistoryVersionDataState = AsyncResult<Uint8Array>;
 
 export type HistoryVersionsStateLoading = AsyncLoading<"versions">;
 export type HistoryVersionsStateError = AsyncError<"versions">;

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -130,22 +130,22 @@ export type CommentReactionOptions = {
   emoji: string;
 };
 
-export type ThreadsStateSuccess<M extends BaseMetadata> = AsyncSuccess<ThreadData<M>[], "threads">; // prettier-ignore
-export type ThreadsState<M extends BaseMetadata> = AsyncResult<ThreadData<M>[], "threads">; // prettier-ignore
+export type ThreadsAsyncSuccess<M extends BaseMetadata> = AsyncSuccess<ThreadData<M>[], "threads">; // prettier-ignore
+export type ThreadsAsyncResult<M extends BaseMetadata> = AsyncResult<ThreadData<M>[], "threads">; // prettier-ignore
 
-export type InboxNotificationsStateSuccess = AsyncSuccess<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
-export type InboxNotificationsState = AsyncResult<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
+export type InboxNotificationsAsyncSuccess = AsyncSuccess<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
+export type InboxNotificationsAsyncResult = AsyncResult<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
 
-export type UnreadInboxNotificationsCountStateSuccess = AsyncSuccess<number, "count">; // prettier-ignore
-export type UnreadInboxNotificationsCountState = AsyncResult<number, "count">;
+export type UnreadInboxNotificationsCountAsyncSuccess = AsyncSuccess<number, "count">; // prettier-ignore
+export type UnreadInboxNotificationsCountAsyncResult = AsyncResult<number, "count">; // prettier-ignore
 
-export type RoomNotificationSettingsStateSuccess = AsyncSuccess<RoomNotificationSettings, "settings">; // prettier-ignore
-export type RoomNotificationSettingsState = AsyncResult<RoomNotificationSettings, "settings">; // prettier-ignore
+export type RoomNotificationSettingsAsyncSuccess = AsyncSuccess<RoomNotificationSettings, "settings">; // prettier-ignore
+export type RoomNotificationSettingsAsyncResult = AsyncResult<RoomNotificationSettings, "settings">; // prettier-ignore
 
-export type HistoryVersionDataState = AsyncResult<Uint8Array>;
+export type HistoryVersionDataAsyncResult = AsyncResult<Uint8Array>;
 
-export type HistoryVersionsStateSuccess = AsyncSuccess<HistoryVersion[], "versions">; // prettier-ignore
-export type HistoryVersionsState = AsyncResult<HistoryVersion[], "versions">;
+export type HistoryVersionsAsyncSuccess = AsyncSuccess<HistoryVersion[], "versions">; // prettier-ignore
+export type HistoryVersionsAsyncResult = AsyncResult<HistoryVersion[], "versions">; // prettier-ignore
 
 export type RoomProviderProps<P extends JsonObject, S extends LsonObject> =
   // prettier-ignore
@@ -885,7 +885,7 @@ export type RoomContextBundle<
        * @example
        * const { threads, error, isLoading } = useThreads();
        */
-      useThreads(options?: UseThreadsOptions<M>): ThreadsState<M>;
+      useThreads(options?: UseThreadsOptions<M>): ThreadsAsyncResult<M>;
 
       /**
        * Returns the user's notification settings for the current room
@@ -895,7 +895,7 @@ export type RoomContextBundle<
        * const [{ settings }, updateSettings] = useRoomNotificationSettings();
        */
       useRoomNotificationSettings(): [
-        RoomNotificationSettingsState,
+        RoomNotificationSettingsAsyncResult,
         (settings: Partial<RoomNotificationSettings>) => void,
       ];
 
@@ -905,7 +905,7 @@ export type RoomContextBundle<
        * @example
        * const { versions, error, isLoading } = useHistoryVersions();
        */
-      useHistoryVersions(): HistoryVersionsState;
+      useHistoryVersions(): HistoryVersionsAsyncResult;
 
       /**
        * (Private beta) Returns the data of a specific version of the current room.
@@ -913,7 +913,7 @@ export type RoomContextBundle<
        * @example
        * const { data, error, isLoading } = useHistoryVersionData(version.id);
        */
-      useHistoryVersionData(id: string): HistoryVersionDataState;
+      useHistoryVersionData(id: string): HistoryVersionDataAsyncResult;
 
       suspense: Resolve<
         RoomContextBundleCommon<P, S, U, E, M> &
@@ -990,7 +990,7 @@ export type RoomContextBundle<
              * @example
              * const { threads } = useThreads();
              */
-            useThreads(options?: UseThreadsOptions<M>): ThreadsStateSuccess<M>;
+            useThreads(options?: UseThreadsOptions<M>): ThreadsAsyncSuccess<M>;
 
             /**
              * (Private beta) Returns a history of versions of the current room.
@@ -998,7 +998,7 @@ export type RoomContextBundle<
              * @example
              * const { versions } = useHistoryVersions();
              */
-            useHistoryVersions(): HistoryVersionsStateSuccess;
+            useHistoryVersions(): HistoryVersionsAsyncSuccess;
 
             // /**
             //  * Returns the data of a specific version of the current room's history.
@@ -1016,7 +1016,7 @@ export type RoomContextBundle<
              * const [{ settings }, updateSettings] = useRoomNotificationSettings();
              */
             useRoomNotificationSettings(): [
-              RoomNotificationSettingsStateSuccess,
+              RoomNotificationSettingsAsyncSuccess,
               (settings: Partial<RoomNotificationSettings>) => void,
             ];
           }
@@ -1100,7 +1100,7 @@ export type LiveblocksContextBundle<
        * @example
        * const { inboxNotifications, error, isLoading } = useInboxNotifications();
        */
-      useInboxNotifications(): InboxNotificationsState;
+      useInboxNotifications(): InboxNotificationsAsyncResult;
 
       /**
        * Returns the number of unread inbox notifications for the current user.
@@ -1108,7 +1108,7 @@ export type LiveblocksContextBundle<
        * @example
        * const { count, error, isLoading } = useUnreadInboxNotificationsCount();
        */
-      useUnreadInboxNotificationsCount(): UnreadInboxNotificationsCountState;
+      useUnreadInboxNotificationsCount(): UnreadInboxNotificationsCountAsyncResult;
 
       /**
        * @experimental
@@ -1118,7 +1118,7 @@ export type LiveblocksContextBundle<
        */
       useUserThreads_experimental(
         options?: UseUserThreadsOptions<M>
-      ): ThreadsState<M>;
+      ): ThreadsAsyncResult<M>;
 
       suspense: Resolve<
         LiveblocksContextBundleCommon<M> &
@@ -1129,7 +1129,7 @@ export type LiveblocksContextBundle<
              * @example
              * const { inboxNotifications } = useInboxNotifications();
              */
-            useInboxNotifications(): InboxNotificationsStateSuccess;
+            useInboxNotifications(): InboxNotificationsAsyncSuccess;
 
             /**
              * Returns the number of unread inbox notifications for the current user.
@@ -1137,7 +1137,7 @@ export type LiveblocksContextBundle<
              * @example
              * const { count } = useUnreadInboxNotificationsCount();
              */
-            useUnreadInboxNotificationsCount(): UnreadInboxNotificationsCountStateSuccess;
+            useUnreadInboxNotificationsCount(): UnreadInboxNotificationsCountAsyncSuccess;
 
             /**
              * @experimental
@@ -1147,7 +1147,7 @@ export type LiveblocksContextBundle<
              */
             useUserThreads_experimental(
               options?: UseUserThreadsOptions<M>
-            ): ThreadsStateSuccess<M>;
+            ): ThreadsAsyncSuccess<M>;
           }
       >;
     }

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -14,7 +14,8 @@ import type {
   User,
 } from "@liveblocks/client";
 import type {
-  AsyncResultWithDataField,
+  AsyncResult,
+  AsyncSuccess,
   BaseMetadata,
   Client,
   CommentBody,
@@ -89,18 +90,11 @@ export type UseThreadsOptions<M extends BaseMetadata> = {
   scrollOnLoad?: boolean;
 };
 
-export type UserAsyncResult<T> = AsyncResultWithDataField<T, "user">;
-export type UserAsyncSuccess<T> = Resolve<
-  UserAsyncResult<T> & { readonly isLoading: false; readonly error?: undefined }
->;
+export type UserAsyncResult<T> = AsyncResult<T, "user">;
+export type UserAsyncSuccess<T> = AsyncSuccess<T, "user">;
 
-export type RoomInfoAsyncResult = AsyncResultWithDataField<DRI, "info">;
-export type RoomInfoAsyncSuccess = Resolve<
-  RoomInfoAsyncResult & {
-    readonly isLoading: false;
-    readonly error?: undefined;
-  }
->;
+export type RoomInfoAsyncResult = AsyncResult<DRI, "info">;
+export type RoomInfoAsyncSuccess = AsyncSuccess<DRI, "info">;
 
 // prettier-ignore
 export type CreateThreadOptions<M extends BaseMetadata> =

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -14,6 +14,7 @@ import type {
   User,
 } from "@liveblocks/client";
 import type {
+  AsyncLoading,
   AsyncResult,
   AsyncSuccess,
   BaseMetadata,
@@ -130,12 +131,14 @@ export type CommentReactionOptions = {
   emoji: string;
 };
 
-export type ThreadsStateLoading = {
-  isLoading: true;
-  threads?: never;
-  error?: never;
-};
+export type ThreadsStateLoading = AsyncLoading<"threads">;
+export type ThreadsStateSuccess<M extends BaseMetadata> = AsyncSuccess<
+  ThreadData<M>[],
+  "threads"
+>;
 
+// XXX Refactor this type away! We should NOT have threads & error state simultaneously!
+// XXX Re-express this as AsyncSuccess<ThreadData<M>[], 'threads'>
 export type ThreadsStateResolved<M extends BaseMetadata> = {
   isLoading: false;
   threads: ThreadData<M>[];

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -14,7 +14,6 @@ import type {
   User,
 } from "@liveblocks/client";
 import type {
-  AsyncLoading,
   AsyncResult,
   AsyncSuccess,
   BaseMetadata,
@@ -131,21 +130,8 @@ export type CommentReactionOptions = {
   emoji: string;
 };
 
-export type ThreadsStateLoading = AsyncLoading<"threads">;
 export type ThreadsStateSuccess<M extends BaseMetadata> = AsyncSuccess<ThreadData<M>[], "threads">; // prettier-ignore
-
-// XXX Refactor this type away! We should NOT have threads & error state simultaneously!
-// XXX Re-express this as AsyncSuccess<ThreadData<M>[], 'threads'>
-export type ThreadsStateResolved<M extends BaseMetadata> = {
-  isLoading: false;
-  threads: ThreadData<M>[];
-  error?: Error;
-};
-
-export type ThreadsState<M extends BaseMetadata> =
-  | ThreadsStateLoading
-  // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
-  | ThreadsStateResolved<M>;
+export type ThreadsState<M extends BaseMetadata> = AsyncResult<ThreadData<M>[], "threads">; // prettier-ignore
 
 export type InboxNotificationsStateSuccess = AsyncSuccess<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
 export type InboxNotificationsState = AsyncResult<InboxNotificationData[], "inboxNotifications">; // prettier-ignore

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -147,25 +147,17 @@ export type ThreadsState<M extends BaseMetadata> =
   // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
   | ThreadsStateResolved<M>;
 
-export type InboxNotificationsStateLoading = AsyncLoading<"inboxNotifications">;
-export type InboxNotificationsStateError = AsyncError<"inboxNotifications">;
 export type InboxNotificationsStateSuccess = AsyncSuccess<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
 export type InboxNotificationsState = AsyncResult<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
 
-export type UnreadInboxNotificationsCountStateLoading = AsyncLoading<"count">;
-export type UnreadInboxNotificationsCountStateError = AsyncError<"count">;
 export type UnreadInboxNotificationsCountStateSuccess = AsyncSuccess<number, "count">; // prettier-ignore
 export type UnreadInboxNotificationsCountState = AsyncResult<number, "count">;
 
-export type RoomNotificationSettingsStateLoading = AsyncLoading<"settings">;
-export type RoomNotificationSettingsStateError = AsyncError<"settings">;
 export type RoomNotificationSettingsStateSuccess = AsyncSuccess<RoomNotificationSettings, "settings">; // prettier-ignore
 export type RoomNotificationSettingsState = AsyncResult<RoomNotificationSettings, "settings">; // prettier-ignore
 
 export type HistoryVersionDataState = AsyncResult<Uint8Array>;
 
-export type HistoryVersionsStateLoading = AsyncLoading<"versions">;
-export type HistoryVersionsStateError = AsyncError<"versions">;
 export type HistoryVersionsStateSuccess = AsyncSuccess<HistoryVersion[], "versions">; // prettier-ignore
 export type HistoryVersionsState = AsyncResult<HistoryVersion[], "versions">;
 

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -14,6 +14,7 @@ import type {
   User,
 } from "@liveblocks/client";
 import type {
+  AsyncError,
   AsyncLoading,
   AsyncResult,
   AsyncSuccess,
@@ -132,10 +133,7 @@ export type CommentReactionOptions = {
 };
 
 export type ThreadsStateLoading = AsyncLoading<"threads">;
-export type ThreadsStateSuccess<M extends BaseMetadata> = AsyncSuccess<
-  ThreadData<M>[],
-  "threads"
->;
+export type ThreadsStateSuccess<M extends BaseMetadata> = AsyncSuccess<ThreadData<M>[], "threads">; // prettier-ignore
 
 // XXX Refactor this type away! We should NOT have threads & error state simultaneously!
 // XXX Re-express this as AsyncSuccess<ThreadData<M>[], 'threads'>
@@ -145,130 +143,57 @@ export type ThreadsStateResolved<M extends BaseMetadata> = {
   error?: Error;
 };
 
-export type ThreadsStateSuccess<M extends BaseMetadata> = {
-  isLoading: false;
-  threads: ThreadData<M>[];
-  error?: never;
-};
-
 export type ThreadsState<M extends BaseMetadata> =
   | ThreadsStateLoading
+  // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
   | ThreadsStateResolved<M>;
 
-export type InboxNotificationsStateLoading = {
-  isLoading: true;
-  inboxNotifications?: never;
-  error?: never;
-};
+export type InboxNotificationsStateLoading = AsyncLoading<"inboxNotifications">;
+export type InboxNotificationsStateError = AsyncError<"inboxNotifications">;
+export type InboxNotificationsStateSuccess = AsyncSuccess<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
+export type InboxNotificationsState = AsyncResult<InboxNotificationData[], "inboxNotifications">; // prettier-ignore
 
-export type InboxNotificationsStateSuccess = {
-  isLoading: false;
-  inboxNotifications: InboxNotificationData[];
-  error?: never;
-};
+export type UnreadInboxNotificationsCountStateLoading = AsyncLoading<"count">;
+export type UnreadInboxNotificationsCountStateError = AsyncError<"count">;
+export type UnreadInboxNotificationsCountStateSuccess = AsyncSuccess<number, "count">; // prettier-ignore
+export type UnreadInboxNotificationsCountState = AsyncResult<number, "count">;
 
-export type InboxNotificationsStateError = {
-  isLoading: false;
-  inboxNotifications?: never;
-  error: Error;
-};
+export type RoomNotificationSettingsStateLoading = AsyncLoading<"settings">;
+export type RoomNotificationSettingsStateError = AsyncError<"settings">;
+export type RoomNotificationSettingsStateSuccess = AsyncSuccess<RoomNotificationSettings, "settings">; // prettier-ignore
+export type RoomNotificationSettingsState = AsyncResult<RoomNotificationSettings, "settings">; // prettier-ignore
 
-// TODO Think about ways to remove these types as global exports
-export type InboxNotificationsState =
-  | InboxNotificationsStateLoading
-  | InboxNotificationsStateSuccess
-  | InboxNotificationsStateError;
+export type HistoryVersionDataStateLoading = AsyncLoading;
+export type HistoryVersionDataStateError = AsyncError;
 
-export type UnreadInboxNotificationsCountStateLoading = {
-  isLoading: true;
-  count?: never;
-  error?: never;
-};
-
-export type UnreadInboxNotificationsCountStateSuccess = {
-  isLoading: false;
-  count: number;
-  error?: never;
-};
-
-export type UnreadInboxNotificationsCountStateError = {
-  isLoading: false;
-  count?: never;
-  error: Error;
-};
-
-// TODO Think about ways to remove these types as global exports
-export type UnreadInboxNotificationsCountState =
-  | UnreadInboxNotificationsCountStateLoading
-  | UnreadInboxNotificationsCountStateSuccess
-  | UnreadInboxNotificationsCountStateError;
-
-export type RoomNotificationSettingsStateLoading = {
-  isLoading: true;
-  settings?: never;
-  error?: never;
-};
-
-export type RoomNotificationSettingsStateError = {
-  isLoading: false;
-  settings?: never;
-  error: Error;
-};
-
-export type RoomNotificationSettingsStateSuccess = {
-  isLoading: false;
-  settings: RoomNotificationSettings;
-  error?: never;
-};
-
-export type RoomNotificationSettingsState =
-  | RoomNotificationSettingsStateLoading
-  | RoomNotificationSettingsStateError
-  | RoomNotificationSettingsStateSuccess;
-
-export type HistoryVersionDataStateLoading = {
-  isLoading: true;
-  data?: never;
-  error?: never;
-};
-
+// XXX Refactor this type away! We should NOT have data & error state simultaneously!
+// XXX Re-express this as AsyncSuccess<Uint8Array>
 export type HistoryVersionDataStateResolved = {
   isLoading: false;
   data: Uint8Array;
   error?: Error;
 };
 
-export type HistoryVersionDataStateError = {
-  isLoading: false;
-  data?: never;
-  error: Error;
-};
-
 export type HistoryVersionDataState =
   | HistoryVersionDataStateLoading
+  // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
   | HistoryVersionDataStateResolved
   | HistoryVersionDataStateError;
 
-export type HistoryVersionsStateLoading = {
-  isLoading: true;
-  versions?: never;
-  error?: never;
-};
+export type HistoryVersionsStateLoading = AsyncLoading<"versions">;
+export type HistoryVersionsStateError = AsyncError<"versions">;
 
+// XXX Refactor this type away! We should NOT have data & error state simultaneously!
+// XXX Re-express this as AsyncSuccess<HistoryVersion[], 'versions'>
 export type HistoryVersionsStateResolved = {
   isLoading: false;
   versions: HistoryVersion[];
   error?: Error;
 };
 
-export type HistoryVersionsStateError = {
-  isLoading: false;
-  versions?: never;
-  error: Error;
-};
-
 export type HistoryVersionsState =
   | HistoryVersionsStateLoading
+  // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
   | HistoryVersionsStateResolved
   | HistoryVersionsStateError;
 

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -14,7 +14,6 @@ import type {
   User,
 } from "@liveblocks/client";
 import type {
-  AsyncError,
   AsyncLoading,
   AsyncResult,
   AsyncSuccess,
@@ -167,20 +166,8 @@ export type HistoryVersionDataState = AsyncResult<Uint8Array>;
 
 export type HistoryVersionsStateLoading = AsyncLoading<"versions">;
 export type HistoryVersionsStateError = AsyncError<"versions">;
-
-// XXX Refactor this type away! We should NOT have data & error state simultaneously!
-// XXX Re-express this as AsyncSuccess<HistoryVersion[], 'versions'>
-export type HistoryVersionsStateResolved = {
-  isLoading: false;
-  versions: HistoryVersion[];
-  error?: Error;
-};
-
-export type HistoryVersionsState =
-  | HistoryVersionsStateLoading
-  // XXX Refactor this member away! We should NOT have threads & error state simultaneously!
-  | HistoryVersionsStateResolved
-  | HistoryVersionsStateError;
+export type HistoryVersionsStateSuccess = AsyncSuccess<HistoryVersion[], "versions">; // prettier-ignore
+export type HistoryVersionsState = AsyncResult<HistoryVersion[], "versions">;
 
 export type RoomProviderProps<P extends JsonObject, S extends LsonObject> =
   // prettier-ignore
@@ -1033,7 +1020,7 @@ export type RoomContextBundle<
              * @example
              * const { versions } = useHistoryVersions();
              */
-            useHistoryVersions(): HistoryVersionsStateResolved;
+            useHistoryVersions(): HistoryVersionsStateSuccess;
 
             // /**
             //  * Returns the data of a specific version of the current room's history.

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -153,8 +153,8 @@ type UpdateNotificationSettingsOptimisticUpdate = {
   settings: Partial<RoomNotificationSettings>;
 };
 
-type QueryState = AsyncResult<undefined>;
-//                            ^^^^^^^^^ We don't store the actual query result in this status
+type QueryAsyncResult = AsyncResult<undefined>;
+//                                  ^^^^^^^^^ We don't store the actual query result in this status
 
 const QUERY_STATE_LOADING = Object.freeze({ isLoading: true });
 const QUERY_STATE_OK = Object.freeze({ isLoading: false, data: undefined });
@@ -173,7 +173,7 @@ export function makeVersionsQueryKey(roomId: string) {
 }
 
 type InternalState<M extends BaseMetadata> = Readonly<{
-  queries: Record<string, QueryState>;
+  queries: Record<string, QueryAsyncResult>;
   optimisticUpdates: readonly OptimisticUpdate<M>[];
 
   rawThreadsById: Record<string, ThreadDataWithDeleteInfo<M>>;
@@ -194,7 +194,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
    * e.g. 'room-abc-{}'               - loading
    */
   // TODO Query state should not be exposed publicly by the store!
-  queries: Record<string, QueryState>;
+  queries: Record<string, QueryAsyncResult>;
 
   /**
    * All threads in a sorted array, optimistic updates applied, without deleted
@@ -444,7 +444,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }));
   }
 
-  private setQueryState(queryKey: string, queryState: QueryState): void {
+  private setQueryState(queryKey: string, queryState: QueryAsyncResult): void {
     this._store.set((state) => ({
       ...state,
       queries: {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -26,6 +26,7 @@ import {
 } from "@liveblocks/core";
 
 import { isMoreRecentlyUpdated } from "./lib/compare";
+import type { RoomNotificationSettingsAsyncResult } from "./types";
 
 type OptimisticUpdate<M extends BaseMetadata> =
   | CreateThreadOptimisticUpdate<M>
@@ -314,7 +315,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
   public getNotificationSettingsAsync(
     roomId: string
-  ): AsyncResult<RoomNotificationSettings, "settings"> {
+  ): RoomNotificationSettingsAsyncResult {
     const state = this.get();
 
     const query = state.queries[makeNotificationSettingsQueryKey(roomId)];

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -26,7 +26,10 @@ import {
 } from "@liveblocks/core";
 
 import { isMoreRecentlyUpdated } from "./lib/compare";
-import type { RoomNotificationSettingsAsyncResult } from "./types";
+import type {
+  RoomNotificationSettingsAsyncResult,
+  ThreadsAsyncResult,
+} from "./types";
 
 type OptimisticUpdate<M extends BaseMetadata> =
   | CreateThreadOptimisticUpdate<M>
@@ -254,10 +257,12 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // Auto-bind all of this class methods once here, so we can use stable
     // references to them (most important for use in useSyncExternalStore)
     this.getThreads = this.getThreads.bind(this);
+    this.getUserThreads = this.getUserThreads.bind(this);
     this.getInboxNotifications = this.getInboxNotifications.bind(this);
     this.getInboxNotificationsAsync =
       this.getInboxNotificationsAsync.bind(this);
     this.subscribeThreads = this.subscribeThreads.bind(this);
+    this.subscribeUserThreads = this.subscribeUserThreads.bind(this);
     this.subscribeInboxNotifications =
       this.subscribeInboxNotifications.bind(this);
     this.subscribeNotificationSettings =
@@ -283,6 +288,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public getThreads(): UmbrellaStoreState<M> {
+    return this.get();
+  }
+
+  public getUserThreads(): UmbrellaStoreState<M> {
     return this.get();
   }
 
@@ -375,6 +384,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public subscribeThreads(callback: () => void): () => void {
+    // TODO Make this actually only update when threads are invalidated
+    return this.subscribe(callback);
+  }
+
+  public subscribeUserThreads(callback: () => void): () => void {
     // TODO Make this actually only update when threads are invalidated
     return this.subscribe(callback);
   }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -255,13 +255,14 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // references to them (most important for use in useSyncExternalStore)
     this.getThreads = this.getThreads.bind(this);
     this.getUserThreads = this.getUserThreads.bind(this);
-    this.getInboxNotifications = this.getInboxNotifications.bind(this);
+    this.getThreadsAndInboxNotifications =
+      this.getThreadsAndInboxNotifications.bind(this);
     this.getInboxNotificationsAsync =
       this.getInboxNotificationsAsync.bind(this);
     this.subscribeThreads = this.subscribeThreads.bind(this);
     this.subscribeUserThreads = this.subscribeUserThreads.bind(this);
-    this.subscribeInboxNotifications =
-      this.subscribeInboxNotifications.bind(this);
+    this.subscribeThreadsOrInboxNotifications =
+      this.subscribeThreadsOrInboxNotifications.bind(this);
     this.subscribeNotificationSettings =
       this.subscribeNotificationSettings.bind(this);
     this.subscribeVersions = this.subscribeVersions.bind(this);
@@ -335,7 +336,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public getInboxNotifications(): UmbrellaStoreState<M> {
-    // TODO Now that we have getInboxNotificationsAsync, can we get rid of this method already?
+    return this.get();
+  }
+
+  public getThreadsAndInboxNotifications(): UmbrellaStoreState<M> {
     return this.get();
   }
 
@@ -432,7 +436,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this.subscribe(callback);
   }
 
-  public subscribeInboxNotifications(callback: () => void): () => void {
+  public subscribeThreadsOrInboxNotifications(
+    callback: () => void
+  ): () => void {
     // TODO Make this actually only update when inbox notifications are invalidated
     return this.subscribe(callback);
   }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -26,10 +26,7 @@ import {
 } from "@liveblocks/core";
 
 import { isMoreRecentlyUpdated } from "./lib/compare";
-import type {
-  RoomNotificationSettingsAsyncResult,
-  ThreadsAsyncResult,
-} from "./types";
+import type { RoomNotificationSettingsAsyncResult } from "./types";
 
 type OptimisticUpdate<M extends BaseMetadata> =
   | CreateThreadOptimisticUpdate<M>
@@ -291,8 +288,28 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this.get();
   }
 
-  public getThreadsAsync(): ThreadsAsyncResult<M> {
-    return this.get();
+  /**
+   * Returns the async result of the given queryKey. If the query is success,
+   * then it will return the entire store's state in the payload.
+   */
+  // TODO: This return type is a bit weird! Feels like we haven't found the
+  // right abstraction here yet.
+  public getThreadsAsync(
+    queryKey: string
+  ): AsyncResult<UmbrellaStoreState<M>, "fullState"> {
+    const internalState = this._store.get();
+
+    const query = internalState.queries[queryKey];
+    if (query === undefined || query.isLoading) {
+      return ASYNC_LOADING;
+    }
+
+    if (query.error) {
+      return query;
+    }
+
+    // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
+    return { isLoading: false, fullState: this.get() };
   }
 
   public getUserThreads(): UmbrellaStoreState<M> {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -160,8 +160,8 @@ type UpdateNotificationSettingsOptimisticUpdate = {
 type QueryAsyncResult = AsyncResult<undefined>;
 //                                  ^^^^^^^^^ We don't store the actual query result in this status
 
-const QUERY_STATE_LOADING = Object.freeze({ isLoading: true });
-const QUERY_STATE_OK = Object.freeze({ isLoading: false, data: undefined });
+const ASYNC_LOADING = Object.freeze({ isLoading: true });
+const ASYNC_OK = Object.freeze({ isLoading: false, data: undefined });
 
 // TODO Stop exporting this constant!
 export const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
@@ -318,7 +318,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
     const query = internalState.queries[INBOX_NOTIFICATIONS_QUERY];
     if (query === undefined || query.isLoading) {
-      return QUERY_STATE_LOADING;
+      return ASYNC_LOADING;
     }
 
     if (query.error !== undefined) {
@@ -338,7 +338,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
     const query = state.queries[makeNotificationSettingsQueryKey(roomId)];
     if (query === undefined || query.isLoading) {
-      return QUERY_STATE_LOADING;
+      return ASYNC_LOADING;
     }
 
     if (query.error !== undefined) {
@@ -359,7 +359,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
     const query = state.queries[makeVersionsQueryKey(roomId)];
     if (query === undefined || query.isLoading) {
-      return QUERY_STATE_LOADING;
+      return ASYNC_LOADING;
     }
 
     if (query.error !== undefined) {
@@ -917,11 +917,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
   //
 
   public setQueryLoading(queryKey: string): void {
-    this.setQueryState(queryKey, QUERY_STATE_LOADING);
+    this.setQueryState(queryKey, ASYNC_LOADING);
   }
 
   private setQueryOK(queryKey: string): void {
-    this.setQueryState(queryKey, QUERY_STATE_OK);
+    this.setQueryState(queryKey, ASYNC_OK);
   }
 
   public setQueryError(queryKey: string, error: Error): void {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1,6 +1,5 @@
 import type {
   AsyncResult,
-  AsyncResultWithDataField,
   BaseMetadata,
   CommentData,
   CommentReaction,
@@ -292,7 +291,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
-  public getInboxNotificationsAsync(): AsyncResultWithDataField<
+  public getInboxNotificationsAsync(): AsyncResult<
     InboxNotificationData[],
     "inboxNotifications"
   > {
@@ -315,7 +314,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
   public getNotificationSettingsAsync(
     roomId: string
-  ): AsyncResultWithDataField<RoomNotificationSettings, "settings"> {
+  ): AsyncResult<RoomNotificationSettings, "settings"> {
     const state = this.get();
 
     const query = state.queries[makeNotificationSettingsQueryKey(roomId)];
@@ -336,7 +335,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
   public getVersionsAsync(
     roomId: string
-  ): AsyncResultWithDataField<HistoryVersion[], "versions"> {
+  ): AsyncResult<HistoryVersion[], "versions"> {
     const state = this.get();
 
     const query = state.queries[makeVersionsQueryKey(roomId)];

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -291,9 +291,18 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this.get();
   }
 
+  public getThreadsAsync(): ThreadsAsyncResult<M> {
+    return this.get();
+  }
+
   public getUserThreads(): UmbrellaStoreState<M> {
     return this.get();
   }
+
+  // XXX Add soon, too
+  // public getUserThreadsAsync(): ThreadsAsyncResult<M> {
+  //   return this.get();
+  // }
 
   public getInboxNotifications(): UmbrellaStoreState<M> {
     // TODO Now that we have getInboxNotificationsAsync, can we get rid of this method already?

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -316,10 +316,23 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this.get();
   }
 
-  // XXX Add soon, too
-  // public getUserThreadsAsync(): ThreadsAsyncResult<M> {
-  //   return this.get();
-  // }
+  public getUserThreadsAsync(
+    queryKey: string
+  ): AsyncResult<UmbrellaStoreState<M>, "fullState"> {
+    const internalState = this._store.get();
+
+    const query = internalState.queries[queryKey];
+    if (query === undefined || query.isLoading) {
+      return ASYNC_LOADING;
+    }
+
+    if (query.error) {
+      return query;
+    }
+
+    // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
+    return { isLoading: false, fullState: this.get() };
+  }
 
   public getInboxNotifications(): UmbrellaStoreState<M> {
     // TODO Now that we have getInboxNotificationsAsync, can we get rid of this method already?

--- a/packages/liveblocks-react/src/use-scroll-to-comment-on-load-effect.ts
+++ b/packages/liveblocks-react/src/use-scroll-to-comment-on-load-effect.ts
@@ -1,11 +1,11 @@
 import type { BaseMetadata } from "@liveblocks/client";
 import * as React from "react";
 
-import type { ThreadsState } from "./types";
+import type { ThreadsAsyncResult } from "./types";
 
 function handleScrollToCommentOnLoad(
   shouldScrollOnLoad: boolean,
-  state: ThreadsState<BaseMetadata>
+  state: ThreadsAsyncResult<BaseMetadata>
 ) {
   if (shouldScrollOnLoad === false) return;
 
@@ -41,7 +41,7 @@ function handleScrollToCommentOnLoad(
  */
 export function useScrollToCommentOnLoadEffect(
   shouldScrollOnLoad: boolean,
-  state: ThreadsState<BaseMetadata>
+  state: ThreadsAsyncResult<BaseMetadata>
 ) {
   React.useEffect(
     () => {

--- a/packages/liveblocks-react/src/use-scroll-to-comment-on-load-effect.ts
+++ b/packages/liveblocks-react/src/use-scroll-to-comment-on-load-effect.ts
@@ -9,7 +9,7 @@ function handleScrollToCommentOnLoad(
 ) {
   if (shouldScrollOnLoad === false) return;
 
-  if (state.isLoading) return;
+  if (!state.threads) return;
 
   const isWindowDefined = typeof window !== "undefined";
   if (!isWindowDefined) return;


### PR DESCRIPTION
This is in preparation of upcoming pagination implementation, which will have to change these types. This PR makes no functional changes. It just changes the type aliases, but the types are exactly identical, just simpler to read.
