### PR TITLE
Fix anchored threads lifecycle for TipTap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fix an issue with `AnchoredThreads` component not working correctly on certain
   React versions.
 
+### `@liveblocks/react-tiptap`
+
+- Fix an issue with `AnchoredThreads` component not working correctly on certain
+  React versions.
+
 ## 2.11.0
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-react-tiptap/src/comments/AnchoredThreads.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/AnchoredThreads.tsx
@@ -230,15 +230,17 @@ function ThreadWrapper({
   isActive,
   ...props
 }: ThreadWrapperProps) {
+  const divRef = useRef<HTMLDivElement>(null);
 
-  const handleRef = useCallback(
-    (el: HTMLDivElement) => {
-      onItemAdd(thread.id, el);
-      return () => onItemRemove(thread.id);
-    },
-    [thread.id, onItemAdd, onItemRemove]
-  );
+  useLayoutEffect(() => {
+    const el = divRef.current;
+    if (el === null) return;
 
+    onItemAdd(thread.id, el);
+    return () => {
+      onItemRemove(thread.id);
+    };
+  }, [onItemAdd, onItemRemove, thread.id]);
 
   function handleThreadClick() {
     onThreadClick(thread.id);
@@ -246,7 +248,7 @@ function ThreadWrapper({
 
   return (
     <div
-      ref={handleRef}
+      ref={divRef}
       className={classNames(
         "lb-tiptap-anchored-threads-thread-container",
         className


### PR DESCRIPTION
This is the exact same fix for TipTap as we had for Lexical since most of the component is similar. 