### PR TITLE
[Hackathon] Open API spec cleanups

### DIFF
--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -798,7 +798,7 @@
         }
       }
     },
-    "/schemas/{id}": {
+    "/schemas/{schemaId}": {
       "get": {
         "summary": "Get schema",
         "description": "This endpoint retrieves a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. Corresponds to [`liveblocks.getSchema`](/docs/api-reference/liveblocks-node#get-create-new-schema).",
@@ -806,7 +806,7 @@
         "parameters": [
           {
             "schema": { "type": "string" },
-            "name": "id",
+            "name": "schemaId",
             "in": "path",
             "required": true,
             "description": "ID of the schema"
@@ -839,19 +839,19 @@
         }
       },
       "put": {
+        "operationId": "put-update-new-schema",
         "summary": "Update schema",
         "description": "This endpoint updates the body for the schema. A schema can only be updated if it is not used by any room. Corresponds to [`liveblocks.updateSchema`](/docs/api-reference/liveblocks-node#put-update-new-schema).",
         "tags": ["Schema validation"],
         "parameters": [
           {
             "schema": { "type": "string" },
-            "name": "id",
+            "name": "schemaId",
             "in": "path",
             "required": true,
             "description": "ID of the schema"
           }
         ],
-        "operationId": "put-update-new-schema",
         "requestBody": {
           "content": {
             "application/json": {
@@ -899,7 +899,7 @@
         "parameters": [
           {
             "schema": { "type": "string" },
-            "name": "id",
+            "name": "schemaId",
             "in": "path",
             "required": true,
             "description": "ID of the schema"

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -275,7 +275,7 @@
     "/v2/rooms/{roomId}/update-room-id": {
       "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
-        "operationId": "post-rooms-update-roomId",
+        "operationId": "post-rooms-roomId-update-room-id",
         "summary": "Update room ID",
         "description": "This endpoint permanently updates the room’s ID.",
         "tags": ["Room"],
@@ -378,7 +378,7 @@
     "/v2/rooms/{roomId}/broadcast_event": {
       "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
-        "operationId": "post-broadcast-event",
+        "operationId": "post-rooms-roomId-broadcast-event",
         "summary": "Broadcast event to a room",
         "description": "This endpoint enables the broadcast of an event to a room without having to connect to it via the `client` from `@liveblocks/client`. It takes any valid JSON as a request body. The `connectionId` passed to event listeners is `-1` when using this API. Corresponds to [`liveblocks.broadcastEvent`](/docs/api-reference/liveblocks-node#post-broadcast-event).",
         "tags": ["Room"],
@@ -668,7 +668,7 @@
     },
     "/v2/schemas": {
       "post": {
-        "operationId": "post-create-new-schema",
+        "operationId": "post-schemas",
         "summary": "Create schema",
         "description": "This endpoint creates a new schema which can be referenced later to enforce a room’s Storage data structure. Corresponds to [`liveblocks.createSchema`](/docs/api-reference/liveblocks-node#post-create-new-schema). \n\nThe schema consists of a name (for referencing it), and a body, which specifies the exact allowed shape of data in the room. This body is a multi-line string written in the Liveblocks [schema syntax](/docs/platform/schema-validation/syntax).",
         "tags": ["Schema validation"],
@@ -716,7 +716,7 @@
     "/v2/schemas/{schemaId}": {
       "parameters": [{ "$ref": "#/components/parameters/schemaId" }],
       "get": {
-        "operationId": "get-create-new-schema",
+        "operationId": "get-schemas-schemaId",
         "summary": "Get schema",
         "description": "This endpoint retrieves a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. Corresponds to [`liveblocks.getSchema`](/docs/api-reference/liveblocks-node#get-create-new-schema).",
         "tags": ["Schema validation"],
@@ -746,7 +746,7 @@
         }
       },
       "put": {
-        "operationId": "put-update-new-schema",
+        "operationId": "put-schemas-schemaId",
         "summary": "Update schema",
         "description": "This endpoint updates the body for the schema. A schema can only be updated if it is not used by any room. Corresponds to [`liveblocks.updateSchema`](/docs/api-reference/liveblocks-node#put-update-new-schema).",
         "tags": ["Schema validation"],
@@ -791,7 +791,7 @@
         }
       },
       "delete": {
-        "operationId": "delete-a-schema",
+        "operationId": "delete-schemas-schemaId",
         "summary": "Delete schema",
         "description": "This endpoint deletes a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. A schema can only be deleted if it is not attached to a room. Corresponds to [`liveblocks.deleteSchema`](/docs/api-reference/liveblocks-node#delete-a-schema).",
         "tags": ["Schema validation"],
@@ -805,7 +805,7 @@
     "/v2/rooms/{roomId}/schema": {
       "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
-        "operationId": "get-new-schema",
+        "operationId": "get-rooms-roomId-schema",
         "summary": "Get schema by room ID",
         "description": "This endpoint retrieves the schema attached to a room.  Corresponds to [`liveblocks.getSchemaByRoomId`](/docs/api-reference/liveblocks-node#get-new-schema).",
         "tags": ["Schema validation"],
@@ -836,7 +836,7 @@
         }
       },
       "post": {
-        "operationId": "post-attach-schema-to-room",
+        "operationId": "post-rooms-roomId-schema",
         "summary": "Attach schema to room",
         "description": "This endpoint attaches a schema to a room, and instantly enables runtime schema validation for the room. Corresponds to [`liveblocks.attachSchemaToRoom`](/docs/api-reference/liveblocks-node#post-attach-schema-to-room).\n\nIf the current contents of the room’s Storage do not match the schema, attaching will fail and the error message will give details on why the schema failed to attach.",
         "tags": ["Schema validation"],
@@ -868,7 +868,7 @@
         }
       },
       "delete": {
-        "operationId": "delete-detach-schema-to-room",
+        "operationId": "delete-rooms-roomId-schema",
         "summary": "Detach schema from room",
         "description": "This endpoint detaches the schema from a room. Corresponds to [`liveblocks.detachSchemaFromRoom`](/docs/api-reference/liveblocks-node#delete-detach-schema-to-room).",
         "tags": ["Schema validation"],
@@ -1540,7 +1540,7 @@
     "/v2/rooms/{roomId}/authorize": {
       "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
-        "operationId": "post-authorize",
+        "operationId": "post-rooms-roomId-authorize",
         "summary": "Get single-room token with secret key",
         "description": "**Deprecated.** Prefer using [access tokens](#post-authorize-user) or [ID tokens](#post-identify-user) instead. Read more in our [migration guide](/docs/platform/upgrading/1.2).\n\nThis endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When making this request, you’ll have to use your secret key.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. Setting the `userId` is optional if you want to use public rooms, but it is required to enter a private room (because permissions are assigned to specific user IDs). In case you want to use the group permission system, you can also declare which `groupIds` this user belongs to.\n\nThe property userId is used by Liveblocks to calculate your account’s Monthly Active Users. One unique userId corresponds to one MAU. If you don’t pass a userId, we will create for you a new anonymous userId on each connection, but your MAUs will be higher.\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name.",
         "tags": ["Deprecated"],
@@ -1587,7 +1587,7 @@
     "/v2/rooms/{roomId}/public/authorize": {
       "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
-        "operationId": "post-public-authorize",
+        "operationId": "post-rooms-roomId-public-authorize",
         "summary": "Get single-room token with public key",
         "description": "**Deprecated.** When you update Liveblocks to 1.2, you no longer need to get a JWT token when using a public key.\n\nThis endpoint works with the public key and can be used client side. That means you don’t need to implement a dedicated authorization endpoint server side. \nThe generated JWT token works only with public room (`defaultAccesses: [\"room:write\"]`).",
         "tags": ["Deprecated"],
@@ -1636,7 +1636,7 @@
         { "$ref": "#/components/parameters/inboxNotificationId" }
       ],
       "get": {
-        "operationId": "get-users-userId-inboxNotifications-inboxNotificationId",
+        "operationId": "get-users-userId-inbox-notifications-inboxNotificationId",
         "summary": "Get inbox notification",
         "description": "This endpoint returns a user’s inbox notification by its ID. Corresponds to [`liveblocks.getInboxNotification`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications-inboxNotificationId).",
         "tags": ["Notifications"],
@@ -1664,7 +1664,7 @@
         }
       },
       "delete": {
-        "operationId": "delete-users-userId-inboxNotifications-inboxNotificationId",
+        "operationId": "delete-users-userId-inbox-notifications-inboxNotificationId",
         "summary": "Delete inbox notification",
         "description": "This endpoint deletes a user’s inbox notification by its ID.",
         "tags": ["Notifications"],
@@ -1679,7 +1679,7 @@
     "/v2/users/{userId}/inbox-notifications": {
       "parameters": [{ "$ref": "#/components/parameters/userId" }],
       "get": {
-        "operationId": "get-users-userId-inboxNotifications",
+        "operationId": "get-users-userId-inbox-notifications",
         "summary": "Get all inbox notifications",
         "description": "This endpoint returns all the user’s inbox notifications. Corresponds to [`liveblocks.getInboxNotifications`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications).",
         "tags": ["Notifications"],
@@ -1717,7 +1717,7 @@
         }
       },
       "delete": {
-        "operationId": "delete-users-userId-inboxNotifications",
+        "operationId": "delete-users-userId-inbox-notifications",
         "summary": "Delete all inbox notifications",
         "description": "This endpoint deletes all the user’s inbox notifications.",
         "tags": ["Notifications"],

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": { "title": "API v2", "version": "2.0" },
-  "servers": [{ "url": "https://api.liveblocks.io/v2" }],
+  "servers": [{ "url": "https://api.liveblocks.io" }],
   "paths": {
-    "/rooms": {
+    "/v2/rooms": {
       "get": {
         "operationId": "get-rooms",
         "summary": "Get rooms",
@@ -139,7 +139,7 @@
         }
       }
     },
-    "/rooms/{roomId}": {
+    "/v2/rooms/{roomId}": {
       "parameters": [
         {
           "name": "roomId",
@@ -270,7 +270,7 @@
         }
       }
     },
-    "/rooms/{roomId}/update-room-id": {
+    "/v2/rooms/{roomId}/update-room-id": {
       "parameters": [
         {
           "name": "roomId",
@@ -337,7 +337,7 @@
         }
       }
     },
-    "/rooms/{roomId}/active_users": {
+    "/v2/rooms/{roomId}/active_users": {
       "parameters": [
         {
           "name": "roomId",
@@ -389,7 +389,7 @@
         }
       }
     },
-    "/rooms/{roomId}/broadcast_event": {
+    "/v2/rooms/{roomId}/broadcast_event": {
       "parameters": [
         {
           "name": "roomId",
@@ -426,7 +426,7 @@
         }
       }
     },
-    "/rooms/{roomId}/storage": {
+    "/v2/rooms/{roomId}/storage": {
       "parameters": [
         {
           "name": "roomId",
@@ -584,7 +584,7 @@
         }
       }
     },
-    "/rooms/{roomId}/ydoc": {
+    "/v2/rooms/{roomId}/ydoc": {
       "parameters": [
         {
           "name": "roomId",
@@ -675,7 +675,7 @@
         }
       }
     },
-    "/rooms/{roomId}/ydoc-binary": {
+    "/v2/rooms/{roomId}/ydoc-binary": {
       "parameters": [
         {
           "name": "roomId",
@@ -712,7 +712,7 @@
         }
       }
     },
-    "/schemas": {
+    "/v2/schemas": {
       "post": {
         "operationId": "post-create-new-schema",
         "summary": "Create schema",
@@ -759,7 +759,7 @@
         }
       }
     },
-    "/schemas/{schemaId}": {
+    "/v2/schemas/{schemaId}": {
       "parameters": [
         {
           "name": "schemaId",
@@ -856,7 +856,7 @@
         }
       }
     },
-    "/rooms/{roomId}/schema": {
+    "/v2/rooms/{roomId}/schema": {
       "parameters": [
         {
           "name": "roomId",
@@ -944,7 +944,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads": {
+    "/v2/rooms/{roomId}/threads": {
       "parameters": [
         {
           "name": "roomId",
@@ -1079,7 +1079,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}": {
+    "/v2/rooms/{roomId}/threads/{threadId}": {
       "parameters": [
         {
           "name": "roomId",
@@ -1153,7 +1153,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/participants": {
+    "/v2/rooms/{roomId}/threads/{threadId}/participants": {
       "parameters": [
         {
           "name": "roomId",
@@ -1203,7 +1203,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/metadata": {
+    "/v2/rooms/{roomId}/threads/{threadId}/metadata": {
       "parameters": [
         {
           "name": "roomId",
@@ -1256,7 +1256,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/mark-as-resolved": {
+    "/v2/rooms/{roomId}/threads/{threadId}/mark-as-resolved": {
       "parameters": [
         {
           "name": "roomId",
@@ -1292,7 +1292,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/mark-as-unresolved": {
+    "/v2/rooms/{roomId}/threads/{threadId}/mark-as-unresolved": {
       "parameters": [
         {
           "name": "roomId",
@@ -1328,7 +1328,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/comments": {
+    "/v2/rooms/{roomId}/threads/{threadId}/comments": {
       "parameters": [
         {
           "name": "roomId",
@@ -1395,7 +1395,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/comments/{commentId}": {
+    "/v2/rooms/{roomId}/threads/{threadId}/comments/{commentId}": {
       "parameters": [
         {
           "name": "roomId",
@@ -1514,7 +1514,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/add-reaction": {
+    "/v2/rooms/{roomId}/threads/{threadId}/comments/{commentId}/add-reaction": {
       "parameters": [
         {
           "name": "roomId",
@@ -1584,7 +1584,7 @@
         }
       }
     },
-    "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/remove-reaction": {
+    "/v2/rooms/{roomId}/threads/{threadId}/comments/{commentId}/remove-reaction": {
       "parameters": [
         {
           "name": "roomId",
@@ -1639,7 +1639,7 @@
         }
       }
     },
-    "/authorize-user": {
+    "/v2/authorize-user": {
       "post": {
         "operationId": "post-authorize-user",
         "summary": "Get access token with secret key",
@@ -1688,7 +1688,7 @@
         }
       }
     },
-    "/identify-user": {
+    "/v2/identify-user": {
       "post": {
         "operationId": "post-identify-user",
         "summary": "Get ID token with secret key",
@@ -1733,7 +1733,7 @@
         }
       }
     },
-    "/rooms/{roomId}/authorize": {
+    "/v2/rooms/{roomId}/authorize": {
       "parameters": [
         {
           "name": "roomId",
@@ -1788,7 +1788,7 @@
         "x-badge": "Deprecated"
       }
     },
-    "/rooms/{roomId}/public/authorize": {
+    "/v2/rooms/{roomId}/public/authorize": {
       "parameters": [
         {
           "name": "roomId",
@@ -1842,7 +1842,7 @@
         "x-badge": "Deprecated"
       }
     },
-    "/users/{userId}/inbox-notifications/{inboxNotificationId}": {
+    "/v2/users/{userId}/inbox-notifications/{inboxNotificationId}": {
       "parameters": [
         {
           "schema": { "type": "string" },
@@ -1898,7 +1898,7 @@
         }
       }
     },
-    "/users/{userId}/inbox-notifications": {
+    "/v2/users/{userId}/inbox-notifications": {
       "parameters": [
         {
           "schema": { "type": "string" },
@@ -1958,7 +1958,7 @@
         }
       }
     },
-    "/rooms/{roomId}/users/{userId}/notification-settings": {
+    "/v2/rooms/{roomId}/users/{userId}/notification-settings": {
       "parameters": [
         {
           "schema": { "type": "string" },
@@ -2038,7 +2038,7 @@
         }
       }
     },
-    "/inbox-notifications/trigger": {
+    "/v2/inbox-notifications/trigger": {
       "post": {
         "operationId": "post-inbox-notifications-trigger",
         "summary": "Trigger inbox notification",

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -1,14 +1,7 @@
 {
   "openapi": "3.1.0",
-  "info": {
-    "title": "API v2",
-    "version": "2.0"
-  },
-  "servers": [
-    {
-      "url": "https://api.liveblocks.io/v2"
-    }
-  ],
+  "info": { "title": "API v2", "version": "2.0" },
+  "servers": [{ "url": "https://api.liveblocks.io/v2" }],
   "paths": {
     "/rooms": {
       "get": {
@@ -28,26 +21,19 @@
             "description": "A limit on the number of rooms to be returned. The limit can range between 1 and 100, and defaults to 20."
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "in": "query",
             "name": "startingAfter",
             "description": "A cursor used for pagination. Get the value from the `nextCursor` response of the previous page."
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "in": "query",
             "name": "query",
             "description": "Query to filter rooms. You can filter by `roomId` and `metadata`, for example, `metadata[\"roomType\"]:\"whiteboard\" AND roomId^\"liveblocks:engineering\"`. Learn more about [filtering rooms with query language](/docs/guides/how-to-filter-rooms-using-query-language)."
           },
           {
-            "schema": {
-              "type": "string",
-              "examples": ["userId=user1"]
-            },
+            "schema": { "type": "string", "examples": ["userId=user1"] },
             "in": "query",
             "name": "userId",
             "description": "A filter on users accesses."
@@ -67,9 +53,7 @@
             "description": "Success. Returns the list of rooms, the next page cursor, and the next page URL.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetRooms"
-                },
+                "schema": { "$ref": "#/components/schemas/GetRooms" },
                 "examples": {
                   "example": {
                     "value": {
@@ -86,12 +70,8 @@
                             "type": ["whiteboard"]
                           },
                           "defaultAccesses": ["room:write"],
-                          "groupsAccesses": {
-                            "product": ["room:write"]
-                          },
-                          "usersAccesses": {
-                            "vinod": ["room:write"]
-                          }
+                          "groupsAccesses": { "product": ["room:write"] },
+                          "usersAccesses": { "vinod": ["room:write"] }
                         }
                       ]
                     }
@@ -100,15 +80,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "operationId": "get-rooms"
       },
@@ -122,9 +96,7 @@
             "description": "Success. Returns the created room.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Room"
-                },
+                "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
                   "example": {
                     "value": {
@@ -132,56 +104,34 @@
                       "id": "my-room-3ebc26e2bf96",
                       "lastConnectionAt": "2022-08-22T15:10:25.225Z",
                       "createdAt": "2022-08-22T15:10:25.225Z",
-                      "metadata": {
-                        "color": "blue"
-                      },
+                      "metadata": { "color": "blue" },
                       "defaultAccesses": ["room:write"],
-                      "groupsAccesses": {
-                        "product": ["room:write"]
-                      },
-                      "usersAccesses": {
-                        "alice": ["room:write"]
-                      }
+                      "groupsAccesses": { "product": ["room:write"] },
+                      "usersAccesses": { "alice": ["room:write"] }
                     }
                   }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "409": {
-            "$ref": "#/components/responses/409"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "409": { "$ref": "#/components/responses/409" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "operationId": "post-rooms",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateRoom"
-              },
+              "schema": { "$ref": "#/components/schemas/CreateRoom" },
               "examples": {
                 "example": {
                   "value": {
                     "id": "my-room-3ebc26e2bf96",
                     "defaultAccesses": ["room:write"],
-                    "metadata": {
-                      "color": "blue"
-                    },
-                    "usersAccesses": {
-                      "alice": ["room:write"]
-                    },
-                    "groupsAccesses": {
-                      "product": ["room:write"]
-                    }
+                    "metadata": { "color": "blue" },
+                    "usersAccesses": { "alice": ["room:write"] },
+                    "groupsAccesses": { "product": ["room:write"] }
                   }
                 }
               }
@@ -197,9 +147,7 @@
         "operationId": "get-rooms-roomId",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -211,9 +159,7 @@
             "description": "Success. Returns the room.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Room"
-                },
+                "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
                   "example": {
                     "value": {
@@ -227,9 +173,7 @@
                         "target": ["abc", "def"]
                       },
                       "defaultAccesses": ["room:write"],
-                      "groupsAccesses": {
-                        "marketing": ["room:write"]
-                      },
+                      "groupsAccesses": { "marketing": ["room:write"] },
                       "usersAccesses": {
                         "alice": ["room:write"],
                         "vinod": ["room:write"]
@@ -240,15 +184,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "description": "This endpoint returns a room by its ID. Corresponds to [`liveblocks.getRoom`](/docs/api-reference/liveblocks-node#get-rooms-roomid)."
       },
@@ -257,9 +195,7 @@
         "tags": ["Room"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -271,9 +207,7 @@
             "description": "Success. Returns the updated room.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Room"
-                },
+                "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
                   "example": {
                     "value": {
@@ -287,9 +221,7 @@
                         "target": ["abc", "def"]
                       },
                       "defaultAccesses": ["room:write"],
-                      "groupsAccesses": {
-                        "marketing": ["room:write"]
-                      },
+                      "groupsAccesses": { "marketing": ["room:write"] },
                       "usersAccesses": {
                         "alice": ["room:write"],
                         "vinod": ["room:write"]
@@ -300,27 +232,17 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "operationId": "post-rooms-roomId",
         "description": "This endpoint updates specific properties of a room. Corresponds to [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomid). \n\nIt’s not necessary to provide the entire room’s information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"usersAccesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateRoom"
-              },
+              "schema": { "$ref": "#/components/schemas/UpdateRoom" },
               "examples": {
                 "example": {
                   "value": {
@@ -329,27 +251,17 @@
                       "vinod": ["room:write"],
                       "alice": ["room:write"]
                     },
-                    "groupsAccesses": {
-                      "marketing": ["room:write"]
-                    },
-                    "metadata": {
-                      "color": "blue"
-                    }
+                    "groupsAccesses": { "marketing": ["room:write"] },
+                    "metadata": { "color": "blue" }
                   }
                 }
               }
             },
             "application/xml": {
-              "schema": {
-                "type": "object",
-                "properties": {}
-              }
+              "schema": { "type": "object", "properties": {} }
             },
             "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {}
-              }
+              "schema": { "type": "object", "properties": {} }
             }
           }
         }
@@ -358,27 +270,15 @@
         "summary": "Delete room",
         "tags": ["Room"],
         "responses": {
-          "204": {
-            "description": "Success. The room was deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "204": { "description": "Success. The room was deleted" },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -395,9 +295,7 @@
         "tags": ["Room"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -409,9 +307,7 @@
             "description": "Success. Returns the updated room with the new ID.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Room"
-                },
+                "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
                   "example": {
                     "value": {
@@ -425,9 +321,7 @@
                         "target": ["abc", "def"]
                       },
                       "defaultAccesses": ["room:write"],
-                      "groupsAccesses": {
-                        "marketing": ["room:write"]
-                      },
+                      "groupsAccesses": { "marketing": ["room:write"] },
                       "usersAccesses": {
                         "alice": ["room:write"],
                         "vinod": ["room:write"]
@@ -438,18 +332,10 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "operationId": "post-rooms-update-roomId",
         "description": "This endpoint permanently updates the room’s ID.",
@@ -457,24 +343,14 @@
           "content": {
             "application/json": {
               "examples": {
-                "example": {
-                  "value": {
-                    "newRoomId": "new-room-id"
-                  }
-                }
+                "example": { "value": { "newRoomId": "new-room-id" } }
               }
             },
             "application/xml": {
-              "schema": {
-                "type": "object",
-                "properties": {}
-              }
+              "schema": { "type": "object", "properties": {} }
             },
             "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {}
-              }
+              "schema": { "type": "object", "properties": {} }
             }
           }
         }
@@ -488,9 +364,7 @@
         "description": "This endpoint returns a list of users currently present in the requested room. Corresponds to [`liveblocks.getActiveUsers`](/docs/api-reference/liveblocks-node#get-rooms-roomid-active-users). \n\nFor optimal performance, we recommend calling this endpoint no more than once every 10 seconds. \nDuplicates can occur if a user is in the requested room with multiple browser tabs opened.",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -528,15 +402,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         }
       }
     },
@@ -547,9 +415,7 @@
         "tags": ["Room"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -561,18 +427,10 @@
           "204": {
             "description": "Success. An event was broadcast to the room."
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "requestBody": {
           "description": "Any valid JSON.",
@@ -580,12 +438,7 @@
             "schema": {},
             "application/json": {
               "examples": {
-                "example": {
-                  "value": {
-                    "type": "EMOJI",
-                    "emoji": "🔥"
-                  }
-                }
+                "example": { "value": { "type": "EMOJI", "emoji": "🔥" } }
               }
             }
           }
@@ -599,19 +452,14 @@
         "tags": ["Storage"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
             "description": "ID of the room"
           },
           {
-            "schema": {
-              "type": "string",
-              "enum": ["plain-lson", "json"]
-            },
+            "schema": { "type": "string", "enum": ["plain-lson", "json"] },
             "name": "format",
             "in": "query",
             "required": false,
@@ -626,12 +474,8 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "liveblocksType": {
-                      "type": "string"
-                    },
-                    "data": {
-                      "type": ["string", "object"]
-                    }
+                    "liveblocksType": { "type": "string" },
+                    "data": { "type": ["string", "object"] }
                   }
                 },
                 "examples": {
@@ -641,9 +485,7 @@
                       "data": {
                         "aLiveObject": {
                           "liveblocksType": "LiveObject",
-                          "data": {
-                            "a": 1
-                          }
+                          "data": { "a": 1 }
                         },
                         "aLiveList": {
                           "liveblocksType": "LiveList",
@@ -651,10 +493,7 @@
                         },
                         "aLiveMap": {
                           "liveblocksType": "LiveMap",
-                          "data": {
-                            "a": 1,
-                            "b": 2
-                          }
+                          "data": { "a": 1, "b": 2 }
                         }
                       }
                     }
@@ -663,15 +502,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "operationId": "get-rooms-roomId-storage"
       },
@@ -681,9 +514,7 @@
         "operationId": "post-rooms-roomId-storage",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -698,12 +529,8 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "liveblocksType": {
-                      "type": "string"
-                    },
-                    "data": {
-                      "type": ["string", "object"]
-                    }
+                    "liveblocksType": { "type": "string" },
+                    "data": { "type": ["string", "object"] }
                   }
                 },
                 "examples": {
@@ -713,9 +540,7 @@
                       "data": {
                         "aLiveObject": {
                           "liveblocksType": "LiveObject",
-                          "data": {
-                            "a": 1
-                          }
+                          "data": { "a": 1 }
                         },
                         "aLiveList": {
                           "liveblocksType": "LiveList",
@@ -723,10 +548,7 @@
                         },
                         "aLiveMap": {
                           "liveblocksType": "LiveMap",
-                          "data": {
-                            "a": 1,
-                            "b": 2
-                          }
+                          "data": { "a": 1, "b": 2 }
                         }
                       }
                     }
@@ -735,15 +557,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "description": "This endpoint initializes or reinitializes a room’s Storage. The room must already exist. Calling this endpoint will disconnect all users from the room if there are any, triggering a reconnect. Corresponds to [`liveblocks.initializeStorageDocument`](/docs/api-reference/liveblocks-node#post-rooms-roomId-storage).\n\nThe format of the request body is the same as what’s returned by the get Storage endpoint.\n\nFor each Liveblocks data structure that you want to create, you need a JSON element having two properties:\n- `\"liveblocksType\"` => `\"LiveObject\" | \"LiveList\" | \"LiveMap\"`\n- `\"data\"` => contains the nested data structures (children) and data.\n\nThe root’s type can only be LiveObject.\n\nA utility function, `toPlainLson` is included in `@liveblocks/client` from `1.0.9` to help convert `LiveObject`, `LiveList`, and `LiveMap` to the structure expected by the endpoint.",
         "requestBody": {
@@ -752,12 +568,8 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "liveblocksType": {
-                    "type": "string"
-                  },
-                  "data": {
-                    "type": "object"
-                  }
+                  "liveblocksType": { "type": "string" },
+                  "data": { "type": "object" }
                 }
               },
               "examples": {
@@ -767,9 +579,7 @@
                     "data": {
                       "aLiveObject": {
                         "liveblocksType": "LiveObject",
-                        "data": {
-                          "a": 1
-                        }
+                        "data": { "a": 1 }
                       },
                       "aLiveList": {
                         "liveblocksType": "LiveList",
@@ -777,10 +587,7 @@
                       },
                       "aLiveMap": {
                         "liveblocksType": "LiveMap",
-                        "data": {
-                          "a": 1,
-                          "b": 2
-                        }
+                        "data": { "a": 1, "b": 2 }
                       }
                     }
                   }
@@ -796,9 +603,7 @@
         "operationId": "delete-rooms-roomId-storage",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -806,18 +611,10 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success. The room has no more Storage."
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "200": { "description": "Success. The room has no more Storage." },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "description": "This endpoint deletes all of the room’s Storage data. Calling this endpoint will disconnect all users from the room if there are any. Corresponds to [`liveblocks.deleteStorageDocument`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-storage).\n"
       }
@@ -832,15 +629,11 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
-            "schema": {
-              "type": "boolean"
-            },
+            "schema": { "type": "boolean" },
             "name": "formatting",
             "in": "query",
             "allowEmptyValue": true,
@@ -848,9 +641,7 @@
             "description": "If present, YText will return formatting."
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "key",
             "in": "query",
             "required": false,
@@ -872,28 +663,16 @@
             "description": "Success. Returns the room’s Yjs document as JSON.",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object"
-                },
+                "schema": { "type": "object" },
                 "examples": {
-                  "example": {
-                    "value": {
-                      "someYText": "Contents of YText"
-                    }
-                  }
+                  "example": { "value": { "someYText": "Contents of YText" } }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "operationId": "get-rooms-roomId-ydoc"
       },
@@ -902,9 +681,7 @@
         "tags": ["Yjs"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -914,42 +691,25 @@
             "name": "guid",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the subdocument"
           }
         ],
         "responses": {
           "200": {
             "description": "Success. The given room’s Yjs doc has been updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "status": 200
-                }
-              }
-            }
+            "content": { "application/json": { "schema": { "status": 200 } } }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "operationId": "put-rooms-roomId-ydoc",
         "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document. To send an update to a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).\n\nThe update is typically obtained by calling `Y.encodeStateAsUpdate(doc)`. See the [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more details. When manually making this HTTP call, set the HTTP header `Content-Type` to `application/octet-stream`, and send the binary update (a `Uint8Array`) in the body of the HTTP request. This endpoint does not accept JSON, unlike most other endpoints.",
         "requestBody": {
           "content": {
             "application/octet-stream": {
-              "schema": {
-                "format": "binary",
-                "type": "array"
-              }
+              "schema": { "format": "binary", "type": "array" }
             }
           }
         }
@@ -965,18 +725,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "guid",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the subdocument"
           }
         ],
@@ -984,22 +740,12 @@
           "200": {
             "description": "Success. Returns the room’s Yjs document encoded as a binary Yjs update.",
             "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "array"
-                }
-              }
+              "application/octet-stream": { "schema": { "type": "array" } }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" }
         },
         "operationId": "get-rooms-roomId-ydoc-binary"
       }
@@ -1014,9 +760,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SchemaRequest"
-              },
+              "schema": { "$ref": "#/components/schemas/SchemaRequest" },
               "examples": {
                 "example": {
                   "value": {
@@ -1033,9 +777,7 @@
             "description": "Success. Creates the new schema and returns it as JSON.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SchemaResponse"
-                },
+                "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
                   "example": {
                     "value": {
@@ -1051,12 +793,8 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422-schema-validation"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "422": { "$ref": "#/components/responses/422-schema-validation" }
         }
       }
     },
@@ -1067,9 +805,7 @@
         "tags": ["Schema validation"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "id",
             "in": "path",
             "required": true,
@@ -1082,9 +818,7 @@
             "description": "Success. Found the schema and returns it as JSON.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SchemaResponse"
-                },
+                "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
                   "example": {
                     "value": {
@@ -1100,12 +834,8 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-schema-validation"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "404": { "$ref": "#/components/responses/404-schema-validation" }
         }
       },
       "put": {
@@ -1114,9 +844,7 @@
         "tags": ["Schema validation"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "id",
             "in": "path",
             "required": true,
@@ -1127,9 +855,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateSchema"
-              },
+              "schema": { "$ref": "#/components/schemas/UpdateSchema" },
               "examples": {
                 "example": {
                   "value": {
@@ -1145,9 +871,7 @@
             "description": "Success. Updates the new schema and increments the version. The schema `body` is returned as JSON.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SchemaResponse"
-                },
+                "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
                   "example": {
                     "value": {
@@ -1163,15 +887,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403-schema-validation"
-          },
-          "422": {
-            "$ref": "#/components/responses/422-schema-validation"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403-schema-validation" },
+          "422": { "$ref": "#/components/responses/422-schema-validation" }
         }
       },
       "delete": {
@@ -1180,9 +898,7 @@
         "tags": ["Schema validation"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "id",
             "in": "path",
             "required": true,
@@ -1191,15 +907,9 @@
         ],
         "operationId": "delete-a-schema",
         "responses": {
-          "200": {
-            "description": "Success. Schema was delated"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403-schema-validation"
-          }
+          "200": { "description": "Success. Schema was delated" },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403-schema-validation" }
         }
       }
     },
@@ -1210,9 +920,7 @@
         "tags": ["Schema validation"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -1225,9 +933,7 @@
             "description": "Success. Found the schema attached to the room and returns it as JSON.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SchemaResponse"
-                },
+                "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
                   "example": {
                     "value": {
@@ -1243,15 +949,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403-schema-validation"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-schema-validation"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403-schema-validation" },
+          "404": { "$ref": "#/components/responses/404-schema-validation" }
         }
       },
       "post": {
@@ -1260,9 +960,7 @@
         "tags": ["Schema validation"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -1273,15 +971,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AttachSchema"
-              },
+              "schema": { "$ref": "#/components/schemas/AttachSchema" },
               "examples": {
-                "example": {
-                  "value": {
-                    "schema": "my-schema@1"
-                  }
-                }
+                "example": { "value": { "schema": "my-schema@1" } }
               }
             }
           }
@@ -1291,28 +983,16 @@
             "description": "Success. Found the schema attached to the room. Returns the schema ID as JSON.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AttachSchema"
-                },
+                "schema": { "$ref": "#/components/schemas/AttachSchema" },
                 "examples": {
-                  "example": {
-                    "value": {
-                      "schema": "my-schema@1"
-                    }
-                  }
+                  "example": { "value": { "schema": "my-schema@1" } }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-schema-validation"
-          },
-          "409": {
-            "$ref": "#/components/responses/409-schema-validation"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "404": { "$ref": "#/components/responses/404-schema-validation" },
+          "409": { "$ref": "#/components/responses/409-schema-validation" }
         }
       },
       "delete": {
@@ -1321,9 +1001,7 @@
         "tags": ["Schema validation"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -1335,15 +1013,9 @@
           "200": {
             "description": "Success. Detached the schema from the room."
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-schema-validation"
-          },
-          "409": {
-            "$ref": "#/components/responses/409-schema-validation"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "404": { "$ref": "#/components/responses/404-schema-validation" },
+          "409": { "$ref": "#/components/responses/409-schema-validation" }
         }
       }
     },
@@ -1357,15 +1029,11 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "in": "query",
             "name": "query",
             "description": "Query to filter threads. You can filter by `metadata` and `resolved`, for example, `metadata[\"status\"]:\"open\" AND metadata[\"color\"]:\"red\" AND resolved:true`. Learn more about [filtering threads with query language](/docs/guides/how-to-filter-threads-using-query-language)."
@@ -1382,9 +1050,7 @@
                   "properties": {
                     "data": {
                       "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Thread"
-                      }
+                      "items": { "$ref": "#/components/schemas/Thread" }
                     }
                   }
                 },
@@ -1420,15 +1086,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       },
       "post": {
@@ -1441,9 +1101,7 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           }
         ],
@@ -1452,9 +1110,7 @@
             "description": "Success. Returns the created thread.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Thread"
-                },
+                "schema": { "$ref": "#/components/schemas/Thread" },
                 "examples": {
                   "example": {
                     "value": {
@@ -1469,52 +1125,34 @@
                           "id": "comment-id",
                           "userId": "alice",
                           "createdAt": "2022-07-13T14:32:50.697Z",
-                          "body": {
-                            "version": 1,
-                            "content": []
-                          }
+                          "body": { "version": 1, "content": [] }
                         }
                       ],
                       "createdAt": "2022-07-13T14:32:50.697Z",
-                      "metadata": {
-                        "color": "blue"
-                      }
+                      "metadata": { "color": "blue" }
                     }
                   }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "409": {
-            "$ref": "#/components/responses/409-thread"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "409": { "$ref": "#/components/responses/409-thread" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateThread"
-              },
+              "schema": { "$ref": "#/components/schemas/CreateThread" },
               "examples": {
                 "example": {
                   "value": {
                     "comment": {
                       "userId": "alice",
                       "createdAt": "2022-07-13T14:32:50.697Z",
-                      "body": {
-                        "version": 1,
-                        "content": []
-                      }
+                      "body": { "version": 1, "content": [] }
                     },
-                    "metadata": {
-                      "color": "blue"
-                    }
+                    "metadata": { "color": "blue" }
                   }
                 }
               }
@@ -1534,18 +1172,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
@@ -1554,9 +1188,7 @@
             "description": "Success. Returns requested thread.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Thread"
-                },
+                "schema": { "$ref": "#/components/schemas/Thread" },
                 "examples": {
                   "Success": {
                     "value": {
@@ -1585,15 +1217,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       },
       "delete": {
@@ -1606,34 +1232,22 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
         "responses": {
-          "204": {
-            "description": "Success. The thread has been deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "204": { "description": "Success. The thread has been deleted." },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       }
     },
@@ -1648,18 +1262,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
@@ -1673,31 +1283,21 @@
                   "properties": {
                     "participantIds": {
                       "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                      "items": { "type": "string" }
                     }
                   }
                 },
                 "examples": {
                   "Success": {
-                    "value": {
-                      "participantIds": ["user-1", "user-2"]
-                    }
+                    "value": { "participantIds": ["user-1", "user-2"] }
                   }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       }
     },
@@ -1712,18 +1312,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
@@ -1732,38 +1328,22 @@
             "description": "Success. Returns the updated metadata.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ThreadMetadata"
-                },
-                "examples": {
-                  "Success": {
-                    "value": {
-                      "color": "yellow"
-                    }
-                  }
-                }
+                "schema": { "$ref": "#/components/schemas/ThreadMetadata" },
+                "examples": { "Success": { "value": { "color": "yellow" } } }
               }
             }
           },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateThread"
-              },
+              "schema": { "$ref": "#/components/schemas/UpdateThread" },
               "examples": {
                 "example": {
                   "value": {
-                    "metadata": {
-                      "color": "yellow"
-                    },
+                    "metadata": { "color": "yellow" },
                     "userId": "alice",
                     "createdAt": "2023-07-13T14:32:50.697Z"
                   }
@@ -1785,18 +1365,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
@@ -1805,18 +1381,12 @@
             "description": "Success. Returns the updated thread.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Thread"
-                }
+                "schema": { "$ref": "#/components/schemas/Thread" }
               }
             }
           },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       }
     },
@@ -1831,18 +1401,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
@@ -1851,18 +1417,12 @@
             "description": "Success. Returns the updated thread.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Thread"
-                }
+                "schema": { "$ref": "#/components/schemas/Thread" }
               }
             }
           },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       }
     },
@@ -1877,18 +1437,14 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           }
         ],
@@ -1897,9 +1453,7 @@
             "description": "Success. Returns the created comment.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Comment"
-                },
+                "schema": { "$ref": "#/components/schemas/Comment" },
                 "examples": {
                   "example": {
                     "value": {
@@ -1909,44 +1463,28 @@
                       "id": "comment-id",
                       "userId": "alice",
                       "createdAt": "2022-07-13T14:32:50.697Z",
-                      "body": {
-                        "version": 1,
-                        "content": []
-                      }
+                      "body": { "version": 1, "content": [] }
                     }
                   }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          },
-          "409": {
-            "$ref": "#/components/responses/409-comment"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" },
+          "409": { "$ref": "#/components/responses/409-comment" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateComment"
-              },
+              "schema": { "$ref": "#/components/schemas/CreateComment" },
               "examples": {
                 "example": {
                   "value": {
                     "userId": "alice",
                     "createdAt": "2022-07-13T14:32:50.697Z",
-                    "body": {
-                      "version": 1,
-                      "content": []
-                    }
+                    "body": { "version": 1, "content": [] }
                   }
                 }
               }
@@ -1966,27 +1504,21 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           },
           {
             "name": "commentId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the comment"
           }
         ],
@@ -1995,9 +1527,7 @@
             "description": "Success. Returns the requested comment.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Comment"
-                },
+                "schema": { "$ref": "#/components/schemas/Comment" },
                 "examples": {
                   "Success": {
                     "value": {
@@ -2016,15 +1546,9 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       },
       "post": {
@@ -2037,27 +1561,21 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           },
           {
             "name": "commentId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the comment"
           }
         ],
@@ -2066,9 +1584,7 @@
             "description": "Success. Returns the edited comment.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UpdateComment"
-                },
+                "schema": { "$ref": "#/components/schemas/UpdateComment" },
                 "examples": {
                   "example": {
                     "value": {
@@ -2078,43 +1594,27 @@
                       "id": "comment-id",
                       "userId": "alice",
                       "createdAt": "2023-07-13T14:32:50.697Z",
-                      "body": {
-                        "version": 1,
-                        "content": []
-                      }
+                      "body": { "version": 1, "content": [] }
                     }
                   }
                 }
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-thread"
-          },
-          "409": {
-            "$ref": "#/components/responses/409-comment"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" },
+          "409": { "$ref": "#/components/responses/409-comment" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateComment"
-              },
+              "schema": { "$ref": "#/components/schemas/CreateComment" },
               "examples": {
                 "example": {
                   "value": {
                     "editedAt": "2023-07-13T14:32:50.697Z",
-                    "body": {
-                      "version": 1,
-                      "content": []
-                    }
+                    "body": { "version": 1, "content": [] }
                   }
                 }
               }
@@ -2130,43 +1630,29 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           },
           {
             "name": "commentId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the comment"
           }
         ],
         "responses": {
-          "204": {
-            "description": "Success. The comment was deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-comment"
-          }
+          "204": { "description": "Success. The comment was deleted" },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-comment" }
         },
         "operationId": "delete-rooms-roomId-threads-threadId-comments-commentId",
         "description": "This endpoint deletes a comment. A deleted comment is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId)."
@@ -2183,27 +1669,21 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           },
           {
             "name": "commentId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the comment"
           }
         ],
@@ -2212,9 +1692,7 @@
             "description": "Success. Returns the created reaction.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CommentReaction"
-                },
+                "schema": { "$ref": "#/components/schemas/CommentReaction" },
                 "examples": {
                   "example": {
                     "value": {
@@ -2227,25 +1705,15 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-comment"
-          },
-          "409": {
-            "$ref": "#/components/responses/409-comment-reaction"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-comment" },
+          "409": { "$ref": "#/components/responses/409-comment-reaction" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AddCommentReaction"
-              },
+              "schema": { "$ref": "#/components/schemas/AddCommentReaction" },
               "examples": {
                 "example": {
                   "value": {
@@ -2271,43 +1739,29 @@
             "name": "roomId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the room"
           },
           {
             "name": "threadId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the thread"
           },
           {
             "name": "commentId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the comment"
           }
         ],
         "responses": {
-          "204": {
-            "description": "Success. The comment reaction was deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404-comment-reaction"
-          }
+          "204": { "description": "Success. The comment reaction was deleted" },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-comment-reaction" }
         },
         "requestBody": {
           "content": {
@@ -2339,9 +1793,7 @@
             "description": "Success. Returns an access token that can be used to enter one or more rooms.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenResponse"
-                },
+                "schema": { "$ref": "#/components/schemas/TokenResponse" },
                 "examples": {
                   "example": {
                     "value": {
@@ -2352,16 +1804,12 @@
               }
             }
           },
-          "403": {
-            "$ref": "#/components/responses/403"
-          }
+          "403": { "$ref": "#/components/responses/403" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AuthorizeUserRequest"
-              },
+              "schema": { "$ref": "#/components/schemas/AuthorizeUserRequest" },
               "examples": {
                 "example": {
                   "value": {
@@ -2394,9 +1842,7 @@
             "description": "Success. Returns an ID token that can be used to enter one or more rooms.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenResponse"
-                },
+                "schema": { "$ref": "#/components/schemas/TokenResponse" },
                 "examples": {
                   "example": {
                     "value": {
@@ -2407,16 +1853,12 @@
               }
             }
           },
-          "403": {
-            "$ref": "#/components/responses/403"
-          }
+          "403": { "$ref": "#/components/responses/403" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IdentifyUserRequest"
-              },
+              "schema": { "$ref": "#/components/schemas/IdentifyUserRequest" },
               "examples": {
                 "example": {
                   "value": {
@@ -2443,9 +1885,7 @@
         "tags": ["Deprecated"],
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -2458,9 +1898,7 @@
             "description": "Success. Returns an old-style single-room token.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Authorization"
-                },
+                "schema": { "$ref": "#/components/schemas/Authorization" },
                 "examples": {
                   "example": {
                     "value": {
@@ -2471,34 +1909,21 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAuthorization"
-              },
+              "schema": { "$ref": "#/components/schemas/CreateAuthorization" },
               "examples": {
                 "example": {
                   "value": {
                     "userId": "b2c1c290-f2c9-45de-a74e-6b7aa0690f59",
                     "groupIds": ["g1", "g2"],
-                    "userInfo": {
-                      "name": "bob",
-                      "colors": ["blue", "red"]
-                    }
+                    "userInfo": { "name": "bob", "colors": ["blue", "red"] }
                   }
                 }
               }
@@ -2515,9 +1940,7 @@
         "operationId": "post-public-authorize",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
@@ -2529,9 +1952,7 @@
             "description": "Success. Returns the JWT token.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Authorization"
-                },
+                "schema": { "$ref": "#/components/schemas/Authorization" },
                 "examples": {
                   "example": {
                     "value": {
@@ -2542,15 +1963,9 @@
               }
             }
           },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         },
         "description": "**Deprecated.** When you update Liveblocks to 1.2, you no longer need to get a JWT token when using a public key.\n\nThis endpoint works with the public key and can be used client side. That means you don’t need to implement a dedicated authorization endpoint server side. \nThe generated JWT token works only with public room (`defaultAccesses: [\"room:write\"]`).",
         "requestBody": {
@@ -2574,17 +1989,13 @@
     "/users/{userId}/inbox-notifications/{inboxNotificationId}": {
       "parameters": [
         {
-          "schema": {
-            "type": "string"
-          },
+          "schema": { "type": "string" },
           "name": "userId",
           "in": "path",
           "required": true
         },
         {
-          "schema": {
-            "type": "string"
-          },
+          "schema": { "type": "string" },
           "name": "inboxNotificationId",
           "in": "path",
           "required": true
@@ -2598,18 +2009,14 @@
             "name": "userId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the user"
           },
           {
             "name": "inboxNotificationId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the inbox notification"
           }
         ],
@@ -2633,15 +2040,9 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" }
         }
       },
       "delete": {
@@ -2652,45 +2053,31 @@
             "name": "userId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the user"
           },
           {
             "name": "inboxNotificationId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the inbox notification"
           }
         ],
         "operationId": "delete-users-userId-inboxNotifications-inboxNotificationId",
         "description": "This endpoint deletes a user’s inbox notification by its ID.",
         "responses": {
-          "204": {
-            "description": ""
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
+          "204": { "description": "" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" }
         }
       }
     },
     "/users/{userId}/inbox-notifications": {
       "parameters": [
         {
-          "schema": {
-            "type": "string"
-          },
+          "schema": { "type": "string" },
           "name": "userId",
           "in": "path",
           "required": true
@@ -2704,27 +2091,17 @@
             "name": "userId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the user"
           }
         ],
         "operationId": "delete-users-userId-inboxNotifications",
         "description": "This endpoint deletes all the user’s inbox notifications.",
         "responses": {
-          "204": {
-            "description": ""
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
+          "204": { "description": "" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" }
         }
       },
       "get": {
@@ -2735,15 +2112,11 @@
             "name": "userId",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "description": "ID of the user"
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "in": "query",
             "name": "query",
             "description": "Query to filter notifications. You can filter by `unread`, for example, `unread:true`."
@@ -2772,29 +2145,21 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          }
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" }
         }
       }
     },
     "/rooms/{roomId}/users/{userId}/notification-settings": {
       "parameters": [
         {
-          "schema": {
-            "type": "string"
-          },
+          "schema": { "type": "string" },
           "name": "roomId",
           "in": "path",
           "required": true
         },
         {
-          "schema": {
-            "type": "string"
-          },
+          "schema": { "type": "string" },
           "name": "userId",
           "in": "path",
           "required": true
@@ -2807,18 +2172,14 @@
         "description": "This endpoint returns a user’s notification settings for a specific room. Corresponds to [`liveblocks.getRoomNotificationSettings`](/docs/api-reference/liveblocks-node#get-rooms-roomId-users-userId-notification-settings).",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
             "description": "ID of the room"
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "userId",
             "in": "path",
             "required": true,
@@ -2836,15 +2197,9 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" }
         }
       },
       "post": {
@@ -2854,18 +2209,14 @@
         "description": "This endpoint updates a user’s notification settings for a specific room. Corresponds to [`liveblocks.updateRoomNotificationSettings`](/docs/api-reference/liveblocks-node#post-rooms-roomId-users-userId-notification-settings).",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
             "description": "ID of the room"
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "userId",
             "in": "path",
             "required": true,
@@ -2883,18 +2234,10 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "422": {
-            "description": "Unprocessable Entity"
-          }
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" },
+          "422": { "description": "Unprocessable Entity" }
         },
         "requestBody": {
           "content": {
@@ -2913,18 +2256,14 @@
         "description": "This endpoint deletes a user’s notification settings for a specific room. Corresponds to [`liveblocks.deleteRoomNotificationSettings`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-users-userId-notification-settings).",
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "roomId",
             "in": "path",
             "required": true,
             "description": "ID of the room"
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "name": "userId",
             "in": "path",
             "required": true,
@@ -2932,18 +2271,10 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
+          "204": { "description": "No Content" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" }
         }
       }
     },
@@ -2955,21 +2286,11 @@
         "operationId": "post-inbox-notifications-trigger",
         "description": "This endpoint triggers an inbox notification. Corresponds to [`liveblocks.triggerInboxNotification`](/docs/api-reference/liveblocks-node#post-inbox-notifications-trigger).",
         "responses": {
-          "200": {
-            "description": "No Content"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "422": {
-            "description": "Unprocessable Entity"
-          }
+          "200": { "description": "No Content" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" },
+          "422": { "description": "Unprocessable Entity" }
         },
         "requestBody": {
           "content": {
@@ -2989,38 +2310,21 @@
         "title": "Room",
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["room"]
-          },
-          "lastConnectionAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
+          "id": { "type": "string" },
+          "type": { "type": "string", "enum": ["room"] },
+          "lastConnectionAt": { "type": "string", "format": "date-time" },
+          "createdAt": { "type": "string", "format": "date-time" },
           "metadata": {
             "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "additionalProperties": { "type": "string" }
           },
           "defaultAccesses": {
             "type": ["string", "array"],
             "uniqueItems": true,
             "items": {}
           },
-          "usersAccesses": {
-            "type": "object"
-          },
-          "groupsAccesses": {
-            "type": "object"
-          }
+          "usersAccesses": { "type": "object" },
+          "groupsAccesses": { "type": "object" }
         }
       },
       "UpdateRoom": {
@@ -3030,9 +2334,7 @@
         "properties": {
           "defaultAccesses": {
             "type": ["array", "null"],
-            "items": {
-              "type": "string"
-            }
+            "items": { "type": "string" }
           },
           "usersAccesses": {
             "type": ["object", "null"],
@@ -3052,24 +2354,11 @@
         "title": "CreateRoom",
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "defaultAccesses": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "usersAccesses": {
-            "type": "object"
-          },
-          "groupsAccesses": {
-            "type": "object"
-          },
-          "metadata": {
-            "type": "object"
-          }
+          "id": { "type": "string" },
+          "defaultAccesses": { "type": "array", "items": { "type": "string" } },
+          "usersAccesses": { "type": "object" },
+          "groupsAccesses": { "type": "object" },
+          "metadata": { "type": "object" }
         },
         "required": ["id", "defaultAccesses"]
       },
@@ -3077,10 +2366,7 @@
         "title": "Error",
         "type": "object",
         "properties": {
-          "error": {
-            "type": "string",
-            "description": "Error code"
-          },
+          "error": { "type": "string", "description": "Error code" },
           "message": {
             "type": "string",
             "description": "Message explaining the error"
@@ -3098,38 +2384,24 @@
       "Authorization": {
         "title": "Authorization",
         "type": "object",
-        "properties": {
-          "token": {
-            "type": "string"
-          }
-        }
+        "properties": { "token": { "type": "string" } }
       },
       "TokenResponse": {
         "title": "An HTTP response body containing a token.",
         "type": "object",
-        "properties": {
-          "token": {
-            "type": "string"
-          }
-        }
+        "properties": { "token": { "type": "string" } }
       },
       "AuthorizeUserRequest": {
         "title": "AuthorizeUserRequest",
         "type": "object",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "userInfo": {
-            "type": "object"
-          },
+          "userId": { "type": "string" },
+          "userInfo": { "type": "object" },
           "permissions": {
             "type": "object",
             "additionalProperties": {
               "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "items": { "type": "string" }
             }
           }
         }
@@ -3138,75 +2410,38 @@
         "title": "IdentifyUserRequest",
         "type": "object",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "groupIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "userInfo": {
-            "type": "object"
-          }
+          "userId": { "type": "string" },
+          "groupIds": { "type": "array", "items": { "type": "string" } },
+          "userInfo": { "type": "object" }
         }
       },
       "CreateAuthorization": {
         "title": "CreateAuthorization",
         "type": "object",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "userInfo": {
-            "type": "object"
-          },
-          "groupIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
+          "userId": { "type": "string" },
+          "userInfo": { "type": "object" },
+          "groupIds": { "type": "array", "items": { "type": "string" } }
         }
       },
       "GetRooms": {
         "title": "GetRooms",
         "type": "object",
         "properties": {
-          "nextPage": {
-            "type": "string"
-          },
+          "nextPage": { "type": "string" },
           "data": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "lastConnectionAt": {
-                  "type": "string"
-                },
-                "createdAt": {
-                  "type": "string"
-                },
-                "metadata": {
-                  "type": "object"
-                },
-                "defaultAccesses": {
-                  "type": ["string", "array"],
-                  "items": {}
-                },
-                "usersAccesses": {
-                  "type": "object"
-                },
-                "groupsAccesses": {
-                  "type": "object"
-                }
+                "id": { "type": "string" },
+                "type": { "type": "string" },
+                "lastConnectionAt": { "type": "string" },
+                "createdAt": { "type": "string" },
+                "metadata": { "type": "object" },
+                "defaultAccesses": { "type": ["string", "array"], "items": {} },
+                "usersAccesses": { "type": "object" },
+                "groupsAccesses": { "type": "object" }
               }
             }
           }
@@ -3221,12 +2456,8 @@
             "items": {
               "type": "object",
               "properties": {
-                "type": {
-                  "type": "string"
-                },
-                "connectionId": {
-                  "type": "number"
-                }
+                "type": { "type": "string" },
+                "connectionId": { "type": "number" }
               }
             }
           }
@@ -3235,101 +2466,53 @@
       "PublicAuthorizeBodyRequest": {
         "title": "PublicAuthorizeBodyRequest",
         "type": "object",
-        "properties": {
-          "publicApiKey": {
-            "type": "string"
-          }
-        }
+        "properties": { "publicApiKey": { "type": "string" } }
       },
       "SchemaResponse": {
         "title": "Schema",
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "number"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "body": {
-            "type": "string"
-          }
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "version": { "type": "number" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "body": { "type": "string" }
         }
       },
       "SchemaRequest": {
         "title": "SchemaRequest",
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "body": {
-            "type": "string"
-          }
+          "name": { "type": "string" },
+          "body": { "type": "string" }
         }
       },
       "UpdateSchema": {
         "title": "UpdateSchema",
         "type": "object",
-        "properties": {
-          "body": {
-            "type": "string"
-          }
-        }
+        "properties": { "body": { "type": "string" } }
       },
       "AttachSchema": {
         "title": "AttachSchema",
         "type": "object",
-        "properties": {
-          "schema": {
-            "type": "string"
-          }
-        }
+        "properties": { "schema": { "type": "string" } }
       },
       "Thread": {
         "type": "object",
         "title": "Thread",
         "properties": {
-          "type": {
-            "const": "thread"
-          },
-          "id": {
-            "type": "string"
-          },
-          "roomId": {
-            "type": "string"
-          },
+          "type": { "const": "thread" },
+          "id": { "type": "string" },
+          "roomId": { "type": "string" },
           "comments": {
             "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Comment"
-            }
+            "items": { "$ref": "#/components/schemas/Comment" }
           },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "metadata": {
-            "type": "object"
-          },
-          "resolved": {
-            "type": "boolean"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time"
-          }
+          "createdAt": { "type": "string", "format": "date-time" },
+          "metadata": { "type": "object" },
+          "resolved": { "type": "boolean" },
+          "updatedAt": { "type": "string", "format": "date-time" }
         },
         "required": [
           "type",
@@ -3371,33 +2554,19 @@
           "comment": {
             "type": "object",
             "properties": {
-              "userId": {
-                "type": "string"
-              },
-              "createdAt": {
-                "type": "string",
-                "format": "date-time"
-              },
+              "userId": { "type": "string" },
+              "createdAt": { "type": "string", "format": "date-time" },
               "body": {
                 "type": "object",
                 "properties": {
-                  "version": {
-                    "type": "number"
-                  },
-                  "content": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    }
-                  }
+                  "version": { "type": "number" },
+                  "content": { "type": "array", "items": { "type": "object" } }
                 }
               }
             },
             "required": ["userId", "body"]
           },
-          "metadata": {
-            "type": "object"
-          }
+          "metadata": { "type": "object" }
         },
         "required": ["comment"],
         "examples": [
@@ -3405,14 +2574,9 @@
             "comment": {
               "userId": "alice",
               "createdAt": "2022-07-13T14:32:50.697Z",
-              "body": {
-                "version": 1,
-                "content": []
-              }
+              "body": { "version": 1, "content": [] }
             },
-            "metadata": {
-              "color": "blue"
-            }
+            "metadata": { "color": "blue" }
           }
         ],
         "description": ""
@@ -3421,23 +2585,14 @@
         "title": "UpdateThread",
         "type": "object",
         "properties": {
-          "metadata": {
-            "type": "object"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time"
-          }
+          "metadata": { "type": "object" },
+          "userId": { "type": "string" },
+          "updatedAt": { "type": "string", "format": "date-time" }
         },
         "required": ["metadata", "userId"],
         "examples": [
           {
-            "metadata": {
-              "color": "blue"
-            },
+            "metadata": { "color": "blue" },
             "userId": "alice",
             "createdAt": "2023-07-13T14:32:50.697Z"
           }
@@ -3447,16 +2602,9 @@
       "ThreadMetadata": {
         "type": "object",
         "title": "ThreadMetadata",
-        "properties": {
-          "type": "object"
-        },
+        "properties": { "type": "object" },
         "required": [],
-        "examples": [
-          {
-            "color": "blue",
-            "age": 25
-          }
-        ],
+        "examples": [{ "color": "blue", "age": 25 }],
         "description": ""
       },
       "Comment": {
@@ -3469,33 +2617,14 @@
             "default": "comment",
             "examples": ["comment"]
           },
-          "threadId": {
-            "type": "string"
-          },
-          "roomId": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "editedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "deletedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "body": {
-            "type": "object"
-          }
+          "threadId": { "type": "string" },
+          "roomId": { "type": "string" },
+          "id": { "type": "string" },
+          "userId": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "editedAt": { "type": "string", "format": "date-time" },
+          "deletedAt": { "type": "string", "format": "date-time" },
+          "body": { "type": "object" }
         },
         "required": ["type", "threadId", "roomId", "id", "userId", "createdAt"],
         "examples": [
@@ -3516,25 +2645,13 @@
         "title": "CreateComment",
         "type": "object",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
+          "userId": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
           "body": {
             "type": "object",
             "properties": {
-              "version": {
-                "type": "number"
-              },
-              "content": {
-                "type": "array",
-                "items": {
-                  "type": "object"
-                }
-              }
+              "version": { "type": "number" },
+              "content": { "type": "array", "items": { "type": "object" } }
             }
           }
         },
@@ -3543,10 +2660,7 @@
           {
             "userId": "alice",
             "createdAt": "2022-07-13T14:32:50.697Z",
-            "body": {
-              "version": 1,
-              "content": []
-            }
+            "body": { "version": 1, "content": [] }
           }
         ],
         "description": ""
@@ -3555,22 +2669,12 @@
         "title": "UpdateComment",
         "type": "object",
         "properties": {
-          "editedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
+          "editedAt": { "type": "string", "format": "date-time" },
           "body": {
             "type": "object",
             "properties": {
-              "version": {
-                "type": "number"
-              },
-              "content": {
-                "type": "array",
-                "items": {
-                  "type": "object"
-                }
-              }
+              "version": { "type": "number" },
+              "content": { "type": "array", "items": { "type": "object" } }
             }
           }
         },
@@ -3578,10 +2682,7 @@
         "examples": [
           {
             "editedAt": "2022-07-13T14:32:50.697Z",
-            "body": {
-              "version": 1,
-              "content": []
-            }
+            "body": { "version": 1, "content": [] }
           }
         ],
         "description": ""
@@ -3590,16 +2691,9 @@
         "type": "object",
         "title": "CommentReaction",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "emoji": {
-            "type": "string"
-          }
+          "userId": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "emoji": { "type": "string" }
         },
         "required": ["userId", "emoji"],
         "examples": [
@@ -3614,16 +2708,9 @@
         "type": "object",
         "title": "AddCommentReaction",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "emoji": {
-            "type": "string"
-          }
+          "userId": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "emoji": { "type": "string" }
         },
         "required": ["userId", "emoji"],
         "examples": [
@@ -3638,16 +2725,9 @@
         "type": "object",
         "title": "RemoveCommentReaction",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "removedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "emoji": {
-            "type": "string"
-          }
+          "userId": { "type": "string" },
+          "removedAt": { "type": "string", "format": "date-time" },
+          "emoji": { "type": "string" }
         },
         "required": ["userId", "emoji"],
         "examples": [
@@ -3662,85 +2742,43 @@
         "title": "InboxNotificationThreadData",
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string"
-          },
-          "threadId": {
-            "type": "string"
-          },
-          "roomId": {
-            "type": "string"
-          },
-          "readAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "notifiedAt": {
-            "type": "string",
-            "format": "date-time"
-          }
+          "id": { "type": "string" },
+          "kind": { "type": "string" },
+          "threadId": { "type": "string" },
+          "roomId": { "type": "string" },
+          "readAt": { "type": "string", "format": "date-time" },
+          "notifiedAt": { "type": "string", "format": "date-time" }
         }
       },
       "InboxNotificationCustomData": {
         "title": "InboxNotificationCustomData",
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string"
-          },
-          "subjectId": {
-            "type": "string"
-          },
-          "roomId": {
-            "type": "string"
-          },
-          "readAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "notifiedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "activityData": {
-            "type": "object"
-          }
+          "id": { "type": "string" },
+          "kind": { "type": "string" },
+          "subjectId": { "type": "string" },
+          "roomId": { "type": "string" },
+          "readAt": { "type": "string", "format": "date-time" },
+          "notifiedAt": { "type": "string", "format": "date-time" },
+          "activityData": { "type": "object" }
         }
       },
       "UserRoomNotificationSettings": {
         "title": "UserRoomNotificationSettings",
         "type": "object",
         "properties": {
-          "threads": {
-            "enum": ["all", "replies_and_mentions", "none"]
-          }
+          "threads": { "enum": ["all", "replies_and_mentions", "none"] }
         }
       },
       "TriggerInboxNotification": {
         "title": "TriggerInboxNotification",
         "type": "object",
         "properties": {
-          "userId": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string"
-          },
-          "subjectId": {
-            "type": "string"
-          },
-          "roomId": {
-            "type": "string"
-          },
-          "activityData": {
-            "type": "object"
-          }
+          "userId": { "type": "string" },
+          "kind": { "type": "string" },
+          "subjectId": { "type": "string" },
+          "roomId": { "type": "string" },
+          "activityData": { "type": "object" }
         },
         "required": ["userId", "kind", "subjectId", "activityData"],
         "examples": [
@@ -3748,9 +2786,7 @@
             "userId": "alice",
             "kind": "file-uploaded",
             "subjectId": "file123",
-            "activityData": {
-              "url": "url-to-file"
-            }
+            "activityData": { "url": "url-to-file" }
           }
         ]
       }
@@ -3767,9 +2803,7 @@
         "description": "Missing or wrong credentials.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "WRONG_KEY_USED": {
                 "value": {
@@ -3795,9 +2829,7 @@
         "description": "Unauthorized access.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "INVALID_SECRET_KEY": {
                 "value": {
@@ -3831,9 +2863,7 @@
         "description": "Room not found.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "ROOM_NOT_FOUND": {
                 "value": {
@@ -3851,9 +2881,7 @@
         "description": "Room already exists.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "ROOM_ALREADY_EXISTS": {
                 "value": {
@@ -3866,10 +2894,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -3877,9 +2902,7 @@
         "description": "Unprocessable entity.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "UNPROCESSABLE_ENTITY": {
                 "value": {
@@ -3897,9 +2920,7 @@
         "description": "Unauthorized access.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "SCHEMA_FROZEN": {
                 "value": {
@@ -3940,9 +2961,7 @@
         "description": "Schema not found.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "SCHEMA_NOT_FOUND": {
                 "value": {
@@ -3960,9 +2979,7 @@
         "description": "Existing room data does not match this schema.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "SCHEMA_NOT_COMPATIBLE": {
                 "value": {
@@ -3975,10 +2992,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -3986,9 +3000,7 @@
         "description": "Unprocessable entity.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "UNPROCESSABLE_ENTITY": {
                 "value": {
@@ -4014,9 +3026,7 @@
         "description": "Thread already exists.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "RESOURCE_ALREADY_EXISTS": {
                 "value": {
@@ -4027,10 +3037,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -4038,9 +3045,7 @@
         "description": "Thread not found.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "RESOURCE_NOT_FOUND": {
                 "value": {
@@ -4051,10 +3056,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -4062,9 +3064,7 @@
         "description": "Comment already exists.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "RESOURCE_ALREADY_EXISTS": {
                 "value": {
@@ -4075,10 +3075,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -4086,9 +3083,7 @@
         "description": "Comment not found.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "RESOURCE_NOT_FOUND": {
                 "value": {
@@ -4099,10 +3094,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -4110,9 +3102,7 @@
         "description": "Reaction already exists.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "RESOURCE_ALREADY_EXISTS": {
                 "value": {
@@ -4123,10 +3113,7 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       },
@@ -4134,9 +3121,7 @@
         "description": "Comment not found.",
         "content": {
           "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
+            "schema": { "$ref": "#/components/schemas/Error" },
             "examples": {
               "RESOURCE_NOT_FOUND": {
                 "value": {
@@ -4147,40 +3132,21 @@
             }
           },
           "application/xml": {
-            "schema": {
-              "type": "object",
-              "properties": {}
-            }
+            "schema": { "type": "object", "properties": {} }
           }
         }
       }
     }
   },
   "tags": [
-    {
-      "name": "Authentication"
-    },
-    {
-      "name": "Room"
-    },
-    {
-      "name": "Storage"
-    },
-    {
-      "name": "Yjs"
-    },
-    {
-      "name": "Schema validation"
-    },
-    {
-      "name": "Comments"
-    },
-    {
-      "name": "Notifications"
-    },
-    {
-      "name": "Deprecated"
-    }
+    { "name": "Authentication" },
+    { "name": "Room" },
+    { "name": "Storage" },
+    { "name": "Yjs" },
+    { "name": "Schema validation" },
+    { "name": "Comments" },
+    { "name": "Notifications" },
+    { "name": "Deprecated" }
   ],
   "x-internal": true
 }

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -1851,7 +1851,10 @@
         "name": "schemaId",
         "required": true,
         "description": "ID of the schema",
-        "schema": { "type": "string" },
+        "schema": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]{1,64}@[1-9]\\d*$"
+        },
         "in": "path"
       },
       "threadId": {

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -2,6 +2,16 @@
   "openapi": "3.1.0",
   "info": { "title": "API v2", "version": "2.0" },
   "servers": [{ "url": "https://api.liveblocks.io" }],
+  "tags": [
+    { "name": "Authentication" },
+    { "name": "Room" },
+    { "name": "Storage" },
+    { "name": "Yjs" },
+    { "name": "Schema validation" },
+    { "name": "Comments" },
+    { "name": "Notifications" },
+    { "name": "Deprecated" }
+  ],
   "paths": {
     "/v2/rooms": {
       "get": {
@@ -2897,15 +2907,5 @@
       }
     }
   },
-  "tags": [
-    { "name": "Authentication" },
-    { "name": "Room" },
-    { "name": "Storage" },
-    { "name": "Yjs" },
-    { "name": "Schema validation" },
-    { "name": "Comments" },
-    { "name": "Notifications" },
-    { "name": "Deprecated" }
-  ],
   "x-internal": true
 }

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -66,7 +66,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/GetRooms" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "nextCursor": "W1siaWQiLCJVRzhWYl82SHRUS0NzXzFvci1HZHQiXSxbImNyZWF0ZWRBdCIsMTY2MDAwMDk4ODEzN11d",
                       "nextPage": "/v2/rooms?startingAfter=W1siaWQiLCJVRzhWYl82SHRUS0NzXzFvci1HZHQiXSxbImNyZWF0ZWRBdCIsMTY2MDAwMDk4ODEzN11d",
@@ -106,7 +106,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/CreateRoom" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "id": "my-room-3ebc26e2bf96",
                     "defaultAccesses": ["room:write"],
@@ -126,7 +126,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "room",
                       "id": "my-room-3ebc26e2bf96",
@@ -163,7 +163,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "room",
                       "id": "react-todo-list",
@@ -201,7 +201,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/UpdateRoom" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "defaultAccesses": ["room:write"],
                     "usersAccesses": {
@@ -229,7 +229,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "room",
                       "id": "react-todo-list",
@@ -283,7 +283,7 @@
           "content": {
             "application/json": {
               "examples": {
-                "example": { "value": { "newRoomId": "new-room-id" } }
+                "Example 1": { "value": { "newRoomId": "new-room-id" } }
               }
             },
             "application/xml": {
@@ -301,7 +301,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Room" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "room",
                       "id": "react-todo-list",
@@ -347,7 +347,7 @@
                   "$ref": "#/components/schemas/ActiveUsersResponse"
                 },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "data": [
                         {
@@ -388,7 +388,7 @@
             "schema": {},
             "application/json": {
               "examples": {
-                "example": { "value": { "type": "EMOJI", "emoji": "🔥" } }
+                "Example 1": { "value": { "type": "EMOJI", "emoji": "🔥" } }
               }
             }
           }
@@ -433,7 +433,7 @@
                   }
                 },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "liveblocksType": "LiveObject",
                       "data": {
@@ -477,7 +477,7 @@
                 }
               },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "liveblocksType": "LiveObject",
                     "data": {
@@ -513,7 +513,7 @@
                   }
                 },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "liveblocksType": "LiveObject",
                       "data": {
@@ -595,7 +595,7 @@
               "application/json": {
                 "schema": { "type": "object" },
                 "examples": {
-                  "example": { "value": { "someYText": "Contents of YText" } }
+                  "Example 1": { "value": { "someYText": "Contents of YText" } }
                 }
               }
             }
@@ -677,7 +677,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/SchemaRequest" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "name": "my-schema",
                     "body": "type Logo {\nname: string\ntheme: string\n}\n\ntype Storage {\nlogo: LiveObject<Logo>\n"
@@ -694,7 +694,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "id": "my-schema@1",
                       "name": "my-schema",
@@ -727,7 +727,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "id": "my-schema@1",
                       "name": "my-schema",
@@ -755,7 +755,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/UpdateSchema" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "body": "type Logo {\nname: string\ntheme: string\n}\n\ntype Storage {\nlogo: LiveObject<Logo>\n"
                   }
@@ -771,7 +771,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "id": "my-schema@2",
                       "name": "my-schema",
@@ -816,7 +816,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/SchemaResponse" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "id": "my-schema@1",
                       "name": "my-schema",
@@ -845,7 +845,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/AttachSchema" },
               "examples": {
-                "example": { "value": { "schema": "my-schema@1" } }
+                "Example 1": { "value": { "schema": "my-schema@1" } }
               }
             }
           }
@@ -857,7 +857,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/AttachSchema" },
                 "examples": {
-                  "example": { "value": { "schema": "my-schema@1" } }
+                  "Example 1": { "value": { "schema": "my-schema@1" } }
                 }
               }
             }
@@ -958,7 +958,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/CreateThread" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "comment": {
                       "userId": "alice",
@@ -979,7 +979,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Thread" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "thread",
                       "id": "thread-id",
@@ -1124,7 +1124,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/UpdateThread" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "metadata": { "color": "yellow" },
                     "userId": "alice",
@@ -1213,7 +1213,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/CreateComment" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "userId": "alice",
                     "createdAt": "2022-07-13T14:32:50.697Z",
@@ -1231,7 +1231,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Comment" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "comment",
                       "threadId": "thread-id",
@@ -1303,7 +1303,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/CreateComment" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "editedAt": "2023-07-13T14:32:50.697Z",
                     "body": { "version": 1, "content": [] }
@@ -1320,7 +1320,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/UpdateComment" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "type": "comment",
                       "threadId": "thread-id",
@@ -1370,7 +1370,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/AddCommentReaction" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "emoji": "👨‍👩‍👧",
                     "createdAt": "2022-07-13T14:32:50.697Z",
@@ -1388,7 +1388,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/CommentReaction" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "emoji": "👨‍👩‍👧",
                       "createdAt": "2022-07-13T14:32:50.697Z",
@@ -1424,7 +1424,7 @@
                 "$ref": "#/components/schemas/RemoveCommentReaction"
               },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "emoji": "👨‍👩‍👧",
                     "userId": "alice",
@@ -1454,7 +1454,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/AuthorizeUserRequest" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "userId": "user-123",
                     "userInfo": {
@@ -1479,7 +1479,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/TokenResponse" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIi..."
                     }
@@ -1503,7 +1503,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/IdentifyUserRequest" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "userId": "user-123",
                     "groupIds": ["marketing", "engineering"],
@@ -1524,7 +1524,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/TokenResponse" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIi..."
                     }
@@ -1549,7 +1549,7 @@
             "application/json": {
               "schema": { "$ref": "#/components/schemas/CreateAuthorization" },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "userId": "b2c1c290-f2c9-45de-a74e-6b7aa0690f59",
                     "groupIds": ["g1", "g2"],
@@ -1567,7 +1567,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Authorization" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
                     }
@@ -1598,7 +1598,7 @@
                 "$ref": "#/components/schemas/PublicAuthorizeBodyRequest"
               },
               "examples": {
-                "example": {
+                "Example 1": {
                   "value": {
                     "publicApiKey": "pk_test_lOMrmwejSWLaPYQc5_JuGHXXX"
                   }
@@ -1614,7 +1614,7 @@
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Authorization" },
                 "examples": {
-                  "example": {
+                  "Example 1": {
                     "value": {
                       "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
                     }

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -140,20 +140,20 @@
       }
     },
     "/rooms/{roomId}": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId",
         "summary": "Get room",
         "description": "This endpoint returns a room by its ID. Corresponds to [`liveblocks.getRoom`](/docs/api-reference/liveblocks-node#get-rooms-roomid).",
         "tags": ["Room"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns the room.",
@@ -194,15 +194,6 @@
         "summary": "Update room",
         "description": "This endpoint updates specific properties of a room. Corresponds to [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomid). \n\nIt’s not necessary to provide the entire room’s information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"usersAccesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.",
         "tags": ["Room"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -270,15 +261,6 @@
         "summary": "Delete room",
         "description": "This endpoint deletes a room. A deleted room is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteRoom`](/docs/api-reference/liveblocks-node#delete-rooms-roomid).",
         "tags": ["Room"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "responses": {
           "204": { "description": "Success. The room was deleted" },
           "401": { "$ref": "#/components/responses/401" },
@@ -289,20 +271,20 @@
       }
     },
     "/rooms/{roomId}/update-room-id": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "The new ID for the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-update-roomId",
         "summary": "Update room ID",
         "description": "This endpoint permanently updates the room’s ID.",
         "tags": ["Room"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "The new ID for the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -356,20 +338,20 @@
       }
     },
     "/rooms/{roomId}/active_users": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-active-users",
         "summary": "Get active users",
         "description": "This endpoint returns a list of users currently present in the requested room. Corresponds to [`liveblocks.getActiveUsers`](/docs/api-reference/liveblocks-node#get-rooms-roomid-active-users). \n\nFor optimal performance, we recommend calling this endpoint no more than once every 10 seconds. \nDuplicates can occur if a user is in the requested room with multiple browser tabs opened.",
         "tags": ["Room"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns the list of active users for the specified room.",
@@ -408,20 +390,20 @@
       }
     },
     "/rooms/{roomId}/broadcast_event": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-broadcast-event",
         "summary": "Broadcast event to a room",
         "description": "This endpoint enables the broadcast of an event to a room without having to connect to it via the `client` from `@liveblocks/client`. It takes any valid JSON as a request body. The `connectionId` passed to event listeners is `-1` when using this API. Corresponds to [`liveblocks.broadcastEvent`](/docs/api-reference/liveblocks-node#post-broadcast-event).",
         "tags": ["Room"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "description": "Any valid JSON.",
           "content": {
@@ -445,6 +427,15 @@
       }
     },
     "/rooms/{roomId}/storage": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-storage",
         "summary": "Get Storage document",
@@ -452,18 +443,11 @@
         "tags": ["Storage"],
         "parameters": [
           {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          },
-          {
-            "schema": { "type": "string", "enum": ["plain-lson", "json"] },
             "name": "format",
-            "in": "query",
             "required": false,
-            "description": "Use `?format=json` to output a simplified JSON representation of the Storage tree. In that format, each LiveObject and LiveMap will be formatted as a simple JSON object, and each LiveList will be formatted as a simple JSON array. This is a lossy format because information about the original data structures is not retained, but it may be easier to work with."
+            "description": "Use `?format=json` to output a simplified JSON representation of the Storage tree. In that format, each LiveObject and LiveMap will be formatted as a simple JSON object, and each LiveList will be formatted as a simple JSON array. This is a lossy format because information about the original data structures is not retained, but it may be easier to work with.",
+            "schema": { "type": "string", "enum": ["plain-lson", "json"] },
+            "in": "query"
           }
         ],
         "responses": {
@@ -512,15 +496,6 @@
         "summary": "Initialize Storage document",
         "description": "This endpoint initializes or reinitializes a room’s Storage. The room must already exist. Calling this endpoint will disconnect all users from the room if there are any, triggering a reconnect. Corresponds to [`liveblocks.initializeStorageDocument`](/docs/api-reference/liveblocks-node#post-rooms-roomId-storage).\n\nThe format of the request body is the same as what’s returned by the get Storage endpoint.\n\nFor each Liveblocks data structure that you want to create, you need a JSON element having two properties:\n- `\"liveblocksType\"` => `\"LiveObject\" | \"LiveList\" | \"LiveMap\"`\n- `\"data\"` => contains the nested data structures (children) and data.\n\nThe root’s type can only be LiveObject.\n\nA utility function, `toPlainLson` is included in `@liveblocks/client` from `1.0.9` to help convert `LiveObject`, `LiveList`, and `LiveMap` to the structure expected by the endpoint.",
         "tags": ["Storage"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -601,15 +576,6 @@
         "summary": "Delete Storage document",
         "description": "This endpoint deletes all of the room’s Storage data. Calling this endpoint will disconnect all users from the room if there are any. Corresponds to [`liveblocks.deleteStorageDocument`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-storage).\n",
         "tags": ["Storage"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "responses": {
           "200": { "description": "Success. The room has no more Storage." },
           "401": { "$ref": "#/components/responses/401" },
@@ -619,6 +585,15 @@
       }
     },
     "/rooms/{roomId}/ydoc": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-ydoc",
         "summary": "Get Yjs document",
@@ -626,36 +601,29 @@
         "tags": ["Yjs"],
         "parameters": [
           {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "schema": { "type": "boolean" },
             "name": "formatting",
-            "in": "query",
-            "allowEmptyValue": true,
             "required": false,
-            "description": "If present, YText will return formatting."
+            "description": "If present, YText will return formatting.",
+            "schema": { "type": "boolean" },
+            "in": "query",
+            "allowEmptyValue": true
           },
           {
-            "schema": { "type": "string" },
             "name": "key",
-            "in": "query",
             "required": false,
-            "description": "Returns only a single key’s value, e.g. `doc.get(key).toJSON()`."
+            "description": "Returns only a single key’s value, e.g. `doc.get(key).toJSON()`.",
+            "schema": { "type": "string" },
+            "in": "query"
           },
           {
+            "name": "type",
+            "required": false,
+            "description": "Used with key to override the inferred type, i.e. `\"ymap\"` will return `doc.get(key, Y.Map)`.",
             "schema": {
               "type": "string",
               "enum": ["ymap", "ytext", "yxmltext", "yxmlfragment", "yarray"]
             },
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "description": "Used with key to override the inferred type, i.e. `\"ymap\"` will return `doc.get(key, Y.Map)`."
+            "in": "query"
           }
         ],
         "responses": {
@@ -682,18 +650,11 @@
         "tags": ["Yjs"],
         "parameters": [
           {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          },
-          {
             "name": "guid",
-            "in": "query",
             "required": false,
+            "description": "ID of the subdocument",
             "schema": { "type": "string" },
-            "description": "ID of the subdocument"
+            "in": "query"
           }
         ],
         "requestBody": {
@@ -715,6 +676,15 @@
       }
     },
     "/rooms/{roomId}/ydoc-binary": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-ydoc-binary",
         "summary": "Get Yjs document encoded as a binary Yjs update",
@@ -722,18 +692,11 @@
         "tags": ["Yjs"],
         "parameters": [
           {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
             "name": "guid",
-            "in": "query",
             "required": false,
+            "description": "ID of the subdocument",
             "schema": { "type": "string" },
-            "description": "ID of the subdocument"
+            "in": "query"
           }
         ],
         "responses": {
@@ -797,20 +760,20 @@
       }
     },
     "/schemas/{schemaId}": {
+      "parameters": [
+        {
+          "name": "schemaId",
+          "required": true,
+          "description": "ID of the schema",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-create-new-schema",
         "summary": "Get schema",
         "description": "This endpoint retrieves a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. Corresponds to [`liveblocks.getSchema`](/docs/api-reference/liveblocks-node#get-create-new-schema).",
         "tags": ["Schema validation"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "schemaId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the schema"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Found the schema and returns it as JSON.",
@@ -841,15 +804,6 @@
         "summary": "Update schema",
         "description": "This endpoint updates the body for the schema. A schema can only be updated if it is not used by any room. Corresponds to [`liveblocks.updateSchema`](/docs/api-reference/liveblocks-node#put-update-new-schema).",
         "tags": ["Schema validation"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "schemaId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the schema"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -895,15 +849,6 @@
         "summary": "Delete schema",
         "description": "This endpoint deletes a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. A schema can only be deleted if it is not attached to a room. Corresponds to [`liveblocks.deleteSchema`](/docs/api-reference/liveblocks-node#delete-a-schema).",
         "tags": ["Schema validation"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "schemaId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the schema"
-          }
-        ],
         "responses": {
           "200": { "description": "Success. Schema was delated" },
           "401": { "$ref": "#/components/responses/401" },
@@ -912,20 +857,20 @@
       }
     },
     "/rooms/{roomId}/schema": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-new-schema",
         "summary": "Get schema by room ID",
         "description": "This endpoint retrieves the schema attached to a room.  Corresponds to [`liveblocks.getSchemaByRoomId`](/docs/api-reference/liveblocks-node#get-new-schema).",
         "tags": ["Schema validation"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Found the schema attached to the room and returns it as JSON.",
@@ -957,15 +902,6 @@
         "summary": "Attach schema to room",
         "description": "This endpoint attaches a schema to a room, and instantly enables runtime schema validation for the room. Corresponds to [`liveblocks.attachSchemaToRoom`](/docs/api-reference/liveblocks-node#post-attach-schema-to-room).\n\nIf the current contents of the room’s Storage do not match the schema, attaching will fail and the error message will give details on why the schema failed to attach.",
         "tags": ["Schema validation"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -998,15 +934,6 @@
         "summary": "Detach schema from room",
         "description": "This endpoint detaches the schema from a room. Corresponds to [`liveblocks.detachSchemaFromRoom`](/docs/api-reference/liveblocks-node#delete-detach-schema-to-room).",
         "tags": ["Schema validation"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Detached the schema from the room."
@@ -1018,6 +945,15 @@
       }
     },
     "/rooms/{roomId}/threads": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-threads",
         "summary": "Get room threads",
@@ -1025,17 +961,10 @@
         "tags": ["Comments"],
         "parameters": [
           {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "schema": { "type": "string" },
-            "in": "query",
             "name": "query",
-            "description": "Query to filter threads. You can filter by `metadata` and `resolved`, for example, `metadata[\"status\"]:\"open\" AND metadata[\"color\"]:\"red\" AND resolved:true`. Learn more about [filtering threads with query language](/docs/guides/how-to-filter-threads-using-query-language)."
+            "description": "Query to filter threads. You can filter by `metadata` and `resolved`, for example, `metadata[\"status\"]:\"open\" AND metadata[\"color\"]:\"red\" AND resolved:true`. Learn more about [filtering threads with query language](/docs/guides/how-to-filter-threads-using-query-language).",
+            "schema": { "type": "string" },
+            "in": "query"
           }
         ],
         "responses": {
@@ -1094,15 +1023,6 @@
         "summary": "Create thread",
         "description": "This endpoint creates a new thread and the first comment in the thread. Corresponds to [`liveblocks.createThread`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads).\n\nA comment’s body is an array of paragraphs, each containing child nodes. Here’s an example of how to construct a comment’s body, which can be submitted under `comment.body`.\n\n```json\n\"version\": 1,\n\"content\": [\n  {\n    \"type\": \"paragraph\",\n    \"children\": [{ \"text\": \"Hello \" }, { \"text\": \"world\", \"bold\": true }]\n  }\n]\n```",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1160,27 +1080,27 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-threads-threadId",
         "summary": "Get thread",
         "description": "This endpoint returns a thread by its ID. Corresponds to [`liveblocks.getThread`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns requested thread.",
@@ -1225,22 +1145,6 @@
         "summary": "Delete thread",
         "description": "This endpoint deletes a thread by its ID. Corresponds to [`liveblocks.deleteThread`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-threads-threadId).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "responses": {
           "204": { "description": "Success. The thread has been deleted." },
           "401": { "$ref": "#/components/responses/401" },
@@ -1250,27 +1154,27 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/participants": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-threads-threadId-participants",
         "summary": "Get thread participants",
         "description": "This endpoint returns the list of thread participants. It is a list of unique user IDs representing all the thread comment authors and mentioned users in comments. Corresponds to [`liveblocks.getThreadParticipants`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId-participants).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns the thread’s participants",
@@ -1300,27 +1204,27 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/metadata": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-metadata",
         "summary": "Edit thread metadata",
         "description": "This endpoint edits the metadata of a thread. The metadata is a JSON object that can be used to store any information you want about the thread, in `string`, `number`, or `boolean` form. Set a property to `null` to remove it. Corresponds to [`liveblocks.editThreadMetadata`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-metadata).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1353,27 +1257,27 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/mark-as-resolved": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-mark-as-resolved",
         "summary": "Mark thread as resolved",
         "description": "This endpoint marks a thread as resolved.",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns the updated thread.",
@@ -1389,27 +1293,27 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/mark-as-unresolved": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-mark-as-unresolved",
         "summary": "Mark thread as unresolved",
         "description": "This endpoint marks a thread as unresolved.",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns the updated thread.",
@@ -1425,27 +1329,27 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-comments",
         "summary": "Create comment",
         "description": "This endpoint creates a new comment, adding it as a reply to a thread. Corresponds to [`liveblocks.createComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments).\n\nA comment’s body is an array of paragraphs, each containing child nodes. Here’s an example of how to construct a comment’s body, which can be submitted under `body`.\n\n```json\n\"version\": 1,\n\"content\": [\n  {\n    \"type\": \"paragraph\",\n    \"children\": [{ \"text\": \"Hello \" }, { \"text\": \"world\", \"bold\": true }]\n  }\n]\n",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1492,34 +1396,34 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "commentId",
+          "required": true,
+          "description": "ID of the comment",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "get": {
         "operationId": "get-rooms-roomId-threads-threadId-comments-commentId",
         "summary": "Get comment",
         "description": "This endpoint returns a comment by its ID. Corresponds to [`liveblocks.getComment`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId-comments-commentId).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          },
-          {
-            "name": "commentId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the comment"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Success. Returns the requested comment.",
@@ -1554,29 +1458,6 @@
         "summary": "Edit comment",
         "description": "This endpoint edits the specified comment. Corresponds to [`liveblocks.editComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId).\n\nA comment’s body is an array of paragraphs, each containing child nodes. Here’s an example of how to construct a comment’s body, which can be submitted under `body`.\n\n```json\n\"version\": 1,\n\"content\": [\n  {\n    \"type\": \"paragraph\",\n    \"children\": [{ \"text\": \"Hello \" }, { \"text\": \"world\", \"bold\": true }]\n  }\n]\n",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          },
-          {
-            "name": "commentId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the comment"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1625,29 +1506,6 @@
         "summary": "Delete comment",
         "description": "This endpoint deletes a comment. A deleted comment is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          },
-          {
-            "name": "commentId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the comment"
-          }
-        ],
         "responses": {
           "204": { "description": "Success. The comment was deleted" },
           "401": { "$ref": "#/components/responses/401" },
@@ -1657,34 +1515,34 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/add-reaction": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "commentId",
+          "required": true,
+          "description": "ID of the comment",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-add-reaction",
         "summary": "Add comment reaction",
         "description": "This endpoint adds a reaction to a comment. Corresponds to [`liveblocks.addCommentReaction`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId-add-reaction).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          },
-          {
-            "name": "commentId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the comment"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1727,34 +1585,34 @@
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/remove-reaction": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "threadId",
+          "required": true,
+          "description": "ID of the thread",
+          "schema": { "type": "string" },
+          "in": "path"
+        },
+        {
+          "name": "commentId",
+          "required": true,
+          "description": "ID of the comment",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-remove-reaction",
         "summary": "Remove comment reaction",
         "description": "This endpoint removes a comment reaction. A deleted comment reaction is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.removeCommentReaction`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId-add-reaction).",
         "tags": ["Comments"],
-        "parameters": [
-          {
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the room"
-          },
-          {
-            "name": "threadId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the thread"
-          },
-          {
-            "name": "commentId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the comment"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1876,20 +1734,20 @@
       }
     },
     "/rooms/{roomId}/authorize": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-authorize",
         "summary": "Get single-room token with secret key",
         "description": "**Deprecated.** Prefer using [access tokens](#post-authorize-user) or [ID tokens](#post-identify-user) instead. Read more in our [migration guide](/docs/platform/upgrading/1.2).\n\nThis endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When making this request, you’ll have to use your secret key.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. Setting the `userId` is optional if you want to use public rooms, but it is required to enter a private room (because permissions are assigned to specific user IDs). In case you want to use the group permission system, you can also declare which `groupIds` this user belongs to.\n\nThe property userId is used by Liveblocks to calculate your account’s Monthly Active Users. One unique userId corresponds to one MAU. If you don’t pass a userId, we will create for you a new anonymous userId on each connection, but your MAUs will be higher.\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name.",
         "tags": ["Deprecated"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1931,20 +1789,20 @@
       }
     },
     "/rooms/{roomId}/public/authorize": {
+      "parameters": [
+        {
+          "name": "roomId",
+          "required": true,
+          "description": "ID of the room",
+          "schema": { "type": "string" },
+          "in": "path"
+        }
+      ],
       "post": {
         "operationId": "post-public-authorize",
         "summary": "Get single-room token with public key",
         "description": "**Deprecated.** When you update Liveblocks to 1.2, you no longer need to get a JWT token when using a public key.\n\nThis endpoint works with the public key and can be used client side. That means you don’t need to implement a dedicated authorization endpoint server side. \nThe generated JWT token works only with public room (`defaultAccesses: [\"room:write\"]`).",
         "tags": ["Deprecated"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2004,22 +1862,6 @@
         "summary": "Get inbox notification",
         "description": "This endpoint returns a user’s inbox notification by its ID. Corresponds to [`liveblocks.getInboxNotification`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications-inboxNotificationId).",
         "tags": ["Notifications"],
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the user"
-          },
-          {
-            "name": "inboxNotificationId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the inbox notification"
-          }
-        ],
         "responses": {
           "200": {
             "description": "",
@@ -2048,22 +1890,6 @@
         "summary": "Delete inbox notification",
         "description": "This endpoint deletes a user’s inbox notification by its ID.",
         "tags": ["Notifications"],
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the user"
-          },
-          {
-            "name": "inboxNotificationId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the inbox notification"
-          }
-        ],
         "responses": {
           "204": { "description": "" },
           "401": { "description": "Unauthorized" },
@@ -2088,17 +1914,10 @@
         "tags": ["Notifications"],
         "parameters": [
           {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the user"
-          },
-          {
-            "schema": { "type": "string" },
-            "in": "query",
             "name": "query",
-            "description": "Query to filter notifications. You can filter by `unread`, for example, `unread:true`."
+            "description": "Query to filter notifications. You can filter by `unread`, for example, `unread:true`.",
+            "schema": { "type": "string" },
+            "in": "query"
           }
         ],
         "responses": {
@@ -2131,15 +1950,6 @@
         "summary": "Delete all inbox notifications",
         "description": "This endpoint deletes all the user’s inbox notifications.",
         "tags": ["Notifications"],
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the user"
-          }
-        ],
         "responses": {
           "204": { "description": "" },
           "401": { "description": "Unauthorized" },
@@ -2168,22 +1978,6 @@
         "summary": "Get room notification settings",
         "description": "This endpoint returns a user’s notification settings for a specific room. Corresponds to [`liveblocks.getRoomNotificationSettings`](/docs/api-reference/liveblocks-node#get-rooms-roomId-users-userId-notification-settings).",
         "tags": ["Notifications"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          },
-          {
-            "schema": { "type": "string" },
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the user"
-          }
-        ],
         "responses": {
           "200": {
             "description": "",
@@ -2205,22 +1999,6 @@
         "summary": "Update room notification settings",
         "description": "This endpoint updates a user’s notification settings for a specific room. Corresponds to [`liveblocks.updateRoomNotificationSettings`](/docs/api-reference/liveblocks-node#post-rooms-roomId-users-userId-notification-settings).",
         "tags": ["Notifications"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          },
-          {
-            "schema": { "type": "string" },
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the user"
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2252,22 +2030,6 @@
         "summary": "Delete room notification settings",
         "description": "This endpoint deletes a user’s notification settings for a specific room. Corresponds to [`liveblocks.deleteRoomNotificationSettings`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-users-userId-notification-settings).",
         "tags": ["Notifications"],
-        "parameters": [
-          {
-            "schema": { "type": "string" },
-            "name": "roomId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the room"
-          },
-          {
-            "schema": { "type": "string" },
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "ID of the user"
-          }
-        ],
         "responses": {
           "204": { "description": "No Content" },
           "401": { "description": "Unauthorized" },

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -5,47 +5,48 @@
   "paths": {
     "/rooms": {
       "get": {
+        "operationId": "get-rooms",
         "summary": "Get rooms",
         "description": "This endpoint returns a list of your rooms. The rooms are returned sorted by creation date, from newest to oldest. You can filter rooms by room ID prefixes, metadata, users accesses, and groups accesses. Corresponds to [`liveblocks.getRooms`](/docs/api-reference/liveblocks-node#get-rooms).\n\nThere is a pagination system where the next page URL is returned in the response as `nextPage`. You can also paginate by using `nextCursor` in combination with `startingAfter`.\nYou can also limit the number of rooms by query.\n\nFiltering by metadata works by giving key values like `metadata.color=red`. Of course you can combine multiple metadata clauses to refine the response like `metadata.color=red&metadata.type=text`. Notice here the operator AND is applied between each clauses.\n\nFiltering by groups or userId works by giving a list of groups like `groupIds=marketing,GZo7tQ,product` or/and a userId like `userId=user1`.\nNotice here the operator OR is applied between each `groupIds` and the `userId`.\n",
         "tags": ["Room"],
         "parameters": [
           {
+            "name": "limit",
+            "description": "A limit on the number of rooms to be returned. The limit can range between 1 and 100, and defaults to 20.",
             "schema": {
               "type": "number",
               "minimum": 1,
               "maximum": 100,
               "default": 20
             },
-            "in": "query",
-            "name": "limit",
-            "description": "A limit on the number of rooms to be returned. The limit can range between 1 and 100, and defaults to 20."
+            "in": "query"
           },
           {
-            "schema": { "type": "string" },
-            "in": "query",
             "name": "startingAfter",
-            "description": "A cursor used for pagination. Get the value from the `nextCursor` response of the previous page."
-          },
-          {
+            "description": "A cursor used for pagination. Get the value from the `nextCursor` response of the previous page.",
             "schema": { "type": "string" },
-            "in": "query",
+            "in": "query"
+          },
+          {
             "name": "query",
-            "description": "Query to filter rooms. You can filter by `roomId` and `metadata`, for example, `metadata[\"roomType\"]:\"whiteboard\" AND roomId^\"liveblocks:engineering\"`. Learn more about [filtering rooms with query language](/docs/guides/how-to-filter-rooms-using-query-language)."
+            "description": "Query to filter rooms. You can filter by `roomId` and `metadata`, for example, `metadata[\"roomType\"]:\"whiteboard\" AND roomId^\"liveblocks:engineering\"`. Learn more about [filtering rooms with query language](/docs/guides/how-to-filter-rooms-using-query-language).",
+            "schema": { "type": "string" },
+            "in": "query"
           },
           {
-            "schema": { "type": "string", "examples": ["userId=user1"] },
-            "in": "query",
             "name": "userId",
-            "description": "A filter on users accesses."
+            "description": "A filter on users accesses.",
+            "schema": { "type": "string", "examples": ["userId=user1"] },
+            "in": "query"
           },
           {
+            "name": "groupIds",
+            "description": "A filter on groups accesses. Multiple groups can be used.",
             "schema": {
               "type": "string",
               "examples": ["groupsIds=group1,group2"]
             },
-            "in": "query",
-            "name": "groupIds",
-            "description": "A filter on groups accesses. Multiple groups can be used."
+            "in": "query"
           }
         ],
         "responses": {
@@ -83,14 +84,31 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "422": { "$ref": "#/components/responses/422" }
-        },
-        "operationId": "get-rooms"
+        }
       },
       "post": {
+        "operationId": "post-rooms",
         "summary": "Create room",
         "description": "This endpoint creates a new room. `id` and `defaultAccesses` are required. Corresponds to [`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms). \n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 40 characters. `usersAccesses` is optional field.\n- `groupsAccesses` are optional fields.\n",
         "tags": ["Room"],
-        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateRoom" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "id": "my-room-3ebc26e2bf96",
+                    "defaultAccesses": ["room:write"],
+                    "metadata": { "color": "blue" },
+                    "usersAccesses": { "alice": ["room:write"] },
+                    "groupsAccesses": { "product": ["room:write"] }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the created room.",
@@ -118,33 +136,15 @@
           "403": { "$ref": "#/components/responses/403" },
           "409": { "$ref": "#/components/responses/409" },
           "422": { "$ref": "#/components/responses/422" }
-        },
-        "operationId": "post-rooms",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateRoom" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "id": "my-room-3ebc26e2bf96",
-                    "defaultAccesses": ["room:write"],
-                    "metadata": { "color": "blue" },
-                    "usersAccesses": { "alice": ["room:write"] },
-                    "groupsAccesses": { "product": ["room:write"] }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
     "/rooms/{roomId}": {
       "get": {
-        "summary": "Get room",
-        "tags": ["Room"],
         "operationId": "get-rooms-roomId",
+        "summary": "Get room",
+        "description": "This endpoint returns a room by its ID. Corresponds to [`liveblocks.getRoom`](/docs/api-reference/liveblocks-node#get-rooms-roomid).",
+        "tags": ["Room"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -187,11 +187,12 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "description": "This endpoint returns a room by its ID. Corresponds to [`liveblocks.getRoom`](/docs/api-reference/liveblocks-node#get-rooms-roomid)."
+        }
       },
       "post": {
+        "operationId": "post-rooms-roomId",
         "summary": "Update room",
+        "description": "This endpoint updates specific properties of a room. Corresponds to [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomid). \n\nIt’s not necessary to provide the entire room’s information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"usersAccesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.",
         "tags": ["Room"],
         "parameters": [
           {
@@ -202,6 +203,32 @@
             "description": "ID of the room"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateRoom" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "defaultAccesses": ["room:write"],
+                    "usersAccesses": {
+                      "vinod": ["room:write"],
+                      "alice": ["room:write"]
+                    },
+                    "groupsAccesses": { "marketing": ["room:write"] },
+                    "metadata": { "color": "blue" }
+                  }
+                }
+              }
+            },
+            "application/xml": {
+              "schema": { "type": "object", "properties": {} }
+            },
+            "multipart/form-data": {
+              "schema": { "type": "object", "properties": {} }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the updated room.",
@@ -236,46 +263,13 @@
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" },
           "422": { "$ref": "#/components/responses/422" }
-        },
-        "operationId": "post-rooms-roomId",
-        "description": "This endpoint updates specific properties of a room. Corresponds to [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomid). \n\nIt’s not necessary to provide the entire room’s information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"usersAccesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateRoom" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "defaultAccesses": ["room:write"],
-                    "usersAccesses": {
-                      "vinod": ["room:write"],
-                      "alice": ["room:write"]
-                    },
-                    "groupsAccesses": { "marketing": ["room:write"] },
-                    "metadata": { "color": "blue" }
-                  }
-                }
-              }
-            },
-            "application/xml": {
-              "schema": { "type": "object", "properties": {} }
-            },
-            "multipart/form-data": {
-              "schema": { "type": "object", "properties": {} }
-            }
-          }
         }
       },
       "delete": {
+        "operationId": "delete-rooms-roomId",
         "summary": "Delete room",
+        "description": "This endpoint deletes a room. A deleted room is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteRoom`](/docs/api-reference/liveblocks-node#delete-rooms-roomid).",
         "tags": ["Room"],
-        "responses": {
-          "204": { "description": "Success. The room was deleted" },
-          "401": { "$ref": "#/components/responses/401" },
-          "403": { "$ref": "#/components/responses/403" },
-          "404": { "$ref": "#/components/responses/404" },
-          "422": { "$ref": "#/components/responses/422" }
-        },
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -285,13 +279,20 @@
             "description": "ID of the room"
           }
         ],
-        "operationId": "delete-rooms-roomId",
-        "description": "This endpoint deletes a room. A deleted room is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteRoom`](/docs/api-reference/liveblocks-node#delete-rooms-roomid)."
+        "responses": {
+          "204": { "description": "Success. The room was deleted" },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
+        }
       }
     },
     "/rooms/{roomId}/update-room-id": {
       "post": {
+        "operationId": "post-rooms-update-roomId",
         "summary": "Update room ID",
+        "description": "This endpoint permanently updates the room’s ID.",
         "tags": ["Room"],
         "parameters": [
           {
@@ -302,6 +303,21 @@
             "description": "The new ID for the room"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example": { "value": { "newRoomId": "new-room-id" } }
+              }
+            },
+            "application/xml": {
+              "schema": { "type": "object", "properties": {} }
+            },
+            "multipart/form-data": {
+              "schema": { "type": "object", "properties": {} }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the updated room with the new ID.",
@@ -336,32 +352,15 @@
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" },
           "422": { "$ref": "#/components/responses/422" }
-        },
-        "operationId": "post-rooms-update-roomId",
-        "description": "This endpoint permanently updates the room’s ID.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "examples": {
-                "example": { "value": { "newRoomId": "new-room-id" } }
-              }
-            },
-            "application/xml": {
-              "schema": { "type": "object", "properties": {} }
-            },
-            "multipart/form-data": {
-              "schema": { "type": "object", "properties": {} }
-            }
-          }
         }
       }
     },
     "/rooms/{roomId}/active_users": {
       "get": {
-        "summary": "Get active users",
-        "tags": ["Room"],
         "operationId": "get-rooms-roomId-active-users",
+        "summary": "Get active users",
         "description": "This endpoint returns a list of users currently present in the requested room. Corresponds to [`liveblocks.getActiveUsers`](/docs/api-reference/liveblocks-node#get-rooms-roomid-active-users). \n\nFor optimal performance, we recommend calling this endpoint no more than once every 10 seconds. \nDuplicates can occur if a user is in the requested room with multiple browser tabs opened.",
+        "tags": ["Room"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -410,6 +409,7 @@
     },
     "/rooms/{roomId}/broadcast_event": {
       "post": {
+        "operationId": "post-broadcast-event",
         "summary": "Broadcast event to a room",
         "description": "This endpoint enables the broadcast of an event to a room without having to connect to it via the `client` from `@liveblocks/client`. It takes any valid JSON as a request body. The `connectionId` passed to event listeners is `-1` when using this API. Corresponds to [`liveblocks.broadcastEvent`](/docs/api-reference/liveblocks-node#post-broadcast-event).",
         "tags": ["Room"],
@@ -422,16 +422,6 @@
             "description": "ID of the room"
           }
         ],
-        "operationId": "post-broadcast-event",
-        "responses": {
-          "204": {
-            "description": "Success. An event was broadcast to the room."
-          },
-          "401": { "$ref": "#/components/responses/401" },
-          "403": { "$ref": "#/components/responses/403" },
-          "404": { "$ref": "#/components/responses/404" },
-          "422": { "$ref": "#/components/responses/422" }
-        },
         "requestBody": {
           "description": "Any valid JSON.",
           "content": {
@@ -442,11 +432,21 @@
               }
             }
           }
+        },
+        "responses": {
+          "204": {
+            "description": "Success. An event was broadcast to the room."
+          },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404" },
+          "422": { "$ref": "#/components/responses/422" }
         }
       }
     },
     "/rooms/{roomId}/storage": {
       "get": {
+        "operationId": "get-rooms-roomId-storage",
         "summary": "Get Storage document",
         "description": "Returns the contents of the room’s Storage tree.  Corresponds to [`liveblocks.getStorageDocument`](/docs/api-reference/liveblocks-node#get-rooms-roomId-storage). \n\nThe default outputted format is called “plain LSON”, which includes information on the Live data structures in the tree. These nodes show up in the output as objects with two properties, for example:\n\n```json\n{\n  \"liveblocksType\": \"LiveObject\",\n  \"data\": ...\n}\n```\n\nIf you’re not interested in this information, you can use the simpler `?format=json` query param, see below.",
         "tags": ["Storage"],
@@ -505,13 +505,13 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "operationId": "get-rooms-roomId-storage"
+        }
       },
       "post": {
-        "summary": "Initialize Storage document",
-        "tags": ["Storage"],
         "operationId": "post-rooms-roomId-storage",
+        "summary": "Initialize Storage document",
+        "description": "This endpoint initializes or reinitializes a room’s Storage. The room must already exist. Calling this endpoint will disconnect all users from the room if there are any, triggering a reconnect. Corresponds to [`liveblocks.initializeStorageDocument`](/docs/api-reference/liveblocks-node#post-rooms-roomId-storage).\n\nThe format of the request body is the same as what’s returned by the get Storage endpoint.\n\nFor each Liveblocks data structure that you want to create, you need a JSON element having two properties:\n- `\"liveblocksType\"` => `\"LiveObject\" | \"LiveList\" | \"LiveMap\"`\n- `\"data\"` => contains the nested data structures (children) and data.\n\nThe root’s type can only be LiveObject.\n\nA utility function, `toPlainLson` is included in `@liveblocks/client` from `1.0.9` to help convert `LiveObject`, `LiveList`, and `LiveMap` to the structure expected by the endpoint.",
+        "tags": ["Storage"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -521,6 +521,40 @@
             "description": "ID of the room"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "liveblocksType": { "type": "string" },
+                  "data": { "type": "object" }
+                }
+              },
+              "examples": {
+                "example": {
+                  "value": {
+                    "liveblocksType": "LiveObject",
+                    "data": {
+                      "aLiveObject": {
+                        "liveblocksType": "LiveObject",
+                        "data": { "a": 1 }
+                      },
+                      "aLiveList": {
+                        "liveblocksType": "LiveList",
+                        "data": ["a", "b"]
+                      },
+                      "aLiveMap": {
+                        "liveblocksType": "LiveMap",
+                        "data": { "a": 1, "b": 2 }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. The Storage is initialized. Returns the room’s Storage as JSON.",
@@ -560,47 +594,13 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "description": "This endpoint initializes or reinitializes a room’s Storage. The room must already exist. Calling this endpoint will disconnect all users from the room if there are any, triggering a reconnect. Corresponds to [`liveblocks.initializeStorageDocument`](/docs/api-reference/liveblocks-node#post-rooms-roomId-storage).\n\nThe format of the request body is the same as what’s returned by the get Storage endpoint.\n\nFor each Liveblocks data structure that you want to create, you need a JSON element having two properties:\n- `\"liveblocksType\"` => `\"LiveObject\" | \"LiveList\" | \"LiveMap\"`\n- `\"data\"` => contains the nested data structures (children) and data.\n\nThe root’s type can only be LiveObject.\n\nA utility function, `toPlainLson` is included in `@liveblocks/client` from `1.0.9` to help convert `LiveObject`, `LiveList`, and `LiveMap` to the structure expected by the endpoint.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "liveblocksType": { "type": "string" },
-                  "data": { "type": "object" }
-                }
-              },
-              "examples": {
-                "example": {
-                  "value": {
-                    "liveblocksType": "LiveObject",
-                    "data": {
-                      "aLiveObject": {
-                        "liveblocksType": "LiveObject",
-                        "data": { "a": 1 }
-                      },
-                      "aLiveList": {
-                        "liveblocksType": "LiveList",
-                        "data": ["a", "b"]
-                      },
-                      "aLiveMap": {
-                        "liveblocksType": "LiveMap",
-                        "data": { "a": 1, "b": 2 }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       },
       "delete": {
-        "summary": "Delete Storage document",
-        "tags": ["Storage"],
         "operationId": "delete-rooms-roomId-storage",
+        "summary": "Delete Storage document",
+        "description": "This endpoint deletes all of the room’s Storage data. Calling this endpoint will disconnect all users from the room if there are any. Corresponds to [`liveblocks.deleteStorageDocument`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-storage).\n",
+        "tags": ["Storage"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -615,12 +615,12 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "description": "This endpoint deletes all of the room’s Storage data. Calling this endpoint will disconnect all users from the room if there are any. Corresponds to [`liveblocks.deleteStorageDocument`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-storage).\n"
+        }
       }
     },
     "/rooms/{roomId}/ydoc": {
       "get": {
+        "operationId": "get-rooms-roomId-ydoc",
         "summary": "Get Yjs document",
         "description": "This endpoint returns a JSON representation of the room’s Yjs document. Corresponds to [`liveblocks.getYjsDocument`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc).",
         "tags": ["Yjs"],
@@ -673,11 +673,12 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "operationId": "get-rooms-roomId-ydoc"
+        }
       },
       "put": {
+        "operationId": "put-rooms-roomId-ydoc",
         "summary": "Send a binary Yjs update",
+        "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document. To send an update to a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).\n\nThe update is typically obtained by calling `Y.encodeStateAsUpdate(doc)`. See the [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more details. When manually making this HTTP call, set the HTTP header `Content-Type` to `application/octet-stream`, and send the binary update (a `Uint8Array`) in the body of the HTTP request. This endpoint does not accept JSON, unlike most other endpoints.",
         "tags": ["Yjs"],
         "parameters": [
           {
@@ -695,6 +696,13 @@
             "description": "ID of the subdocument"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": { "format": "binary", "type": "array" }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. The given room’s Yjs doc has been updated.",
@@ -703,20 +711,12 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "operationId": "put-rooms-roomId-ydoc",
-        "description": "This endpoint is used to send a Yjs binary update to the room’s Yjs document. You can use this endpoint to initialize Yjs data for the room or to update the room’s Yjs document. To send an update to a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.sendYjsBinaryUpdate`](/docs/api-reference/liveblocks-node#put-rooms-roomId-ydoc).\n\nThe update is typically obtained by calling `Y.encodeStateAsUpdate(doc)`. See the [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more details. When manually making this HTTP call, set the HTTP header `Content-Type` to `application/octet-stream`, and send the binary update (a `Uint8Array`) in the body of the HTTP request. This endpoint does not accept JSON, unlike most other endpoints.",
-        "requestBody": {
-          "content": {
-            "application/octet-stream": {
-              "schema": { "format": "binary", "type": "array" }
-            }
-          }
         }
       }
     },
     "/rooms/{roomId}/ydoc-binary": {
       "get": {
+        "operationId": "get-rooms-roomId-ydoc-binary",
         "summary": "Get Yjs document encoded as a binary Yjs update",
         "description": "This endpoint returns the room’s Yjs document encoded as a single binary update. This can be used by `Y.applyUpdate(responseBody)` to get a copy of the document in your back end. See [Yjs documentation](https://docs.yjs.dev/api/document-updates) for more information on working with updates. To return a subdocument instead of the main document, pass its `guid`. Corresponds to [`liveblocks.getYjsDocumentAsBinaryUpdate`](/docs/api-reference/liveblocks-node#get-rooms-roomId-ydoc-binary).",
         "tags": ["Yjs"],
@@ -746,17 +746,15 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404" }
-        },
-        "operationId": "get-rooms-roomId-ydoc-binary"
+        }
       }
     },
     "/schemas": {
       "post": {
+        "operationId": "post-create-new-schema",
         "summary": "Create schema",
         "description": "This endpoint creates a new schema which can be referenced later to enforce a room’s Storage data structure. Corresponds to [`liveblocks.createSchema`](/docs/api-reference/liveblocks-node#post-create-new-schema). \n\nThe schema consists of a name (for referencing it), and a body, which specifies the exact allowed shape of data in the room. This body is a multi-line string written in the Liveblocks [schema syntax](/docs/platform/schema-validation/syntax).",
         "tags": ["Schema validation"],
-        "parameters": [],
-        "operationId": "post-create-new-schema",
         "requestBody": {
           "content": {
             "application/json": {
@@ -800,6 +798,7 @@
     },
     "/schemas/{schemaId}": {
       "get": {
+        "operationId": "get-create-new-schema",
         "summary": "Get schema",
         "description": "This endpoint retrieves a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. Corresponds to [`liveblocks.getSchema`](/docs/api-reference/liveblocks-node#get-create-new-schema).",
         "tags": ["Schema validation"],
@@ -812,7 +811,6 @@
             "description": "ID of the schema"
           }
         ],
-        "operationId": "get-create-new-schema",
         "responses": {
           "200": {
             "description": "Success. Found the schema and returns it as JSON.",
@@ -893,6 +891,7 @@
         }
       },
       "delete": {
+        "operationId": "delete-a-schema",
         "summary": "Delete schema",
         "description": "This endpoint deletes a schema by its ID. The ID is a combination of the schema name and version. For example, `my-schema@1`. A schema can only be deleted if it is not attached to a room. Corresponds to [`liveblocks.deleteSchema`](/docs/api-reference/liveblocks-node#delete-a-schema).",
         "tags": ["Schema validation"],
@@ -905,7 +904,6 @@
             "description": "ID of the schema"
           }
         ],
-        "operationId": "delete-a-schema",
         "responses": {
           "200": { "description": "Success. Schema was delated" },
           "401": { "$ref": "#/components/responses/401" },
@@ -915,6 +913,7 @@
     },
     "/rooms/{roomId}/schema": {
       "get": {
+        "operationId": "get-new-schema",
         "summary": "Get schema by room ID",
         "description": "This endpoint retrieves the schema attached to a room.  Corresponds to [`liveblocks.getSchemaByRoomId`](/docs/api-reference/liveblocks-node#get-new-schema).",
         "tags": ["Schema validation"],
@@ -927,7 +926,6 @@
             "description": "ID of the room"
           }
         ],
-        "operationId": "get-new-schema",
         "responses": {
           "200": {
             "description": "Success. Found the schema attached to the room and returns it as JSON.",
@@ -955,6 +953,7 @@
         }
       },
       "post": {
+        "operationId": "post-attach-schema-to-room",
         "summary": "Attach schema to room",
         "description": "This endpoint attaches a schema to a room, and instantly enables runtime schema validation for the room. Corresponds to [`liveblocks.attachSchemaToRoom`](/docs/api-reference/liveblocks-node#post-attach-schema-to-room).\n\nIf the current contents of the room’s Storage do not match the schema, attaching will fail and the error message will give details on why the schema failed to attach.",
         "tags": ["Schema validation"],
@@ -967,7 +966,6 @@
             "description": "ID of the room"
           }
         ],
-        "operationId": "post-attach-schema-to-room",
         "requestBody": {
           "content": {
             "application/json": {
@@ -996,6 +994,7 @@
         }
       },
       "delete": {
+        "operationId": "delete-detach-schema-to-room",
         "summary": "Detach schema from room",
         "description": "This endpoint detaches the schema from a room. Corresponds to [`liveblocks.detachSchemaFromRoom`](/docs/api-reference/liveblocks-node#delete-detach-schema-to-room).",
         "tags": ["Schema validation"],
@@ -1008,7 +1007,6 @@
             "description": "ID of the room"
           }
         ],
-        "operationId": "delete-detach-schema-to-room",
         "responses": {
           "200": {
             "description": "Success. Detached the schema from the room."
@@ -1021,6 +1019,7 @@
     },
     "/rooms/{roomId}/threads": {
       "get": {
+        "operationId": "get-rooms-roomId-threads",
         "summary": "Get room threads",
         "description": "This endpoint returns the threads in the requested room. Corresponds to [`liveblocks.getThreads`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads).",
         "tags": ["Comments"],
@@ -1039,7 +1038,6 @@
             "description": "Query to filter threads. You can filter by `metadata` and `resolved`, for example, `metadata[\"status\"]:\"open\" AND metadata[\"color\"]:\"red\" AND resolved:true`. Learn more about [filtering threads with query language](/docs/guides/how-to-filter-threads-using-query-language)."
           }
         ],
-        "operationId": "get-rooms-roomId-threads",
         "responses": {
           "200": {
             "description": "Success. Returns list of threads in a room.",
@@ -1092,10 +1090,10 @@
         }
       },
       "post": {
+        "operationId": "post-rooms-roomId-threads",
         "summary": "Create thread",
         "description": "This endpoint creates a new thread and the first comment in the thread. Corresponds to [`liveblocks.createThread`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads).\n\nA comment’s body is an array of paragraphs, each containing child nodes. Here’s an example of how to construct a comment’s body, which can be submitted under `comment.body`.\n\n```json\n\"version\": 1,\n\"content\": [\n  {\n    \"type\": \"paragraph\",\n    \"children\": [{ \"text\": \"Hello \" }, { \"text\": \"world\", \"bold\": true }]\n  }\n]\n```",
         "tags": ["Comments"],
-        "operationId": "post-rooms-roomId-threads",
         "parameters": [
           {
             "name": "roomId",
@@ -1105,6 +1103,25 @@
             "description": "ID of the room"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateThread" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "comment": {
+                      "userId": "alice",
+                      "createdAt": "2022-07-13T14:32:50.697Z",
+                      "body": { "version": 1, "content": [] }
+                    },
+                    "metadata": { "color": "blue" }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the created thread.",
@@ -1139,34 +1156,15 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "409": { "$ref": "#/components/responses/409-thread" }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateThread" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "comment": {
-                      "userId": "alice",
-                      "createdAt": "2022-07-13T14:32:50.697Z",
-                      "body": { "version": 1, "content": [] }
-                    },
-                    "metadata": { "color": "blue" }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
     "/rooms/{roomId}/threads/{threadId}": {
       "get": {
-        "summary": "Get thread",
-        "tags": ["Comments"],
-        "description": "This endpoint returns a thread by its ID. Corresponds to [`liveblocks.getThread`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId).",
         "operationId": "get-rooms-roomId-threads-threadId",
+        "summary": "Get thread",
+        "description": "This endpoint returns a thread by its ID. Corresponds to [`liveblocks.getThread`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId).",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1223,10 +1221,10 @@
         }
       },
       "delete": {
-        "summary": "Delete thread",
-        "tags": ["Comments"],
-        "description": "This endpoint deletes a thread by its ID. Corresponds to [`liveblocks.deleteThread`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-threads-threadId).",
         "operationId": "delete-rooms-roomId-threads-threadId",
+        "summary": "Delete thread",
+        "description": "This endpoint deletes a thread by its ID. Corresponds to [`liveblocks.deleteThread`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-threads-threadId).",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1253,10 +1251,10 @@
     },
     "/rooms/{roomId}/threads/{threadId}/participants": {
       "get": {
-        "summary": "Get thread participants",
-        "tags": ["Comments"],
-        "description": "This endpoint returns the list of thread participants. It is a list of unique user IDs representing all the thread comment authors and mentioned users in comments. Corresponds to [`liveblocks.getThreadParticipants`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId-participants).",
         "operationId": "get-rooms-roomId-threads-threadId-participants",
+        "summary": "Get thread participants",
+        "description": "This endpoint returns the list of thread participants. It is a list of unique user IDs representing all the thread comment authors and mentioned users in comments. Corresponds to [`liveblocks.getThreadParticipants`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId-participants).",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1303,10 +1301,10 @@
     },
     "/rooms/{roomId}/threads/{threadId}/metadata": {
       "post": {
-        "summary": "Edit thread metadata",
-        "tags": ["Comments"],
-        "description": "This endpoint edits the metadata of a thread. The metadata is a JSON object that can be used to store any information you want about the thread, in `string`, `number`, or `boolean` form. Set a property to `null` to remove it. Corresponds to [`liveblocks.editThreadMetadata`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-metadata).",
         "operationId": "post-rooms-roomId-threads-threadId-metadata",
+        "summary": "Edit thread metadata",
+        "description": "This endpoint edits the metadata of a thread. The metadata is a JSON object that can be used to store any information you want about the thread, in `string`, `number`, or `boolean` form. Set a property to `null` to remove it. Corresponds to [`liveblocks.editThreadMetadata`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-metadata).",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1323,19 +1321,6 @@
             "description": "ID of the thread"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "Success. Returns the updated metadata.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ThreadMetadata" },
-                "examples": { "Success": { "value": { "color": "yellow" } } }
-              }
-            }
-          },
-          "403": { "$ref": "#/components/responses/403" },
-          "404": { "$ref": "#/components/responses/404-thread" }
-        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -1351,15 +1336,28 @@
               }
             }
           }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. Returns the updated metadata.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ThreadMetadata" },
+                "examples": { "Success": { "value": { "color": "yellow" } } }
+              }
+            }
+          },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-thread" }
         }
       }
     },
     "/rooms/{roomId}/threads/{threadId}/mark-as-resolved": {
       "post": {
-        "summary": "Mark thread as resolved",
-        "tags": ["Comments"],
-        "description": "This endpoint marks a thread as resolved.",
         "operationId": "post-rooms-roomId-threads-threadId-mark-as-resolved",
+        "summary": "Mark thread as resolved",
+        "description": "This endpoint marks a thread as resolved.",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1392,10 +1390,10 @@
     },
     "/rooms/{roomId}/threads/{threadId}/mark-as-unresolved": {
       "post": {
-        "summary": "Mark thread as unresolved",
-        "tags": ["Comments"],
-        "description": "This endpoint marks a thread as unresolved.",
         "operationId": "post-rooms-roomId-threads-threadId-mark-as-unresolved",
+        "summary": "Mark thread as unresolved",
+        "description": "This endpoint marks a thread as unresolved.",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1428,10 +1426,10 @@
     },
     "/rooms/{roomId}/threads/{threadId}/comments": {
       "post": {
+        "operationId": "post-rooms-roomId-threads-threadId-comments",
         "summary": "Create comment",
         "description": "This endpoint creates a new comment, adding it as a reply to a thread. Corresponds to [`liveblocks.createComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments).\n\nA comment’s body is an array of paragraphs, each containing child nodes. Here’s an example of how to construct a comment’s body, which can be submitted under `body`.\n\n```json\n\"version\": 1,\n\"content\": [\n  {\n    \"type\": \"paragraph\",\n    \"children\": [{ \"text\": \"Hello \" }, { \"text\": \"world\", \"bold\": true }]\n  }\n]\n",
         "tags": ["Comments"],
-        "operationId": "post-rooms-roomId-threads-threadId-comments",
         "parameters": [
           {
             "name": "roomId",
@@ -1448,6 +1446,22 @@
             "description": "ID of the thread"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateComment" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "userId": "alice",
+                    "createdAt": "2022-07-13T14:32:50.697Z",
+                    "body": { "version": 1, "content": [] }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the created comment.",
@@ -1474,31 +1488,15 @@
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404-thread" },
           "409": { "$ref": "#/components/responses/409-comment" }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateComment" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "userId": "alice",
-                    "createdAt": "2022-07-13T14:32:50.697Z",
-                    "body": { "version": 1, "content": [] }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}": {
       "get": {
-        "summary": "Get comment",
-        "tags": ["Comments"],
-        "description": "This endpoint returns a comment by its ID. Corresponds to [`liveblocks.getComment`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId-comments-commentId).",
         "operationId": "get-rooms-roomId-threads-threadId-comments-commentId",
+        "summary": "Get comment",
+        "description": "This endpoint returns a comment by its ID. Corresponds to [`liveblocks.getComment`](/docs/api-reference/liveblocks-node#get-rooms-roomId-threads-threadId-comments-commentId).",
+        "tags": ["Comments"],
         "parameters": [
           {
             "name": "roomId",
@@ -1552,10 +1550,10 @@
         }
       },
       "post": {
+        "operationId": "post-rooms-roomId-threads-threadId-comments-commentId",
         "summary": "Edit comment",
         "description": "This endpoint edits the specified comment. Corresponds to [`liveblocks.editComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId).\n\nA comment’s body is an array of paragraphs, each containing child nodes. Here’s an example of how to construct a comment’s body, which can be submitted under `body`.\n\n```json\n\"version\": 1,\n\"content\": [\n  {\n    \"type\": \"paragraph\",\n    \"children\": [{ \"text\": \"Hello \" }, { \"text\": \"world\", \"bold\": true }]\n  }\n]\n",
         "tags": ["Comments"],
-        "operationId": "post-rooms-roomId-threads-threadId-comments-commentId",
         "parameters": [
           {
             "name": "roomId",
@@ -1579,6 +1577,21 @@
             "description": "ID of the comment"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateComment" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "editedAt": "2023-07-13T14:32:50.697Z",
+                    "body": { "version": 1, "content": [] }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the edited comment.",
@@ -1605,25 +1618,12 @@
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404-thread" },
           "409": { "$ref": "#/components/responses/409-comment" }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateComment" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "editedAt": "2023-07-13T14:32:50.697Z",
-                    "body": { "version": 1, "content": [] }
-                  }
-                }
-              }
-            }
-          }
         }
       },
       "delete": {
+        "operationId": "delete-rooms-roomId-threads-threadId-comments-commentId",
         "summary": "Delete comment",
+        "description": "This endpoint deletes a comment. A deleted comment is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId).",
         "tags": ["Comments"],
         "parameters": [
           {
@@ -1653,17 +1653,15 @@
           "401": { "$ref": "#/components/responses/401" },
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404-comment" }
-        },
-        "operationId": "delete-rooms-roomId-threads-threadId-comments-commentId",
-        "description": "This endpoint deletes a comment. A deleted comment is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteComment`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId)."
+        }
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/add-reaction": {
       "post": {
+        "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-add-reaction",
         "summary": "Add comment reaction",
         "description": "This endpoint adds a reaction to a comment. Corresponds to [`liveblocks.addCommentReaction`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId-add-reaction).",
         "tags": ["Comments"],
-        "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-add-reaction",
         "parameters": [
           {
             "name": "roomId",
@@ -1687,6 +1685,22 @@
             "description": "ID of the comment"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AddCommentReaction" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "emoji": "👨‍👩‍👧",
+                    "createdAt": "2022-07-13T14:32:50.697Z",
+                    "userId": "alice"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the created reaction.",
@@ -1709,31 +1723,15 @@
           "403": { "$ref": "#/components/responses/403" },
           "404": { "$ref": "#/components/responses/404-comment" },
           "409": { "$ref": "#/components/responses/409-comment-reaction" }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/AddCommentReaction" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "emoji": "👨‍👩‍👧",
-                    "createdAt": "2022-07-13T14:32:50.697Z",
-                    "userId": "alice"
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/remove-reaction": {
       "post": {
+        "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-remove-reaction",
         "summary": "Remove comment reaction",
         "description": "This endpoint removes a comment reaction. A deleted comment reaction is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.removeCommentReaction`](/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId-add-reaction).",
         "tags": ["Comments"],
-        "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-remove-reaction",
         "parameters": [
           {
             "name": "roomId",
@@ -1757,12 +1755,6 @@
             "description": "ID of the comment"
           }
         ],
-        "responses": {
-          "204": { "description": "Success. The comment reaction was deleted" },
-          "401": { "$ref": "#/components/responses/401" },
-          "403": { "$ref": "#/components/responses/403" },
-          "404": { "$ref": "#/components/responses/404-comment-reaction" }
-        },
         "requestBody": {
           "content": {
             "application/json": {
@@ -1780,32 +1772,21 @@
               }
             }
           }
+        },
+        "responses": {
+          "204": { "description": "Success. The comment reaction was deleted" },
+          "401": { "$ref": "#/components/responses/401" },
+          "403": { "$ref": "#/components/responses/403" },
+          "404": { "$ref": "#/components/responses/404-comment-reaction" }
         }
       }
     },
     "/authorize-user": {
       "post": {
-        "summary": "Get access token with secret key",
-        "tags": ["Authentication"],
         "operationId": "post-authorize-user",
-        "responses": {
-          "200": {
-            "description": "Success. Returns an access token that can be used to enter one or more rooms.",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/TokenResponse" },
-                "examples": {
-                  "example": {
-                    "value": {
-                      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIi..."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": { "$ref": "#/components/responses/403" }
-        },
+        "summary": "Get access token with secret key",
+        "description": "This endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When making this request, you’ll have to use your secret key.\n\n**Important:** The difference with an [ID token](#post-identify-user) is that an access token holds all the permissions, and is the source of truth. With ID tokens, permissions are set in the Liveblocks back end (through REST API calls) and \"checked at the door\" every time they are used to enter a room.\n\n**Note:** When using the `@liveblocks/node` package, you can use [`Liveblocks.prepareSession`](/docs/api-reference/liveblocks-node#access-tokens) in your back end to build this request.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. The property `userId` is used by Liveblocks to calculate your account’s Monthly Active Users. One unique `userId` corresponds to one MAU.\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name.\n\nLastly, you’ll specify the exact permissions to give to the user using the `permissions` field. This is done in an object where the keys are room names, or room name patterns (ending in a `*`), and a list of permissions to assign the user for any room that matches that name exactly (or starts with the pattern’s prefix). For tips, see [Manage permissions with access tokens](/docs/authentication/access-token).",
+        "tags": ["Authentication"],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1829,17 +1810,9 @@
             }
           }
         },
-        "description": "This endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When making this request, you’ll have to use your secret key.\n\n**Important:** The difference with an [ID token](#post-identify-user) is that an access token holds all the permissions, and is the source of truth. With ID tokens, permissions are set in the Liveblocks back end (through REST API calls) and \"checked at the door\" every time they are used to enter a room.\n\n**Note:** When using the `@liveblocks/node` package, you can use [`Liveblocks.prepareSession`](/docs/api-reference/liveblocks-node#access-tokens) in your back end to build this request.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. The property `userId` is used by Liveblocks to calculate your account’s Monthly Active Users. One unique `userId` corresponds to one MAU.\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name.\n\nLastly, you’ll specify the exact permissions to give to the user using the `permissions` field. This is done in an object where the keys are room names, or room name patterns (ending in a `*`), and a list of permissions to assign the user for any room that matches that name exactly (or starts with the pattern’s prefix). For tips, see [Manage permissions with access tokens](/docs/authentication/access-token)."
-      }
-    },
-    "/identify-user": {
-      "post": {
-        "summary": "Get ID token with secret key",
-        "tags": ["Authentication"],
-        "operationId": "post-identify-user",
         "responses": {
           "200": {
-            "description": "Success. Returns an ID token that can be used to enter one or more rooms.",
+            "description": "Success. Returns an access token that can be used to enter one or more rooms.",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/TokenResponse" },
@@ -1854,7 +1827,15 @@
             }
           },
           "403": { "$ref": "#/components/responses/403" }
-        },
+        }
+      }
+    },
+    "/identify-user": {
+      "post": {
+        "operationId": "post-identify-user",
+        "summary": "Get ID token with secret key",
+        "description": "This endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When using this endpoint to obtain ID tokens, you should manage your permissions by assigning user and/or group permissions to rooms explicitly, see our [Manage permissions with ID tokens](/docs/authentication/id-token) section.\n\n**Important:** The difference with an [access token](#post-authorize-user) is that an ID token doesn’t hold any permissions itself. With ID tokens, permissions are set in the Liveblocks back end (through REST API calls) and \"checked at the door\" every time they are used to enter a room. With access tokens, all permissions are set in the token itself, and thus controlled from your back end entirely.\n\n**Note:** When using the `@liveblocks/node` package, you can use [`Liveblocks.identifyUser`](/docs/api-reference/liveblocks-node) in your back end to build this request.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. The property `userId` is used by Liveblocks to calculate your account’s Monthly Active Users. One unique `userId` corresponds to one MAU.\n\nIf you want to use group permissions, you can also declare which `groupIds` this user belongs to. The group ID values are yours, but they will have to match the group IDs you assign permissions to when assigning permissions to rooms, see [Manage permissions with ID tokens](/docs/authentication/id-token)).\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name.",
+        "tags": ["Authentication"],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1874,13 +1855,30 @@
             }
           }
         },
-        "description": "This endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When using this endpoint to obtain ID tokens, you should manage your permissions by assigning user and/or group permissions to rooms explicitly, see our [Manage permissions with ID tokens](/docs/authentication/id-token) section.\n\n**Important:** The difference with an [access token](#post-authorize-user) is that an ID token doesn’t hold any permissions itself. With ID tokens, permissions are set in the Liveblocks back end (through REST API calls) and \"checked at the door\" every time they are used to enter a room. With access tokens, all permissions are set in the token itself, and thus controlled from your back end entirely.\n\n**Note:** When using the `@liveblocks/node` package, you can use [`Liveblocks.identifyUser`](/docs/api-reference/liveblocks-node) in your back end to build this request.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. The property `userId` is used by Liveblocks to calculate your account’s Monthly Active Users. One unique `userId` corresponds to one MAU.\n\nIf you want to use group permissions, you can also declare which `groupIds` this user belongs to. The group ID values are yours, but they will have to match the group IDs you assign permissions to when assigning permissions to rooms, see [Manage permissions with ID tokens](/docs/authentication/id-token)).\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name."
+        "responses": {
+          "200": {
+            "description": "Success. Returns an ID token that can be used to enter one or more rooms.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TokenResponse" },
+                "examples": {
+                  "example": {
+                    "value": {
+                      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIi..."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": { "$ref": "#/components/responses/403" }
+        }
       }
     },
     "/rooms/{roomId}/authorize": {
       "post": {
+        "operationId": "post-authorize",
         "summary": "Get single-room token with secret key",
-        "x-badge": "Deprecated",
         "description": "**Deprecated.** Prefer using [access tokens](#post-authorize-user) or [ID tokens](#post-identify-user) instead. Read more in our [migration guide](/docs/platform/upgrading/1.2).\n\nThis endpoint lets your application server (your back end) obtain a token that one of its clients (your frontend) can use to enter a Liveblocks room. You use this endpoint to implement your own application’s custom authentication endpoint. When making this request, you’ll have to use your secret key.\n\nYou can pass the property `userId` in the request’s body. This can be whatever internal identifier you use for your user accounts as long as it uniquely identifies an account. Setting the `userId` is optional if you want to use public rooms, but it is required to enter a private room (because permissions are assigned to specific user IDs). In case you want to use the group permission system, you can also declare which `groupIds` this user belongs to.\n\nThe property userId is used by Liveblocks to calculate your account’s Monthly Active Users. One unique userId corresponds to one MAU. If you don’t pass a userId, we will create for you a new anonymous userId on each connection, but your MAUs will be higher.\n\nAdditionally, you can set custom metadata to the token, which will be publicly accessible by other clients through the `user.info` property. This is useful for storing static data like avatar images or the user’s display name.",
         "tags": ["Deprecated"],
         "parameters": [
@@ -1892,7 +1890,22 @@
             "description": "ID of the room"
           }
         ],
-        "operationId": "post-authorize",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateAuthorization" },
+              "examples": {
+                "example": {
+                  "value": {
+                    "userId": "b2c1c290-f2c9-45de-a74e-6b7aa0690f59",
+                    "groupIds": ["g1", "g2"],
+                    "userInfo": { "name": "bob", "colors": ["blue", "red"] }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns an old-style single-room token.",
@@ -1914,30 +1927,15 @@
           "404": { "$ref": "#/components/responses/404" },
           "422": { "$ref": "#/components/responses/422" }
         },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateAuthorization" },
-              "examples": {
-                "example": {
-                  "value": {
-                    "userId": "b2c1c290-f2c9-45de-a74e-6b7aa0690f59",
-                    "groupIds": ["g1", "g2"],
-                    "userInfo": { "name": "bob", "colors": ["blue", "red"] }
-                  }
-                }
-              }
-            }
-          }
-        }
+        "x-badge": "Deprecated"
       }
     },
     "/rooms/{roomId}/public/authorize": {
       "post": {
-        "summary": "Get single-room token with public key",
-        "x-badge": "Deprecated",
-        "tags": ["Deprecated"],
         "operationId": "post-public-authorize",
+        "summary": "Get single-room token with public key",
+        "description": "**Deprecated.** When you update Liveblocks to 1.2, you no longer need to get a JWT token when using a public key.\n\nThis endpoint works with the public key and can be used client side. That means you don’t need to implement a dedicated authorization endpoint server side. \nThe generated JWT token works only with public room (`defaultAccesses: [\"room:write\"]`).",
+        "tags": ["Deprecated"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -1947,6 +1945,22 @@
             "description": "ID of the room"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicAuthorizeBodyRequest"
+              },
+              "examples": {
+                "example": {
+                  "value": {
+                    "publicApiKey": "pk_test_lOMrmwejSWLaPYQc5_JuGHXXX"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Success. Returns the JWT token.",
@@ -1967,23 +1981,7 @@
           "404": { "$ref": "#/components/responses/404" },
           "422": { "$ref": "#/components/responses/422" }
         },
-        "description": "**Deprecated.** When you update Liveblocks to 1.2, you no longer need to get a JWT token when using a public key.\n\nThis endpoint works with the public key and can be used client side. That means you don’t need to implement a dedicated authorization endpoint server side. \nThe generated JWT token works only with public room (`defaultAccesses: [\"room:write\"]`).",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PublicAuthorizeBodyRequest"
-              },
-              "examples": {
-                "example": {
-                  "value": {
-                    "publicApiKey": "pk_test_lOMrmwejSWLaPYQc5_JuGHXXX"
-                  }
-                }
-              }
-            }
-          }
-        }
+        "x-badge": "Deprecated"
       }
     },
     "/users/{userId}/inbox-notifications/{inboxNotificationId}": {
@@ -2002,7 +2000,9 @@
         }
       ],
       "get": {
+        "operationId": "get-users-userId-inboxNotifications-inboxNotificationId",
         "summary": "Get inbox notification",
+        "description": "This endpoint returns a user’s inbox notification by its ID. Corresponds to [`liveblocks.getInboxNotification`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications-inboxNotificationId).",
         "tags": ["Notifications"],
         "parameters": [
           {
@@ -2020,8 +2020,6 @@
             "description": "ID of the inbox notification"
           }
         ],
-        "operationId": "get-users-userId-inboxNotifications-inboxNotificationId",
-        "description": "This endpoint returns a user’s inbox notification by its ID. Corresponds to [`liveblocks.getInboxNotification`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications-inboxNotificationId).",
         "responses": {
           "200": {
             "description": "",
@@ -2046,7 +2044,9 @@
         }
       },
       "delete": {
+        "operationId": "delete-users-userId-inboxNotifications-inboxNotificationId",
         "summary": "Delete inbox notification",
+        "description": "This endpoint deletes a user’s inbox notification by its ID.",
         "tags": ["Notifications"],
         "parameters": [
           {
@@ -2064,8 +2064,6 @@
             "description": "ID of the inbox notification"
           }
         ],
-        "operationId": "delete-users-userId-inboxNotifications-inboxNotificationId",
-        "description": "This endpoint deletes a user’s inbox notification by its ID.",
         "responses": {
           "204": { "description": "" },
           "401": { "description": "Unauthorized" },
@@ -2083,29 +2081,10 @@
           "required": true
         }
       ],
-      "delete": {
-        "summary": "Delete all inbox notifications",
-        "tags": ["Notifications"],
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "ID of the user"
-          }
-        ],
-        "operationId": "delete-users-userId-inboxNotifications",
-        "description": "This endpoint deletes all the user’s inbox notifications.",
-        "responses": {
-          "204": { "description": "" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "404": { "description": "Not Found" }
-        }
-      },
       "get": {
+        "operationId": "get-users-userId-inboxNotifications",
         "summary": "Get all inbox notifications",
+        "description": "This endpoint returns all the user’s inbox notifications. Corresponds to [`liveblocks.getInboxNotifications`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications).",
         "tags": ["Notifications"],
         "parameters": [
           {
@@ -2122,8 +2101,6 @@
             "description": "Query to filter notifications. You can filter by `unread`, for example, `unread:true`."
           }
         ],
-        "operationId": "get-users-userId-inboxNotifications",
-        "description": "This endpoint returns all the user’s inbox notifications. Corresponds to [`liveblocks.getInboxNotifications`](/docs/api-reference/liveblocks-node#get-users-userId-inboxNotifications).",
         "responses": {
           "200": {
             "description": "",
@@ -2148,6 +2125,27 @@
           "401": { "description": "Unauthorized" },
           "403": { "description": "Forbidden" }
         }
+      },
+      "delete": {
+        "operationId": "delete-users-userId-inboxNotifications",
+        "summary": "Delete all inbox notifications",
+        "description": "This endpoint deletes all the user’s inbox notifications.",
+        "tags": ["Notifications"],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "ID of the user"
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" }
+        }
       }
     },
     "/rooms/{roomId}/users/{userId}/notification-settings": {
@@ -2166,10 +2164,10 @@
         }
       ],
       "get": {
-        "summary": "Get room notification settings",
-        "tags": ["Notifications"],
         "operationId": "get-rooms-roomId-users-userId-notification-settings",
+        "summary": "Get room notification settings",
         "description": "This endpoint returns a user’s notification settings for a specific room. Corresponds to [`liveblocks.getRoomNotificationSettings`](/docs/api-reference/liveblocks-node#get-rooms-roomId-users-userId-notification-settings).",
+        "tags": ["Notifications"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -2203,10 +2201,10 @@
         }
       },
       "post": {
-        "summary": "Update room notification settings",
-        "tags": ["Notifications"],
         "operationId": "post-rooms-roomId-users-userId-notification-settings",
+        "summary": "Update room notification settings",
         "description": "This endpoint updates a user’s notification settings for a specific room. Corresponds to [`liveblocks.updateRoomNotificationSettings`](/docs/api-reference/liveblocks-node#post-rooms-roomId-users-userId-notification-settings).",
+        "tags": ["Notifications"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -2223,6 +2221,15 @@
             "description": "ID of the user"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserRoomNotificationSettings"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",
@@ -2238,22 +2245,13 @@
           "403": { "description": "Forbidden" },
           "404": { "description": "Not Found" },
           "422": { "description": "Unprocessable Entity" }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserRoomNotificationSettings"
-              }
-            }
-          }
         }
       },
       "delete": {
-        "summary": "Delete room notification settings",
-        "tags": ["Notifications"],
         "operationId": "delete-rooms-roomId-users-userId-notification-settings",
+        "summary": "Delete room notification settings",
         "description": "This endpoint deletes a user’s notification settings for a specific room. Corresponds to [`liveblocks.deleteRoomNotificationSettings`](/docs/api-reference/liveblocks-node#delete-rooms-roomId-users-userId-notification-settings).",
+        "tags": ["Notifications"],
         "parameters": [
           {
             "schema": { "type": "string" },
@@ -2279,19 +2277,11 @@
       }
     },
     "/inbox-notifications/trigger": {
-      "parameters": [],
       "post": {
-        "summary": "Trigger inbox notification",
-        "tags": ["Notifications"],
         "operationId": "post-inbox-notifications-trigger",
+        "summary": "Trigger inbox notification",
         "description": "This endpoint triggers an inbox notification. Corresponds to [`liveblocks.triggerInboxNotification`](/docs/api-reference/liveblocks-node#post-inbox-notifications-trigger).",
-        "responses": {
-          "200": { "description": "No Content" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "404": { "description": "Not Found" },
-          "422": { "description": "Unprocessable Entity" }
-        },
+        "tags": ["Notifications"],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2300,6 +2290,13 @@
               }
             }
           }
+        },
+        "responses": {
+          "200": { "description": "No Content" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not Found" },
+          "422": { "description": "Unprocessable Entity" }
         }
       }
     }

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -150,15 +150,7 @@
       }
     },
     "/v2/rooms/{roomId}": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-rooms-roomId",
         "summary": "Get room",
