### PR TITLE
prosemirror node api

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -84,7 +84,7 @@ jobs:
           "packages/liveblocks-zustand" "packages/liveblocks-yjs"
           "packages/liveblocks-react-ui" "packages/liveblocks-react-lexical"
           "packages/liveblocks-node-lexical" "packages/liveblocks-react-tiptap"
-          "packages/liveblocks-emails"
+          "packages/liveblocks-emails" "packages/liveblocks-node-prosemirror"
 
       - name: Build all packages
         run: |
@@ -105,6 +105,7 @@ jobs:
           "packages/liveblocks-yjs" "packages/liveblocks-react-lexical"
           "packages/liveblocks-node-lexical" "packages/liveblocks-react-ui"
           "packages/liveblocks-react-tiptap" "packages/liveblocks-emails"
+          "packages/liveblocks-node-prosemirror"
 
       - name:
           Creating release tag, don't forget to fill the changelog if necessary!

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
             "@liveblocks/react-lexical",
             "@liveblocks/react-tiptap",
             "@liveblocks/node-lexical",
+            "@liveblocks/node-prosemirror",
             "@liveblocks/codemod",
             "@liveblocks/emails",
           ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2184,19 +2184,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@bundled-es-modules/cookie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
-      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "cookie": "^0.5.0"
+        "cookie": "^0.7.2"
       }
     },
     "node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3006,9 +3008,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.6.tgz",
-      "integrity": "sha512-yfZzps3Cso2UbM7WlxKwZQh2Hs6plrbjs1QnzQDZhK2DgyCo6D8AaHps9olkNcUFlcYERMqU3uJSp1gmy3s/qQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3961,6 +3963,10 @@
     },
     "node_modules/@liveblocks/node-lexical": {
       "resolved": "packages/liveblocks-node-lexical",
+      "link": true
+    },
+    "node_modules/@liveblocks/node-prosemirror": {
+      "resolved": "packages/liveblocks-node-prosemirror",
       "link": true
     },
     "node_modules/@liveblocks/query-parser": {
@@ -9206,9 +9212,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.7.2.tgz",
-      "integrity": "sha512-rGAH90LPMR5OIG7vuTDRw8WxDYxPXSxuGtu++mxPF+Bv7V2ijPOy3P1oyV1G3KGoS0pPiNugLh+tVLsElcx/9Q==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.9.1.tgz",
+      "integrity": "sha512-tifnLL/ARzQ6/FGEJjVwj9UT3v+pENdWHdk9x6F3X0mB1y0SeCjV21wpFLYESzwNdBPAj8NMp8Behv7dBnhIfw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9218,14 +9224,85 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.9.1.tgz",
+      "integrity": "sha512-Y0jZxc/pdkvcsftmEZFyG+73um8xrx6/DMfgUcNg3JAM63CISedNcr+OEI11L0oFk1KFT7/aQ9996GM6Kubdqg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.9.1.tgz",
+      "integrity": "sha512-e2P1zGpnnt4+TyxTC5pX/lPxPasZcuHCYXY0iwQ3bf8qRQQEjDfj3X7EI+cXqILtnhOiviEOcYmeu5op2WhQDg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.7.2.tgz",
-      "integrity": "sha512-U4LjkVDrJZEfWeZai8AYT7GaI6d7gzLm7Z7bSzZ0sH5fOry2qkwLycRDI9YZlM95yaVIVB5GE93lrgDS5mOP3A==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.9.1.tgz",
+      "integrity": "sha512-DWUF6NG08/bZDWw0jCeotSTvpkyqZTi4meJPomG9Wzs/Ol7mEwlNCsCViD999g0+IjyXFatBk4DfUq1YDDu++Q==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.9.1.tgz",
+      "integrity": "sha512-0hizL/0j9PragJObjAWUVSuGhN1jKjCFnhLQVRxtx4HutcvS/lhoWMvFg6ZF8xqWgIa06n6A7MaknQkqhTdhKA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.9.1.tgz",
+      "integrity": "sha512-WQqcVGe7i/E+yO3wz5XQteU1ETNZ00euUEl4ylVVmH2NM4Dh0KDjEhbhHlCM0iCfLUo7jhjC7dmS+hMdPUb+Tg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.9.1.tgz",
+      "integrity": "sha512-A/50wPWDqEUUUPhrwRKILP5gXMO5UlQ0F6uBRGYB9CEVOREam9yIgvONOnZVJtszHqOayjIVMXbH/JMBeq11/g==",
+      "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9266,10 +9343,39 @@
         "y-prosemirror": "^1.2.11"
       }
     },
+    "node_modules/@tiptap/extension-document": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.9.1.tgz",
+      "integrity": "sha512-1a+HCoDPnBttjqExfYLwfABq8MYdiowhy/wp8eCxVb6KGFEENO53KapstISvPzqH7eOi+qRjBB1KtVYb/ZXicg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.9.1.tgz",
+      "integrity": "sha512-wJZspSmJRkDBtPkzFz1g7gvZOEOayk8s93UHsgbJxcV4VWHYleZ5XhT74sZunSjefNDm3qC6v2BSgLp3vNHVKQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.7.2.tgz",
-      "integrity": "sha512-1z/kluQUQP3JmWb7vrC/ERi79lNuQegU6WRptRgSSQhFxeDPQX9CBK3I7HYy9bvSxnIa1/3GrKzL6gfaKU8WDA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.9.1.tgz",
+      "integrity": "sha512-MxZ7acNNsoNaKpetxfwi3Z11Bgrh0T2EJlCV77v9N1vWK38+st3H1WJanmLbPNtc2ocvhHJrz+DjDz3CWxQ9rQ==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -9283,10 +9389,181 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.9.1.tgz",
+      "integrity": "sha512-jsRBmX01vr+5H02GljiHMo0n5H1vzoMLmFarxe0Yq2d2l9G/WV2VWX2XnGliqZAYWd1bI0phs7uLQIN3mxGQTw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.9.1.tgz",
+      "integrity": "sha512-fCuaOD/b7nDjm47PZ58oanq7y4ccS2wjPh42Qm0B0yipu/1fmC8eS1SmaXmk28F89BLtuL6uOCtR1spe+lZtlQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.9.1.tgz",
+      "integrity": "sha512-SjZowzLixOFaCrV2cMaWi1mp8REK0zK1b3OcVx7bCZfVSmsOETJyrAIUpCKA8o60NwF7pwhBg0MN8oXlNKMeFw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-history": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.9.1.tgz",
+      "integrity": "sha512-wp9qR1NM+LpvyLZFmdNaAkDq0d4jDJ7z7Fz7icFQPu31NVxfQYO3IXNmvJDCNu8hFAbImpA5aG8MBuwzRo0H9w==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.9.1.tgz",
+      "integrity": "sha512-ydUhABeaBI1CoJp+/BBqPhXINfesp1qMNL/jiDcMsB66fsD4nOyphpAJT7FaRFZFtQVF06+nttBtFZVkITQVqg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.9.1.tgz",
+      "integrity": "sha512-VkNA6Vz96+/+7uBlsgM7bDXXx4b62T1fDam/3UKifA72aD/fZckeWrbT7KrtdUbzuIniJSbA0lpTs5FY29+86Q==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.9.1.tgz",
+      "integrity": "sha512-6O4NtYNR5N2Txi4AC0/4xMRJq9xd4+7ShxCZCDVL0WDVX37IhaqMO7LGQtA6MVlYyNaX4W1swfdJaqrJJ5HIUw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.9.1.tgz",
+      "integrity": "sha512-6J9jtv1XP8dW7/JNSH/K4yiOABc92tBJtgCsgP8Ep4+fjfjdj4HbjS1oSPWpgItucF2Fp/VF8qg55HXhjxHjTw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.9.1.tgz",
+      "integrity": "sha512-JOmT0xd4gd3lIhLwrsjw8lV+ZFROKZdIxLi0Ia05XSu4RLrrvWj0zdKMSB+V87xOWfSB3Epo95zAvnPox5Q16A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.9.1.tgz",
+      "integrity": "sha512-V5aEXdML+YojlPhastcu7w4biDPwmzy/fWq0T2qjfu5Te/THcqDmGYVBKESBm5x6nBy5OLkanw2O+KHu2quDdg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.9.1.tgz",
+      "integrity": "sha512-3wo9uCrkLVLQFgbw2eFU37QAa1jq1/7oExa+FF/DVxdtHRS9E2rnUZ8s2hat/IWzvPUHXMwo3Zg2XfhoamQpCA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.9.1.tgz",
+      "integrity": "sha512-LAxc0SeeiPiAVBwksczeA7BJSZb6WtVpYhy5Esvy9K0mK5kttB4KxtnXWeQzMIJZQbza65yftGKfQlexf/Y7yg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
     "node_modules/@tiptap/pm": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.7.2.tgz",
