### PR TITLE
Pagination example

### DIFF
--- a/examples/nextjs-comments-notifications/src/app/[room]/page.tsx
+++ b/examples/nextjs-comments-notifications/src/app/[room]/page.tsx
@@ -25,6 +25,8 @@ function Example() {
       window.clearTimeout(fetchTimeoutRef.current);
     }
 
+    console.log("Fetching more threads");
+
     setFetching(true);
 
     fetchTimeoutRef.current = window.setTimeout(() => {

--- a/examples/nextjs-comments-notifications/src/app/[room]/page.tsx
+++ b/examples/nextjs-comments-notifications/src/app/[room]/page.tsx
@@ -6,7 +6,7 @@ import { Composer, Thread } from "@liveblocks/react-ui";
 import { ClientSideSuspense } from "@liveblocks/react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useExampleRoomId } from "../../example.client";
-import { Suspense } from "react";
+import { Suspense, useRef, useState } from "react";
 
 /**
  * Displays a list of threads, along with a composer for creating
@@ -16,11 +16,37 @@ import { Suspense } from "react";
 function Example() {
   const { threads } = useThreads();
 
+  // TODO: Use actual pagination implementation
+  const hasMore = true;
+  const [isFetching, setFetching] = useState(false);
+  const fetchTimeoutRef = useRef<number | null>(null);
+  const fetchMore = () => {
+    if (fetchTimeoutRef.current !== null) {
+      window.clearTimeout(fetchTimeoutRef.current);
+    }
+
+    setFetching(true);
+
+    fetchTimeoutRef.current = window.setTimeout(() => {
+      setFetching(false);
+    }, 2000);
+  };
+
   return (
     <div className="threads">
       {threads.map((thread) => (
         <Thread key={thread.id} thread={thread} className="thread" />
       ))}
+      {/* A button to load more threads which is disabled while fetching new threads and hidden when there is nothing more to fetch */}
+      {hasMore && (
+        <button
+          onClick={fetchMore}
+          disabled={isFetching}
+          className="button primary"
+        >
+          {isFetching ? "…" : "Load more"}
+        </button>
+      )}
       <Composer className="composer" />
     </div>
   );

--- a/examples/nextjs-comments-notifications/src/components/InboxPopover.tsx
+++ b/examples/nextjs-comments-notifications/src/components/InboxPopover.tsx
@@ -10,7 +10,7 @@ import {
 } from "@liveblocks/react/suspense";
 import { ClientSideSuspense } from "@liveblocks/react";
 import { Loading } from "./Loading";