@@ -281,15 +273,7 @@
       }
     },
     "/v2/rooms/{roomId}/update-room-id": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "The new ID for the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
         "operationId": "post-rooms-update-roomId",
         "summary": "Update room ID",
@@ -348,15 +332,7 @@
       }
     },
     "/v2/rooms/{roomId}/active_users": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-rooms-roomId-active-users",
         "summary": "Get active users",
@@ -400,15 +376,7 @@
       }
     },
     "/v2/rooms/{roomId}/broadcast_event": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
         "operationId": "post-broadcast-event",
         "summary": "Broadcast event to a room",
@@ -437,15 +405,7 @@
       }
     },
     "/v2/rooms/{roomId}/storage": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-rooms-roomId-storage",
         "summary": "Get Storage document",
@@ -595,15 +555,7 @@
       }
     },
     "/v2/rooms/{roomId}/ydoc": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-rooms-roomId-ydoc",
         "summary": "Get Yjs document",
@@ -686,15 +638,7 @@
       }
     },
     "/v2/rooms/{roomId}/ydoc-binary": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-rooms-roomId-ydoc-binary",
         "summary": "Get Yjs document encoded as a binary Yjs update",
@@ -770,15 +714,7 @@
       }
     },
     "/v2/schemas/{schemaId}": {
-      "parameters": [
-        {
-          "name": "schemaId",
-          "required": true,
-          "description": "ID of the schema",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/schemaId" }],
       "get": {
         "operationId": "get-create-new-schema",
         "summary": "Get schema",
@@ -867,15 +803,7 @@
       }
     },
     "/v2/rooms/{roomId}/schema": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-new-schema",
         "summary": "Get schema by room ID",
@@ -955,15 +883,7 @@
       }
     },
     "/v2/rooms/{roomId}/threads": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "get": {
         "operationId": "get-rooms-roomId-threads",
         "summary": "Get room threads",
@@ -1091,20 +1011,8 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" }
       ],
       "get": {
         "operationId": "get-rooms-roomId-threads-threadId",
@@ -1165,20 +1073,8 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/participants": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" }
       ],
       "get": {
         "operationId": "get-rooms-roomId-threads-threadId-participants",
@@ -1215,20 +1111,8 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/metadata": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" }
       ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-metadata",
