### PR TITLE
Expose `onComposerSubmit` on `Thread`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.8.1
+
+### `@liveblocks/react-ui`
+
+- Expose `onComposerSubmit` on `Thread` to react to the inner composer of a
+  thread.
+
 ## 2.8.0
 
 We are introducing attachments to allow users to add files to their comments,

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -125,6 +125,13 @@ about this change in our
     Whether to show deleted comments.
   </PropertiesListItem>
   <PropertiesListItem
+    name="onComposerSubmit"
+    type="function"
+    detailedType="(comment: ComposerSubmitComment, event: FormEvent<HTMLFormElement>) => Promise<void> | void"
+  >
+    The event handler called when the composer is submitted.
+  </PropertiesListItem>
+  <PropertiesListItem
     name="onResolvedChange"
     type="function"
     detailedType="(resolved: boolean) => void"

--- a/packages/liveblocks-react-ui/src/components/Thread.tsx
+++ b/packages/liveblocks-react-ui/src/components/Thread.tsx
@@ -41,6 +41,7 @@ import { classNames } from "../utils/class-names";
 import { findLastIndex } from "../utils/find-last-index";
 import type { CommentProps } from "./Comment";
 import { Comment } from "./Comment";
+import type { ComposerProps } from "./Composer";
 import { Composer } from "./Composer";
 import { Button } from "./internal/Button";
 import { Tooltip, TooltipProvider } from "./internal/Tooltip";
@@ -124,6 +125,11 @@ export interface ThreadProps<M extends BaseMetadata = DM>
   onAttachmentClick?: CommentProps["onAttachmentClick"];
 
   /**
+   * The event handler called when the composer is submitted.
+   */
+  onComposerSubmit?: ComposerProps["onComposerSubmit"];
+
+  /**
    * Override the component's strings.
    */
   overrides?: Partial<
@@ -160,6 +166,7 @@ export const Thread = forwardRef(
       onAuthorClick,
       onMentionClick,
       onAttachmentClick,
+      onComposerSubmit,
       overrides,
       className,
       ...props
@@ -365,6 +372,7 @@ export const Thread = forwardRef(
               threadId={thread.id}
               defaultCollapsed={showComposer === "collapsed" ? true : undefined}
               showAttachments={showAttachments}
+              onComposerSubmit={onComposerSubmit}
               overrides={{
                 COMPOSER_PLACEHOLDER: $.THREAD_COMPOSER_PLACEHOLDER,
                 COMPOSER_SEND: $.THREAD_COMPOSER_SEND,


### PR DESCRIPTION
Based on a report on Discord, this PR exposes the existing `onComposerSubmit` callback of `Composer` components on `Thread` ones (each `Thread` contains a single `Composer` to reply to the thread).
This allows reacting to the inner `Composer` of a thread in the same way you can on `Composer` directly.