### PR TITLE
Rename `EventSource`s `.clear()` to `._forceClear()` and mark it as internal

### DIFF
--- a/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.ts
+++ b/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.ts
@@ -156,7 +156,7 @@ export class MockWebSocketServer {
    * those behaviors.
    */
   public onConnection(callback: (conn: Connection) => void): void {
-    this.newConnectionCallbacks.clear();
+    this.newConnectionCallbacks._forceClear();
     this.newConnectionCallbacks.subscribe(callback);
   }
 

--- a/packages/liveblocks-core/src/lib/EventSource.ts
+++ b/packages/liveblocks-core/src/lib/EventSource.ts
@@ -27,12 +27,6 @@ export type EventSource<T> = Observable<T> & {
    */
   notify(event: T): void;
   /**
-   * Clear all registered event listeners. None of the registered functions
-   * will ever get called again. Be careful when using this API, because the
-   * subscribers may not have any idea they won't be notified anymore.
-   */
-  clear(): void;
-  /**
    * Returns the number of active subscribers.
    */
   count(): number;
@@ -51,6 +45,17 @@ export type EventSource<T> = Observable<T> & {
    * in a readonly fashion. Safe to publicly expose.
    */
   observable: Observable<T>;
+  /**
+   * Clears all registered event listeners. None of the registered functions
+   * will ever get called again.
+   *
+   * WARNING!
+   * Be careful when using this API, because the subscribers may not have any
+   * idea they won't be notified anymore.
+   *
+   * @internal
+   */
+  _forceClear(): void;
 };
 
 export type EventEmitter<T> = (event: T) => void;
@@ -133,7 +138,7 @@ export function makeEventSource<T>(): EventSource<T> {
     _observers.forEach((callback) => callback(event));
   }
 
-  function clear() {
+  function _forceClear() {
     _onetimeObservers.clear();
     _observers.clear();
   }
@@ -147,7 +152,7 @@ export function makeEventSource<T>(): EventSource<T> {
     notify: notifyOrBuffer,
     subscribe,
     subscribeOnce,
-    clear,
+    _forceClear,
     count,
 
     waitUntil,

--- a/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
@@ -459,20 +459,12 @@ function createComposerAttachmentsManager(
     notifySubscribers();
   }
 
-  function dispose() {
-    clear();
-    // TODO Avoid having to rely on this API
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    (eventSource as any)._forceClear();
-  }
-
   return {
     addAttachments,
     removeAttachment,
     getSnapshot,
     subscribe: eventSource.subscribe,
     clear,
-    dispose,
   };
 }
 
@@ -495,10 +487,10 @@ export function useComposerAttachmentsManager(
     frozenAttachmentsManager.addAttachments(frozenDefaultAttachments);
   }, [frozenDefaultAttachments, frozenAttachmentsManager]);
 
-  // Cleanup on unmount
+  // Clear on unmount
   useEffect(() => {
     return () => {
-      frozenAttachmentsManager.dispose();
+      frozenAttachmentsManager.clear();
     };
   }, [frozenAttachmentsManager]);
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
@@ -461,7 +461,9 @@ function createComposerAttachmentsManager(
 
   function dispose() {
     clear();
-    eventSource.clear();
+    // TODO Avoid having to rely on this API
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+    (eventSource as any)._forceClear();
   }
 
   return {


### PR DESCRIPTION
This API only really exists for unit testing purposes, and should never be relied on in real world scenarios, as it will lead to gotchas and surprises.
