### PR TITLE
Tweak package publish script

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -129,12 +129,3 @@ for pkgdir in "$@"; do
     echo "  - https://www.npmjs.com/package/$pkgname"
 done
 echo ""
-
-echo "==> Pushing changes to GitHub"
-if ! git push-current; then
-    err "WARNING: Could not push this branch to GitHub!"
-    err "Please manually fix that now, before writing the release notes!"
-    exit 2
-else
-    echo "Done! Please finish it off by writing a nice changelog entry on GitHub."
-fi

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -92,7 +92,7 @@ commit_to_git () {
         if [ "$PUSH_COMMIT" = "true" ]; then
             echo "==> Pushing changes to GitHub"
             if ! git push-current; then
-                echo "WARNING: Could not push this branch to GitHub!" >&2
+                echo "ERROR: Could not push this branch to GitHub!" >&2
                 echo "Please manually fix that now." >&2
                 exit 2
             else

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -111,6 +111,16 @@ jobs:
           GIT_TAG: ${{ inputs.tag }}
           GITHUB_URL: "https://github.com/liveblocks/liveblocks"
         run: |
+          echo "==> Pushing changes to GitHub"
+          if [ "$(git current-branch)" = "main" ]; then
+            if !git push origin main; then
+                err "WARNING: Could not push this branch to GitHub!"
+                err "Please manually fix that now, before writing the release notes!"
+                exit 2
+            else
+                echo "Done! Please finish it off by writing a nice changelog entry on GitHub."
+            fi
+          fi
           git tag "$GIT_TAG" -m "Release $GIT_TAG"
           git push origin "$GIT_TAG"
           BRANCH="$(git current-branch)"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -114,8 +114,8 @@ jobs:
           echo "==> Pushing changes to GitHub"
           if [ "$(git current-branch)" = "main" ]; then
             if !git push origin main; then
-                err "WARNING: Could not push this branch to GitHub!"
-                err "Please manually fix that now, before writing the release notes!"
+                echo "WARNING: Could not push this branch to GitHub!" >&2
+                echo "Please manually fix that now, before writing the release notes!" >&2
                 exit 2
             else
                 echo "Done! Please finish it off by writing a nice changelog entry on GitHub."

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -114,7 +114,7 @@ jobs:
           echo "==> Pushing changes to GitHub"
           if [ "$(git current-branch)" = "main" ]; then
             if !git push origin main; then
-                echo "WARNING: Could not push this branch to GitHub!" >&2
+                echo "ERROR: Could not push this branch to GitHub!" >&2
                 echo "Please manually fix that now, before writing the release notes!" >&2
                 exit 2
             else


### PR DESCRIPTION
Only push newly created Git commit with the version bump when on `main` branch. On branches/PRs this just causes needless noise. I found myself always reverting this commit immediately after publishing a new version, to avoid merge conflicts and PR noise.
