### PR TITLE
Remove beta warning for @liveblocks/emails

### DIFF
--- a/docs/pages/api-reference/liveblocks-emails.mdx
+++ b/docs/pages/api-reference/liveblocks-emails.mdx
@@ -11,10 +11,6 @@ emails with [Notifications](/docs/products/notifications) and
 [webhooks](/docs/platform/webhooks). This library is only intended for use in
 your Node.js back end.
 
-<Banner type="warning" title="Package still in beta">
-  This package is currently in beta and has not been publicly released yet.
-</Banner>
-
 ## Requirements
 
 `@liveblocks/emails` requires the


### PR DESCRIPTION
Removing beta warning as it's publicly released

--- 

### TODO

- [ ] Merge after marketing push