-      "integrity": "sha512-RiRPlwpuE6IHDJytE0tglbFlWELOaqeyGRGv25wBTjzV1plnqC5B3U65XY/8kKuuLjdd3NpRfR68DXBafusSBg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.9.1.tgz",
+      "integrity": "sha512-mvV86fr7kEuDYEApQ2uMPCKL2uagUE0BsXiyyz3KOkY1zifyVm1fzdkscb24Qy1GmLzWAIIihA+3UHNRgYdOlQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9307,7 +9584,7 @@
         "prosemirror-tables": "^1.4.0",
         "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.0",
-        "prosemirror-view": "^1.33.10"
+        "prosemirror-view": "^1.34.3"
       },
       "funding": {
         "type": "github",
@@ -9315,13 +9592,13 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.7.2.tgz",
-      "integrity": "sha512-4d1TQMRHtqagCarty1iQIJMLYZ2YzBHBgAt4HlPeoDUI4MHZutOIdkl1UXmxZwh/d5p6a+tZGTVOV4aKXMW2Iw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.9.1.tgz",
+      "integrity": "sha512-LQJ34ZPfXtJF36SZdcn4Fiwsl2WxZ9YRJI87OLnsjJ45O+gV/PfBzz/4ap+LF8LOS0AbbGhTTjBOelPoNm+aYA==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.7.2",
-        "@tiptap/extension-floating-menu": "^2.7.2",
+        "@tiptap/extension-bubble-menu": "^2.9.1",
+        "@tiptap/extension-floating-menu": "^2.9.1",
         "@types/use-sync-external-store": "^0.0.6",
         "fast-deep-equal": "^3",
         "use-sync-external-store": "^1.2.2"
@@ -9350,6 +9627,40 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.9.1.tgz",
+      "integrity": "sha512-nsw6UF/7wDpPfHRhtGOwkj1ipIEiWZS1VGw+c14K61vM1CNj0uQ4jogbHwHZqN1dlL5Hh+FCqUHDPxG6ECbijg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tiptap/core": "^2.9.1",
+        "@tiptap/extension-blockquote": "^2.9.1",
+        "@tiptap/extension-bold": "^2.9.1",
+        "@tiptap/extension-bullet-list": "^2.9.1",
+        "@tiptap/extension-code": "^2.9.1",
+        "@tiptap/extension-code-block": "^2.9.1",
+        "@tiptap/extension-document": "^2.9.1",
+        "@tiptap/extension-dropcursor": "^2.9.1",
+        "@tiptap/extension-gapcursor": "^2.9.1",
+        "@tiptap/extension-hard-break": "^2.9.1",
+        "@tiptap/extension-heading": "^2.9.1",
+        "@tiptap/extension-history": "^2.9.1",
+        "@tiptap/extension-horizontal-rule": "^2.9.1",
+        "@tiptap/extension-italic": "^2.9.1",
+        "@tiptap/extension-list-item": "^2.9.1",
+        "@tiptap/extension-ordered-list": "^2.9.1",
+        "@tiptap/extension-paragraph": "^2.9.1",
+        "@tiptap/extension-strike": "^2.9.1",
+        "@tiptap/extension-text": "^2.9.1",
+        "@tiptap/extension-text-style": "^2.9.1",
+        "@tiptap/pm": "^2.9.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
       }
     },
     "node_modules/@tiptap/suggestion": {
@@ -9915,11 +10226,36 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
       "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -18312,9 +18648,10 @@
       "peer": true
     },
     "node_modules/lib0": {
-      "version": "0.2.93",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.93.tgz",
-      "integrity": "sha512-M5IKsiFJYulS+8Eal8f+zAqf5ckm1vffW0fFDxfgxJ+uiVopvDdd3PxJmz0GsVi3YNO7QCFSq0nAsiDmNhLj9Q==",
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
+      "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -21454,12 +21791,13 @@
       }
     },
     "node_modules/prosemirror-markdown": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.0.tgz",
-      "integrity": "sha512-UziddX3ZYSYibgx8042hfGKmukq5Aljp2qoBiJRejD/8MH70siQNz5RB1TrdTPheqLMy4aCe4GYNF10/3lQS5g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.1.tgz",
+      "integrity": "sha512-Sl+oMfMtAjWtlcZoj/5L/Q39MpEnVZ840Xo330WJWUvgyhNmLBLN7MsHn07s53nG/KImevWHSE6fEj4q/GihHw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
         "prosemirror-model": "^1.20.0"
       }
