### PR TITLE
Return empty threads list if `getThreads` response was a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
-## 2.11.1
-
-### `@liveblocks/react`
-
-- Fix regression with `useThreads` that caused the hook to return an error if
-  its associated room did not exist.
-
 ## 2.11.0
 
 ### `@liveblocks/react-ui`
 
 - Upgrade dependencies.
+
+### `@liveblocks/react`
+
+- Fix regression with `useThreads` that caused the hook to return an error if
+  its associated room did not exist.
 
 ## 2.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.11.1
+
+### `@liveblocks/react`
+
+- Fix regression with `useThreads` that caused the hook to return an error if
+  its associated room did not exist.
+
 ## 2.11.0
 
 ### `@liveblocks/react-ui`


### PR DESCRIPTION
We introduced a regression in version `2.10.1` by not correctly handling 404 responses when calling `get(Room)Threads` endpoint. This PR reverts that change so that a `404` response is interpreted as an empty list of threads. One caveat (that we also had prior to 2.10.1) is that we use a fake `requestedAt` date created on the client to use for the poller. This is not ideal and would require some deeper thoughts.