### PR TITLE
Refactorings towards a unified API client

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -600,12 +600,12 @@ export function createClient<U extends BaseUserMeta = DU>(
 
   const currentUserIdStore = createStore<string | null>(null);
 
-  const fetcher =
+  const fetchPolyfill =
     clientOptions.polyfills?.fetch || /* istanbul ignore next */ fetch;
 
   const httpClientLike = createNotificationsApi({
     baseUrl,
-    fetcher,
+    fetchPolyfill,
     authManager,
     currentUserIdStore,
   });

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -684,16 +684,6 @@ export function createClient<U extends BaseUserMeta = DU>(
   );
 }
 
-export class NotificationsApiError extends Error {
-  constructor(
-    public message: string,
-    public status: number,
-    public details?: JsonObject
-  ) {
-    super(message);
-  }
-}
-
 function checkBounds(
   option: string,
   value: unknown,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -601,7 +601,8 @@ export function createClient<U extends BaseUserMeta = DU>(
   const currentUserIdStore = createStore<string | null>(null);
 
   const fetchPolyfill =
-    clientOptions.polyfills?.fetch || /* istanbul ignore next */ fetch;
+    clientOptions.polyfills?.fetch ||
+    /* istanbul ignore next */ globalThis.fetch?.bind(globalThis);
 
   const httpClientLike = createNotificationsApi({
     baseUrl,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -655,6 +655,9 @@ export function createClient<U extends BaseUserMeta = DU>(
 
       logout,
 
+      // XXX Eventually, once this is actually using the HttpClient class,
+      // "just" expose a reference to it here, instead of spreading all of its
+      // methods
       ...httpClientLike,
 
       // Internal

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -604,7 +604,7 @@ export function createClient<U extends BaseUserMeta = DU>(
     clientOptions.polyfills?.fetch ||
     /* istanbul ignore next */ globalThis.fetch?.bind(globalThis);
 
-  const httpClientLike = createNotificationsApi({
+  const notificationsAPI = createNotificationsApi({
     baseUrl,
     fetchPolyfill,
     authManager,
@@ -656,10 +656,7 @@ export function createClient<U extends BaseUserMeta = DU>(
 
       logout,
 
-      // XXX Eventually, once this is actually using the HttpClient class,
-      // "just" expose a reference to it here, instead of spreading all of its
-      // methods
-      ...httpClientLike,
+      ...notificationsAPI,
 
       // Internal
       [kInternal]: {
@@ -672,9 +669,10 @@ export function createClient<U extends BaseUserMeta = DU>(
         },
 
         // "All" threads (= "user" threads)
-        getUserThreads_experimental: httpClientLike.getUserThreads_experimental,
+        getUserThreads_experimental:
+          notificationsAPI.getUserThreads_experimental,
         getUserThreadsSince_experimental:
-          httpClientLike.getUserThreadsSince_experimental,
+          notificationsAPI.getUserThreadsSince_experimental,
       },
     },
     kInternal,

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -5,7 +5,7 @@ import { urljoin } from "./lib/url";
 import { raise } from "./lib/utils";
 import { PKG_VERSION } from "./version";
 
-export class CommentsApiError extends Error {
+export class HttpError extends Error {
   constructor(
     public message: string,
     public status: number,
@@ -15,15 +15,9 @@ export class CommentsApiError extends Error {
   }
 }
 
-export class NotificationsApiError extends Error {
-  constructor(
-    public message: string,
-    public status: number,
-    public details?: JsonObject
-  ) {
-    super(message);
-  }
-}
+// TODO Deprecate these error aliases
+export const CommentsApiError = HttpError;
+export const NotificationsApiError = HttpError;
 
 export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
   if (authValue.type === "public") {
@@ -124,23 +118,13 @@ export class HttpClient {
     // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
     if (!response.ok) {
       if (response.status >= 400 && response.status < 600) {
-        let error: NotificationsApiError;
-
+        let error: HttpError;
         try {
           const errorBody = (await response.json()) as { message: string };
-
-          error = new NotificationsApiError(
-            errorBody.message,
-            response.status,
-            errorBody
-          );
+          error = new HttpError(errorBody.message, response.status, errorBody);
         } catch {
-          error = new NotificationsApiError(
-            response.statusText,
-            response.status
-          );
+          error = new HttpError(response.statusText, response.status);
         }
-
         throw error;
       }
     }
@@ -175,20 +159,13 @@ export class HttpClient {
     // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
     if (!response.ok) {
       if (response.status >= 400 && response.status < 600) {
-        let error: CommentsApiError;
-
+        let error: HttpError;
         try {
           const errorBody = (await response.json()) as { message: string };
-
-          error = new CommentsApiError(
-            errorBody.message,
-            response.status,
-            errorBody
-          );
+          error = new HttpError(errorBody.message, response.status, errorBody);
         } catch {
-          error = new CommentsApiError(response.statusText, response.status);
+          error = new HttpError(response.statusText, response.status);
         }
-
         throw error;
       }
     }

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -32,21 +32,6 @@ export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
  * Liveblocks Room instances internally to talk to our client-only REST API
  * backend.
  */
-//
-// XXX This class should be used to replace all of the following:
-// XXX
-// XXX From src/notifications.ts:
-// XXX - ✅ fetchJson + createNotificationsApi
-// XXX                             (!! Uses `comments:read` permissions!
-// XXX                               + Updates `currentUserIdStore` as a side effect!)
-// XXX
-// XXX From src/room.ts:
-// XXX - ✅ fetchClientApi         (!! Some cases use the current WebSocket's auth token (whatever it is)...
-// XXX                              ...and some cases use `room:read` + `roomId` permissions!)
-// XXX - ✅ fetchCommentsApi       (!! Uses `room:read` + `roomId` permissions!)
-// XXX - ✅ fetchCommentsJson      (!! Uses `room:read` + `roomId` permissions!)
-// XXX - ✅ fetchNotificationsJson (!! Uses `room:read` + `roomId` permissions!)
-//
 export class HttpClient {
   private _baseUrl: string;
   private _authCallback: () => Promise<AuthValue>;
@@ -79,7 +64,7 @@ export class HttpClient {
    *   5. ...but silently return `{}` if that parsing fails
    *   6. Throw HttpError if response is an error
    */
-  // XXX Ultimately, might be nice to make this a private method?
+  // XXX Ultimately, might be nice to make this a private method? It might be much nicer if this method would _always_ deal with the JSON parsing.
   public async fetch(
     endpoint: URLSafeString,
     options?: RequestInit,

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -1,4 +1,8 @@
 import type { AuthValue } from "./auth-manager";
+import type { QueryParams, URLSafeString } from "./lib/url";
+import { urljoin } from "./lib/url";
+import { raise } from "./lib/utils";
+import { PKG_VERSION } from "./version";
 
 export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
   if (authValue.type === "public") {
@@ -6,4 +10,79 @@ export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
   } else {
     return authValue.token.raw;
   }
+}
+
+/**
+ * @internal
+ *
+ * Small HTTP client for client-only REST API requests (e.g. /v2/c/* URLs).
+ * These URLs all use public key, ID token, or access token authorization. This
+ * HTTP client can be shared and used by both the Liveblocks Client and
+ * Liveblocks Room instances internally to talk to our client-only REST API
+ * backend.
+ */
+//
+// XXX This class should be used to replace all of the following:
+// XXX
+// XXX From src/client.ts:
+// XXX - fetchRoomApi              (!! Uses `room:read` + `roomId` permissions!)
+// XXX
+// XXX From src/notifications.ts:
+// XXX - fetchJson + createNotificationsApi
+//                                 (!! Uses `comments:read` permissions!
+//                                   + Updates `currentUserIdStore` as a side effect!)
+// XXX
+// XXX From src/room.ts:
+// XXX - fetchClientApi            (!! Some cases use the current WebSocket's auth token (whatever it is)...
+//                                  ...and some cases use `room:read` + `roomId` permissions!)
+// XXX - fetchCommentsApi          (!! Uses `room:read` + `roomId` permissions!)
+// XXX - fetchCommentsJson         (!! Uses `room:read` + `roomId` permissions!)
+// XXX - fetchNotificationsJson    (!! Uses `room:read` + `roomId` permissions!)
+//
+export class HttpClient {
+  private _baseUrl: string;
+  private _getAuthToken: () => AuthValue;
+  private _fetcher: typeof fetch;
+
+  constructor(
+    baseUrl: string,
+    getAuthToken: () => AuthValue,
+    fetchPolyfill: typeof fetch
+  ) {
+    this._baseUrl = baseUrl;
+    this._getAuthToken = getAuthToken;
+    this._fetcher = fetchPolyfill;
+  }
+
+  // XXX This method is yet unused. Start using it!
+  // @ts-expect-error
+  private async fetch(
+    endpoint: URLSafeString,
+    options?: RequestInit,
+    params?: QueryParams
+  ) {
+    if (!endpoint.startsWith("/v2/c/")) {
+      raise("This client can only be used to make /v2/c/* requests");
+    }
+
+    const url = urljoin(this._baseUrl, endpoint, params);
+    return await this._fetcher(url, {
+      ...options,
+      headers: {
+        // These headers are default, but can be overriden by custom headers
+        "Content-Type": "application/json; charset=utf-8",
+
+        // Possible header overrides
+        ...options?.headers,
+
+        // Cannot be overriden by custom headers
+        Authorization: `Bearer ${getBearerTokenFromAuthValue(this._getAuthToken())}`,
+        "X-LB-Client": PKG_VERSION || "dev",
+      },
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Public methods
+  // ------------------------------------------------------------------
 }

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -114,63 +114,12 @@ export class HttpClient {
   // 4. Parse response body as Json
   // 5. ...but silently return `{}` if that parsing fails
   // 6. Throw NotificationsApiError if response is an error
-  public async fetchJson_forNotifications_variant1<T extends JsonObject>(
+  public async fetchJson_forNotifications<T extends JsonObject>(
     endpoint: URLSafeString,
     options?: RequestInit,
     params?: QueryParams
   ): Promise<T> {
     const response = await this.fetch(endpoint, options, params);
-
-    // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
-    if (!response.ok) {
-      if (response.status >= 400 && response.status < 600) {
-        let error: NotificationsApiError;
-
-        try {
-          const errorBody = (await response.json()) as { message: string };
-
-          error = new NotificationsApiError(
-            errorBody.message,
-            response.status,
-            errorBody
-          );
-        } catch {
-          error = new NotificationsApiError(
-            response.statusText,
-            response.status
-          );
-        }
-
-        throw error;
-      }
-    }
-
-    let body;
-    try {
-      body = (await response.json()) as T;
-    } catch {
-      // XXX This looks wrong 🤔 !
-      // XXX We should be throwing this error if something fails to parse.
-      body = {} as T;
-    }
-    return body;
-  }
-
-  // XXX Try to DRY up this method with the other fetchJson_for* methods in here
-  //
-  // This will:
-  // 1. Set Content-Type header
-  // 2. Set Authorization header
-  // 3. Call the callback to obtain the `authValue` to use in the Authorization header
-  // 4. Parse response body as Json
-  // 5. ...but silently return `{}` if that parsing fails
-  // 6. Throw a NotificationsApiError if response is an error
-  //
-  async fetchJson_forNotifications_variant2<T>(
-    endpoint: URLSafeString,
-    options?: RequestInit
-  ): Promise<T> {
-    const response = await this.fetch(endpoint, options);
 
     // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
     if (!response.ok) {

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -264,22 +264,6 @@ export class HttpClient {
   // This will:
   // 1. Set Content-Type header
   // 2. Set Authorization header
-  // 3. Take a specific `authValue` to use in the Authorization header
-  // 4. ❗NOT throw if HTTP response is an error
-  // 5. ❗NOT Parse response body as JSON
-  public async fetchResponse_forClientApi(
-    endpoint: URLSafeString,
-    options?: RequestInit,
-    params?: QueryParams
-  ): Promise<Response> {
-    return this.fetch(endpoint, options, params);
-  }
-
-  // XXX Try to DRY up this method with the other fetch*_for* methods in here
-  //
-  // This will:
-  // 1. Set Content-Type header
-  // 2. Set Authorization header
   // 3. ❗Call the callback to obtain the `authValue` to use in the Authorization header
   // 4. ❗NOT throw if HTTP response is an error
   // 5. ❗NOT Parse response body as JSON

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -42,7 +42,7 @@ export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
 export class HttpClient {
   private _baseUrl: string;
   private _getAuthToken: () => AuthValue;
-  private _fetcher: typeof fetch;
+  private _fetchPolyfill: typeof fetch;
 
   constructor(
     baseUrl: string,
@@ -51,7 +51,7 @@ export class HttpClient {
   ) {
     this._baseUrl = baseUrl;
     this._getAuthToken = getAuthToken;
-    this._fetcher = fetchPolyfill;
+    this._fetchPolyfill = fetchPolyfill;
   }
 
   // XXX This method is yet unused. Start using it!
@@ -66,7 +66,7 @@ export class HttpClient {
     }
 
     const url = urljoin(this._baseUrl, endpoint, params);
-    return await this._fetcher(url, {
+    return await this._fetchPolyfill(url, {
       ...options,
       headers: {
         // These headers are default, but can be overriden by custom headers

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -221,11 +221,7 @@ export class HttpClient {
     options?: RequestInit,
     params?: QueryParams
   ): Promise<T> {
-    const response = await this.fetchResponse_forCommentsApi(
-      endpoint,
-      params,
-      options
-    );
+    const response = await this.fetch(endpoint, options, params);
 
     // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
     if (!response.ok) {
@@ -257,22 +253,6 @@ export class HttpClient {
       body = {} as T;
     }
     return body;
-  }
-
-  // XXX Try to DRY up this method with the other fetch*_for* methods in here
-  //
-  // This will:
-  // 1. Set Content-Type header
-  // 2. Set Authorization header
-  // 3. ❗Call the callback to obtain the `authValue` to use in the Authorization header
-  // 4. ❗NOT throw if HTTP response is an error
-  // 5. ❗NOT Parse response body as JSON
-  async fetchResponse_forCommentsApi(
-    endpoint: URLSafeString,
-    params?: QueryParams,
-    options?: RequestInit
-  ): Promise<Response> {
-    return this.fetch(endpoint, options, params);
   }
 
   // ------------------------------------------------------------------

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -1,8 +1,29 @@
 import type { AuthValue } from "./auth-manager";
+import type { JsonObject } from "./lib/Json";
 import type { QueryParams, URLSafeString } from "./lib/url";
 import { urljoin } from "./lib/url";
 import { raise } from "./lib/utils";
 import { PKG_VERSION } from "./version";
+
+export class CommentsApiError extends Error {
+  constructor(
+    public message: string,
+    public status: number,
+    public details?: JsonObject
+  ) {
+    super(message);
+  }
+}
+
+export class NotificationsApiError extends Error {
+  constructor(
+    public message: string,
+    public status: number,
+    public details?: JsonObject
+  ) {
+    super(message);
+  }
+}
 
 export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
   if (authValue.type === "public") {
@@ -26,46 +47,59 @@ export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
 // XXX
 // XXX From src/client.ts:
 // XXX - fetchRoomApi              (!! Uses `room:read` + `roomId` permissions!)
+// XXX   🤔🤔🤔 Check with Nimesh - is this indeed now gone???
 // XXX
 // XXX From src/notifications.ts:
-// XXX - fetchJson + createNotificationsApi
-//                                 (!! Uses `comments:read` permissions!
-//                                   + Updates `currentUserIdStore` as a side effect!)
+// XXX - ✅ fetchJson + createNotificationsApi
+// XXX                             (!! Uses `comments:read` permissions!
+// XXX                               + Updates `currentUserIdStore` as a side effect!)
 // XXX
 // XXX From src/room.ts:
-// XXX - fetchClientApi            (!! Some cases use the current WebSocket's auth token (whatever it is)...
-//                                  ...and some cases use `room:read` + `roomId` permissions!)
-// XXX - fetchCommentsApi          (!! Uses `room:read` + `roomId` permissions!)
-// XXX - fetchCommentsJson         (!! Uses `room:read` + `roomId` permissions!)
-// XXX - fetchNotificationsJson    (!! Uses `room:read` + `roomId` permissions!)
+// XXX - ✅ fetchClientApi         (!! Some cases use the current WebSocket's auth token (whatever it is)...
+// XXX                              ...and some cases use `room:read` + `roomId` permissions!)
+// XXX - ✅ fetchCommentsApi       (!! Uses `room:read` + `roomId` permissions!)
+// XXX - ✅ fetchCommentsJson      (!! Uses `room:read` + `roomId` permissions!)
+// XXX - ✅ fetchNotificationsJson (!! Uses `room:read` + `roomId` permissions!)
 //
 export class HttpClient {
   private _baseUrl: string;
-  private _getAuthToken: () => AuthValue;
+  private _authCallback?: () => Promise<AuthValue>;
   private _fetchPolyfill: typeof fetch;
 
   constructor(
     baseUrl: string,
-    getAuthToken: () => AuthValue,
-    fetchPolyfill: typeof fetch
+    fetchPolyfill: typeof fetch,
+    authCallback?: () => Promise<AuthValue>
   ) {
     this._baseUrl = baseUrl;
-    this._getAuthToken = getAuthToken;
     this._fetchPolyfill = fetchPolyfill;
+    this._authCallback = authCallback;
   }
 
-  // XXX This method is yet unused. Start using it!
-  // @ts-expect-error
-  private async fetch(
+  /**
+   * Constructs and makes the HTTP request, but does not handle the response.
+   */
+  public async fetch(
     endpoint: URLSafeString,
     options?: RequestInit,
-    params?: QueryParams
-  ) {
+    params?: QueryParams,
+    authValue?: AuthValue
+  ): Promise<Response> {
     if (!endpoint.startsWith("/v2/c/")) {
       raise("This client can only be used to make /v2/c/* requests");
     }
 
     const url = urljoin(this._baseUrl, endpoint, params);
+
+    if (!authValue) {
+      if (!this._authCallback) {
+        raise(
+          "No auth value was provided, and no auth callback was set up for this HttpClient instance. Cannot make this request."
+        );
+      }
+      authValue = await this._authCallback();
+    }
+
     return await this._fetchPolyfill(url, {
       ...options,
       headers: {
@@ -76,10 +110,201 @@ export class HttpClient {
         ...options?.headers,
 
         // Cannot be overriden by custom headers
-        Authorization: `Bearer ${getBearerTokenFromAuthValue(this._getAuthToken())}`,
+        Authorization: `Bearer ${getBearerTokenFromAuthValue(authValue)}`,
         "X-LB-Client": PKG_VERSION || "dev",
       },
     });
+  }
+
+  // ------------------------------------------------------------------
+  // XXX Temporary methods
+  // ------------------------------------------------------------------
+
+  // XXX Try to DRY up this method with the other fetchJson_for* methods in here
+  //
+  // This will:
+  // 1. Set Content-Type header
+  // 2. Set Authorization header
+  // 3. Call the callback to obtain the `authValue` to use in the Authorization header
+  // 4. Parse response body as Json
+  // 5. ...but silently return `{}` if that parsing fails
+  // 6. Throw NotificationsApiError if response is an error
+  public async fetchJson_forNotifications_variant1<T extends JsonObject>(
+    endpoint: URLSafeString,
+    options?: RequestInit,
+    params?: QueryParams
+  ): Promise<T> {
+    const response = await this.fetch(endpoint, options, params);
+
+    // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
+    if (!response.ok) {
+      if (response.status >= 400 && response.status < 600) {
+        let error: NotificationsApiError;
+
+        try {
+          const errorBody = (await response.json()) as { message: string };
+
+          error = new NotificationsApiError(
+            errorBody.message,
+            response.status,
+            errorBody
+          );
+        } catch {
+          error = new NotificationsApiError(
+            response.statusText,
+            response.status
+          );
+        }
+
+        throw error;
+      }
+    }
+
+    let body;
+    try {
+      body = (await response.json()) as T;
+    } catch {
+      // XXX This looks wrong 🤔 !
+      // XXX We should be throwing this error if something fails to parse.
+      body = {} as T;
+    }
+    return body;
+  }
+
+  // XXX Try to DRY up this method with the other fetchJson_for* methods in here
+  //
+  // This will:
+  // 1. Set Content-Type header
+  // 2. Set Authorization header
+  // 3. Call the callback to obtain the `authValue` to use in the Authorization header
+  // 4. Parse response body as Json
+  // 5. ...but silently return `{}` if that parsing fails
+  // 6. Throw a NotificationsApiError if response is an error
+  //
+  async fetchJson_forNotifications_variant2<T>(
+    endpoint: URLSafeString,
+    options?: RequestInit
+  ): Promise<T> {
+    const response = await this.fetch(endpoint, options);
+
+    // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
+    if (!response.ok) {
+      if (response.status >= 400 && response.status < 600) {
+        let error: NotificationsApiError;
+
+        try {
+          const errorBody = (await response.json()) as { message: string };
+
+          error = new NotificationsApiError(
+            errorBody.message,
+            response.status,
+            errorBody
+          );
+        } catch {
+          error = new NotificationsApiError(
+            response.statusText,
+            response.status
+          );
+        }
+
+        throw error;
+      }
+    }
+
+    let body;
+    try {
+      body = (await response.json()) as T;
+    } catch {
+      // XXX This looks wrong 🤔 !
+      // XXX We should be throwing this error if something fails to parse.
+      body = {} as T;
+    }
+    return body;
+  }
+
+  // XXX Try to DRY up this method with the other fetchJson_for* methods in here
+  //
+  // This will:
+  // 1. Set Content-Type header
+  // 2. Set Authorization header
+  // 3. Call the callback to obtain the `authValue` to use in the Authorization header
+  // 4. Parse response body as Json
+  // 5. ...but silently return `{}` if that parsing fails
+  // 6. Throw CommentsApiError if response is an error
+  public async fetchJson_forComments<T>(
+    endpoint: URLSafeString,
+    options?: RequestInit,
+    params?: QueryParams
+  ): Promise<T> {
+    const response = await this.fetchResponse_forCommentsApi(
+      endpoint,
+      params,
+      options
+    );
+
+    // XXX Maybe DRY up and transfer this error handling to HttpClient's fetch method too?
+    if (!response.ok) {
+      if (response.status >= 400 && response.status < 600) {
+        let error: CommentsApiError;
+
+        try {
+          const errorBody = (await response.json()) as { message: string };
+
+          error = new CommentsApiError(
+            errorBody.message,
+            response.status,
+            errorBody
+          );
+        } catch {
+          error = new CommentsApiError(response.statusText, response.status);
+        }
+
+        throw error;
+      }
+    }
+
+    let body;
+    try {
+      body = (await response.json()) as T;
+    } catch {
+      // XXX This looks wrong 🤔 !
+      // XXX We should be throwing this error if something fails to parse.
+      body = {} as T;
+    }
+    return body;
+  }
+
+  // XXX Try to DRY up this method with the other fetch*_for* methods in here
+  //
+  // This will:
+  // 1. Set Content-Type header
+  // 2. Set Authorization header
+  // 3. Take a specific `authValue` to use in the Authorization header
+  // 4. ❗NOT throw if HTTP response is an error
+  // 5. ❗NOT Parse response body as JSON
+  public async fetchResponse_forClientApi(
+    endpoint: URLSafeString,
+    authValue: AuthValue,
+    options?: RequestInit,
+    params?: QueryParams
+  ): Promise<Response> {
+    return this.fetch(endpoint, options, params, authValue);
+  }
+
+  // XXX Try to DRY up this method with the other fetch*_for* methods in here
+  //
+  // This will:
+  // 1. Set Content-Type header
+  // 2. Set Authorization header
+  // 3. ❗Call the callback to obtain the `authValue` to use in the Authorization header
+  // 4. ❗NOT throw if HTTP response is an error
+  // 5. ❗NOT Parse response body as JSON
+  async fetchResponse_forCommentsApi(
+    endpoint: URLSafeString,
+    params?: QueryParams,
+    options?: RequestInit
+  ): Promise<Response> {
+    return this.fetch(endpoint, options, params);
   }
 
   // ------------------------------------------------------------------

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -165,7 +165,7 @@ export class HttpClient {
   // 4. Parse response body as Json
   // 5. ...but silently return `{}` if that parsing fails
   // 6. Throw CommentsApiError if response is an error
-  public async fetchJson_forComments<T>(
+  public async fetchJson_forComments<T extends JsonObject>(
     endpoint: URLSafeString,
     options?: RequestInit,
     params?: QueryParams

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -45,10 +45,6 @@ export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
 //
 // XXX This class should be used to replace all of the following:
 // XXX
-// XXX From src/client.ts:
-// XXX - fetchRoomApi              (!! Uses `room:read` + `roomId` permissions!)
-// XXX   🤔🤔🤔 Check with Nimesh - is this indeed now gone???
-// XXX
 // XXX From src/notifications.ts:
 // XXX - ✅ fetchJson + createNotificationsApi
 // XXX                             (!! Uses `comments:read` permissions!

--- a/packages/liveblocks-core/src/http-client.ts
+++ b/packages/liveblocks-core/src/http-client.ts
@@ -15,10 +15,6 @@ export class HttpError extends Error {
   }
 }
 
-// TODO Deprecate these error aliases
-export const CommentsApiError = HttpError;
-export const NotificationsApiError = HttpError;
-
 export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
   if (authValue.type === "public") {
     return authValue.publicApiKey;

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -76,7 +76,11 @@ export type {
   DU,
   KDAD,
 } from "./globals/augmentation";
-export { CommentsApiError, NotificationsApiError } from "./http-client";
+export {
+  CommentsApiError,
+  HttpError,
+  NotificationsApiError,
+} from "./http-client";
 export {
   legacy_patchImmutableObject,
   lsonToJson,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -76,11 +76,7 @@ export type {
   DU,
   KDAD,
 } from "./globals/augmentation";
-export {
-  CommentsApiError,
-  HttpError,
-  NotificationsApiError,
-} from "./http-client";
+export { HttpError } from "./http-client";
 export {
   legacy_patchImmutableObject,
   lsonToJson,
@@ -304,3 +300,14 @@ export type { DevTools };
 // Store
 export type { Store } from "./lib/create-store";
 export { createStore } from "./lib/create-store";
+
+// Deprecated APIs
+
+/**
+ * @deprecated Use HttpError instead.
+ */
+export const CommentsApiError = HttpError;
+/**
+ * @deprecated Use HttpError instead.
+ */
+export const NotificationsApiError = HttpError;

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -302,12 +302,8 @@ export type { Store } from "./lib/create-store";
 export { createStore } from "./lib/create-store";
 
 // Deprecated APIs
-
-/**
- * @deprecated Use HttpError instead.
- */
+import { HttpError } from "./http-client";
+/** @deprecated Use HttpError instead. */
 export const CommentsApiError = HttpError;
-/**
- * @deprecated Use HttpError instead.
- */
+/** @deprecated Use HttpError instead. */
 export const NotificationsApiError = HttpError;

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -26,7 +26,7 @@ export type {
   ResolveRoomsInfoArgs,
   ResolveUsersArgs,
 } from "./client";
-export { createClient, NotificationsApiError } from "./client";
+export { createClient } from "./client";
 export type {
   CommentBodyLinkElementArgs,
   CommentBodyMentionElementArgs,
@@ -76,6 +76,7 @@ export type {
   DU,
   KDAD,
 } from "./globals/augmentation";
+export { CommentsApiError, NotificationsApiError } from "./http-client";
 export {
   legacy_patchImmutableObject,
   lsonToJson,
@@ -244,7 +245,6 @@ export type {
   StorageStatus,
 } from "./room";
 export type { GetThreadsOptions, UploadAttachmentOptions } from "./room";
-export { CommentsApiError } from "./room";
 export type { Immutable } from "./types/Immutable";
 export type {
   IWebSocket,

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -79,7 +79,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   async function getInboxNotifications(options?: { cursor?: string }) {
     const PAGE_SIZE = 50;
 
-    const json = await httpClient.fetchJson_forNotifications_variant1<{
+    const json = await httpClient.fetchJson_forNotifications<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       meta: {
@@ -102,7 +102,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function getInboxNotificationsSince(since: Date) {
-    const json = await httpClient.fetchJson_forNotifications_variant1<{
+    const json = await httpClient.fetchJson_forNotifications<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       deletedThreads: ThreadDeleteInfoPlain[];
@@ -129,7 +129,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function getUnreadInboxNotificationsCount() {
-    const { count } = await httpClient.fetchJson_forNotifications_variant1<{
+    const { count } = await httpClient.fetchJson_forNotifications<{
       count: number;
     }>(url`/v2/c/inbox-notifications/count`);
 
@@ -137,7 +137,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function markAllInboxNotificationsAsRead() {
-    await httpClient.fetchJson_forNotifications_variant1(
+    await httpClient.fetchJson_forNotifications(
       url`/v2/c/inbox-notifications/read`,
       {
         method: "POST",
@@ -147,7 +147,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function markInboxNotificationsAsRead(inboxNotificationIds: string[]) {
-    await httpClient.fetchJson_forNotifications_variant1(
+    await httpClient.fetchJson_forNotifications(
       url`/v2/c/inbox-notifications/read`,
       {
         method: "POST",
@@ -172,7 +172,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function deleteAllInboxNotifications() {
-    await httpClient.fetchJson_forNotifications_variant1(
+    await httpClient.fetchJson_forNotifications(
       url`/v2/c/inbox-notifications`,
       {
         method: "DELETE",
@@ -181,7 +181,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function deleteInboxNotification(inboxNotificationId: string) {
-    await httpClient.fetchJson_forNotifications_variant1(
+    await httpClient.fetchJson_forNotifications(
       url`/v2/c/inbox-notifications/${inboxNotificationId}`,
       {
         method: "DELETE",
@@ -198,7 +198,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
 
     const PAGE_SIZE = 50;
 
-    const json = await httpClient.fetchJson_forNotifications_variant1<{
+    const json = await httpClient.fetchJson_forNotifications<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       deletedThreads: ThreadDeleteInfoPlain[];
@@ -226,7 +226,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   async function getUserThreadsSince_experimental(
     options: GetThreadsSinceOptions
   ) {
-    const json = await httpClient.fetchJson_forNotifications_variant1<{
+    const json = await httpClient.fetchJson_forNotifications<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       deletedThreads: ThreadDeleteInfoPlain[];

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -66,6 +66,8 @@ export function createNotificationsApi<M extends BaseMetadata>({
       authValue.token.parsed.k === TokenKind.ACCESS_TOKEN
     ) {
       const userId = authValue.token.parsed.uid;
+
+      // NOTE: currentUserIdStore is updated here as a side-effect!
       currentUserIdStore.set(() => userId);
     }
 

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -35,12 +35,12 @@ export function createNotificationsApi<M extends BaseMetadata>({
   baseUrl,
   authManager,
   currentUserIdStore,
-  fetcher,
+  fetchPolyfill,
 }: {
   baseUrl: string;
   authManager: AuthManager;
   currentUserIdStore: Store<string | null>;
-  fetcher: (url: string, init?: RequestInit) => Promise<Response>;
+  fetchPolyfill: (url: string, init?: RequestInit) => Promise<Response>;
 }): NotificationsApi<M> & {
   getUserThreads_experimental(options?: GetThreadsOptions<M>): Promise<{
     threads: ThreadData<M>[];
@@ -82,7 +82,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
     }
 
     const url = urljoin(baseUrl, endpoint, params);
-    const response = await fetcher(url.toString(), {
+    const response = await fetchPolyfill(url.toString(), {
       ...options,
       headers: {
         ...options?.headers,

--- a/packages/liveblocks-core/src/notifications.ts
+++ b/packages/liveblocks-core/src/notifications.ts
@@ -79,7 +79,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   async function getInboxNotifications(options?: { cursor?: string }) {
     const PAGE_SIZE = 50;
 
-    const json = await httpClient.fetchJson_forNotifications<{
+    const json = await httpClient.fetchJson<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       meta: {
@@ -102,7 +102,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function getInboxNotificationsSince(since: Date) {
-    const json = await httpClient.fetchJson_forNotifications<{
+    const json = await httpClient.fetchJson<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       deletedThreads: ThreadDeleteInfoPlain[];
@@ -129,7 +129,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function getUnreadInboxNotificationsCount() {
-    const { count } = await httpClient.fetchJson_forNotifications<{
+    const { count } = await httpClient.fetchJson<{
       count: number;
     }>(url`/v2/c/inbox-notifications/count`);
 
@@ -137,23 +137,17 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function markAllInboxNotificationsAsRead() {
-    await httpClient.fetchJson_forNotifications(
-      url`/v2/c/inbox-notifications/read`,
-      {
-        method: "POST",
-        body: JSON.stringify({ inboxNotificationIds: "all" }),
-      }
-    );
+    await httpClient.fetchJson(url`/v2/c/inbox-notifications/read`, {
+      method: "POST",
+      body: JSON.stringify({ inboxNotificationIds: "all" }),
+    });
   }
 
   async function markInboxNotificationsAsRead(inboxNotificationIds: string[]) {
-    await httpClient.fetchJson_forNotifications(
-      url`/v2/c/inbox-notifications/read`,
-      {
-        method: "POST",
-        body: JSON.stringify({ inboxNotificationIds }),
-      }
-    );
+    await httpClient.fetchJson(url`/v2/c/inbox-notifications/read`, {
+      method: "POST",
+      body: JSON.stringify({ inboxNotificationIds }),
+    });
   }
 
   const batchedMarkInboxNotificationsAsRead = new Batch<string, string>(
@@ -172,16 +166,13 @@ export function createNotificationsApi<M extends BaseMetadata>({
   }
 
   async function deleteAllInboxNotifications() {
-    await httpClient.fetchJson_forNotifications(
-      url`/v2/c/inbox-notifications`,
-      {
-        method: "DELETE",
-      }
-    );
+    await httpClient.fetchJson(url`/v2/c/inbox-notifications`, {
+      method: "DELETE",
+    });
   }
 
   async function deleteInboxNotification(inboxNotificationId: string) {
-    await httpClient.fetchJson_forNotifications(
+    await httpClient.fetchJson(
       url`/v2/c/inbox-notifications/${inboxNotificationId}`,
       {
         method: "DELETE",
@@ -198,7 +189,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
 
     const PAGE_SIZE = 50;
 
-    const json = await httpClient.fetchJson_forNotifications<{
+    const json = await httpClient.fetchJson<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       deletedThreads: ThreadDeleteInfoPlain[];
@@ -226,7 +217,7 @@ export function createNotificationsApi<M extends BaseMetadata>({
   async function getUserThreadsSince_experimental(
     options: GetThreadsSinceOptions
   ) {
-    const json = await httpClient.fetchJson_forNotifications<{
+    const json = await httpClient.fetchJson<{
       threads: ThreadDataPlain<M>[];
       inboxNotifications: InboxNotificationDataPlain[];
       deletedThreads: ThreadDeleteInfoPlain[];

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -29,9 +29,9 @@ import type { LiveNode, LiveStructure, LsonObject } from "./crdts/Lson";
 import type { StorageCallback, StorageUpdate } from "./crdts/StorageUpdates";
 import type { DE, DM, DP, DS, DU } from "./globals/augmentation";
 import {
-  CommentsApiError,
   getBearerTokenFromAuthValue,
   HttpClient,
+  HttpError,
 } from "./http-client";
 import { kInternal } from "./internal";
 import { assertNever, nn } from "./lib/assert";
@@ -3123,7 +3123,7 @@ export function createRoom<
         throw abortError;
       }
 
-      if (err instanceof CommentsApiError && err.status === 413) {
+      if (err instanceof HttpError && err.status === 413) {
         throw err;
       }
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3085,7 +3085,7 @@ export function createRoom<
     commentId: string;
     emoji: string;
   }) {
-    await httpClient2.fetchJson_forComments<CommentData>(
+    await httpClient2.fetchJson_forComments<CommentDataPlain>(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}/reactions/${emoji}`,
       { method: "DELETE" }
     );

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3336,7 +3336,7 @@ export function createRoom<
     endpoint: URLSafeString,
     options?: RequestInit
   ): Promise<T> {
-    return await httpClient1.fetchJson_forNotifications_variant2<T>(
+    return await httpClient2.fetchJson_forNotifications_variant2<T>(
       endpoint,
       options
     );

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1603,7 +1603,9 @@ export function createRoom<
     }
 
     const url = urljoin(config.baseUrl, endpoint, params);
-    const fetcher = config.polyfills?.fetch || /* istanbul ignore next */ fetch;
+    const fetcher =
+      config.polyfills?.fetch ||
+      /* istanbul ignore next */ globalThis.fetch?.bind(globalThis);
     return await fetcher(url, {
       ...options,
       headers: {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2792,8 +2792,9 @@ export function createRoom<
   };
 
   async function getThreadsSince(options: GetThreadsSinceOptions) {
-    const response = await httpClient2.fetchResponse_forCommentsApi(
+    const response = await httpClient2.fetch(
       url`/v2/c/rooms/${config.roomId}/threads/delta`,
+      undefined,
       { since: options?.since?.toISOString() }
     );
 
@@ -2847,8 +2848,9 @@ export function createRoom<
 
     const PAGE_SIZE = 50;
 
-    const response = await httpClient2.fetchResponse_forCommentsApi(
+    const response = await httpClient2.fetch(
       url`/v2/c/rooms/${config.roomId}/threads`,
+      undefined,
       {
         cursor: options?.cursor,
         query,
@@ -2891,7 +2893,7 @@ export function createRoom<
   }
 
   async function getThread(threadId: string) {
-    const response = await httpClient2.fetchResponse_forCommentsApi(
+    const response = await httpClient2.fetch(
       url`/v2/c/rooms/${config.roomId}/thread-with-notification/${threadId}`
     );
 
@@ -3248,9 +3250,8 @@ export function createRoom<
         ) {
           try {
             // Abort the multi-part upload if it was created
-            await httpClient2.fetchResponse_forCommentsApi(
+            await httpClient2.fetch(
               url`/v2/c/rooms/${config.roomId}/attachments/${attachment.id}/multipart/${uploadId}`,
-              undefined,
               { method: "DELETE" }
             );
           } catch (error) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2933,7 +2933,7 @@ export function createRoom<
     body: CommentBody;
     attachmentIds?: string[];
   }) {
-    const thread = await httpClient2.fetchJson_forComments<ThreadDataPlain<M>>(
+    const thread = await httpClient2.fetchJson<ThreadDataPlain<M>>(
       url`/v2/c/rooms/${config.roomId}/threads`,
       {
         method: "POST",
@@ -2953,7 +2953,7 @@ export function createRoom<
   }
 
   async function deleteThread(threadId: string) {
-    await httpClient2.fetchJson_forComments(
+    await httpClient2.fetchJson(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}`,
       { method: "DELETE" }
     );
@@ -2967,7 +2967,7 @@ export function createRoom<
     metadata: Patchable<M>;
     threadId: string;
   }) {
-    return await httpClient2.fetchJson_forComments<M>(
+    return await httpClient2.fetchJson<M>(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/metadata`,
       {
         method: "POST",
@@ -2977,14 +2977,14 @@ export function createRoom<
   }
 
   async function markThreadAsResolved(threadId: string) {
-    await httpClient2.fetchJson_forComments(
+    await httpClient2.fetchJson(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/mark-as-resolved`,
       { method: "POST" }
     );
   }
 
   async function markThreadAsUnresolved(threadId: string) {
-    await httpClient2.fetchJson_forComments(
+    await httpClient2.fetchJson(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/mark-as-unresolved`,
       { method: "POST" }
     );
@@ -3001,7 +3001,7 @@ export function createRoom<
     body: CommentBody;
     attachmentIds?: string[];
   }) {
-    const comment = await httpClient2.fetchJson_forComments<CommentDataPlain>(
+    const comment = await httpClient2.fetchJson<CommentDataPlain>(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments`,
       {
         method: "POST",
@@ -3027,7 +3027,7 @@ export function createRoom<
     body: CommentBody;
     attachmentIds?: string[];
   }) {
-    const comment = await httpClient2.fetchJson_forComments<CommentDataPlain>(
+    const comment = await httpClient2.fetchJson<CommentDataPlain>(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}`,
       {
         method: "POST",
@@ -3049,7 +3049,7 @@ export function createRoom<
     threadId: string;
     commentId: string;
   }) {
-    await httpClient2.fetchJson_forComments(
+    await httpClient2.fetchJson(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}`,
       { method: "DELETE" }
     );
@@ -3064,14 +3064,13 @@ export function createRoom<
     commentId: string;
     emoji: string;
   }) {
-    const reaction =
-      await httpClient2.fetchJson_forComments<CommentUserReactionPlain>(
-        url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}/reactions`,
-        {
-          method: "POST",
-          body: JSON.stringify({ emoji }),
-        }
-      );
+    const reaction = await httpClient2.fetchJson<CommentUserReactionPlain>(
+      url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}/reactions`,
+      {
+        method: "POST",
+        body: JSON.stringify({ emoji }),
+      }
+    );
 
     return convertToCommentUserReaction(reaction);
   }
@@ -3085,7 +3084,7 @@ export function createRoom<
     commentId: string;
     emoji: string;
   }) {
-    await httpClient2.fetchJson_forComments<CommentDataPlain>(
+    await httpClient2.fetchJson<CommentDataPlain>(
       url`/v2/c/rooms/${config.roomId}/threads/${threadId}/comments/${commentId}/reactions/${emoji}`,
       { method: "DELETE" }
     );
@@ -3135,7 +3134,7 @@ export function createRoom<
       // If the file is small enough, upload it in a single request
       return autoRetry(
         () =>
-          httpClient2.fetchJson_forComments<CommentAttachment>(
+          httpClient2.fetchJson<CommentAttachment>(
             url`/v2/c/rooms/${config.roomId}/attachments/${attachment.id}/upload/${encodeURIComponent(attachment.name)}`,
             {
               method: "PUT",
@@ -3161,7 +3160,7 @@ export function createRoom<
       // Create a multi-part upload
       const createMultiPartUpload = await autoRetry(
         () =>
-          httpClient2.fetchJson_forComments<{
+          httpClient2.fetchJson<{
             uploadId: string;
             key: string;
           }>(
@@ -3202,7 +3201,7 @@ export function createRoom<
             uploadedPartsPromises.push(
               autoRetry(
                 () =>
-                  httpClient2.fetchJson_forComments<{
+                  httpClient2.fetchJson<{
                     partNumber: number;
                     etag: string;
                   }>(
@@ -3233,7 +3232,7 @@ export function createRoom<
           (a, b) => a.partNumber - b.partNumber
         );
 
-        return httpClient2.fetchJson_forComments<CommentAttachment>(
+        return httpClient2.fetchJson<CommentAttachment>(
           url`/v2/c/rooms/${config.roomId}/attachments/${attachment.id}/multipart/${uploadId}/complete`,
           {
             method: "POST",
@@ -3265,7 +3264,7 @@ export function createRoom<
   }
 
   async function getAttachmentUrls(attachmentIds: string[]) {
-    const { urls } = await httpClient2.fetchJson_forComments<{
+    const { urls } = await httpClient2.fetchJson<{
       urls: (string | null)[];
     }>(url`/v2/c/rooms/${config.roomId}/attachments/presigned-urls`, {
       method: "POST",
@@ -3299,7 +3298,7 @@ export function createRoom<
     endpoint: URLSafeString,
     options?: RequestInit
   ): Promise<T> {
-    return await httpClient2.fetchJson_forNotifications<T>(endpoint, options);
+    return await httpClient2.fetchJson<T>(endpoint, options);
   }
 
   function getNotificationSettings(): Promise<RoomNotificationSettings> {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1610,7 +1610,7 @@ export function createRoom<
     endpoint: "/send-message" | "/text-metadata",
     body: JsonObject
   ) {
-    return httpClient1.fetchResponse_forClientApi(
+    return httpClient1.fetch(
       endpoint === "/send-message"
         ? url`/v2/c/rooms/${config.roomId}/send-message`
         : url`/v2/c/rooms/${config.roomId}/text-metadata`,
@@ -1622,52 +1622,43 @@ export function createRoom<
   }
 
   async function createTextMention(userId: string, mentionId: string) {
-    return httpClient1.fetchResponse_forClientApi(
-      url`/v2/c/rooms/${config.roomId}/text-mentions`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          userId,
-          mentionId,
-        }),
-      }
-    );
+    return httpClient1.fetch(url`/v2/c/rooms/${config.roomId}/text-mentions`, {
+      method: "POST",
+      body: JSON.stringify({
+        userId,
+        mentionId,
+      }),
+    });
   }
 
   async function deleteTextMention(mentionId: string) {
-    return httpClient1.fetchResponse_forClientApi(
+    return httpClient1.fetch(
       url`/v2/c/rooms/${config.roomId}/text-mentions/${mentionId}`,
       { method: "DELETE" }
     );
   }
 
   async function reportTextEditor(type: "lexical", rootKey: string) {
-    return httpClient2.fetchResponse_forClientApi(
-      url`/v2/c/rooms/${config.roomId}/text-metadata`,
-      {
-        method: "POST",
-        body: JSON.stringify({ type, rootKey }),
-      }
-    );
+    return httpClient2.fetch(url`/v2/c/rooms/${config.roomId}/text-metadata`, {
+      method: "POST",
+      body: JSON.stringify({ type, rootKey }),
+    });
   }
 
   async function listTextVersions() {
-    return httpClient2.fetchResponse_forClientApi(
-      url`/v2/c/rooms/${config.roomId}/versions`
-    );
+    return httpClient2.fetch(url`/v2/c/rooms/${config.roomId}/versions`);
   }
 
   async function getTextVersion(versionId: string) {
-    return httpClient2.fetchResponse_forClientApi(
+    return httpClient2.fetch(
       url`/v2/c/rooms/${config.roomId}/y-version/${versionId}`
     );
   }
 
   async function createTextVersion() {
-    return httpClient2.fetchResponse_forClientApi(
-      url`/v2/c/rooms/${config.roomId}/version`,
-      { method: "POST" }
-    );
+    return httpClient2.fetch(url`/v2/c/rooms/${config.roomId}/version`, {
+      method: "POST",
+    });
   }
 
   function sendMessages(messages: ClientMsg<P, E>[]) {
@@ -2504,7 +2495,7 @@ export function createRoom<
   async function streamStorage() {
     // TODO: Handle potential race conditions where the room get disconnected while the request is pending
     if (!managedSocket.authValue) return;
-    const result = await httpClient1.fetchResponse_forClientApi(
+    const result = await httpClient1.fetch(
       url`/v2/c/rooms/${config.roomId}/storage`
     );
     const items = (await result.json()) as IdTuple<SerializedCrdt>[];

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3295,14 +3295,11 @@ export function createRoom<
     return batchedGetAttachmentUrls.get(attachmentId);
   }
 
-  async function fetchNotificationsJson<T>(
+  async function fetchNotificationsJson<T extends JsonObject>(
     endpoint: URLSafeString,
     options?: RequestInit
   ): Promise<T> {
-    return await httpClient2.fetchJson_forNotifications_variant2<T>(
-      endpoint,
-      options
-    );
+    return await httpClient2.fetchJson_forNotifications<T>(endpoint, options);
   }
 
   function getNotificationSettings(): Promise<RoomNotificationSettings> {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
@@ -6,7 +6,7 @@ import {
   type CommentBodyMention,
   type CommentLocalAttachment,
   type CommentMixedAttachment,
-  CommentsApiError,
+  HttpError,
   makeEventSource,
   type OpaqueRoom,
 } from "@liveblocks/core";
@@ -374,7 +374,7 @@ function createComposerAttachmentsManager(
             ...attachment,
             status: "error",
             error:
-              error instanceof CommentsApiError && error.status === 413
+              error instanceof HttpError && error.status === 413
                 ? new AttachmentTooLargeError("File is too large.", "server")
                 : error,
           });

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -37,16 +37,15 @@ import type {
 } from "@liveblocks/core";
 import {
   assert,
-  CommentsApiError,
   console,
   createCommentId,
   createThreadId,
   deprecateIf,
   errorIf,
+  HttpError,
   kInternal,
   makeEventSource,
   makePoller,
-  NotificationsApiError,
   ServerMsgCode,
 } from "@liveblocks/core";
 import * as React from "react";
@@ -215,7 +214,7 @@ function getCurrentUserId(room: OpaqueRoom): string {
   }
 }
 
-function handleApiError(err: CommentsApiError | NotificationsApiError): Error {
+function handleApiError(err: HttpError): Error {
   const message = `Request failed with status ${err.status}: ${err.message}`;
 
   // Log details about FORBIDDEN errors
@@ -395,13 +394,13 @@ function makeRoomExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
   ) {
     store.removeOptimisticUpdate(optimisticUpdateId);
 
-    if (innerError instanceof CommentsApiError) {
+    if (innerError instanceof HttpError) {
       const error = handleApiError(innerError);
       commentsErrorEventSource.notify(createPublicError(error));
       return;
     }
 
-    if (innerError instanceof NotificationsApiError) {
+    if (innerError instanceof HttpError) {
       handleApiError(innerError);
       // TODO: Create public error and notify via notificationsErrorEventSource?
       return;


### PR DESCRIPTION
This DRYs up all the various HTTP fetch calls our client is making into a single "http client" abstraction, responsible for constructing, making, authorizing the request, and parsing/throwing the response. There used to be many various and subtly different ways we did this before, mostly copy-pasted and slightly adjusted. This PR mostly DRYs them all up. I've very carefully refactored things here, so it should not have introduced a breaking change.

I don't consider this fully done yet. This is step 1 of 2.

- **Step 1** (this PR): Have a single `HttpClient.fetch()` and `HttpClient.fetchJson()` method as the foundational building blocks for making HTTP calls from the client.
- **Step 2**: Move all possible API calls on there as methods, fully type-safe, and, make the `fetch` and `fetchJson` private methods.

The only "public" change here should be the removal of the `NotificationsApiError` and `CommentsApiError` classes, which are now both `HttpError` (which is more closely to what it actually is).