@@ -26378,11 +26716,12 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.18",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
-      "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
+      "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.86"
+        "lib0": "^0.2.98"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -26872,6 +27211,283 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "packages/liveblocks-node-prosemirror": {
+      "name": "@liveblocks/node-prosemirror",
+      "version": "2.11.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@liveblocks/core": "2.11.0",
+        "@liveblocks/node": "2.11.0",
+        "yjs": "^13.6.20"
+      },
+      "devDependencies": {
+        "@liveblocks/eslint-config": "*",
+        "@liveblocks/jest-config": "*",
+        "@types/node": "^20.14.8",
+        "msw": "^2.6.4"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^2.9.1",
+        "@tiptap/react": "^2.9.1",
+        "@tiptap/starter-kit": "^2.9.1",
+        "prosemirror-markdown": "^1.13.1",
+        "y-prosemirror": "^1.2.12",
+        "yjs": "^13.6.20"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@inquirer/confirm": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
+      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@inquirer/core": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
+      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@inquirer/type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@mswjs/interceptors": {
+      "version": "0.36.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
+      "integrity": "sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/@types/node": {
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/msw": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.6.4.tgz",
+      "integrity": "sha512-Pm4LmWQeytDsNCR+A7gt39XAdtH6zQb6jnIKRig0FlvYOn8eksn3s1nXxUfz5KYUjbckof7Z4p2ewzgffPoCbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.36.5",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/liveblocks-node-prosemirror/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/liveblocks-node/node_modules/@mswjs/cookies": {
@@ -33616,18 +34232,18 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@bundled-es-modules/cookie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
-      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
       "dev": true,
       "requires": {
-        "cookie": "^0.5.0"
+        "cookie": "^0.7.2"
       },
       "dependencies": {
         "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+          "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
           "dev": true
         }
       }
@@ -34058,9 +34674,9 @@
       }
     },
     "@inquirer/figures": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.6.tgz",
-      "integrity": "sha512-yfZzps3Cso2UbM7WlxKwZQh2Hs6plrbjs1QnzQDZhK2DgyCo6D8AaHps9olkNcUFlcYERMqU3uJSp1gmy3s/qQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
       "dev": true
     },
     "@inquirer/type": {
@@ -36233,6 +36849,186 @@
           "dev": true,
           "requires": {
             "undici-types": "~5.26.4"
+          }
+        }
+      }
+    },
+    "@liveblocks/node-prosemirror": {
+      "version": "file:packages/liveblocks-node-prosemirror",
+      "requires": {
+        "@liveblocks/core": "2.11.0",
+        "@liveblocks/eslint-config": "*",
+        "@liveblocks/jest-config": "*",
+        "@liveblocks/node": "2.11.0",
+        "@types/node": "^20.14.8",
+        "msw": "^2.6.4",
+        "yjs": "^13.6.20"
+      },
+      "dependencies": {
+        "@inquirer/confirm": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
+          "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
+          "dev": true,
+          "requires": {
+            "@inquirer/core": "^10.1.0",
+            "@inquirer/type": "^3.0.1"
+          }
+        },
+        "@inquirer/core": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
+          "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
+          "dev": true,
+          "requires": {
+            "@inquirer/figures": "^1.0.8",
+            "@inquirer/type": "^3.0.1",
+            "ansi-escapes": "^4.3.2",
+            "cli-width": "^4.1.0",
+            "mute-stream": "^2.0.0",
+            "signal-exit": "^4.1.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^6.2.0",
+            "yoctocolors-cjs": "^2.1.2"
+          }
+        },
+        "@inquirer/type": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+          "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+          "dev": true,
+          "requires": {}
+        },
+        "@mswjs/interceptors": {
+          "version": "0.36.10",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
+          "integrity": "sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==",
+          "dev": true,
+          "requires": {
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/logger": "^0.3.0",
+            "@open-draft/until": "^2.0.0",
+            "is-node-process": "^1.2.0",
+            "outvariant": "^1.4.3",
+            "strict-event-emitter": "^0.5.1"
+          }
+        },
+        "@open-draft/until": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+          "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+          "dev": true
+        },
+        "@types/cookie": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+          "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+          "dev": true
+        },
+        "@types/node": {
+          "version": "20.17.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+          "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~6.19.2"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+          "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+          "dev": true
+        },
+        "headers-polyfill": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+          "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+          "dev": true
+        },
+        "msw": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.6.4.tgz",
+          "integrity": "sha512-Pm4LmWQeytDsNCR+A7gt39XAdtH6zQb6jnIKRig0FlvYOn8eksn3s1nXxUfz5KYUjbckof7Z4p2ewzgffPoCbg==",
+          "dev": true,
+          "requires": {
+            "@bundled-es-modules/cookie": "^2.0.1",
+            "@bundled-es-modules/statuses": "^1.0.1",
+            "@bundled-es-modules/tough-cookie": "^0.1.6",
+            "@inquirer/confirm": "^5.0.0",
+            "@mswjs/interceptors": "^0.36.5",
+            "@open-draft/deferred-promise": "^2.2.0",
+            "@open-draft/until": "^2.1.0",
+            "@types/cookie": "^0.6.0",
+            "@types/statuses": "^2.0.4",
+            "chalk": "^4.1.2",
+            "graphql": "^16.8.1",
+            "headers-polyfill": "^4.0.2",
+            "is-node-process": "^1.2.0",
+            "outvariant": "^1.4.3",
+            "path-to-regexp": "^6.3.0",
+            "strict-event-emitter": "^0.5.1",
+            "type-fest": "^4.26.1",
+            "yargs": "^17.7.2"
+          }
+        },
+        "mute-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+          "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "strict-event-emitter": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+          "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "4.26.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+          "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "5.6.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+          "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "undici-types": {
+          "version": "6.19.8",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -40936,18 +41732,53 @@
       }
     },
     "@tiptap/core": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.7.2.tgz",
-      "integrity": "sha512-rGAH90LPMR5OIG7vuTDRw8WxDYxPXSxuGtu++mxPF+Bv7V2ijPOy3P1oyV1G3KGoS0pPiNugLh+tVLsElcx/9Q==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.9.1.tgz",
+      "integrity": "sha512-tifnLL/ARzQ6/FGEJjVwj9UT3v+pENdWHdk9x6F3X0mB1y0SeCjV21wpFLYESzwNdBPAj8NMp8Behv7dBnhIfw==",
+      "requires": {}
+    },
+    "@tiptap/extension-blockquote": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.9.1.tgz",
+      "integrity": "sha512-Y0jZxc/pdkvcsftmEZFyG+73um8xrx6/DMfgUcNg3JAM63CISedNcr+OEI11L0oFk1KFT7/aQ9996GM6Kubdqg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-bold": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.9.1.tgz",
+      "integrity": "sha512-e2P1zGpnnt4+TyxTC5pX/lPxPasZcuHCYXY0iwQ3bf8qRQQEjDfj3X7EI+cXqILtnhOiviEOcYmeu5op2WhQDg==",
+      "peer": true,
       "requires": {}
     },
     "@tiptap/extension-bubble-menu": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.7.2.tgz",
-      "integrity": "sha512-U4LjkVDrJZEfWeZai8AYT7GaI6d7gzLm7Z7bSzZ0sH5fOry2qkwLycRDI9YZlM95yaVIVB5GE93lrgDS5mOP3A==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.9.1.tgz",
+      "integrity": "sha512-DWUF6NG08/bZDWw0jCeotSTvpkyqZTi4meJPomG9Wzs/Ol7mEwlNCsCViD999g0+IjyXFatBk4DfUq1YDDu++Q==",
       "requires": {
         "tippy.js": "^6.3.7"
       }
