### PR TITLE
Use delta endpoints for `getThreadsSince` and `getUserThreadsSince` methods

### DIFF
--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -277,7 +277,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
       meta: {
         requestedAt: string;
       };
-    }>(url`/v2/c/threads`, undefined, {
+    }>(url`/v2/c/threads/delta`, undefined, {
       since: options.since.toISOString(),
     });
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2903,7 +2903,7 @@ export function createRoom<
 
   async function getThreadsSince(options: GetThreadsSinceOptions) {
     const response = await fetchCommentsApi(
-      url`/v2/c/rooms/${config.roomId}/threads`,
+      url`/v2/c/rooms/${config.roomId}/threads/delta`,
       { since: options?.since?.toISOString() },
       {
         headers: {

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1,5 +1,10 @@
 import "@testing-library/jest-dom";
 
+import type {
+  InboxNotificationData,
+  InboxNotificationDataPlain,
+  ThreadData,
+} from "@liveblocks/core";
 import { nanoid, ServerMsgCode } from "@liveblocks/core";
 import type { AST } from "@liveblocks/query-parser";
 import { QueryParser } from "@liveblocks/query-parser";
@@ -12,6 +17,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { addSeconds } from "date-fns";
+import {
+  type ResponseResolver,
+  rest,
+  type RestContext,
+  type RestRequest,
+} from "msw";
 import { setupServer } from "msw/node";
 import type { ReactNode } from "react";
 import React, { Suspense } from "react";
@@ -69,6 +80,27 @@ afterEach(() => {
 });
 
 afterAll(() => server.close());
+
+function mockGetThreadsSince(
+  resolver: ResponseResolver<
+    RestRequest<never, { roomId: string }>,
+    RestContext,
+    {
+      data: ThreadData<any>[];
+      inboxNotifications: InboxNotificationData[];
+      deletedThreads: ThreadData[];
+      deletedInboxNotifications: InboxNotificationDataPlain[];
+      meta: {
+        requestedAt: string;
+      };
+    }
+  >
+) {
+  return rest.get(
+    "https://api.liveblocks.io/v2/c/rooms/:roomId/threads/delta",
+    resolver
+  );
+}
 
 describe("useThreads", () => {
   beforeAll(() => {
@@ -1315,7 +1347,21 @@ describe("useThreads", () => {
     const originalThreads = [...threads];
 
     server.use(
-      mockGetThreads(async (req, res, ctx) => {
+      mockGetThreads(async (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: threads,
+            deletedThreads: [],
+            inboxNotifications: [],
+            deletedInboxNotifications: [],
+            meta: {
+              requestedAt: new Date().toISOString(),
+              nextCursor: null,
+            },
+          })
+        );
+      }),
+      mockGetThreadsSince(async (req, res, ctx) => {
         const url = new URL(req.url);
         const since = url.searchParams.get("since");
 
@@ -1332,24 +1378,12 @@ describe("useThreads", () => {
               deletedInboxNotifications: [],
               meta: {
                 requestedAt: new Date().toISOString(),
-                nextCursor: null,
               },
             })
           );
         }
 
-        return res(
-          ctx.json({
-            data: threads,
-            deletedThreads: [],
-            inboxNotifications: [],
-            deletedInboxNotifications: [],
-            meta: {
-              requestedAt: new Date().toISOString(),
-              nextCursor: null,
-            },
-          })
-        );
+        return res(ctx.status(500));
       })
     );
 
@@ -1486,7 +1520,21 @@ describe("useThreads", () => {
     const threads = [dummyThreadData({ roomId }), dummyThreadData({ roomId })];
 
     server.use(
-      mockGetThreads(async (req, res, ctx) => {
+      mockGetThreads(async (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: threads,
+            deletedThreads: [],
+            inboxNotifications: [],
+            deletedInboxNotifications: [],
+            meta: {
+              requestedAt: new Date().toISOString(),
+              nextCursor: null,
+            },
+          })
+        );
+      }),
+      mockGetThreadsSince(async (req, res, ctx) => {
         const url = new URL(req.url);
         const since = url.searchParams.get("since");
 
@@ -1503,24 +1551,12 @@ describe("useThreads", () => {
               deletedInboxNotifications: [],
               meta: {
                 requestedAt: new Date().toISOString(),
-                nextCursor: null,
               },
             })
           );
         }
 
-        return res(
-          ctx.json({
-            data: threads,
-            deletedThreads: [],
-            inboxNotifications: [],
-            deletedInboxNotifications: [],
-            meta: {
-              requestedAt: new Date().toISOString(),
-              nextCursor: null,
-            },
-          })
-        );
+        return res(ctx.status(500));
       })
     );
 
@@ -1669,6 +1705,21 @@ describe("useThreads: polling", () => {
 
     server.use(
       mockGetThreads(async (_req, res, ctx) => {
+        getThreadsReqCount++;
+        return res(
+          ctx.json({
+            data: threads,
+            inboxNotifications: [],
+            deletedThreads: [],
+            deletedInboxNotifications: [],
+            meta: {
+              requestedAt: now,
+              nextCursor: null,
+            },
+          })
+        );
+      }),
+      mockGetThreadsSince(async (_req, res, ctx) => {
         getThreadsReqCount++;
         return res(
           ctx.json({


### PR DESCRIPTION
We already do this for `getInboxNotificationsSince` method but missed doing the same for `getThreadsSince` and `getUserThreadsSince` methods. 