### PR TITLE
Store prefactorings

### DIFF
--- a/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
@@ -107,11 +107,11 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
   const roomId = room.id;
   const threads = useSyncExternalStoreWithSelector(
     store.subscribeThreads,
-    store.getThreads,
-    store.getThreads,
+    store.getFullState,
+    store.getFullState,
     useCallback(
       () =>
-        selectThreads(store.getThreads(), {
+        selectThreads(store.getFullState(), {
           roomId,
           orderBy: "age",
           query: {
@@ -220,7 +220,7 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
       const selection = $getSelection();
 
       const threadIds = $getThreadIds(selection).filter((id) => {
-        return selectThreads(store.getThreads(), {
+        return selectThreads(store.getFullState(), {
           roomId,
           orderBy: "age",
           query: {

--- a/packages/liveblocks-react/src/__tests__/selectThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectThreads.test.ts
@@ -29,7 +29,7 @@ describe("selectThreads", () => {
 
     store.updateThreadsAndNotifications([thread1, thread2], [], [], []);
 
-    const resolvedThreads = selectThreads(store.getThreads(), {
+    const resolvedThreads = selectThreads(store.getFullState(), {
       roomId: "room_1",
       query: { resolved: true },
       orderBy: "age",

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -19,7 +19,7 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore();
 
     // Sync getters
-    expect(store.getThreads()).toEqual(empty);
+    expect(store.getFullState()).toEqual(empty);
 
     // Sync async-results getters
     expect(store.getInboxNotificationsAsync()).toEqual(loading);
@@ -31,7 +31,7 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore();
 
     // IMPORTANT! Strict equality expected!
-    expect(store.getThreads()).toBe(store.getThreads());
+    expect(store.getFullState()).toBe(store.getFullState());
 
     // Sync async-results getter
     // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -791,7 +791,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
 ): ThreadData<M> {
   const { store } = getExtrasForClient<M>(client);
 
-  const getter = store.getThreadsAndInboxNotifications;
+  const getter = store.getFullState;
 
   const selector = useCallback(
     (state: ReturnType<typeof getter>) => {
@@ -1204,7 +1204,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
     return incrementUserThreadsQuerySubscribers(queryKey);
   }, [client, queryKey]);
 
-  const query = store.getUserThreads().queries2[queryKey];
+  const query = store.getFullState().queries2[queryKey];
 
   if (query === undefined || query.isLoading) {
     throw getUserThreads(queryKey, options);
@@ -1214,7 +1214,7 @@ function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
     throw query.error;
   }
 
-  const getter = store.getUserThreads;
+  const getter = store.getFullState;
 
   const selector = useCallback(
     (state: ReturnType<typeof getter>): ThreadsAsyncSuccess<M> => {

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -56,7 +56,7 @@ import type {
   UseUserThreadsOptions,
 } from "./types";
 import type { UmbrellaStoreState } from "./umbrella-store";
-import { INBOX_NOTIFICATIONS_QUERY, UmbrellaStore } from "./umbrella-store";
+import { UmbrellaStore } from "./umbrella-store";
 
 /**
  * Raw access to the React context where the LiveblocksProvider stores the
@@ -279,13 +279,18 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     if (lastRequestedAt === undefined) {
       const result = await client.getInboxNotifications();
 
-      store.updateThreadsAndNotifications(
-        result.threads,
-        result.inboxNotifications,
-        [],
-        [],
-        INBOX_NOTIFICATIONS_QUERY
-      );
+      store.batch(() => {
+        // 1️⃣
+        store.updateThreadsAndNotifications(
+          result.threads,
+          result.inboxNotifications,
+          [],
+          []
+        );
+
+        // 2️⃣
+        store.setQuery1OK();
+      });
 
       lastRequestedAt = result.requestedAt;
     } else {
@@ -293,13 +298,18 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
         since: lastRequestedAt,
       });
 
-      store.updateThreadsAndNotifications(
-        result.threads.updated,
-        result.inboxNotifications.updated,
-        result.threads.deleted,
-        result.inboxNotifications.deleted,
-        INBOX_NOTIFICATIONS_QUERY
-      );
+      store.batch(() => {
+        // 1️⃣
+        store.updateThreadsAndNotifications(
+          result.threads.updated,
+          result.inboxNotifications.updated,
+          result.threads.deleted,
+          result.inboxNotifications.deleted
+        );
+
+        // 2️⃣
+        store.setQuery1OK();
+      });
 
       if (lastRequestedAt < result.requestedAt) {
         lastRequestedAt = result.requestedAt;
@@ -325,7 +335,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
    * delays. Will throw eventually only if all retries fail.
    */
   const waitUntilInboxNotificationsLoaded = memoizeOnSuccess(async () => {
-    store.setQuery1Loading(INBOX_NOTIFICATIONS_QUERY);
+    store.setQuery1Loading();
 
     try {
       await autoRetry(
@@ -335,7 +345,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
       );
     } catch (err) {
       // Store the error in the cache as a side-effect, for non-Suspense
-      store.setQuery1Error(INBOX_NOTIFICATIONS_QUERY, err as Error);
+      store.setQuery1Error(err as Error);
 
       // Rethrow it for Suspense, where this promise must fail
       throw err;
@@ -369,7 +379,7 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
       // Decrement
       if (pollerSubscribers <= 0) {
         console.warn(
-          `Internal unexpected behavior. Cannot decrease subscriber count for query "${INBOX_NOTIFICATIONS_QUERY}"`
+          "Unexpected internal error: cannot decrease subscriber count for inbox notifications."
         );
         return;
       }
@@ -397,13 +407,19 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
         since,
       });
       isFetchingUserThreadsUpdates = false;
-      store.updateThreadsAndNotifications(
-        updates.threads.updated,
-        [],
-        updates.threads.deleted,
-        [],
-        USER_THREADS_QUERY
-      );
+
+      store.batch(() => {
+        // 1️⃣
+        store.updateThreadsAndNotifications(
+          updates.threads.updated,
+          [],
+          updates.threads.deleted,
+          []
+        );
+
+        // 2️⃣
+        store.setQuery2OK(USER_THREADS_QUERY);
+      });
 
       userThreadslastRequestedAt = updates.requestedAt;
     } catch (err) {
@@ -468,13 +484,18 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     try {
       const result = await request;
 
-      store.updateThreadsAndNotifications(
-        result.threads,
-        result.inboxNotifications,
-        [],
-        [],
-        queryKey
-      );
+      store.batch(() => {
+        // 1️⃣
+        store.updateThreadsAndNotifications(
+          result.threads,
+          result.inboxNotifications,
+          [],
+          []
+        );
+
+        // 2️⃣
+        store.setQuery2OK(queryKey);
+      });
 
       /**
        * We set the `userThreadslastRequestedAt` value to the timestamp returned by the current request if:

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -429,13 +429,18 @@ function makeExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     try {
       const result = await request;
 
-      store.updateThreadsAndNotifications(
-        result.threads as ThreadData<M>[], // TODO: Figure out how to remove this casting
-        result.inboxNotifications,
-        [],
-        [],
-        queryKey
-      );
+      store.batch(() => {
+        // 1️⃣
+        store.updateThreadsAndNotifications(
+          result.threads as ThreadData<M>[], // TODO: Figure out how to remove this casting
+          result.inboxNotifications,
+          [],
+          []
+        );
+
+        // 2️⃣
+        store.setQuery2OK(queryKey);
+      });
 
       const lastRequestedAt = lastRequestedAtByRoom.get(room.id);
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -864,7 +864,7 @@ function RoomProviderInner<
       }
       const { thread, inboxNotification } = info;
 
-      const existingThread = store.getThreads().threadsById[message.threadId];
+      const existingThread = store.getFullState().threadsById[message.threadId];
 
       switch (message.type) {
         case ServerMsgCode.COMMENT_EDITED:
@@ -1578,7 +1578,7 @@ function useDeleteThread(): (threadId: string) => void {
     (threadId: string): void => {
       const { store, onMutationFailure } = getExtrasForClient(client);
 
-      const thread = store.getThreads().threadsById[threadId];
+      const thread = store.getFullState().threadsById[threadId];
 
       const userId = getCurrentUserId(room);
 
@@ -1729,7 +1729,7 @@ function useEditComment(): (options: EditCommentOptions) => void {
       const editedAt = new Date();
 
       const { store, onMutationFailure } = getExtrasForClient(client);
-      const thread = store.getThreads().threadsById[threadId];
+      const thread = store.getFullState().threadsById[threadId];
       if (thread === undefined) {
         console.warn(
           `Internal unexpected behavior. Cannot edit comment in thread "${threadId}" because the thread does not exist in the cache.`
@@ -1953,7 +1953,7 @@ function useMarkThreadAsRead() {
     (threadId: string) => {
       const { store, onMutationFailure } = getExtrasForClient(client);
       const inboxNotification = Object.values(
-        store.getInboxNotifications().inboxNotificationsById
+        store.getFullState().inboxNotificationsById
       ).find(
         (inboxNotification) =>
           inboxNotification.kind === "thread" &&
@@ -2126,8 +2126,8 @@ function useThreadSubscription(threadId: string): ThreadSubscription {
 
   return useSyncExternalStoreWithSelector(
     store.subscribeThreads,
-    store.getThreads,
-    store.getThreads,
+    store.getFullState,
+    store.getFullState,
     selector
   );
 }
@@ -2508,7 +2508,7 @@ function useThreadsSuspense<M extends BaseMetadata>(
   const { store, getThreadsAndInboxNotifications } =
     getExtrasForClient<M>(client);
 
-  const query = store.getThreads().queries2[queryKey];
+  const query = store.getFullState().queries2[queryKey];
 
   if (query === undefined || query.isLoading) {
     throw getThreadsAndInboxNotifications(room, queryKey, options);
@@ -2519,7 +2519,7 @@ function useThreadsSuspense<M extends BaseMetadata>(
   }
 
   const selector = React.useCallback(
-    (state: ReturnType<typeof store.getThreads>): ThreadsAsyncSuccess<M> => {
+    (state: ReturnType<typeof store.getFullState>): ThreadsAsyncSuccess<M> => {
       return {
         threads: selectThreads(state, {
           roomId: room.id,
@@ -2539,8 +2539,8 @@ function useThreadsSuspense<M extends BaseMetadata>(
 
   const state = useSyncExternalStoreWithSelector(
     store.subscribeThreads,
-    store.getThreads,
-    store.getThreads,
+    store.getFullState,
+    store.getFullState,
     selector
   );
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -266,10 +266,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
     // Auto-bind all of this class methods once here, so we can use stable
     // references to them (most important for use in useSyncExternalStore)
-    this.getThreads = this.getThreads.bind(this);
-    this.getUserThreads = this.getUserThreads.bind(this);
-    this.getThreadsAndInboxNotifications =
-      this.getThreadsAndInboxNotifications.bind(this);
+    this.getFullState = this.getFullState.bind(this);
     this.getInboxNotificationsAsync =
       this.getInboxNotificationsAsync.bind(this);
     this.subscribeThreads = this.subscribeThreads.bind(this);
@@ -302,7 +299,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return this._store.batch(callback);
   }
 
-  public getThreads(): UmbrellaStoreState<M> {
+  public getFullState(): UmbrellaStoreState<M> {
     return this.get();
   }
 
@@ -327,11 +324,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }
 
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
-    return { isLoading: false, fullState: this.get() };
-  }
-
-  public getUserThreads(): UmbrellaStoreState<M> {
-    return this.get();
+    return { isLoading: false, fullState: this.getFullState() };
   }
 
   public getUserThreadsAsync(
@@ -349,15 +342,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }
 
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
-    return { isLoading: false, fullState: this.get() };
-  }
-
-  public getInboxNotifications(): UmbrellaStoreState<M> {
-    return this.get();
-  }
-
-  public getThreadsAndInboxNotifications(): UmbrellaStoreState<M> {
-    return this.get();
+    return { isLoading: false, fullState: this.getFullState() };
   }
 
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
@@ -376,7 +361,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return query;
     }
 
-    const inboxNotifications = this.get().inboxNotifications;
+    const inboxNotifications = this.getFullState().inboxNotifications;
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return { isLoading: false, inboxNotifications };
   }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -161,7 +161,7 @@ const ASYNC_LOADING = Object.freeze({ isLoading: true });
 const ASYNC_OK = Object.freeze({ isLoading: false, data: undefined });
 
 // TODO Stop exporting this constant!
-export const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
+const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
 
 // TODO Stop exporting this helper!
 export function makeNotificationSettingsQueryKey(roomId: string) {
@@ -296,6 +296,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
       this._stateCached = internalToExternalState(rawState);
     }
     return this._stateCached;
+  }
+
+  public batch(callback: () => void): void {
+    return this._store.batch(callback);
   }
 
   public getThreads(): UmbrellaStoreState<M> {
@@ -903,11 +907,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     threads: ThreadData<M>[],
     inboxNotifications: InboxNotificationData[],
     deletedThreads: ThreadDeleteInfo[],
-    deletedInboxNotifications: InboxNotificationDeleteInfo[],
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    queryKey?: "INBOX_NOTIFICATIONS" | (string & {})
+    deletedInboxNotifications: InboxNotificationDeleteInfo[]
   ): void {
-    // Batch 1️⃣ + 2️⃣ + 3️⃣
+    // Batch 1️⃣ + 2️⃣
     this._store.batch(() => {
       // 1️⃣
       this.updateThreadsCache((cache) =>
@@ -924,15 +926,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
           deletedNotifications: deletedInboxNotifications,
         })
       );
-
-      // 3️⃣
-      if (queryKey !== undefined) {
-        if (queryKey === "INBOX_NOTIFICATIONS") {
-          this.setQuery1OK(queryKey);
-        } else {
-          this.setQuery2OK(queryKey);
-        }
-      }
     });
   }
 
@@ -1000,16 +993,16 @@ export class UmbrellaStore<M extends BaseMetadata> {
   //
 
   // Query 1
-  public setQuery1Loading(queryKey: string): void {
-    this.setQuery1State(queryKey, ASYNC_LOADING);
+  public setQuery1Loading(): void {
+    this.setQuery1State(INBOX_NOTIFICATIONS_QUERY, ASYNC_LOADING);
   }
 
-  private setQuery1OK(queryKey: string): void {
-    this.setQuery1State(queryKey, ASYNC_OK);
+  public setQuery1OK(): void {
+    this.setQuery1State(INBOX_NOTIFICATIONS_QUERY, ASYNC_OK);
   }
 
-  public setQuery1Error(queryKey: string, error: Error): void {
-    this.setQuery1State(queryKey, { isLoading: false, error });
+  public setQuery1Error(error: Error): void {
+    this.setQuery1State(INBOX_NOTIFICATIONS_QUERY, { isLoading: false, error });
   }
 
   // Query 2
@@ -1017,7 +1010,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     this.setQuery2State(queryKey, ASYNC_LOADING);
   }
 
-  private setQuery2OK(queryKey: string): void {
+  public setQuery2OK(queryKey: string): void {
     this.setQuery2State(queryKey, ASYNC_OK);
   }
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -160,9 +160,6 @@ type QueryAsyncResult = AsyncResult<undefined>;
 const ASYNC_LOADING = Object.freeze({ isLoading: true });
 const ASYNC_OK = Object.freeze({ isLoading: false, data: undefined });
 
-// TODO Stop exporting this constant!
-const INBOX_NOTIFICATIONS_QUERY = "INBOX_NOTIFICATIONS";
-
 // TODO Stop exporting this helper!
 export function makeNotificationSettingsQueryKey(roomId: string) {
   return `${roomId}:NOTIFICATION_SETTINGS`;
@@ -177,7 +174,7 @@ type InternalState<M extends BaseMetadata> = Readonly<{
   // This is a temporary refactoring artifact from Vincent and Nimesh.
   // Each query corresponds to a resource which should eventually have its own type.
   // This is why we split it for now.
-  queries1: Record<string, QueryAsyncResult>; // Inbox notifications
+  query1: QueryAsyncResult | undefined; // Inbox notifications
   queries2: Record<string, QueryAsyncResult>; // Threads
   queries3: Record<string, QueryAsyncResult>; // Notification settings
   queries4: Record<string, QueryAsyncResult>; // Versions
@@ -254,7 +251,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     this._store = createStore<InternalState<M>>({
       rawThreadsById: {},
       // queries: {},
-      queries1: {},
+      query1: undefined,
       queries2: {},
       queries3: {},
       queries4: {},
@@ -352,7 +349,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   > {
     const internalState = this._store.get();
 
-    const query = internalState.queries1[INBOX_NOTIFICATIONS_QUERY];
+    const query = internalState.query1;
     if (query === undefined || query.isLoading) {
       return ASYNC_LOADING;
     }
@@ -506,13 +503,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }));
   }
 
-  private setQuery1State(queryKey: string, queryState: QueryAsyncResult): void {
+  private setQuery1State(queryState: QueryAsyncResult): void {
     this._store.set((state) => ({
       ...state,
-      queries1: {
-        ...state.queries1,
-        [queryKey]: queryState,
-      },
+      query1: queryState,
     }));
   }
 
@@ -979,15 +973,15 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
   // Query 1
   public setQuery1Loading(): void {
-    this.setQuery1State(INBOX_NOTIFICATIONS_QUERY, ASYNC_LOADING);
+    this.setQuery1State(ASYNC_LOADING);
   }
 
   public setQuery1OK(): void {
-    this.setQuery1State(INBOX_NOTIFICATIONS_QUERY, ASYNC_OK);
+    this.setQuery1State(ASYNC_OK);
   }
 
   public setQuery1Error(error: Error): void {
-    this.setQuery1State(INBOX_NOTIFICATIONS_QUERY, { isLoading: false, error });
+    this.setQuery1State({ isLoading: false, error });
   }
 
   // Query 2


### PR DESCRIPTION
- Refactor `INBOX_NOTIFICATIONS_QUERY` away as an implementation detail
- Make `queries1` a single `query1` instead (no more map, but singular query state)
- Remove various aliases of `store.get()` and expose only a single `store.getFullState()` for now