+    },
+    "@tiptap/extension-bullet-list": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.9.1.tgz",
+      "integrity": "sha512-0hizL/0j9PragJObjAWUVSuGhN1jKjCFnhLQVRxtx4HutcvS/lhoWMvFg6ZF8xqWgIa06n6A7MaknQkqhTdhKA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-code": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.9.1.tgz",
+      "integrity": "sha512-WQqcVGe7i/E+yO3wz5XQteU1ETNZ00euUEl4ylVVmH2NM4Dh0KDjEhbhHlCM0iCfLUo7jhjC7dmS+hMdPUb+Tg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-code-block": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.9.1.tgz",
+      "integrity": "sha512-A/50wPWDqEUUUPhrwRKILP5gXMO5UlQ0F6uBRGYB9CEVOREam9yIgvONOnZVJtszHqOayjIVMXbH/JMBeq11/g==",
+      "peer": true,
+      "requires": {}
     },
     "@tiptap/extension-collaboration": {
       "version": "2.7.2",
@@ -40963,18 +41794,116 @@
       "peer": true,
       "requires": {}
     },
+    "@tiptap/extension-document": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.9.1.tgz",
+      "integrity": "sha512-1a+HCoDPnBttjqExfYLwfABq8MYdiowhy/wp8eCxVb6KGFEENO53KapstISvPzqH7eOi+qRjBB1KtVYb/ZXicg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-dropcursor": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.9.1.tgz",
+      "integrity": "sha512-wJZspSmJRkDBtPkzFz1g7gvZOEOayk8s93UHsgbJxcV4VWHYleZ5XhT74sZunSjefNDm3qC6v2BSgLp3vNHVKQ==",
+      "peer": true,
+      "requires": {}
+    },
     "@tiptap/extension-floating-menu": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.7.2.tgz",
-      "integrity": "sha512-1z/kluQUQP3JmWb7vrC/ERi79lNuQegU6WRptRgSSQhFxeDPQX9CBK3I7HYy9bvSxnIa1/3GrKzL6gfaKU8WDA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.9.1.tgz",
+      "integrity": "sha512-MxZ7acNNsoNaKpetxfwi3Z11Bgrh0T2EJlCV77v9N1vWK38+st3H1WJanmLbPNtc2ocvhHJrz+DjDz3CWxQ9rQ==",
       "requires": {
         "tippy.js": "^6.3.7"
       }
     },
+    "@tiptap/extension-gapcursor": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.9.1.tgz",
+      "integrity": "sha512-jsRBmX01vr+5H02GljiHMo0n5H1vzoMLmFarxe0Yq2d2l9G/WV2VWX2XnGliqZAYWd1bI0phs7uLQIN3mxGQTw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-hard-break": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.9.1.tgz",
+      "integrity": "sha512-fCuaOD/b7nDjm47PZ58oanq7y4ccS2wjPh42Qm0B0yipu/1fmC8eS1SmaXmk28F89BLtuL6uOCtR1spe+lZtlQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-heading": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.9.1.tgz",
+      "integrity": "sha512-SjZowzLixOFaCrV2cMaWi1mp8REK0zK1b3OcVx7bCZfVSmsOETJyrAIUpCKA8o60NwF7pwhBg0MN8oXlNKMeFw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-history": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.9.1.tgz",
+      "integrity": "sha512-wp9qR1NM+LpvyLZFmdNaAkDq0d4jDJ7z7Fz7icFQPu31NVxfQYO3IXNmvJDCNu8hFAbImpA5aG8MBuwzRo0H9w==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-horizontal-rule": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.9.1.tgz",
+      "integrity": "sha512-ydUhABeaBI1CoJp+/BBqPhXINfesp1qMNL/jiDcMsB66fsD4nOyphpAJT7FaRFZFtQVF06+nttBtFZVkITQVqg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-italic": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.9.1.tgz",
+      "integrity": "sha512-VkNA6Vz96+/+7uBlsgM7bDXXx4b62T1fDam/3UKifA72aD/fZckeWrbT7KrtdUbzuIniJSbA0lpTs5FY29+86Q==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-list-item": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.9.1.tgz",
+      "integrity": "sha512-6O4NtYNR5N2Txi4AC0/4xMRJq9xd4+7ShxCZCDVL0WDVX37IhaqMO7LGQtA6MVlYyNaX4W1swfdJaqrJJ5HIUw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-ordered-list": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.9.1.tgz",
+      "integrity": "sha512-6J9jtv1XP8dW7/JNSH/K4yiOABc92tBJtgCsgP8Ep4+fjfjdj4HbjS1oSPWpgItucF2Fp/VF8qg55HXhjxHjTw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-paragraph": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.9.1.tgz",
+      "integrity": "sha512-JOmT0xd4gd3lIhLwrsjw8lV+ZFROKZdIxLi0Ia05XSu4RLrrvWj0zdKMSB+V87xOWfSB3Epo95zAvnPox5Q16A==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-strike": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.9.1.tgz",
+      "integrity": "sha512-V5aEXdML+YojlPhastcu7w4biDPwmzy/fWq0T2qjfu5Te/THcqDmGYVBKESBm5x6nBy5OLkanw2O+KHu2quDdg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-text": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.9.1.tgz",
+      "integrity": "sha512-3wo9uCrkLVLQFgbw2eFU37QAa1jq1/7oExa+FF/DVxdtHRS9E2rnUZ8s2hat/IWzvPUHXMwo3Zg2XfhoamQpCA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@tiptap/extension-text-style": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.9.1.tgz",
+      "integrity": "sha512-LAxc0SeeiPiAVBwksczeA7BJSZb6WtVpYhy5Esvy9K0mK5kttB4KxtnXWeQzMIJZQbza65yftGKfQlexf/Y7yg==",
+      "peer": true,
+      "requires": {}
+    },
     "@tiptap/pm": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.7.2.tgz",
-      "integrity": "sha512-RiRPlwpuE6IHDJytE0tglbFlWELOaqeyGRGv25wBTjzV1plnqC5B3U65XY/8kKuuLjdd3NpRfR68DXBafusSBg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.9.1.tgz",
+      "integrity": "sha512-mvV86fr7kEuDYEApQ2uMPCKL2uagUE0BsXiyyz3KOkY1zifyVm1fzdkscb24Qy1GmLzWAIIihA+3UHNRgYdOlQ==",
       "peer": true,
       "requires": {
         "prosemirror-changeset": "^2.2.1",
@@ -40994,16 +41923,16 @@
         "prosemirror-tables": "^1.4.0",
         "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.0",
-        "prosemirror-view": "^1.33.10"
+        "prosemirror-view": "^1.34.3"
       }
     },
     "@tiptap/react": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.7.2.tgz",