@@ -1268,20 +1152,8 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/mark-as-resolved": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" }
       ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-mark-as-resolved",
@@ -1304,20 +1176,8 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/mark-as-unresolved": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" }
       ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-mark-as-unresolved",
@@ -1340,20 +1200,8 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/comments": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" }
       ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-comments",
@@ -1407,27 +1255,9 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/comments/{commentId}": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "commentId",
-          "required": true,
-          "description": "ID of the comment",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" },
+        { "$ref": "#/components/parameters/commentId" }
       ],
       "get": {
         "operationId": "get-rooms-roomId-threads-threadId-comments-commentId",
@@ -1526,27 +1356,9 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/comments/{commentId}/add-reaction": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "commentId",
-          "required": true,
-          "description": "ID of the comment",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" },
+        { "$ref": "#/components/parameters/commentId" }
       ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-add-reaction",
@@ -1596,27 +1408,9 @@
     },
     "/v2/rooms/{roomId}/threads/{threadId}/comments/{commentId}/remove-reaction": {
       "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "threadId",
-          "required": true,
-          "description": "ID of the thread",
-          "schema": { "type": "string" },
-          "in": "path"
-        },
-        {
-          "name": "commentId",
-          "required": true,
-          "description": "ID of the comment",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/threadId" },
+        { "$ref": "#/components/parameters/commentId" }
       ],
       "post": {
         "operationId": "post-rooms-roomId-threads-threadId-comments-commentId-remove-reaction",
@@ -1744,15 +1538,7 @@
       }
     },
     "/v2/rooms/{roomId}/authorize": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
         "operationId": "post-authorize",
         "summary": "Get single-room token with secret key",
