### PR TITLE
Find a way to properly downcast client metadata type

### DIFF
--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -1,3 +1,5 @@
+import { kInternal } from "@liveblocks/core";
+
 import { ThreadDB } from "../../ThreadDB";
 import { UmbrellaStore } from "../../umbrella-store";
 
@@ -11,7 +13,13 @@ const empty = {
   versionsByRoomId: {},
 } as const;
 
-const NO_CLIENT = "not passing in a real client in this unit test" as any;
+const NO_CLIENT = {
+  [kInternal]: {
+    as() {
+      return NO_CLIENT;
+    },
+  },
+} as any;
 
 const loading = { isLoading: true };
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1,6 +1,8 @@
 import type {
   AsyncResult,
   BaseMetadata,
+  BaseUserMeta,
+  Client,
   CommentData,
   CommentReaction,
   CommentUserReaction,
@@ -537,7 +539,7 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
 };
 
 export class UmbrellaStore<M extends BaseMetadata> {
-  private _client: OpaqueClient;
+  private _client: Client<BaseUserMeta, M>;
 
   // Raw threads DB (without any optimistic updates applied)
   private _rawThreadsDB: ThreadDB<M>;
@@ -560,13 +562,13 @@ export class UmbrellaStore<M extends BaseMetadata> {
   private _userThreads: Map<string, PaginatedResource> = new Map();
 
   constructor(client: OpaqueClient) {
-    this._client = client;
+    this._client = client[kInternal].as<M>();
 
     const inboxFetcher = async (cursor?: string) => {
-      const result = await client.getInboxNotifications({ cursor });
+      const result = await this._client.getInboxNotifications({ cursor });
 
       this.updateThreadsAndNotifications(
-        result.threads as ThreadData<M>[], // TODO: Figure out how to remove this casting
+        result.threads,
         result.inboxNotifications
       );
 
@@ -1296,7 +1298,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }
 
     this.updateThreadsAndNotifications(
-      result.threads.updated as ThreadData<M>[],
+      result.threads.updated,
       result.inboxNotifications.updated,
       result.threads.deleted,
       result.inboxNotifications.deleted
@@ -1319,7 +1321,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
       const result = await room.getThreads({ cursor, query });
       this.updateThreadsAndNotifications(
-        result.threads as ThreadData<M>[], // TODO: Figure out how to remove this casting
+        result.threads,
         result.inboxNotifications
       );
 
@@ -1375,7 +1377,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     });
 
     this.updateThreadsAndNotifications(
-      updates.threads.updated as ThreadData<M>[],
+      updates.threads.updated,
       updates.inboxNotifications.updated,
       updates.threads.deleted,
       updates.inboxNotifications.deleted
@@ -1396,7 +1398,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
         query,
       });
       this.updateThreadsAndNotifications(
-        result.threads as ThreadData<M>[], // TODO: Figure out how to remove this casting
+        result.threads,
         result.inboxNotifications
       );
 
@@ -1441,7 +1443,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }
 
     this.updateThreadsAndNotifications(
-      result.threads.updated as ThreadData<M>[],
+      result.threads.updated,
       result.inboxNotifications.updated,
       result.threads.deleted,
       result.inboxNotifications.deleted


### PR DESCRIPTION
Here's a fix for the ` as ThreadData<M>[]`-style downcasts that we have been doing in quite a few places. It relies on adding an internal function that at runtime doesn't do anything, but at the type-level can be used to safely downcast a the Client's type, so that all methods on it will be "bound" to a specific `M` (instead of `BaseMetadata`). This way, the various places where we have to cast can be removed, and it's all fully inferred. It's been on my mind for a long time to fix this.