-      "integrity": "sha512-4d1TQMRHtqagCarty1iQIJMLYZ2YzBHBgAt4HlPeoDUI4MHZutOIdkl1UXmxZwh/d5p6a+tZGTVOV4aKXMW2Iw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.9.1.tgz",
+      "integrity": "sha512-LQJ34ZPfXtJF36SZdcn4Fiwsl2WxZ9YRJI87OLnsjJ45O+gV/PfBzz/4ap+LF8LOS0AbbGhTTjBOelPoNm+aYA==",
       "requires": {
-        "@tiptap/extension-bubble-menu": "^2.7.2",
-        "@tiptap/extension-floating-menu": "^2.7.2",
+        "@tiptap/extension-bubble-menu": "^2.9.1",
+        "@tiptap/extension-floating-menu": "^2.9.1",
         "@types/use-sync-external-store": "^0.0.6",
         "fast-deep-equal": "^3",
         "use-sync-external-store": "^1.2.2"
@@ -41020,6 +41949,35 @@
           "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
           "requires": {}
         }
+      }
+    },
+    "@tiptap/starter-kit": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.9.1.tgz",
+      "integrity": "sha512-nsw6UF/7wDpPfHRhtGOwkj1ipIEiWZS1VGw+c14K61vM1CNj0uQ4jogbHwHZqN1dlL5Hh+FCqUHDPxG6ECbijg==",
+      "peer": true,
+      "requires": {
+        "@tiptap/core": "^2.9.1",
+        "@tiptap/extension-blockquote": "^2.9.1",
+        "@tiptap/extension-bold": "^2.9.1",
+        "@tiptap/extension-bullet-list": "^2.9.1",
+        "@tiptap/extension-code": "^2.9.1",
+        "@tiptap/extension-code-block": "^2.9.1",
+        "@tiptap/extension-document": "^2.9.1",
+        "@tiptap/extension-dropcursor": "^2.9.1",
+        "@tiptap/extension-gapcursor": "^2.9.1",
+        "@tiptap/extension-hard-break": "^2.9.1",
+        "@tiptap/extension-heading": "^2.9.1",
+        "@tiptap/extension-history": "^2.9.1",
+        "@tiptap/extension-horizontal-rule": "^2.9.1",
+        "@tiptap/extension-italic": "^2.9.1",
+        "@tiptap/extension-list-item": "^2.9.1",
+        "@tiptap/extension-ordered-list": "^2.9.1",
+        "@tiptap/extension-paragraph": "^2.9.1",
+        "@tiptap/extension-strike": "^2.9.1",
+        "@tiptap/extension-text": "^2.9.1",
+        "@tiptap/extension-text-style": "^2.9.1",
+        "@tiptap/pm": "^2.9.1"
       }
     },
     "@tiptap/suggestion": {
@@ -41527,11 +42485,33 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "peer": true
+    },
     "@types/lodash": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
       "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
+    },
+    "@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "peer": true,
+      "requires": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "peer": true
     },
     "@types/minimist": {
       "version": "1.2.2"
@@ -47297,9 +48277,9 @@
       "peer": true
     },
     "lib0": {
-      "version": "0.2.93",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.93.tgz",
-      "integrity": "sha512-M5IKsiFJYulS+8Eal8f+zAqf5ckm1vffW0fFDxfgxJ+uiVopvDdd3PxJmz0GsVi3YNO7QCFSq0nAsiDmNhLj9Q==",
+      "version": "0.2.98",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
+      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -49249,11 +50229,12 @@
       }
     },
     "prosemirror-markdown": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.0.tgz",
-      "integrity": "sha512-UziddX3ZYSYibgx8042hfGKmukq5Aljp2qoBiJRejD/8MH70siQNz5RB1TrdTPheqLMy4aCe4GYNF10/3lQS5g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.1.tgz",
+      "integrity": "sha512-Sl+oMfMtAjWtlcZoj/5L/Q39MpEnVZ840Xo330WJWUvgyhNmLBLN7MsHn07s53nG/KImevWHSE6fEj4q/GihHw==",
       "peer": true,
       "requires": {
+        "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
         "prosemirror-model": "^1.20.0"
       }
