### PR TITLE
Stabilize failing e2e test

### DIFF
--- a/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
+++ b/e2e/next-sandbox/pages/inbox-notifications/with-suspense.tsx
@@ -121,7 +121,7 @@ export default function Home() {
 }
 
 function useInboxNotificationsForThisPage() {
-  const { inboxNotifications: allInboxNotifications } = useInboxNotifications();
+  const { inboxNotifications } = useInboxNotifications();
 
   // Filter down inbox notifications to just the notifications from this room,
   // and only the ones that happened since the page was loaded. If we didn't
@@ -130,14 +130,12 @@ function useInboxNotificationsForThisPage() {
   const roomId = getRoomFromUrl();
   const [pageLoadTimestamp] = React.useState(() => Date.now());
 
-  const inboxNotifications = allInboxNotifications.filter(
+  return inboxNotifications.filter(
     (ibn) =>
       ibn.kind === "thread" &&
       ibn.roomId === roomId &&
       ibn.notifiedAt.getTime() > pageLoadTimestamp
   );
-
-  return inboxNotifications;
 }
 
 function TopPart() {

--- a/e2e/next-sandbox/test/inbox-notifications/index.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/index.test.ts
@@ -41,7 +41,7 @@ test.describe("Inbox notifications", () => {
     // Clear out any existing comments before starting the test
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
-    await waitForJson(pages, "#isSynced", true);
+    await waitForJson(pages, "#isSynced", true, { timeout: 10_000 });
 
     await waitForJson(pages, "#numOfThreads", 0, { timeout: 10_000 });
 
@@ -57,7 +57,7 @@ test.describe("Inbox notifications", () => {
 
       // Await confirmation for the thread creation from the server
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true);
+      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
 
       const replyComposer = page1
         .locator(".lb-thread-composer")
@@ -71,7 +71,7 @@ test.describe("Inbox notifications", () => {
         .click();
       await replyComposer.press("Enter");
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true);
+      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
 
       //
       // Assert 1: two comments + one notification should show up on the other side
@@ -104,7 +104,7 @@ test.describe("Inbox notifications", () => {
       await replyComposer.fill("Cool stuff");
       await replyComposer.press("Enter");
       await waitForJson(page2, "#isSynced", false);
-      await waitForJson(page2, "#isSynced", true);
+      await waitForJson(page2, "#isSynced", true, { timeout: 10_000 });
 
       //
       // Assert 1: Marc's reply will show up on the other side and also create a notification for Vincent

--- a/e2e/next-sandbox/test/inbox-notifications/index.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/index.test.ts
@@ -1,8 +1,9 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
-import { genRoomId, preparePage, sleep, waitForJson } from "../utils";
+import { genRoomId, preparePage, waitForJson } from "../utils";
 
+const SLOW = { timeout: 20_000 };
 const TEST_URL = "http://localhost:3007/inbox-notifications";
 
 test.describe("Inbox notifications", () => {
@@ -35,15 +36,15 @@ test.describe("Inbox notifications", () => {
     //
 
     // Wait until the pages are loaded
-    await waitForJson(page1, "#name", "Vincent D.", { timeout: 10_000 });
-    await waitForJson(page2, "#name", "Marc B.", { timeout: 10_000 });
+    await waitForJson(page1, "#name", "Vincent D.", SLOW);
+    await waitForJson(page2, "#name", "Marc B.", SLOW);
 
     // Clear out any existing comments before starting the test
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
-    await waitForJson(pages, "#isSynced", true, { timeout: 10_000 });
+    await waitForJson(pages, "#isSynced", true, SLOW);
 
-    await waitForJson(pages, "#numOfThreads", 0, { timeout: 10_000 });
+    await waitForJson(pages, "#numOfThreads", 0, SLOW);
 
     //
     // Action 1: create a thread and a ping
@@ -57,7 +58,7 @@ test.describe("Inbox notifications", () => {
 
       // Await confirmation for the thread creation from the server
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
+      await waitForJson(page1, "#isSynced", true, SLOW);
 
       const replyComposer = page1
         .locator(".lb-thread-composer")
@@ -71,14 +72,14 @@ test.describe("Inbox notifications", () => {
         .click();
       await replyComposer.press("Enter");
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
+      await waitForJson(page1, "#isSynced", true, SLOW);
 
       //
       // Assert 1: two comments + one notification should show up on the other side
       //
       // Synchronize
       await waitForJson(pages, "#numOfThreads", 1);
-      await waitForJson(pages, "#numOfComments", 2);
+      await waitForJson(pages, "#numOfComments", 2, SLOW);
       await waitForJson(page1, "#numOfNotifications", 0);
       await waitForJson(page2, "#numOfNotifications", 1);
 
@@ -104,15 +105,14 @@ test.describe("Inbox notifications", () => {
       await replyComposer.fill("Cool stuff");
       await replyComposer.press("Enter");
       await waitForJson(page2, "#isSynced", false);
-      await waitForJson(page2, "#isSynced", true, { timeout: 10_000 });
+      await waitForJson(page2, "#isSynced", true, SLOW);
 
       //
       // Assert 1: Marc's reply will show up on the other side and also create a notification for Vincent
       //
       await waitForJson(pages, "#numOfThreads", 1);
-      await waitForJson(pages, "#numOfComments", 3);
-      await waitForJson(page1, "#numOfNotifications", 1);
-      await waitForJson(page2, "#numOfNotifications", 1);
+      await waitForJson(pages, "#numOfComments", 3, SLOW);
+      await waitForJson(pages, "#numOfNotifications", 1);
 
       // The two comments (on the left)
       await expect(page1.locator("#left")).toContainText("Cool stuff");

--- a/e2e/next-sandbox/test/inbox-notifications/index.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/index.test.ts
@@ -41,6 +41,7 @@ test.describe("Inbox notifications", () => {
     // Clear out any existing comments before starting the test
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
+    await waitForJson(pages, "#isSynced", true);
 
     await waitForJson(pages, "#numOfThreads", 0, { timeout: 10_000 });
 
@@ -55,7 +56,7 @@ test.describe("Inbox notifications", () => {
       await newThreadComposer.press("Enter");
 
       // Await confirmation for the thread creation from the server
-      await sleep(100);
+      await waitForJson(page1, "#isSynced", false);
       await waitForJson(page1, "#isSynced", true);
 
       const replyComposer = page1
@@ -69,6 +70,8 @@ test.describe("Inbox notifications", () => {
         .getByText("Marc B.")
         .click();
       await replyComposer.press("Enter");
+      await waitForJson(page1, "#isSynced", false);
+      await waitForJson(page1, "#isSynced", true);
 
       //
       // Assert 1: two comments + one notification should show up on the other side
@@ -100,6 +103,8 @@ test.describe("Inbox notifications", () => {
         .getByRole("textbox");
       await replyComposer.fill("Cool stuff");
       await replyComposer.press("Enter");
+      await waitForJson(page2, "#isSynced", false);
+      await waitForJson(page2, "#isSynced", true);
 
       //
       // Assert 1: Marc's reply will show up on the other side and also create a notification for Vincent
@@ -121,6 +126,6 @@ test.describe("Inbox notifications", () => {
     //
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
-    await sleep(250);
+    await waitForJson(pages, "#isSynced", true);
   });
 });

--- a/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
@@ -41,7 +41,7 @@ test.describe("Inbox notifications", () => {
     // Clear out any existing comments before starting the test
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
-    await waitForJson(pages, "#isSynced", true);
+    await waitForJson(pages, "#isSynced", true, { timeout: 10_000 });
 
     await waitForJson(pages, "#numOfThreads", 0, { timeout: 10_000 });
 
@@ -57,7 +57,7 @@ test.describe("Inbox notifications", () => {
 
       // Await confirmation for the thread creation from the server
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true);
+      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
 
       const replyComposer = page1
         .locator(".lb-thread-composer")
@@ -71,7 +71,7 @@ test.describe("Inbox notifications", () => {
         .click();
       await replyComposer.press("Enter");
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true);
+      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
 
       //
       // Assert 1: two comments + one notification should show up on the other side
@@ -104,7 +104,7 @@ test.describe("Inbox notifications", () => {
       await replyComposer.fill("Cool stuff");
       await replyComposer.press("Enter");
       await waitForJson(page2, "#isSynced", false);
-      await waitForJson(page2, "#isSynced", true);
+      await waitForJson(page2, "#isSynced", true, { timeout: 10_000 });
 
       //
       // Assert 1: Marc's reply will show up on the other side and also create a notification for Vincent

--- a/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
@@ -1,8 +1,9 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
-import { genRoomId, preparePage, sleep, waitForJson } from "../utils";
+import { genRoomId, preparePage, waitForJson } from "../utils";
 
+const SLOW = { timeout: 20_000 };
 const TEST_URL = "http://localhost:3007/inbox-notifications/with-suspense";
 
 test.describe("Inbox notifications", () => {
@@ -35,15 +36,15 @@ test.describe("Inbox notifications", () => {
     //
 
     // Wait until the pages are loaded
-    await waitForJson(page1, "#name", "Vincent D.", { timeout: 10_000 });
-    await waitForJson(page2, "#name", "Marc B.", { timeout: 10_000 });
+    await waitForJson(page1, "#name", "Vincent D.", SLOW);
+    await waitForJson(page2, "#name", "Marc B.", SLOW);
 
     // Clear out any existing comments before starting the test
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
-    await waitForJson(pages, "#isSynced", true, { timeout: 10_000 });
+    await waitForJson(pages, "#isSynced", true, SLOW);
 
-    await waitForJson(pages, "#numOfThreads", 0, { timeout: 10_000 });
+    await waitForJson(pages, "#numOfThreads", 0, SLOW);
 
     //
     // Action 1: create a thread and a ping
@@ -57,7 +58,7 @@ test.describe("Inbox notifications", () => {
 
       // Await confirmation for the thread creation from the server
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
+      await waitForJson(page1, "#isSynced", true, SLOW);
 
       const replyComposer = page1
         .locator(".lb-thread-composer")
@@ -71,14 +72,14 @@ test.describe("Inbox notifications", () => {
         .click();
       await replyComposer.press("Enter");
       await waitForJson(page1, "#isSynced", false);
-      await waitForJson(page1, "#isSynced", true, { timeout: 10_000 });
+      await waitForJson(page1, "#isSynced", true, SLOW);
 
       //
       // Assert 1: two comments + one notification should show up on the other side
       //
       // Synchronize
       await waitForJson(pages, "#numOfThreads", 1);
-      await waitForJson(pages, "#numOfComments", 2);
+      await waitForJson(pages, "#numOfComments", 2, SLOW);
       await waitForJson(page1, "#numOfNotifications", 0);
       await waitForJson(page2, "#numOfNotifications", 1);
 
@@ -104,15 +105,14 @@ test.describe("Inbox notifications", () => {
       await replyComposer.fill("Cool stuff");
       await replyComposer.press("Enter");
       await waitForJson(page2, "#isSynced", false);
-      await waitForJson(page2, "#isSynced", true, { timeout: 10_000 });
+      await waitForJson(page2, "#isSynced", true, SLOW);
 
       //
       // Assert 1: Marc's reply will show up on the other side and also create a notification for Vincent
       //
       await waitForJson(pages, "#numOfThreads", 1);
-      await waitForJson(pages, "#numOfComments", 3);
-      await waitForJson(page1, "#numOfNotifications", 1);
-      await waitForJson(page2, "#numOfNotifications", 1);
+      await waitForJson(pages, "#numOfComments", 3, SLOW);
+      await waitForJson(pages, "#numOfNotifications", 1);
 
       // The two comments (on the left)
       await expect(page1.locator("#left")).toContainText("Cool stuff");

--- a/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
+++ b/e2e/next-sandbox/test/inbox-notifications/with-suspense.test.ts
@@ -41,6 +41,7 @@ test.describe("Inbox notifications", () => {
     // Clear out any existing comments before starting the test
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
+    await waitForJson(pages, "#isSynced", true);
 
     await waitForJson(pages, "#numOfThreads", 0, { timeout: 10_000 });
 
@@ -55,7 +56,7 @@ test.describe("Inbox notifications", () => {
       await newThreadComposer.press("Enter");
 
       // Await confirmation for the thread creation from the server
-      await sleep(100);
+      await waitForJson(page1, "#isSynced", false);
       await waitForJson(page1, "#isSynced", true);
 
       const replyComposer = page1
@@ -69,6 +70,8 @@ test.describe("Inbox notifications", () => {
         .getByText("Marc B.")
         .click();
       await replyComposer.press("Enter");
+      await waitForJson(page1, "#isSynced", false);
+      await waitForJson(page1, "#isSynced", true);
 
       //
       // Assert 1: two comments + one notification should show up on the other side
@@ -100,6 +103,8 @@ test.describe("Inbox notifications", () => {
         .getByRole("textbox");
       await replyComposer.fill("Cool stuff");
       await replyComposer.press("Enter");
+      await waitForJson(page2, "#isSynced", false);
+      await waitForJson(page2, "#isSynced", true);
 
       //
       // Assert 1: Marc's reply will show up on the other side and also create a notification for Vincent
@@ -121,6 +126,6 @@ test.describe("Inbox notifications", () => {
     //
     await page1.locator("#delete-all-mine").click({ force: true });
     await page2.locator("#delete-all-mine").click({ force: true });
-    await sleep(250);
+    await waitForJson(pages, "#isSynced", true);
   });
 });


### PR DESCRIPTION
This is done by adding some more synchronisations before reading the DOM. It's important, after pressing a button, to first observe the "isSynced" value to flip to `false`, before flipping it to `true`. I believe sometimes it was possible for the `waitUntil()` to observe a `true` value before it got flipped to `false`, effectively not making the test wait long enough for the synchronisation to complete.

Hopefully this makes the E2E test a bit more stable! 🤞