@@ -1799,15 +1585,7 @@
       }
     },
     "/v2/rooms/{roomId}/public/authorize": {
-      "parameters": [
-        {
-          "name": "roomId",
-          "required": true,
-          "description": "ID of the room",
-          "schema": { "type": "string" },
-          "in": "path"
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/roomId" }],
       "post": {
         "operationId": "post-public-authorize",
         "summary": "Get single-room token with public key",
@@ -1854,18 +1632,8 @@
     },
     "/v2/users/{userId}/inbox-notifications/{inboxNotificationId}": {
       "parameters": [
-        {
-          "schema": { "type": "string" },
-          "name": "userId",
-          "in": "path",
-          "required": true
-        },
-        {
-          "schema": { "type": "string" },
-          "name": "inboxNotificationId",
-          "in": "path",
-          "required": true
-        }
+        { "$ref": "#/components/parameters/userId" },
+        { "$ref": "#/components/parameters/inboxNotificationId" }
       ],
       "get": {
         "operationId": "get-users-userId-inboxNotifications-inboxNotificationId",
@@ -1909,14 +1677,7 @@
       }
     },
     "/v2/users/{userId}/inbox-notifications": {
-      "parameters": [
-        {
-          "schema": { "type": "string" },
-          "name": "userId",
-          "in": "path",
-          "required": true
-        }
-      ],
+      "parameters": [{ "$ref": "#/components/parameters/userId" }],
       "get": {
         "operationId": "get-users-userId-inboxNotifications",
         "summary": "Get all inbox notifications",
@@ -1970,18 +1731,8 @@
     },
     "/v2/rooms/{roomId}/users/{userId}/notification-settings": {
       "parameters": [
-        {
-          "schema": { "type": "string" },
-          "name": "roomId",
-          "in": "path",
-          "required": true
-        },
-        {
-          "schema": { "type": "string" },
-          "name": "userId",
-          "in": "path",
-          "required": true
-        }
+        { "$ref": "#/components/parameters/roomId" },
+        { "$ref": "#/components/parameters/userId" }
       ],
       "get": {
         "operationId": "get-rooms-roomId-users-userId-notification-settings",
@@ -2074,6 +1825,50 @@
     }
   },
   "components": {
+    "parameters": {
+      "commentId": {
+        "name": "commentId",
+        "required": true,
+        "description": "ID of the comment",
+        "schema": { "type": "string" },
+        "in": "path"
+      },
+      "inboxNotificationId": {
+        "name": "inboxNotificationId",
+        "required": true,
+        "description": "ID of the inbox notification",
+        "schema": { "type": "string" },
+        "in": "path"
+      },
+      "roomId": {
+        "name": "roomId",
+        "required": true,
+        "description": "ID of the room",
+        "schema": { "type": "string" },
+        "in": "path"
+      },
+      "schemaId": {
+        "name": "schemaId",
+        "required": true,
+        "description": "ID of the schema",
+        "schema": { "type": "string" },
+        "in": "path"
+      },
+      "threadId": {
+        "name": "threadId",
+        "required": true,
+        "description": "ID of the thread",
+        "schema": { "type": "string" },
+        "in": "path"
+      },
+      "userId": {
+        "name": "userId",
+        "required": true,
+        "description": "ID of the user",
+        "schema": { "type": "string" },
+        "in": "path"
+      }
+    },
     "schemas": {
       "Room": {
         "title": "Room",


### PR DESCRIPTION
Some cleanups prior to generating/fixing the contents:

- [x] Prettier
- [x] Rename param names to match our internal routes (so they won't be seen as a different route soon)
- [x] Reorder fields in a more natural / human-readable / consistent fashion
- [x] Move all "path params" into a central definition that's shared between all endpoints
- [x] Make all route path start with `/v2`
- [x] ~Can we move all "tags" to the path, not endpoint level?~ Nope, this is not valid syntax.
- [x] Make all route params work with $ref, too