@@ -52421,11 +53402,11 @@
       "version": "21.1.1"
     },
     "yjs": {
-      "version": "13.6.18",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
-      "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
+      "version": "13.6.20",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
+      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
       "requires": {
-        "lib0": "^0.2.86"
+        "lib0": "^0.2.98"
       }
     },
     "yn": {

--- a/packages/liveblocks-node-prosemirror/.envrc
+++ b/packages/liveblocks-node-prosemirror/.envrc
@@ -1,0 +1,5 @@
+# Read the top-level .envrc file as well
+source_up
+
+# Automatically put node_modules/.bin in your $PATH
+layout node

--- a/packages/liveblocks-node-prosemirror/.eslintrc.js
+++ b/packages/liveblocks-node-prosemirror/.eslintrc.js
@@ -1,0 +1,12 @@
+const commonRestrictedSyntax = require("@liveblocks/eslint-config/restricted-syntax");
+
+module.exports = {
+  root: true,
+  extends: ["@liveblocks/eslint-config"],
+  rules: {
+    // -------------------------------
+    // Custom syntax we want to forbid
+    // -------------------------------
+    "no-restricted-syntax": ["error", ...commonRestrictedSyntax],
+  },
+};

--- a/packages/liveblocks-node-prosemirror/CHANGELOG.md
+++ b/packages/liveblocks-node-prosemirror/CHANGELOG.md
@@ -1,0 +1,1 @@
+../../CHANGELOG.md

--- a/packages/liveblocks-node-prosemirror/README.md
+++ b/packages/liveblocks-node-prosemirror/README.md
@@ -1,0 +1,17 @@
+<p align="center">
+  <a href="https://liveblocks.io#gh-light-mode-only">
+    <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/header-light.svg" alt="Liveblocks" />
+  </a>
+  <a href="https://liveblocks.io#gh-dark-mode-only">
+    <img src="https://raw.githubusercontent.com/liveblocks/liveblocks/main/.github/assets/header-dark.svg" alt="Liveblocks" />
+  </a>
+</p>
+
+# `@liveblocks/node-prosemirror`
+
+## License
+
+Licensed under the Apache License 2.0, Copyright © 2021-present
+[Liveblocks](https://liveblocks.io).
+
+See [LICENSE](../../LICENSE) for more information.

--- a/packages/liveblocks-node-prosemirror/jest.config.js
+++ b/packages/liveblocks-node-prosemirror/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('jest').Config} */
+
+const commonJestConfig = require("@liveblocks/jest-config");
+
+module.exports = {
+  // Our standard Jest configuration, used by all projects in this monorepo
+  ...commonJestConfig,
+
+  // Our standard setup assumed jsdom environment. Override it for node here.
+  testEnvironment: "node",
+};

--- a/packages/liveblocks-node-prosemirror/package.json
+++ b/packages/liveblocks-node-prosemirror/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@liveblocks/node-prosemirror",
+  "version": "2.11.0",
+  "description": "A server-side utility that lets you modify prosemirror documents hosted in Liveblocks.",
+  "license": "Apache-2.0",
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "module": "./dist/index.mjs",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist/**",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "format": "(eslint --fix src/ || true) && prettier --write src/",
+    "lint": "eslint src/",
+    "lint:package": "publint --strict && attw --pack",
+    "test": "jest --silent --verbose --color=always",
+    "test:types": "tsd",
+    "test:watch": "jest --silent --verbose --color=always --watch"
+  },
+  "dependencies": {
+    "@liveblocks/core": "2.11.0",
+    "@liveblocks/node": "2.11.0",
+    "yjs": "^13.6.20"
+  },
+  "peerDependencies": {
+    "@tiptap/pm": "^2.9.1",
+    "@tiptap/react": "^2.9.1",
+    "@tiptap/starter-kit": "^2.9.1",
+    "prosemirror-markdown": "^1.13.1",
+    "y-prosemirror": "^1.2.12",
+    "yjs": "^13.6.20"
+  },
+  "devDependencies": {
+    "@liveblocks/eslint-config": "*",
+    "@liveblocks/jest-config": "*",
+    "@types/node": "^20.14.8",
+    "msw": "^2.6.4"
+  },
+  "bugs": {
+    "url": "https://github.com/liveblocks/liveblocks/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/liveblocks/liveblocks.git",
+    "directory": "packages/liveblocks-node"
+  },
+  "homepage": "https://liveblocks.io",
+  "keywords": [
+    "node",
+    "liveblocks",
+    "real-time",
+    "toolkit",
+    "multiplayer",
+    "websockets",
+    "collaboration",
+    "collaborative",
+    "presence",
+    "crdts",
+    "synchronize",
+    "rooms",
+    "documents",
+    "conflict resolution"
+  ]
+}

--- a/packages/liveblocks-node-prosemirror/package.json
+++ b/packages/liveblocks-node-prosemirror/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liveblocks/node-prosemirror",
   "version": "2.11.0",
-  "description": "A server-side utility that lets you modify prosemirror documents hosted in Liveblocks.",
+  "description": "A server-side utility that lets you modify prosemirror and tiptap documents hosted in Liveblocks.",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/packages/liveblocks-node-prosemirror/src/__tests__/index.test.ts
+++ b/packages/liveblocks-node-prosemirror/src/__tests__/index.test.ts
@@ -1,0 +1,178 @@
+import { Liveblocks } from "@liveblocks/node";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { applyUpdate, Doc, encodeStateAsUpdate } from "yjs";
+
+import { withProsemirrorDocument } from "../document";
+
+const DEFAULT_BASE_URL = "https://api.liveblocks.io";
+
+const serverYDoc = new Doc();
+serverYDoc.getXmlFragment("default");
+let serverYdoc: Uint8Array = encodeStateAsUpdate(serverYDoc);
+
+const server = setupServer(
+  http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/ydoc-binary`, () => {
+    return HttpResponse.arrayBuffer(serverYdoc, { status: 200 });
+  }),
+  http.put(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/ydoc`, async ({ request }) => {
+    const update = new Uint8Array(await request.arrayBuffer());
+    applyUpdate(serverYDoc, update);
+    serverYdoc = encodeStateAsUpdate(serverYDoc);
+    return HttpResponse.arrayBuffer(serverYdoc, { status: 200 });
+  })
+);
+
+const client = new Liveblocks({
+  secret: "sk_this_is_just_a_test_key",
+  // @ts-expect-error hidden config
+  baseUrl: DEFAULT_BASE_URL,
+});
+
+beforeAll(() => server.listen());
+afterAll(() => server.close());
+
+describe("withLiveblocksDocument", () => {
+  test("should return an empty document to start", async () => {
+    const text = await withProsemirrorDocument<string>(
+      {
+        client,
+        roomId: "test-room",
+      },
+      (api) => {
+        return api.getText();
+      }
+    );
+    expect(text).toEqual("");
+  });
+
+  test("should update the doc", async () => {
+    const text = await withProsemirrorDocument<string>(
+      {
+        client,
+        roomId: "test-room",
+      },
+      async (api) => {
+        await api.update((_, tr) => {
+          return tr.insertText("hello");
+        });
+
+        return api.getText();
+      }
+    );
+    expect(text).toEqual("hello");
+  });
+
+  test("should set the doc and return text and JSON", async () => {
+    const exampleDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Example Text",
+            },
+          ],
+        },
+      ],
+    };
+
+    const json = await withProsemirrorDocument<string>(
+      {
+        client,
+        roomId: "test-room",
+      },
+      async (api) => {
+        await api.setContent(exampleDoc);
+        return JSON.stringify(api.toJSON());
+      }
+    );
+    expect(json).toEqual(
+      '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Example Text"}]},{"type":"paragraph"}]}'
+    );
+  });
+
+  test("should set the doc and return  Markdown", async () => {
+    const exampleDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Example Text",
+            },
+          ],
+        },
+        {
+          type: "heading",
+          content: [
+            {
+              type: "text",
+              text: "Example Heading",
+            },
+          ],
+          attrs: {
+            level: 1,
+          },
+        },
+      ],
+    };
+
+    const markdown = await withProsemirrorDocument<string>(
+      {
+        client,
+        roomId: "test-room",
+      },
+      async (api) => {
+        await api.setContent(exampleDoc);
+        return api.toMarkdown();
+      }
+    );
+    expect(markdown).toEqual("Example Text\n\n# Example Heading");
+  });
+
+  test("should set the doc and return text using getText and custom blockseperator", async () => {
+    const exampleDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Example Text",
+            },
+          ],
+        },
+        {
+          type: "heading",
+          content: [
+            {
+              type: "text",
+              text: "Example Heading",
+            },
+          ],
+          attrs: {
+            level: 1,
+          },
+        },
+      ],
+    };
+
+    const text = await withProsemirrorDocument<string>(
+      {
+        client,
+        roomId: "test-room",
+      },
+      async (api) => {
+        await api.setContent(exampleDoc);
+        return api.getText({ blockSeparator: "<br/>" });
+      }
+    );
+    expect(text).toEqual("Example Text<br/>Example Heading<br/>");
+  });
+});

--- a/packages/liveblocks-node-prosemirror/src/__tests__/index.test.ts
+++ b/packages/liveblocks-node-prosemirror/src/__tests__/index.test.ts
@@ -32,7 +32,7 @@ const client = new Liveblocks({
 beforeAll(() => server.listen());
 afterAll(() => server.close());
 
-describe("withLiveblocksDocument", () => {
+describe("withProsemirrorDocument", () => {
   test("should return an empty document to start", async () => {
     const text = await withProsemirrorDocument<string>(
       {
@@ -63,7 +63,7 @@ describe("withLiveblocksDocument", () => {
     expect(text).toEqual("hello");
   });
 
-  test("should set the doc and return text and JSON", async () => {
+  test("should set the doc and return JSON", async () => {
     const exampleDoc = {
       type: "doc",
       content: [
@@ -94,7 +94,7 @@ describe("withLiveblocksDocument", () => {
     );
   });
 
-  test("should set the doc and return  Markdown", async () => {
+  test("should set the doc and return Markdown", async () => {
     const exampleDoc = {
       type: "doc",
       content: [

--- a/packages/liveblocks-node-prosemirror/src/comment.ts
+++ b/packages/liveblocks-node-prosemirror/src/comment.ts
@@ -1,0 +1,44 @@
+import { Mark, mergeAttributes } from "@tiptap/core";
+
+export const LIVEBLOCKS_COMMENT_MARK_TYPE = "liveblocksCommentMark";
+
+export const CommentExtension = Mark.create({
+  name: LIVEBLOCKS_COMMENT_MARK_TYPE,
+  excludes: "",
+  inclusive: false,
+  keepOnSplit: true,
+  addAttributes() {
+    // Return an object with attribute configuration
+    return {
+      orphan: {
+        parseHTML: (element) => !!element.getAttribute("data-orphan"),
+        renderHTML: (attributes) => {
+          return (attributes as { orphan: boolean }).orphan
+            ? {
+                "data-orphan": "true",
+              }
+            : {};
+        },
+        default: false,
+      },
+      threadId: {
+        parseHTML: (element) => element.getAttribute("data-lb-thread-id"),
+        renderHTML: (attributes) => {
+          return {
+            "data-lb-thread-id": (attributes as { threadId: string }).threadId,
+          };
+        },
+        default: "",
+      },
+    };
+  },
+
+  renderHTML({ HTMLAttributes }: { HTMLAttributes: Record<string, unknown> }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        class: "lb-root lb-tiptap-thread-mark",
+      }),
+    ];
+  },
+});

--- a/packages/liveblocks-node-prosemirror/src/document.ts
+++ b/packages/liveblocks-node-prosemirror/src/document.ts
@@ -1,0 +1,242 @@
+import type { Liveblocks } from "@liveblocks/node";
+import type { TextSerializer } from "@tiptap/core";
+import { getSchema, getText } from "@tiptap/core";
+import type { Node, ParseOptions, Schema } from "@tiptap/pm/model";
+import { DOMParser } from "@tiptap/pm/model";
+import type { Transaction } from "@tiptap/pm/state";
+import { EditorState } from "@tiptap/pm/state";
+import StarterKit from "@tiptap/starter-kit";
+import type { MarkdownSerializer } from "prosemirror-markdown";
+import { defaultMarkdownSerializer } from "prosemirror-markdown";
+import { initProseMirrorDoc, updateYFragment } from "y-prosemirror";
+import { applyUpdate, Doc, encodeStateAsUpdate, encodeStateVector } from "yjs";
+
+import { CommentExtension } from "./comment";
+import { MentionExtension } from "./mention";
+
+export type LiveblocksProsemirrorOptions = {
+  roomId: string;
+  schema?: Schema;
+  client: Liveblocks;
+  field?: string;
+  parseOptions?: ParseOptions;
+};
+
+export type LiveblocksDocumentApi = {
+  refresh: () => Promise<void>;
+  update: (
+    modifyFn: (doc: Node, tr: Transaction) => Transaction
+  ) => Promise<void>;
+  setContent: (content: null | object | string) => Promise<void>;
+  clearContent: () => Promise<void>;
+  getText: (options?: {
+    blockSeparator?: string;
+    textSerializers?: Record<string, TextSerializer>;
+  }) => string;
+  getEditorState: () => EditorState;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  toJSON: () => any; // upstream ProseMirror uses "any"
+  toMarkdown: () => string;
+};
+
+const DEFAULT_SCHEMA = getSchema([
+  StarterKit,
+  CommentExtension,
+  MentionExtension,
+]);
+
+const getLiveblocksDocumentState = async (
+  roomId: string,
+  client: Liveblocks,
+  schema: Schema,
+  field: string
+) => {
+  const update = new Uint8Array(
+    await client.getYjsDocumentAsBinaryUpdate(roomId)
+  );
+  const ydoc = new Doc();
+  applyUpdate(ydoc, update);
+  const fragment = ydoc.getXmlFragment(field ?? "default");
+  const { mapping, doc } = initProseMirrorDoc(fragment, schema);
+  const state = EditorState.create({
+    schema,
+    doc,
+  });
+
+  return {
+    fragment,
+    state,
+    ydoc,
+    mapping,
+  };
+};
+
+/**
+ *
+ * This is simplified re-implementation of TipTap's createDocument function
+ *
+ * @param content
+ * @param schema
+ * @param parseOptions
+ * @returns
+ */
+const createDocumentFromContent = (
+  content: null | object | string,
+  schema: Schema,
+  parseOptions: ParseOptions = {}
+) => {
+  const emptyState = () => {
+    const element = document.createElement("div");
+    element.innerHTML = "";
+    return DOMParser.fromSchema(schema).parse(element, parseOptions);
+  };
+  if (content === null) {
+    return emptyState();
+  }
+  if (typeof content === "object") {
+    try {
+      return schema.nodeFromJSON(content);
+    } catch (error) {
+      console.warn(
+        "[warn]: Invalid content.",
+        "Passed value:",
+        content,
+        "Error:",
+        error
+      );
+      return emptyState();
+    }
+  }
+  if (typeof content === "string") {
+    const element = document.createElement("div");
+    element.innerHTML = content.trim();
+    return DOMParser.fromSchema(schema).parse(element, parseOptions);
+  }
+
+  return false;
+};
+
+/**
+ *
+ * `withProsemirrorDocument` is the main entry point to access and modify prosemirror (or TipTap) documents on your backend.
+ * This function internally instantiates a Prosemirror state and allows you to modify and export its values asynchronously
+ * with a simplified interface. It's important to note that the api works with Prosemirror's document state and Transactions api.
+ *
+ * @param options Specify the roomId, client, and optionally the prosemirror schema. If no schema is applied, a default schema of TipTap's StarterKit + Liveblocks mentions/comments is used.
+ * @param callback The call back function is optionally async and receives the document API as its only argument.
+ *
+ * @example
+ *
+ * import { Liveblocks } from "@liveblocks/node";
+ * import { withProsemirrorDocument } from "@liveblocks/node-prosemirror";
+ *
+ * const client = new Liveblocks({secret: "sk_your_secret_key"});
+ * const text = await withProsemirrorDocument(
+ *   { client, roomId: "your-room" },
+ *   async (docApi) => {
+ *     await docApi.update((tr) => {
+ *       return tr.insertText("Hello World, from Liveblocks!!", 0);
+ *     });
+ *     return docApi.getTextContent();
+ *   }
+ * );
+ *
+ */
+export async function withProsemirrorDocument<T>(
+  {
+    roomId,
+    schema: maybeSchema,
+    client,
+    field,
+    parseOptions,
+  }: LiveblocksProsemirrorOptions,
+  callback: (api: LiveblocksDocumentApi) => Promise<T> | T
+): Promise<T> {
+  const schema = maybeSchema ?? DEFAULT_SCHEMA;
+  let liveblocksState = await getLiveblocksDocumentState(
+    roomId,
+    client,
+    schema,
+    field ?? "default"
+  );
+
+  const val = await callback({
+    /**
+     * Fetches and resyncs the latest document with Liveblocks
+     */
+    async refresh() {
+      liveblocksState = await getLiveblocksDocumentState(
+        roomId,
+        client,
+        schema,
+        field ?? "default"
+      );
+    },
+    /**
+     * Provide a callback to modify documetns with Lexical's standard api. All calls are discrete.
+     */
+    async update(modifyFn) {
+      const { ydoc, fragment, state, mapping } = liveblocksState;
+      // Flush any pending updates (there really shouldn't be any?), this may be a NOOP
+      const beforeVector = encodeStateVector(ydoc);
+      const afterState = state.apply(modifyFn(state.doc, state.tr));
+      ydoc.transact(() => {
+        updateYFragment(ydoc, fragment, afterState.doc, mapping);
+      });
+      // grab update after diffing
+      const diffUpdate = encodeStateAsUpdate(ydoc, beforeVector);
+      await client.sendYjsBinaryUpdate(roomId, diffUpdate);
+      await this.refresh();
+    },
+    async setContent(content: null | object | string) {
+      const node = createDocumentFromContent(content, schema, parseOptions);
+      console.log("NODE ", node);
+      if (!node) {
+        throw "Invalid content";
+      }
+      await this.update((doc, tr) => {
+        tr.delete(0, doc.content.size);
+        tr.insert(0, node);
+        return tr;
+      });
+    },
+    async clearContent() {
+      await this.setContent(null);
+    },
+
+    /**
+     * Uses TipTap's getText function, which allows passing a custom text serializer
+     */
+    getText(options?: {
+      blockSeparator?: string;
+      textSerializers?: Record<string, TextSerializer>;
+    }) {
+      const { state } = liveblocksState;
+      return getText(state.doc, options);
+    },
+
+    /**
+     * Helper function to return prosemirror document in JSON form
+     */
+    toJSON() {
+      // upstream ProseMirror uses "any" type for json
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return liveblocksState.state.doc.toJSON();
+    },
+    /**
+     * Helper function to return editor state as Markdown. By default it uses the defaultMarkdownSerializer from prosemirror-markdown, but you may pass your own
+     */
+    toMarkdown(serializer?: MarkdownSerializer) {
+      return (serializer ?? defaultMarkdownSerializer).serialize(
+        liveblocksState.state.doc
+      );
+    },
+    /**
+     * Helper function to return the editor's current prosemirror state
+     */
+    getEditorState() {
+      return liveblocksState.state;
+    },
+  });
+  return val;
+}

--- a/packages/liveblocks-node-prosemirror/src/document.ts
+++ b/packages/liveblocks-node-prosemirror/src/document.ts
@@ -79,22 +79,18 @@ const getLiveblocksDocumentState = async (
  * @returns
  */
 const createDocumentFromContent = (content: object, schema: Schema) => {
-  if (typeof content === "object") {
-    try {
-      return schema.nodeFromJSON(content);
-    } catch (error) {
-      console.warn(
-        "[warn]: Invalid content.",
-        "Passed value:",
-        content,
-        "Error:",
-        error
-      );
-      return false;
-    }
+  try {
+    return schema.nodeFromJSON(content);
+  } catch (error) {
+    console.warn(
+      "[warn]: Invalid content.",
+      "Passed value:",
+      content,
+      "Error:",
+      error
+    );
+    return false;
   }
-
-  return false;
 };
 
 /**

--- a/packages/liveblocks-node-prosemirror/src/index.ts
+++ b/packages/liveblocks-node-prosemirror/src/index.ts
@@ -1,0 +1,11 @@
+import { detectDupes } from "@liveblocks/core";
+
+import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
+
+export type {
+  LiveblocksDocumentApi,
+  LiveblocksProsemirrorOptions,
+} from "./document";
+export { withProsemirrorDocument } from "./document";
+
+detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);

--- a/packages/liveblocks-node-prosemirror/src/mention.ts
+++ b/packages/liveblocks-node-prosemirror/src/mention.ts
@@ -1,0 +1,55 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const LIVEBLOCKS_MENTION_TYPE = "liveblocksMention";
+
+export const MentionExtension = Node.create({
+  name: LIVEBLOCKS_MENTION_TYPE,
+  group: "inline",
+  inline: true,
+  selectable: true,
+  atom: true,
+
+  priority: 101,
+  parseHTML() {
+    return [
+      {
+        tag: "liveblocks-mention",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["liveblocks-mention", mergeAttributes(HTMLAttributes)];
+  },
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-id"),
+        renderHTML: (attributes) => {
+          if (!attributes.id) {
+            return {};
+          }
+
+          return {
+            "data-id": attributes.id as string, // "as" typing because TipTap doesn't have a way to type attributes
+          };
+        },
+      },
+      notificationId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-notification-id"),
+        renderHTML: (attributes) => {
+          if (!attributes.notificationId) {
+            return {};
+          }
+
+          return {
+            "data-notification-id": attributes.notificationId as string, // "as" typing because TipTap doesn't have a way to type attributes
+          };
+        },
+      },
+    };
+  },
+});

--- a/packages/liveblocks-node-prosemirror/src/version.ts
+++ b/packages/liveblocks-node-prosemirror/src/version.ts
@@ -1,0 +1,6 @@
+declare const __VERSION__: string;
+declare const TSUP_FORMAT: string;
+
+export const PKG_NAME = "@liveblocks/node-prosemirror";
+export const PKG_VERSION = typeof __VERSION__ === "string" && __VERSION__;
+export const PKG_FORMAT = typeof TSUP_FORMAT === "string" && TSUP_FORMAT;

--- a/packages/liveblocks-node-prosemirror/test-d/index.test-d.ts
+++ b/packages/liveblocks-node-prosemirror/test-d/index.test-d.ts
@@ -1,0 +1,9 @@
+// import { expectType } from "tsd";
+// import { Liveblocks } from "@liveblocks/node";
+
+// const client = new Liveblocks({ secret: "sk_xxx" });
+
+(async function main() {
+  // TODO: Test withProsemirror API
+  // withProsemirror
+})();

--- a/packages/liveblocks-node-prosemirror/tsconfig.json
+++ b/packages/liveblocks-node-prosemirror/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  // Use the same settings for all packages
+  "extends": "../../shared/tsconfig.common.json",
+
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/liveblocks-node-prosemirror/tsup.config.ts
+++ b/packages/liveblocks-node-prosemirror/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  splitting: true,
+  clean: true,
+  target: "es2020",
+  format: ["esm", "cjs"],
+  sourcemap: true,
+
+  esbuildOptions(options, _context) {
+    // Replace __VERSION__ globals with concrete version
+    const pkg = require("./package.json");
+    options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+});


### PR DESCRIPTION
Adds a prosemirror node API similar to the lexical api, also works with TipTap! Includes some niceities from TipTap like `getText` as well as some extras tiptap doesn't have like`getMarkdown`

new wrapper for getting and modifying doc:
```
withProsemirrorDocument({
   client: new Liveblocks();, roomId: "some-room"
}, (api) => {
     // document API
});
```
and the api can be used like this:

```
(api) => { 
     await api.setcontent( /* Some content */ );
     const markDown = api.toMarkdown();
})
```