### PR TITLE
Send client version in header to client-side API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.8.2
+
+### `@liveblocks/client`
+
+- Send client version in HTTP request headers from the client, to ensure
+  backward compatible responses from the server
+
 ## 2.8.1
 
 ### `@liveblocks/react-ui`
@@ -460,7 +467,7 @@ For full upgrade instructions and codemods, see the
 ### `@liveblocks/node`
 
 - Fix "`process` is undefined" issue in Vite builds. This issue was already
-  fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.
+  fixed for `@liveblocks/client`, but not for `@liveblocks/node` yet.
 
 ### DevTools
 

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -30,6 +30,7 @@ import type {
   InboxNotificationDeleteInfo,
   InboxNotificationDeleteInfoPlain,
 } from "./protocol/InboxNotifications";
+import { PKG_VERSION } from "./version";
 
 const MARK_INBOX_NOTIFICATIONS_AS_READ_BATCH_DELAY = 50;
 
@@ -88,6 +89,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       headers: {
         ...options?.headers,
         Authorization: `Bearer ${getAuthBearerHeaderFromAuthValue(authValue)}`,
+        "X-LB-Client": PKG_VERSION || "dev",
       },
     });
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1607,6 +1607,7 @@ export function createRoom<
       headers: {
         ...options?.headers,
         Authorization: `Bearer ${getAuthBearerHeaderFromAuthValue(authValue)}`,
+        "X-LB-Client": PKG_VERSION || "dev",
       },
     });
   }


### PR DESCRIPTION
This will help identify older API clients over time, so we can maintain backward compatible API responses and detect when we can sunset legacy logic in our backend over time.
