### PR TITLE
Mark composers as pending updates

### DIFF
--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -1035,11 +1035,13 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
 
     // Mark the composer as a pending update when it isn't empty
     // or when attachments are being uploaded
+    const isPending = !preventUnsavedChanges
+      ? false
+      : !isEmpty || isUploadingAttachments;
+
     useEffect(() => {
-      if (preventUnsavedChanges) {
-        syncSource.setPending(!isEmpty || isUploadingAttachments);
-      }
-    }, [syncSource, isEmpty, preventUnsavedChanges, isUploadingAttachments]);
+      syncSource.setPending(isPending);
+    }, [syncSource, isPending]);
 
     const createAttachments = useCallback(
       (files: File[]) => {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -1034,11 +1034,12 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
     const syncSource = useSyncSource();
 
     // Mark the composer as a pending update when it isn't empty
+    // or when attachments are being uploaded
     useEffect(() => {
       if (preventUnsavedChanges) {
-        syncSource.setPending(!isEmpty);
+        syncSource.setPending(!isEmpty || isUploadingAttachments);
       }
-    }, [syncSource, isEmpty, preventUnsavedChanges]);
+    }, [syncSource, isEmpty, preventUnsavedChanges, isUploadingAttachments]);
 
     useEffect(
       () => {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -993,6 +993,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
       onComposerSubmit,
       defaultAttachments = [],
       pasteFilesAsAttachments,
+      preventUnsavedChanges = true,
       disabled,
       asChild,
       ...props
@@ -1034,8 +1035,10 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
 
     // Mark the composer as a pending update when it isn't empty
     useEffect(() => {
-      syncSource.setPending(!isEmpty);
-    }, [syncSource, isEmpty]);
+      if (preventUnsavedChanges) {
+        syncSource.setPending(!isEmpty);
+      }
+    }, [syncSource, isEmpty, preventUnsavedChanges]);
 
     useEffect(
       () => {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -15,7 +15,10 @@ import {
 } from "@floating-ui/react-dom";
 import type { CommentAttachment, CommentBody } from "@liveblocks/core";
 import { useRoom } from "@liveblocks/react";
-import { useMentionSuggestions } from "@liveblocks/react/_private";
+import {
+  useMentionSuggestions,
+  useSyncSource,
+} from "@liveblocks/react/_private";
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import type {
   AriaAttributes,
@@ -1027,6 +1030,21 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
     const ref = useRef<HTMLFormElement>(null);
     const mergedRefs = useRefs(forwardedRef, ref);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const syncSource = useSyncSource();
+
+    // Mark the composer as a pending update when it isn't empty
+    useEffect(() => {
+      syncSource.setPending(!isEmpty);
+    }, [syncSource, isEmpty]);
+
+    useEffect(
+      () => {
+        return () => {
+          syncSource.destroy();
+        };
+      },
+      [] // eslint-disable-line react-hooks/exhaustive-deps
+    );
 
     const createAttachments = useCallback(
       (files: File[]) => {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -1040,7 +1040,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
       : !isEmpty || isUploadingAttachments;
 
     useEffect(() => {
-      syncSource.setPending(isPending);
+      syncSource?.setPending(isPending);
     }, [syncSource, isPending]);
 
     const createAttachments = useCallback(

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -1041,15 +1041,6 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
       }
     }, [syncSource, isEmpty, preventUnsavedChanges, isUploadingAttachments]);
 
-    useEffect(
-      () => {
-        return () => {
-          syncSource.destroy();
-        };
-      },
-      [] // eslint-disable-line react-hooks/exhaustive-deps
-    );
-
     const createAttachments = useCallback(
       (files: File[]) => {
         if (!files.length) {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -1037,7 +1037,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
     // or when attachments are being uploaded
     const isPending = !preventUnsavedChanges
       ? false
-      : !isEmpty || isUploadingAttachments;
+      : !isEmpty || isUploadingAttachments || attachments.length > 0;
 
     useEffect(() => {
       syncSource?.setPending(isPending);

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -151,7 +151,8 @@ export interface ComposerFormProps extends ComponentPropsWithSlot<"form"> {
 
   /**
    * Whether to make the `preventUnsavedChanges` client option take
-   * into account this composer. (i.e. when it's not empty or when attachments are uploading)
+   * into account this composer. (i.e. when it's not empty or when attachments are uploading).
+   * Default `true`.
    */
   preventUnsavedChanges?: boolean;
 }

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -151,7 +151,7 @@ export interface ComposerFormProps extends ComponentPropsWithSlot<"form"> {
 
   /**
    * Whether to make the `preventUnsavedChanges` client option take
-   * into account this composer when it's not empty.
+   * into account this composer. (i.e. when it's not empty or when attachments are uploading)
    */
   preventUnsavedChanges?: boolean;
 }

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -148,6 +148,12 @@ export interface ComposerFormProps extends ComponentPropsWithSlot<"form"> {
    * Whether to create attachments when pasting files into the editor.
    */
   pasteFilesAsAttachments?: boolean;
+
+  /**
+   * Whether to make the `preventUnsavedChanges` client option take
+   * into account this composer when it's not empty.
+   */
+  preventUnsavedChanges?: boolean;
 }
 
 export type ComposerSubmitProps = ComponentPropsWithSlot<"button">;

--- a/packages/liveblocks-react/src/use-sync-source.ts
+++ b/packages/liveblocks-react/src/use-sync-source.ts
@@ -7,16 +7,17 @@ import { useClient } from "./liveblocks";
 /**
  * @private For internal use only. Do not rely on this hook.
  */
-export function useSyncSource(): SyncSource {
+export function useSyncSource(): SyncSource | undefined {
   const client = useClient();
-  const syncSource = React.useMemo(
-    () => client[kInternal].createSyncSource(),
-    [client]
-  );
+  const createSyncSource = client[kInternal].createSyncSource;
+  const [syncSource, setSyncSource] = React.useState<SyncSource | undefined>();
 
   React.useEffect(() => {
-    return () => syncSource.destroy();
-  }, [syncSource]);
+    // Create new sync source on mount
+    const newSyncSource = createSyncSource();
+    setSyncSource(newSyncSource);
+    return () => newSyncSource.destroy();
+  }, [createSyncSource]);
 
   return syncSource;
 }


### PR DESCRIPTION
For attachments I'm wondering if the source should be lower since `uploadAttachment` [is technically a room-level API](https://liveblocks.io/docs/api-reference/liveblocks-client#Room.uploadAttachment)?

Fwiw I can't get this to work, even though the `setPending` condition is correct.