### PR TITLE
Update examples deployment workflow

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -59,6 +59,9 @@ jobs:
 
           echo Triggering deployment for nextjs-lexical
           curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_qeKoPfUCRuI6jvBqV556q8V29YtA/IpvamWQh6G; echo
+          
+          echo Triggering deployment for nextjs-linear-like-issue-tracker
+          curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_ilOh5HbvxiAu723gnCAMBksCr3CH/3tTZc8ffgM; echo
 
           echo Triggering deployment for nextjs-live-avatars
           curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_Lm3c8dWsj390sgIDzemHZTZkuIl0/YtDJP3KyCH; echo
@@ -83,10 +86,19 @@ jobs:
 
           echo Triggering deployment for nextjs-notifications-custom
           curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_3MVsF7dPIZBQdUpfzQjVvZ1dBmPp/x1sO6CecOJ; echo
+          
+          echo Triggering deployment for nextjs-notion-like-ai-editor
+          curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_xvFy7XWt32Yz7gkigfCRZL6AeIBH/J4jKuBvLo8; echo
 
           echo Triggering deployment for nextjs-spreadsheet-advanced
           curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_ZJK9PEfgkfsqKRVjxFzwQgAVsdsF/gKp8sJ1f1c; echo
 
+          echo Triggering deployment for nextjs-tldraw-storage
+          curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_mKM14iPdQfC3jH6jQhCKtBoasxQY/0AfEGfHLws; echo
+          
+          echo Triggering deployment for nextjs-tldraw-yjs
+          curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_g3L0m4dKUJ54aupCSjto2tNRjGD1/dH39Y2ZydF; echo
+          
           echo Triggering deployment for nextjs-todo-list
           curl -s -X POST https://api.vercel.com/v1/integrations/deploy/prj_IzfUkw9eZuOyiS7LbvftjAo812Yk/KvR90vWuGh; echo
 


### PR DESCRIPTION
The examples deployment workflow is only up-to-date on the https://github.com/liveblocks/liveblocks/tree/examples branch, that's where it's used so nothing is broken but I think we should try to always work on the examples in the `main` → `examples` direction.