-import { ComponentPropsWithoutRef, useEffect, useState } from "react";
+import { ComponentPropsWithoutRef, useEffect, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import clsx from "clsx";
 import { Link } from "./Link";
@@ -19,13 +19,36 @@ import { usePathname } from "next/navigation";
 function Inbox({ className, ...props }: ComponentPropsWithoutRef<"div">) {
   const { inboxNotifications } = useInboxNotifications();
 
+  // TODO: Use actual pagination implementation
+  const hasMore = true;
+  const [isFetching, setFetching] = useState(false);
+  const fetchTimeoutRef = useRef<number | null>(null);
+  const fetchMore = () => {
+    if (fetchTimeoutRef.current !== null) {
+      window.clearTimeout(fetchTimeoutRef.current);
+    }
+
+    console.log("Fetching more notifications");
+
+    setFetching(true);
+
+    fetchTimeoutRef.current = window.setTimeout(() => {
+      setFetching(false);
+    }, 2000);
+  };
+
   return inboxNotifications.length === 0 ? (
     <div className={clsx(className, "empty")}>
       There aren’t any notifications yet.
     </div>
   ) : (
     <div className={className} {...props}>
-      <InboxNotificationList className="inbox-list">
+      {/* Load more notifications when scrolling to the end of the list */}
+      <InboxNotificationList
+        className="inbox-list"
+        // Only load more notifications if there are more to fetch
+        onReachEnd={hasMore ? fetchMore : undefined}
+      >
         {inboxNotifications.map((inboxNotification) => {
           return (
             <InboxNotification
@@ -36,6 +59,7 @@ function Inbox({ className, ...props }: ComponentPropsWithoutRef<"div">) {
           );
         })}
       </InboxNotificationList>
+      {isFetching && <Loading />}
     </div>
   );
 }

--- a/examples/nextjs-comments-notifications/src/styles/globals.css
+++ b/examples/nextjs-comments-notifications/src/styles/globals.css
@@ -141,6 +141,11 @@ body {
   color: #555;
 }
 
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .button.square {
   padding: 0;
   width: 2rem;
@@ -152,15 +157,25 @@ body {
   color: #953939;
 }
 
-.button:hover,
-.button:focus-visible {
+.button.primary {
+  background: #000;
+  color: #fff;
+}
+
+.button:enabled:hover,
+.button:enabled:focus-visible {
   background: #e8e8e8;
   cursor: pointer;
 }
 
-.button.destructive:hover,
-.button.destructive:focus-visible{
+.button.destructive:enabled:hover,
+.button.destructive:enabled:focus-visible {
   background: #ffd6d6;
+}
+
+.button.primary:enabled:hover,
+.button.primary:enabled:focus-visible {
+  background: #333;
 }
 
 .loading,

--- a/examples/nextjs-comments-notifications/src/styles/globals.css
+++ b/examples/nextjs-comments-notifications/src/styles/globals.css
@@ -269,6 +269,11 @@ body {
   box-shadow: 0 0 0 1px rgb(0 0 0 / 8%);
 }
 
+.inbox-list .loading img {
+  width: 16px;
+  height: 16px;
+}
+
 .inbox-unread-count {
   position: absolute;
   top: 0;

--- a/packages/liveblocks-react-ui/src/components/InboxNotificationList.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotificationList.tsx
@@ -1,11 +1,31 @@
 "use client";
 
 import type { ComponentPropsWithoutRef } from "react";
-import React, { Children, forwardRef } from "react";
+import React, { Children, forwardRef, useRef } from "react";
 
 import { classNames } from "../utils/class-names";
+import { useVisibleCallback } from "../utils/use-visible";
 
-export type InboxNotificationListProps = ComponentPropsWithoutRef<"ol">;
+export interface InboxNotificationListProps
+  extends ComponentPropsWithoutRef<"ol"> {
+  onReachEnd?: () => void;
+}
+
+function ReachEndMarker({
+  enabled,
+  onReachEnd,
+}: {
+  enabled: boolean;
+  onReachEnd: () => void;
+}) {
+  const markerRef = useRef<HTMLDivElement>(null);
+
+  useVisibleCallback(markerRef, onReachEnd, {
+    enabled,
+  });
+
+  return <div ref={markerRef} style={{ height: 0 }} />;
+}
 
 /**
  * Displays inbox notifications as a list.
@@ -20,7 +40,7 @@ export type InboxNotificationListProps = ComponentPropsWithoutRef<"ol">;
 export const InboxNotificationList = forwardRef<
   HTMLOListElement,
   InboxNotificationListProps
->(({ children, className, ...props }, forwardedRef) => {
+>(({ onReachEnd, children, className, ...props }, forwardedRef) => {
   return (
     <ol
       className={classNames("lb-root lb-inbox-notification-list", className)}
@@ -32,6 +52,13 @@ export const InboxNotificationList = forwardRef<
           {child}
         </li>
       ))}
+      {/* Render an invisible marker at the end which is tied to an IntersectionObserver to be alerted when the end of the list has been reached */}
+      {onReachEnd && (
+        <ReachEndMarker
+          onReachEnd={onReachEnd}
+          enabled={Children.count(children) > 0}
+        />
+      )}
     </ol>
   );
 });


### PR DESCRIPTION
This PR tweaks the `nextjs-comments-notifications` example to be used as a playground while building pagination. cc: @nvie @nimeshnayaju 

The example is already "sandboxed" at the user ID level so even though notifications are global, you can create your own spaces that won't pollute other examples/rooms even if using shared API keys.

```
// User 0 in "pagination" sandbox
http://localhost:3000/general?exampleId=pagination&examplePreview=0

// User 1 in "pagination" sandbox
http://localhost:3000/general?exampleId=pagination&examplePreview=1
```

### Changes

2 possible UIs built differently to hopefully maximize the opportunities to find limits in the new pagination APIs (we could try to build even more UI types later?).

#### Threads

The list of threads uses a button-style UI to load more threads infinitely, all built in user-land.

https://github.com/user-attachments/assets/edd7a9f1-0f40-4c18-a7fb-fde6dd7ed553

#### Inbox notifications

The inbox notifications list uses an infinite-scroll-style UI to load more notifications infinitely, built with a mix of new possible first-party APIs (`onReachEnd` callback) and user-land.

https://github.com/user-attachments/assets/72c03970-6397-4e70-86d2-ab5a1b5a3518