### PR TITLE
CHANGELOG — WEEK 46

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -52,9 +52,13 @@ Also, we’re introducing a way to prevent browser tabs from being closed while 
 
 - Added new canvas document type to [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit), powered by [tldraw](https://tldraw.dev/).
 
+## Dashboard
+
+- Redirect users to a specific error page on authentication failure
+
 ## Contributors
 
-ctnicholas, nvie, marcbouchenoire, nimeshnayaju
+ctnicholas, nvie, marcbouchenoire, nimeshnayaju, sugardarius
 
 # Week 45 (2024-11-08)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,13 +15,46 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 46 (2024-11-15)
 
+## v2.12.0
+
+This release adds support for tracking synchronization status of pending local changes for any part of Liveblocks. Whether you use Storage, Text Editors, Threads, or Notifications.
+
+If the client’s sync status is `synchronized`, it means all local pending changes have been persisted by our servers. If there are pending local changes in any part of Liveblocks you’re using, then the client’s sync status will be `synchronizing`.
+
+Also, we’re introducing a way to prevent browser tabs from being closed while local changes are not yet synchronized. To opt-in to this protection, enable `preventUnsavedChanges` option on the client:
+
+- In React: `<LiveblocksProvider preventUnsavedChanges />`
+- Otherwise: `createClient({ preventUnsavedChanges: true })`
+
+### `@liveblocks/client`
+
+- Add new API [`client.getSyncStatus()`](https://liveblocks.io/docs/api-reference/liveblocks-client#Client.getSyncStatus) method.
+- Add new [client config option](https://liveblocks.io/docs/api-reference/liveblocks-client#createClient): `preventUnsavedChanges`.
+- Expose `ToImmutable<T>` helper type.
+
+### `@liveblocks/react`
+
+- Add new hook [`useSyncStatus`](https://liveblocks.io/docs/api-reference/liveblocks-react#useSyncStatus) that can be used to tell whether Liveblocks is synchronizing local changes to the server. Useful to display a "Saving..." spinner in your application, when used with `useSyncStatus({ smooth: true })`.
+- Deprecated APIs:
+  - `useStorageStatus` is now deprecated in favor of `useSyncStatus`.
+
+### `@liveblocks/react-ui`
+
+- Take composers into account when the new `preventUnsavedChanges` option is set.
+
+### `@liveblocks/react-lexical`
+
+- Add new hook `useIsEditorReady` which can be used to show a skeleton UI before the editor has received the initial text from the server.
+- Deprecated APIs:
+  - `useEditorStatus` is now deprecated in favor of `useIsEditorReady` (or `useSyncStatus`).
+
 ## Examples
 
 - Added new canvas document type to [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit), powered by [tldraw](https://tldraw.dev/).
 
 ## Contributors
 
-ctnicholas
+ctnicholas, nvie, marcbouchenoire, nimeshnayaju
 
 # Week 45 (2024-11-08)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,13 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 46 (2024-11-15)
 
+## Examples
+
+- Added new canvas document type to [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit), powered by [tldraw](https://tldraw.dev/).
+
 ## Contributors
+
+ctnicholas
 
 # Week 45 (2024-11-08)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -17,9 +17,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ## v2.12.0
 
-This release adds support for tracking synchronization status of pending local changes for any part of Liveblocks. Whether you use Storage, Text Editors, Threads, or Notifications.
-
-If the client’s sync status is `synchronized`, it means all local pending changes have been persisted by our servers. If there are pending local changes in any part of Liveblocks you’re using, then the client’s sync status will be `synchronizing`.
+This release adds support for tracking synchronization status of pending local changes for any part of Liveblocks. Whether you use Storage, Text Editors, Threads, or Notifications. If the client’s sync status is `synchronized`, it means all local pending changes have been persisted by our servers. If there are pending local changes in any part of Liveblocks you’re using, then the client’s sync status will be `synchronizing`.
 
 Also, we’re introducing a way to prevent browser tabs from being closed while local changes are not yet synchronized. To opt-in to this protection, enable `preventUnsavedChanges` option on the client:
 
@@ -29,12 +27,13 @@ Also, we’re introducing a way to prevent browser tabs from being closed while 
 ### `@liveblocks/client`
 
 - Add new API [`client.getSyncStatus()`](https://liveblocks.io/docs/api-reference/liveblocks-client#Client.getSyncStatus) method.
-- Add new [client config option](https://liveblocks.io/docs/api-reference/liveblocks-client#createClient): `preventUnsavedChanges`.
+- Add new client config option: [`preventUnsavedChanges`](https://liveblocks.io/docs/api-reference/liveblocks-client#prevent-users-losing-unsaved-changes).
 - Expose `ToImmutable<T>` helper type.
 
 ### `@liveblocks/react`
 
 - Add new hook [`useSyncStatus`](https://liveblocks.io/docs/api-reference/liveblocks-react#useSyncStatus) that can be used to tell whether Liveblocks is synchronizing local changes to the server. Useful to display a "Saving..." spinner in your application, when used with `useSyncStatus({ smooth: true })`.
+- Add new `LiveblocksProvider` prop: [`preventUnsavedChanges`](https://liveblocks.io/docs/api-reference/liveblocks-react#prevent-users-losing-unsaved-changes).
 - Deprecated APIs:
   - `useStorageStatus` is now deprecated in favor of `useSyncStatus`.
 
@@ -54,7 +53,7 @@ Also, we’re introducing a way to prevent browser tabs from being closed while 
 
 ## Dashboard
 
-- Redirect users to a specific error page on authentication failure
+- Redirect users to a specific error page on authentication failure.
 
 ## Contributors
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -13,6 +13,10 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 -->
 
+# Week 46 (2024-11-15)
+
+## Contributors
+
 # Week 45 (2024-11-08)
 
 ## v2.11.0


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-46/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 15th of November.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.