### PR TITLE
Add more info on `LiveList` deletion delta updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.10.0 (not published yet)
+
+### `@liveblocks/client`
+
+- In storage update notifications (using
+  `room.subscribe(root, ..., { isDeep: true })`), all LiveList deletion updates
+  will now also include the item that was deleted (#2008)
+
 ## 2.9.2
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-core/src/__tests__/_updatesUtils.ts
+++ b/packages/liveblocks-core/src/__tests__/_updatesUtils.ts
@@ -32,6 +32,7 @@ export type JsonLiveListUpdateDelta<TItem extends Lson> =
   | {
       type: "delete";
       index: number;
+      deletedItem: ToJson<TItem>;
     }
   | {
       type: "set";
@@ -167,10 +168,14 @@ export function listUpdateSet<TItem extends Lson>(
   };
 }
 
-export function listUpdateDelete(index: number): JsonLiveListUpdateDelta<Lson> {
+export function listUpdateDelete(
+  index: number,
+  prev: Json
+): JsonLiveListUpdateDelta<Json> {
   return {
     type: "delete",
     index,
+    deletedItem: prev,
   };
 }
 

--- a/packages/liveblocks-core/src/__tests__/immutable.test.ts
+++ b/packages/liveblocks-core/src/__tests__/immutable.test.ts
@@ -1118,13 +1118,14 @@ describe("legacy_patchImmutableObject", () => {
     const root = new LiveObject<{ list: typeof liveList }>();
     const liveList = new LiveList<LiveObject<{ a: number }>>([]);
     liveList.push(new LiveObject({ a: 1 }));
+    liveList.push(new LiveObject({ a: 2 }));
     root.set("list", liveList);
 
     const updates: StorageUpdate[] = [
       {
         type: "LiveList",
         node: root.get("list"),
-        updates: [{ index: 1, type: "delete" }],
+        updates: [{ index: 1, type: "delete", deletedItem: liveList.get(1)! }],
       },
     ];
 
@@ -1153,7 +1154,7 @@ describe("legacy_patchImmutableObject", () => {
       {
         type: "LiveList",
         node: root.get("list"),
-        updates: [{ index: 0, type: "delete" }],
+        updates: [{ index: 0, type: "delete", deletedItem: liveList.get(0)! }],
       },
     ];
 
@@ -1176,7 +1177,9 @@ describe("legacy_patchImmutableObject", () => {
     liveList.push(new LiveObject({ a: 1 }));
     liveList.push(new LiveObject({ a: 2 }));
     liveList.push(new LiveObject({ a: 3 }));
+    const x = liveList.get(0)!;
     liveList.delete(0);
+    const y = liveList.get(0)!;
     liveList.delete(0);
     root.set("list", liveList);
 
@@ -1185,8 +1188,8 @@ describe("legacy_patchImmutableObject", () => {
         type: "LiveList",
         node: root.get("list"),
         updates: [
-          { index: 0, type: "delete" },
-          { index: 0, type: "delete" },
+          { index: 0, type: "delete", deletedItem: x },
+          { index: 0, type: "delete", deletedItem: y },
         ],
       },
     ];

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.test.ts
@@ -139,7 +139,7 @@ describe("LiveList", () => {
 
         expectUpdates([
           [listUpdate(["a"], [listUpdateInsert(0, "a")])],
-          [listUpdate([], [listUpdateDelete(0)])],
+          [listUpdate([], [listUpdateDelete(0, "a")])],
           [listUpdate(["a"], [listUpdateInsert(0, "a")])],
         ]);
       });
@@ -278,7 +278,7 @@ describe("LiveList", () => {
 
         expectUpdates([
           [listUpdate(["A", "B", "C"], [listUpdateInsert(1, "B")])],
-          [listUpdate(["A", "C"], [listUpdateDelete(1)])],
+          [listUpdate(["A", "C"], [listUpdateDelete(1, "B")])],
           [listUpdate(["A", "B", "C"], [listUpdateInsert(1, "B")])],
         ]);
       });
@@ -348,9 +348,9 @@ describe("LiveList", () => {
         room.history.redo();
 
         expectUpdates([
-          [listUpdate([], [listUpdateDelete(0)])],
+          [listUpdate([], [listUpdateDelete(0, "A")])],
           [listUpdate(["A"], [listUpdateInsert(0, "A")])],
-          [listUpdate([], [listUpdateDelete(0)])],
+          [listUpdate([], [listUpdateDelete(0, "A")])],
         ]);
       });
     });
@@ -571,7 +571,12 @@ describe("LiveList", () => {
         room.history.redo();
 
         expectUpdates([
-          [listUpdate([], [listUpdateDelete(0), listUpdateDelete(0)])],
+          [
+            listUpdate(
+              [],
+              [listUpdateDelete(0, "A"), listUpdateDelete(0, "B")]
+            ),
+          ],
           [
             listUpdate(
               ["A", "B"],
@@ -579,7 +584,12 @@ describe("LiveList", () => {
             ),
           ],
           // Because redo reverse the operations, we delete items from the end
-          [listUpdate([], [listUpdateDelete(1), listUpdateDelete(0)])],
+          [
+            listUpdate(
+              [],
+              [listUpdateDelete(1, "B"), listUpdateDelete(0, "A")]
+            ),
+          ],
         ]);
       });
     });
@@ -1402,7 +1412,7 @@ describe("LiveList", () => {
         {
           type: "LiveList",
           node: listItems,
-          updates: [{ index: 1, type: "delete" }],
+          updates: [{ index: 1, type: "delete", deletedItem: "b" }],
         },
       ]);
 
@@ -1431,9 +1441,9 @@ describe("LiveList", () => {
 
       expect(applyResult).toEqual({
         modified: {
-          node: items,
           type: "LiveList",
-          updates: [{ index: 1, type: "delete" }],
+          node: items,
+          updates: [{ index: 1, type: "delete", deletedItem: secondItem }],
         },
         reverse: [
           {


### PR DESCRIPTION
So users can see which item got deleted.

```ts
export type LiveListUpdateDelta =
  | { type: "insert"; index: number; item: Lson }
  | { type: "delete"; index: number; deletedItem: Lson }
  //                                 ^^^^^^^^^^^ ✨
  | { type: "move"; index: number; previousIndex: number; item: Lson }
  | { type: "set"; index: number; item: Lson };
```

One caveat is that the newly added `deletedItem` returns an `Lson` value (which means it can be either a JSON value, or a `LiveList`, `LiveMap`, or `LiveObject` instance). If it is such a Live structure, that node is already detached from the storage tree. Calling mutations on it will not work, or may have undefined results. However, it should still be possible to call `.toImmutable()` on it, or inspect its children.

Fixes #1965.
