### PR TITLE
Detect invalid chars in secret key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.2 (not yet released
+
+### `@liveblocks/node`
+
+- Detect invalid chars in secret keys and throw a more helpful error message
+
 ## 2.9.1
 
 ### `@liveblocks/client`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.2 (not yet released
+## 2.9.2
 
 ### `@liveblocks/node`
 

--- a/packages/liveblocks-node/src/__tests__/Session.test.ts
+++ b/packages/liveblocks-node/src/__tests__/Session.test.ts
@@ -20,17 +20,17 @@ describe("authorization (new API)", () => {
         secret: 123,
       })
     ).toThrow(
-      'Invalid value for field "secret". Secret keys must start with "sk_". Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.'
+      "Invalid value for field 'secret'. Secret keys must start with 'sk_'. Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys."
     );
   });
 
-  test("throws when an invalid secret key is provided", () => {
+  test("throws when an public key is provided instead of a secret key", () => {
     expect(() =>
       makeSession({
         secret: "pk_thisisntsecret",
       })
     ).toThrow(
-      'Invalid value for field "secret". Secret keys must start with "sk_". Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.'
+      "Invalid value for field 'secret'. Secret keys must start with 'sk_'. Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys."
     );
   });
 

--- a/packages/liveblocks-node/src/__tests__/Session.test.ts
+++ b/packages/liveblocks-node/src/__tests__/Session.test.ts
@@ -34,6 +34,16 @@ describe("authorization (new API)", () => {
     );
   });
 
+  test("throws when an invalid secret key is provided", () => {
+    expect(() =>
+      makeSession({
+        secret: "sk_this…is…truncated",
+      })
+    ).toThrow(
+      "Invalid chars found in field 'secret'. Please check that you correctly copied the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys."
+    );
+  });
+
   test("default set has no permissions", () => {
     expect(makeSession().hasPermissions()).toEqual(false);
   });

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -1,5 +1,8 @@
 const DEFAULT_BASE_URL = "https://api.liveblocks.io";
 
+// Valid alphabet for secret/public keys
+const VALID_KEY_CHARS_REGEX = /^[\w-]+$/;
+
 export function getBaseUrl(baseUrl?: string | undefined): string {
   if (
     typeof baseUrl === "string" &&
@@ -53,7 +56,7 @@ export function assertSecretKey(
     );
   }
 
-  if (!/^[\w-]+$/.test(value)) {
+  if (!VALID_KEY_CHARS_REGEX.test(value)) {
     throw new Error(
       `Invalid chars found in field '${field}'. Please check that you correctly copied the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.`
     );

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -27,7 +27,7 @@ export function assertNonEmpty(
 ): asserts value is string {
   if (!isNonEmpty(value)) {
     throw new Error(
-      `Invalid value for field "${field}". Please provide a non-empty string. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize`
+      `Invalid value for field '${field}'. Please provide a non-empty string. For more information: https://liveblocks.io/docs/api-reference/liveblocks-node#authorize`
     );
   }
 }
@@ -38,7 +38,7 @@ export function assertSecretKey(
 ): asserts value is string {
   if (!isNonEmpty(value) || !value.startsWith("sk_")) {
     throw new Error(
-      `Invalid value for field "${field}". Secret keys must start with "sk_". Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.`
+      `Invalid value for field '${field}'. Secret keys must start with 'sk_'. Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.`
     );
   }
 }

--- a/packages/liveblocks-node/src/utils.ts
+++ b/packages/liveblocks-node/src/utils.ts
@@ -17,8 +17,19 @@ export async function fetchPolyfill(): Promise<typeof fetch> {
     : ((await import("node-fetch")).default as unknown as typeof fetch);
 }
 
-export function isNonEmpty(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function startsWith<P extends string>(
+  value: unknown,
+  prefix: P
+): value is `${P}${string}` {
+  return isString(value) && value.startsWith(prefix);
+}
+
+function isNonEmpty(value: unknown): value is string {
+  return isString(value) && value.length > 0;
 }
 
 export function assertNonEmpty(
@@ -36,9 +47,15 @@ export function assertSecretKey(
   value: unknown,
   field: string
 ): asserts value is string {
-  if (!isNonEmpty(value) || !value.startsWith("sk_")) {
+  if (!startsWith(value, "sk_")) {
     throw new Error(
       `Invalid value for field '${field}'. Secret keys must start with 'sk_'. Please provide the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.`
+    );
+  }
+
+  if (!/^[\w-]+$/.test(value)) {
+    throw new Error(
+      `Invalid chars found in field '${field}'. Please check that you correctly copied the secret key from your Liveblocks dashboard at https://liveblocks.io/dashboard/apikeys.`
     );
   }
 }

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -678,43 +678,37 @@ describe("useInboxNotifications: pagination", () => {
   test("should load the next page of data when `fetchMore` is called", async () => {
     const roomId = nanoid();
 
-    const threadOne = dummyThreadData({
-      roomId,
-      createdAt: new Date("2021-01-01T00:00:00Z"),
-    });
-    const threadTwo = dummyThreadData({
-      roomId,
-      createdAt: new Date("2021-01-02T00:00:00Z"),
-    });
-    const threadThree = dummyThreadData({
-      roomId,
-      createdAt: new Date("2021-01-03T00:00:00Z"),
-    });
+    const thread1 = dummyThreadData({ roomId, createdAt: new Date("2021-01-01") }); // prettier-ignore
+    const thread2 = dummyThreadData({ roomId, createdAt: new Date("2021-01-02") }); // prettier-ignore
+    const thread3 = dummyThreadData({ roomId, createdAt: new Date("2021-01-03") }); // prettier-ignore
 
-    const inboxNotificationsPageOne = [
+    const inboxNotificationsPage1 = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threadOne.id,
+        threadId: thread1.id,
+        notifiedAt: new Date("2021-01-03"),
       }),
     ];
 
-    const inboxNotificationsPageTwo = [
+    const inboxNotificationsPage2 = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threadTwo.id,
+        threadId: thread2.id,
+        notifiedAt: new Date("2021-01-02"),
       }),
     ];
 
-    const inboxNotificationsPageThree = [
+    const inboxNotificationsPage3 = [
       dummyThreadInboxNotificationData({
         roomId,
-        threadId: threadThree.id,
+        threadId: thread3.id,
+        notifiedAt: new Date("2021-01-01"),
       }),
     ];
 
-    let isPageOneRequested = false;
-    let isPageTwoRequested = false;
-    let isPageThreeRequested = false;
+    let isPage1Requested = false;
+    let isPage2Requested = false;
+    let isPage3Requested = false;
 
     server.use(
       mockGetInboxNotifications(async (req, res, ctx) => {
@@ -723,11 +717,11 @@ describe("useInboxNotifications: pagination", () => {
 
         // Request for Page 2
         if (cursor === "cursor-1") {
-          isPageTwoRequested = true;
+          isPage2Requested = true;
           return res(
             ctx.json({
-              threads: [threadTwo],
-              inboxNotifications: inboxNotificationsPageTwo,
+              threads: [thread2],
+              inboxNotifications: inboxNotificationsPage2,
               meta: {
                 requestedAt: new Date().toISOString(),
                 nextCursor: "cursor-2",
@@ -737,11 +731,11 @@ describe("useInboxNotifications: pagination", () => {
         }
         // Request for Page 3
         else if (cursor === "cursor-2") {
-          isPageThreeRequested = true;
+          isPage3Requested = true;
           return res(
             ctx.json({
-              threads: [threadThree],
-              inboxNotifications: inboxNotificationsPageThree,
+              threads: [thread3],
+              inboxNotifications: inboxNotificationsPage3,
               meta: {
                 requestedAt: new Date().toISOString(),
                 nextCursor: "cursor-3",
@@ -751,11 +745,11 @@ describe("useInboxNotifications: pagination", () => {
         }
         // Request for the first page
         else {
-          isPageOneRequested = true;
+          isPage1Requested = true;
           return res(
             ctx.json({
-              threads: [threadOne],
-              inboxNotifications: inboxNotificationsPageOne,
+              threads: [thread1],
+              inboxNotifications: inboxNotificationsPage1,
               meta: {
                 requestedAt: new Date().toISOString(),
                 nextCursor: "cursor-1",
@@ -783,11 +777,11 @@ describe("useInboxNotifications: pagination", () => {
     expect(result.current).toEqual({ isLoading: true });
 
     // Initial load (Page 1)
-    await waitFor(() => expect(isPageOneRequested).toBe(true));
+    await waitFor(() => expect(isPage1Requested).toBe(true));
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
-        inboxNotifications: [...inboxNotificationsPageOne],
+        inboxNotifications: [...inboxNotificationsPage1],
         fetchMore: expect.any(Function),
         isFetchingMore: false,
         hasFetchedAll: false,
@@ -799,13 +793,13 @@ describe("useInboxNotifications: pagination", () => {
 
     // Fetch Page 2
     fetchMore();
-    await waitFor(() => expect(isPageTwoRequested).toBe(true));
+    await waitFor(() => expect(isPage2Requested).toBe(true));
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
         inboxNotifications: [
-          ...inboxNotificationsPageOne,
-          ...inboxNotificationsPageTwo,
+          ...inboxNotificationsPage1,
+          ...inboxNotificationsPage2,
         ],
         fetchMore: expect.any(Function),
         isFetchingMore: false,
@@ -816,14 +810,14 @@ describe("useInboxNotifications: pagination", () => {
 
     // Fetch Page 3
     fetchMore();
-    await waitFor(() => expect(isPageThreeRequested).toBe(true));
+    await waitFor(() => expect(isPage3Requested).toBe(true));
     await waitFor(() =>
       expect(result.current).toEqual({
         isLoading: false,
         inboxNotifications: [
-          ...inboxNotificationsPageOne,
-          ...inboxNotificationsPageTwo,
-          ...inboxNotificationsPageThree,
+          ...inboxNotificationsPage1,
+          ...inboxNotificationsPage2,
+          ...inboxNotificationsPage3,
         ],
         fetchMore: expect.any(Function),
         isFetchingMore: false,


### PR DESCRIPTION
This PR will update the validation of the provided secret key value in the Node client, by providing a more helpful error message if invalid chars (like `…`) are copy/pasted in there accidentally.

Fixes #1909.
