### PR TITLE
Various attachments fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `@liveblocks/react-ui`
 
 - Upgrade dependencies.
+- Fix minor appearance issues related to attachments.
 
 ## 2.10.2
 

--- a/packages/liveblocks-react-ui/src/components/Comment.tsx
+++ b/packages/liveblocks-react-ui/src/components/Comment.tsx
@@ -455,6 +455,7 @@ export function CommentNonInteractiveFileAttachment({
   return (
     <FileAttachment
       className={classNames("lb-comment-attachment", className)}
+      allowMediaPreview={false}
       {...props}
     />
   );

--- a/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
@@ -28,6 +28,7 @@ interface AttachmentProps extends ComponentPropsWithoutRef<"div"> {
   onDeleteClick?: MouseEventHandler<HTMLButtonElement>;
   preventFocusOnDelete?: boolean;
   overrides?: Partial<Overrides>;
+  allowMediaPreview?: boolean;
 }
 
 const fileExtensionRegex = /^(.+?)(\.[^.]+)?$/;
@@ -174,14 +175,17 @@ function AttachmentVideoPreview({
 
 function AttachmentPreview({
   attachment,
+  allowMediaPreview = true,
 }: {
   attachment: CommentMixedAttachment;
+  allowMediaPreview?: boolean;
 }) {
   const isInsideRoom = useIsInsideRoom();
   const isUploaded =
     attachment.type === "attachment" || attachment.status === "uploaded";
 
   if (
+    allowMediaPreview &&
     isUploaded &&
     isInsideRoom &&
     attachment.size <= MAX_DISPLAYED_MEDIA_SIZE
@@ -298,6 +302,7 @@ export function MediaAttachment({
   onClick,
   onDeleteClick,
   preventFocusOnDelete,
+  allowMediaPreview = true,
   className,
   onKeyDown,
   ...props
@@ -332,7 +337,10 @@ export function MediaAttachment({
         ) : isError ? (
           <WarningIcon />
         ) : (
-          <AttachmentPreview attachment={attachment} />
+          <AttachmentPreview
+            attachment={attachment}
+            allowMediaPreview={allowMediaPreview}
+          />
         )}
       </div>
       <div className="lb-attachment-details">
@@ -364,6 +372,7 @@ export function FileAttachment({
   onClick,
   onDeleteClick,
   preventFocusOnDelete,
+  allowMediaPreview = true,
   className,
   onKeyDown,
   ...props
@@ -398,7 +407,10 @@ export function FileAttachment({
         ) : isError ? (
           <WarningIcon />
         ) : (
-          <AttachmentPreview attachment={attachment} />
+          <AttachmentPreview
+            attachment={attachment}
+            allowMediaPreview={allowMediaPreview}
+          />
         )}
       </div>
       <div className="lb-attachment-details">

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -1218,7 +1218,6 @@
 
   &::after {
     content: "";
-    z-index: 1;
     border-radius: inherit;
     box-shadow: var(--lb-highlight-shadow);
     pointer-events: none;


### PR DESCRIPTION
Fixes LB-1329
Fixes https://liveblocks.slack.com/archives/C02PZL7QAAW/p1730404753492929

I'd like to fix one other issue where file names are not URL decoded, but I'd prefer to fix it in the backend rather than in the packages.
![encoded](https://github.com/user-attachments/assets/35bb7343-54df-4526-acff-6231802c2f97)
