### PR TITLE
Update `ThreadData` type to always have an `updatedAt` date

### DIFF
--- a/packages/liveblocks-core/src/convert-plain-data.ts
+++ b/packages/liveblocks-core/src/convert-plain-data.ts
@@ -58,7 +58,7 @@ export function convertToCommentData(data: CommentDataPlain): CommentData {
 export function convertToThreadData<M extends BaseMetadata>(
   data: ThreadDataPlain<M>
 ): ThreadData<M> {
-  const updatedAt = data.updatedAt ? new Date(data.updatedAt) : undefined;
+  const updatedAt = new Date(data.updatedAt);
   const createdAt = new Date(data.createdAt);
 
   const comments = data.comments.map((comment) =>

--- a/packages/liveblocks-core/src/protocol/Comments.ts
+++ b/packages/liveblocks-core/src/protocol/Comments.ts
@@ -155,7 +155,7 @@ export type ThreadData<M extends BaseMetadata = DM> = {
   id: string;
   roomId: string;
   createdAt: Date;
-  updatedAt?: Date;
+  updatedAt: Date;
   comments: CommentData[];
   metadata: M;
   resolved: boolean;

--- a/packages/liveblocks-react/src/__tests__/selectThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/selectThreads.test.ts
@@ -4,10 +4,13 @@ import { selectThreads, UmbrellaStore } from "../umbrella-store";
 
 describe("selectThreads", () => {
   it("should only return resolved threads from a list of threads", () => {
+    const now1 = new Date("2024-01-01");
+    const now2 = new Date("2024-01-02");
     const thread1: ThreadData = {
       type: "thread" as const,
       id: "th_1",
-      createdAt: new Date("2024-01-01"),
+      createdAt: now1,
+      updatedAt: now1,
       roomId: "room_1",
       comments: [],
       metadata: {},
@@ -17,7 +20,8 @@ describe("selectThreads", () => {
     const thread2: ThreadData = {
       type: "thread" as const,
       id: "th_2",
-      createdAt: new Date("2024-01-02"),
+      createdAt: now2,
+      updatedAt: now2,
       roomId: "room_1",
       comments: [],
       metadata: {},

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/_dummies.ts
@@ -9,11 +9,12 @@ import { nanoid } from "@liveblocks/core";
 export function createThread(
   overrides: Partial<ThreadDataWithDeleteInfo<BaseMetadata>> = {}
 ): ThreadDataWithDeleteInfo<BaseMetadata> {
+  const now = new Date();
   const {
     id = `th_${nanoid()}`,
     roomId = `room_${nanoid()}`,
-    createdAt = new Date(),
-    updatedAt,
+    createdAt = now,
+    updatedAt = now,
     deletedAt,
     comments = [],
     metadata = {},

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/_dummies.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/_dummies.ts
@@ -9,18 +9,17 @@ import { nanoid } from "@liveblocks/core";
 export function createThread(
   overrides: Partial<ThreadDataWithDeleteInfo<BaseMetadata>> = {}
 ): ThreadDataWithDeleteInfo<BaseMetadata> {
-  const now = new Date();
   const {
     id = `th_${nanoid()}`,
     roomId = `room_${nanoid()}`,
-    createdAt = now,
-    updatedAt = now,
     deletedAt,
     comments = [],
     metadata = {},
     resolved = false,
   } = overrides;
 
+  const createdAt = overrides.createdAt ?? new Date();
+  const updatedAt = overrides.updatedAt ?? createdAt;
   return {
     type: "thread",
     id,

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/addReaction.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/addReaction.test.ts
@@ -8,6 +8,7 @@ describe("addReaction", () => {
       id: comment.threadId,
       roomId: comment.roomId,
       comments: [comment],
+      createdAt: new Date("2023-12-31"),
     });
 
     const reaction = {
@@ -28,6 +29,35 @@ describe("addReaction", () => {
     expect(updatedThread.updatedAt).toEqual(reaction.createdAt);
   });
 
+  it("should not update updatedAt if not newer", () => {
+    const now = new Date(); // updatedAt date is latest date
+    const comment = createComment({ createdAt: new Date("2024-01-01") });
+    const thread = createThread({
+      id: comment.threadId,
+      roomId: comment.roomId,
+      comments: [comment],
+      createdAt: new Date("2023-12-31"),
+      updatedAt: now,
+    });
+
+    const reaction = {
+      emoji: "👍",
+      createdAt: new Date("2024-01-02"),
+      userId: "user_1",
+    };
+
+    const updatedThread = applyAddReaction(thread, comment.id, reaction);
+
+    expect(updatedThread.comments[0]?.reactions).toHaveLength(1);
+    expect(updatedThread.comments[0]?.reactions[0]?.emoji).toEqual(
+      reaction.emoji
+    );
+    expect(updatedThread.comments[0]?.reactions[0]?.users[0]?.id).toEqual(
+      reaction.userId
+    );
+    expect(updatedThread.updatedAt).toEqual(now); // Not changed!
+  });
+
   it("should add a new reaction to a comment with existing reactions", () => {
     const comment = createComment({
       createdAt: new Date("2024-01-01"),
@@ -43,6 +73,7 @@ describe("addReaction", () => {
       id: comment.threadId,
       roomId: comment.roomId,
       comments: [comment],
+      createdAt: new Date("2023-12-31"),
     });
 
     const newReaction = {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/applyThreadUpdates.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/applyThreadUpdates.test.tsx
@@ -7,20 +7,24 @@ import type {
 import { applyThreadUpdates } from "../../umbrella-store";
 
 describe("applyThreadUpdates", () => {
+  const now1 = new Date("2024-01-01");
   const thread1: ThreadDataWithDeleteInfo = {
     type: "thread" as const,
     id: "th_1",
-    createdAt: new Date("2024-01-01"),
+    createdAt: now1,
+    updatedAt: now1,
     roomId: "room_1",
     comments: [],
     metadata: {},
     resolved: false,
   };
 
+  const now2 = new Date("2024-01-01");
   const thread2: ThreadDataWithDeleteInfo = {
     type: "thread" as const,
     id: "th_2",
-    createdAt: new Date("2024-01-01"),
+    createdAt: now2,
+    updatedAt: now2,
     roomId: "room_1",
     comments: [],
     metadata: {},

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/compareThreads.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/compareThreads.test.ts
@@ -9,8 +9,8 @@ import {
 
 // A bunch of dates
 const examples = [
-  { createdAt: new Date("1999-01-01") },
-  { createdAt: new Date("2024-01-01") },
+  { createdAt: new Date("1999-01-01"), updatedAt: new Date("1999-01-01") },
+  { createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01") },
   { createdAt: new Date("2010-01-01"), updatedAt: new Date("2024-05-05") },
   { createdAt: new Date("2024-01-02"), updatedAt: new Date("2024-03-03") },
   { createdAt: new Date("1999-01-02"), updatedAt: new Date("2000-01-06") },
@@ -19,10 +19,10 @@ const examples = [
 describe("simple comparison checks", () => {
   it("sorts correctly using byFirstCreated", () => {
     expect([...examples].sort(byFirstCreated)).toEqual([
-      { createdAt: new Date("1999-01-01") },
+      { createdAt: new Date("1999-01-01"), updatedAt: new Date("1999-01-01") },
       { createdAt: new Date("1999-01-02"), updatedAt: new Date("2000-01-06") },
       { createdAt: new Date("2010-01-01"), updatedAt: new Date("2024-05-05") },
-      { createdAt: new Date("2024-01-01") },
+      { createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01") },
       { createdAt: new Date("2024-01-02"), updatedAt: new Date("2024-03-03") },
     ]);
   });
@@ -31,9 +31,9 @@ describe("simple comparison checks", () => {
     expect([...examples].sort(byMostRecentlyUpdated)).toEqual([
       { createdAt: new Date("2010-01-01"), updatedAt: new Date("2024-05-05") },
       { createdAt: new Date("2024-01-02"), updatedAt: new Date("2024-03-03") },
-      { createdAt: new Date("2024-01-01") },
+      { createdAt: new Date("2024-01-01"), updatedAt: new Date("2024-01-01") },
       { createdAt: new Date("1999-01-02"), updatedAt: new Date("2000-01-06") },
-      { createdAt: new Date("1999-01-01") },
+      { createdAt: new Date("1999-01-01"), updatedAt: new Date("1999-01-01") },
     ]);
   });
 

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/upsertComment.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/upsertComment.test.ts
@@ -42,6 +42,7 @@ describe("upsertComment", () => {
       id: comment.threadId,
       roomId: comment.roomId,
       comments: [comment],
+      createdAt: new Date("2023-12-31"),
     });
 
     const updatedComment = createComment({
@@ -59,7 +60,8 @@ describe("upsertComment", () => {
     const updatedThread = applyUpsertComment(thread, updatedComment);
     expect(updatedThread.comments).toContainEqual(updatedComment);
     expect(updatedThread.comments).not.toContainEqual(comment);
-    expect(updatedThread.updatedAt).toEqual(updatedComment.editedAt);
+    expect(updatedThread.createdAt).toEqual(new Date("2023-12-31"));
+    expect(updatedThread.updatedAt).toEqual(new Date("2024-01-02"));
   });
 
   it("should not update an existing comment if the new comment is older", () => {

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1321,8 +1321,7 @@ describe("useThreads", () => {
 
         if (since) {
           const updatedThreads = threads.filter((thread) => {
-            if (thread.updatedAt === undefined) return false;
-            return new Date(thread.updatedAt) >= new Date(since);
+            return thread.updatedAt >= new Date(since);
           });
 
           return res(
@@ -1493,8 +1492,7 @@ describe("useThreads", () => {
 
         if (since) {
           const updatedThreads = threads.filter((thread) => {
-            if (thread.updatedAt === undefined) return false;
-            return new Date(thread.updatedAt) >= new Date(since);
+            return thread.updatedAt >= new Date(since);
           });
 
           return res(

--- a/packages/liveblocks-react/src/lib/compare.ts
+++ b/packages/liveblocks-react/src/lib/compare.ts
@@ -26,8 +26,8 @@ export function isNewer(
  * creation date for these threads.
  */
 export function isMoreRecentlyUpdated(
-  a: { createdAt: Date; updatedAt?: Date },
-  b: { createdAt: Date; updatedAt?: Date }
+  a: { createdAt: Date; updatedAt: Date },
+  b: { createdAt: Date; updatedAt: Date }
 ): boolean {
   return byMostRecentlyUpdated(a, b) < 0;
 }
@@ -41,11 +41,8 @@ export function isMoreRecentlyUpdated(
  * This is *NOT* simply the inverse of compareThreads!
  */
 export function byMostRecentlyUpdated(
-  a: { createdAt: Date; updatedAt?: Date },
-  b: { createdAt: Date; updatedAt?: Date }
+  a: { updatedAt: Date },
+  b: { updatedAt: Date }
 ): number {
-  return (
-    (b.updatedAt ?? b.createdAt).getTime() -
-    (a.updatedAt ?? a.createdAt).getTime()
-  );
+  return b.updatedAt.getTime() - a.updatedAt.getTime();
 }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1083,11 +1083,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
           return cache;
         }
 
-        if (
-          !!updatedAt &&
-          !!existing.updatedAt &&
-          existing.updatedAt > updatedAt
-        ) {
+        if (!!updatedAt && existing.updatedAt > updatedAt) {
           return cache;
         }
 
@@ -1624,10 +1620,7 @@ function internalToExternalState<M extends BaseMetadata>(
         }
 
         // If the thread has been updated since the optimistic update, we do not apply the update
-        if (
-          thread.updatedAt !== undefined &&
-          thread.updatedAt > optimisticUpdate.updatedAt
-        ) {
+        if (thread.updatedAt > optimisticUpdate.updatedAt) {
           break;
         }
 
@@ -2005,7 +1998,7 @@ export function applyUpsertComment<M extends BaseMetadata>(
   // If the comment doesn't exist in the thread, add the comment
   if (existingComment === undefined) {
     const updatedAt = new Date(
-      Math.max(thread.updatedAt?.getTime() || 0, comment.createdAt.getTime())
+      Math.max(thread.updatedAt.getTime(), comment.createdAt.getTime())
     );
 
     const updatedThread = {
@@ -2039,7 +2032,7 @@ export function applyUpsertComment<M extends BaseMetadata>(
       ...thread,
       updatedAt: new Date(
         Math.max(
-          thread.updatedAt?.getTime() || 0,
+          thread.updatedAt.getTime(),
           comment.editedAt?.getTime() || comment.createdAt.getTime()
         )
       ),
@@ -2142,7 +2135,7 @@ export function applyAddReaction<M extends BaseMetadata>(
   return {
     ...thread,
     updatedAt: new Date(
-      Math.max(reaction.createdAt.getTime(), thread.updatedAt?.getTime() || 0)
+      Math.max(reaction.createdAt.getTime(), thread.updatedAt.getTime())
     ),
     comments: updatedComments,
   };
@@ -2196,7 +2189,7 @@ export function applyRemoveReaction<M extends BaseMetadata>(
   return {
     ...thread,
     updatedAt: new Date(
-      Math.max(removedAt.getTime(), thread.updatedAt?.getTime() || 0)
+      Math.max(removedAt.getTime(), thread.updatedAt.getTime())
     ),
     comments: updatedComments,
   };


### PR DESCRIPTION
Updates the `ThreadData` type definition to make `updatedAt` a non-optional field. All threads should have an `updatedAt` time at this point, so we can remove a lot of uncertainty in the code around this.
