### PR TITLE
Improve pasting into composers again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Upgrade dependencies.
 - Fix minor appearance issues related to attachments.
+- Fix pasting issues introduced in 2.10.0.
 
 ## 2.10.2
 

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -234,11 +234,11 @@ export function withPaste(
           return;
         }
       } catch {
-        // Fallback to inserting the non-rich text if available
-        insertData(data);
+        // Fallback to default `insertData` behavior
       }
     }
 
+    // Default `insertData` behavior
     insertData(data);
   };
 

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -93,6 +93,13 @@ function flattenListItems(node: HTMLElement): HTMLElement[] {
   return listItems;
 }
 
+function jsxTextChildren(
+  children: DeserializedNode[],
+  attrs?: ComposerBodyTextTag
+) {
+  return children.map((child) => jsx("text", attrs, child));
+}
+
 function deserialize(node: Node): DeserializedNode {
   if (node.nodeType === 3) {
     return node.textContent;
@@ -153,12 +160,13 @@ function deserialize(node: Node): DeserializedNode {
       return jsx("fragment", {}, children);
     }
 
-    return children.map((child) => jsx("text", attrs, child));
+    return jsxTextChildren(children, attrs);
   }
 
   // Guess inline marks based on styles
   if (node.nodeName === "SPAN") {
     const style = (node as HTMLElement).style;
+    const attrs: ComposerBodyTextTag = {};
 
     if (
       style.fontWeight === "bold" ||
@@ -166,12 +174,18 @@ function deserialize(node: Node): DeserializedNode {
       style.fontWeight === "800" ||
       style.fontWeight === "900"
     ) {
-      children = children.map((child) => jsx("text", { bold: true }, child));
+      attrs.bold = true;
     }
 
     if (style.fontStyle === "italic") {
-      children = children.map((child) => jsx("text", { italic: true }, child));
+      attrs.italic = true;
     }
+
+    if (style.textDecoration === "line-through") {
+      attrs.strikethrough = true;
+    }
+
+    return jsxTextChildren(children, attrs);
   }
 
   return children as DeserializedNode;

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -201,8 +201,11 @@ export function withPaste(
       }
     }
 
-    // Deserialize rich text from HTML when pasting
-    if (data.types.includes("text/html")) {
+    // Deserialize rich text from HTML when pasting (unless there's also Slate data)
+    if (
+      data.types.includes("text/html") &&
+      !data.types.includes("application/x-slate-fragment")
+    ) {
       const html = data.getData("text/html");
 
       try {


### PR DESCRIPTION
[The last round of pasting improvements](https://github.com/liveblocks/liveblocks/pull/2009) introduced a few silly mistakes (oh how I wish we could create pasting E2E tests), this PR fixes them.

In commit order:
1. When copy-pasting Slate text, we were not leveraging the Slate data and instead were using its serialized HTML form instead, which results in information loss for custom nodes like mentions but also would never match what was copied 1 to 1 (unlike the Slate data)
2. On error we now fallback to the default behavior but we were invoking it twice
3. When deserializing HTML, we now look at spans to guess non-semantic rich text (bold, italic, etc), but we were doing it in a silly way which didn't support multiple attributes on the same span and most importantly we were not doing anything in case of no attribute so we were losing all plain text nodes