### PR TITLE
Improve mention suggestions click behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### `@liveblocks/react-ui`
 
 - Improve and fix pasting rich text into the composer.
+- Improve mention suggestions click behavior.
 
 ## 2.9.2
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -544,7 +544,15 @@ const ComposerSuggestionsListItem = forwardRef<
   ComposerSuggestionsListItemProps
 >(
   (
-    { value, children, onPointerMove, onPointerDown, asChild, ...props },
+    {
+      value,
+      children,
+      onPointerMove,
+      onPointerDown,
+      onClick,
+      asChild,
+      ...props
+    },
     forwardedRef
   ) => {
     const ref = useRef<HTMLLIElement>(null);
@@ -580,21 +588,26 @@ const ComposerSuggestionsListItem = forwardRef<
       (event: PointerEvent<HTMLLIElement>) => {
         onPointerDown?.(event);
 
-        if (!event.isDefaultPrevented()) {
-          const target = event.target as HTMLElement;
+        event.preventDefault();
+        event.stopPropagation();
+      },
+      [onPointerDown]
+    );
 
-          if (target.hasPointerCapture(event.pointerId)) {
-            target.releasePointerCapture(event.pointerId);
-          }
+    const handleClick = useCallback(
+      (event: MouseEvent<HTMLLIElement>) => {
+        onClick?.(event);
 
-          if (event.button === 0 && event.ctrlKey === false) {
-            onItemSelect(value);
+        const wasDefaultPrevented = event.isDefaultPrevented();
 
-            event.preventDefault();
-          }
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (!wasDefaultPrevented) {
+          onItemSelect(value);
         }
       },
-      [onItemSelect, onPointerDown, value]
+      [onClick, onItemSelect, value]
     );
 
     return (
@@ -605,6 +618,7 @@ const ComposerSuggestionsListItem = forwardRef<
         aria-selected={isSelected || undefined}
         onPointerMove={handlePointerMove}
         onPointerDown={handlePointerDown}
+        onClick={handleClick}
         {...props}
         ref={mergedRefs}
       >


### PR DESCRIPTION
This PR switches `onPointerDown` for a regular `onClick` on mention suggestions, for more consistency with our other mention suggestions dropdowns (e.g. text editors). It also correctly prevents both events from blurring the composer or bubbling up to the composer and above.