### PR TITLE
Fix minor typos

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -1833,7 +1833,7 @@ hear from you.
 When enabled, version history will automatically create versions of your
 [Lexical](https://liveblocks.io/docs/api-reference/liveblocks-react-lexical) or
 [Yjs](/docs/api-reference/liveblocks-yjs) document and allow you to restore to
-specific verions. These components aid in displaying a list of those versions.
+specific versions. These components aid in displaying a list of those versions.
 
 ### Default components
 

--- a/guides/pages/how-to-use-liveblocks-multiplayer-undo-redo-with-redux.mdx
+++ b/guides/pages/how-to-use-liveblocks-multiplayer-undo-redo-with-redux.mdx
@@ -31,7 +31,7 @@ editing the same circle.
 - Initial state => `{ radius: "10px", color: "yellow" }`
 - User A sets the `color` to `blue` => `{ radius: "10px", color: "blue" }`
 - User B sets the `radius` to `20px` => `{ radius: "20px", color: "blue" }`
-- User A realizes that it prefered the circle in yellow and undoes **its last
+- User A realizes that it preferred the circle in yellow and undoes **its last
   modification** => `{ radius: "20px", color: "yellow" }`
 
 A yellow circle with a radius of 20px in a completely new state. **Undo/redo in

--- a/guides/pages/how-to-use-liveblocks-multiplayer-undo-redo-with-zustand.mdx
+++ b/guides/pages/how-to-use-liveblocks-multiplayer-undo-redo-with-zustand.mdx
@@ -31,7 +31,7 @@ editing the same circle.
 - Initial state => `{ radius: "10px", color: "yellow" }`
 - User A sets the `color` to `blue` => `{ radius: "10px", color: "blue" }`
 - User B sets the `radius` to `20px` => `{ radius: "20px", color: "blue" }`
-- User A realizes that it prefered the circle in yellow and undoes **its last
+- User A realizes that it preferred the circle in yellow and undoes **its last
   modification** => `{ radius: "20px", color: "yellow" }`
 
 A yellow circle with a radius of 20px in a completely new state. **Undo/redo in


### PR DESCRIPTION
This pull request includes minor typo corrections in the documentation files to improve readability and accuracy.

Typo corrections:

* [`docs/pages/api-reference/liveblocks-react-ui.mdx`](diffhunk://#diff-ef702f8ee87fbd6217e6e5ead27ca41d627f099bc2034d2b9da7bf0a80495bf5L1836-R1836): Corrected "verions" to "versions".
* [`guides/pages/how-to-use-liveblocks-multiplayer-undo-redo-with-redux.mdx`](diffhunk://#diff-b9966b21dae7324ff806a317054160a67b3aea596df5ceeaed6dc605a370be8cL34-R34): Corrected "prefered" to "preferred".
* [`guides/pages/how-to-use-liveblocks-multiplayer-undo-redo-with-zustand.mdx`](diffhunk://#diff-0118048ec883717080d5fdc2212ad1f78fd27162791305a790917ce0b34423ecL34-R34): Corrected "prefered" to "preferred".