### PR TITLE
Move anchored thread lifecycle inside `useLayouEffect` instead of `ref`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.11.1 (Yet to be published)
+
+### `@liveblocks/react-lexical`
+
+- Fix an issue with `AnchoredThreads` component not working correctly on certain
+  React versions.
+
 ## 2.11.0
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
@@ -314,7 +314,7 @@ function ThreadWrapper({
     });
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = divRef.current;
     if (el === null) return;
 

--- a/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/anchored-threads.tsx
@@ -294,6 +294,7 @@ function ThreadWrapper({
 }: ThreadWrapperProps) {
   const [editor] = useLexicalComposerContext();
   const nodes = useThreadToNodes();
+  const divRef = useRef<HTMLDivElement>(null);
 
   const activeThreads = useActiveThreads();
 
@@ -313,17 +314,19 @@ function ThreadWrapper({
     });
   }
 
-  const handleRef = useCallback(
-    (el: HTMLDivElement) => {
-      onItemAdd(thread.id, el);
-      return () => onItemRemove(thread.id);
-    },
-    [thread.id, onItemAdd, onItemRemove]
-  );
+  useEffect(() => {
+    const el = divRef.current;
+    if (el === null) return;
+
+    onItemAdd(thread.id, el);
+    return () => {
+      onItemRemove(thread.id);
+    };
+  }, [thread.id, onItemAdd, onItemRemove]);
 
   return (
     <div
-      ref={handleRef}
+      ref={divRef}
       className={classNames(
         "lb-lexical-anchored-threads-thread-container",
         className


### PR DESCRIPTION
We currently add/remove each anchored thread in a `ref` callback but ref callback, which doesn't seem to work correctly on all React versions (https://github.com/liveblocks/liveblocks/issues/2010). We now add/remove each anchored thread in a `useEffect` hook. The behavior remains the same but is more consistent overall.

```
Unexpected return value from a callback ref in div. A callback ref should not return a function.
```