### PR TITLE
useEditorState to allow shouldRerenderOnTransaction:false to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 - Fix an issue with `AnchoredThreads` component not working correctly on certain
   React versions.
+- Fixes an issue where react comonents don't update when
+  shouldRerenderOnTransaction: false is set
+
+### `@liveblocks/yjs`
+
+- Adds experimental offline support for `LiveblocksYjsProvider`.
 
 ## 2.11.0
 

--- a/docs/pages/get-started/nextjs-tiptap.mdx
+++ b/docs/pages/get-started/nextjs-tiptap.mdx
@@ -134,7 +134,12 @@ package.
       const liveblocks = useLiveblocksExtension();
 
       const editor = useEditor({
-        extensions: [liveblocks, StarterKit],
+        extensions: [
+          liveblocks,
+          StarterKit.configure({
+            // The Liveblocks extension comes with its own history handling
+            history: false,
+          })],
         immediatelyRender: false,
       });
 

--- a/packages/liveblocks-react-tiptap/src/comments/AnchoredThreads.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/AnchoredThreads.tsx
@@ -3,7 +3,7 @@ import {
   Thread as DefaultThread,
   type ThreadProps,
 } from "@liveblocks/react-ui";
-import type { Editor } from "@tiptap/react";
+import { type Editor, useEditorState } from "@tiptap/react";
 import type { ComponentPropsWithoutRef, ComponentType } from "react";
 import React, {
   useCallback,
@@ -14,7 +14,6 @@ import React, {
 } from "react";
 
 import { classNames } from "../classnames";
-import type { ThreadPluginState } from "../types";
 import { THREADS_PLUGIN_KEY } from "../types";
 import { getRectFromCoords } from "../utils";
 
@@ -60,7 +59,21 @@ export function AnchoredThreads({
   const [elements, setElements] = useState<Map<string, HTMLElement>>(new Map());
   const [positions, setPositions] = useState<Map<string, number>>(new Map()); // A map of thread ids to their 'top' position in the document
 
-  const pluginState = editor ? THREADS_PLUGIN_KEY.getState(editor.state) as ThreadPluginState : null;
+  const { pluginState } = useEditorState({
+    editor,
+    selector: (ctx) => {
+      if (!ctx?.editor?.state) return { pluginState: undefined };
+      const state = THREADS_PLUGIN_KEY.getState(ctx.editor.state);
+      return {
+        pluginState: state,
+      };
+    },
+    equalityFn: (prev, next) => {
+      if (!prev || !next) return false;
+      return prev.pluginState?.selectedThreadId === next.pluginState?.selectedThreadId &&
+        prev.pluginState?.threadPositions === next.pluginState?.threadPositions; // new map is made each time threadPos updates so shallow equality is fine
+    },
+  }) ?? { pluginState: undefined };
 
   // TODO: lexical supoprts multiple threads being active, should probably do that here as well
   const handlePositionThreads = useCallback(() => {

--- a/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
@@ -4,7 +4,7 @@ import type { DM } from "@liveblocks/core";
 import { useCreateThread } from "@liveblocks/react";
 import type { ComposerProps, ComposerSubmitComment } from "@liveblocks/react-ui";
 import { Composer } from "@liveblocks/react-ui";
-import type { Editor } from "@tiptap/react";
+import { type Editor, useEditorState } from "@tiptap/react";
 import type { ComponentRef, FormEvent } from "react";
 import React, { forwardRef, useCallback, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
@@ -28,10 +28,16 @@ export const FloatingComposer = forwardRef<
 >(function FloatingComposer(props, forwardedRef) {
   const createThread = useCreateThread();
   const { editor } = props;
-
-  const storage = editor?.storage.liveblocksComments as CommentsExtensionStorage | undefined;
-
-  const showComposer = !!storage?.pendingCommentSelection;
+  const { showComposer } = useEditorState({
+    editor,
+    selector: (ctx) => ({
+      showComposer: !!(ctx.editor?.storage.liveblocksComments as CommentsExtensionStorage | undefined)?.pendingCommentSelection,
+    }),
+    equalityFn: (prev, next) => {
+      if (!next) return false;
+      return prev.showComposer === next.showComposer;
+    },
+  }) ?? { showComposer: false };
 
   const {
     refs: { setReference, setFloating },

--- a/packages/liveblocks-react-tiptap/src/comments/FloatingThreads.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/FloatingThreads.tsx
@@ -14,7 +14,7 @@ import {
   Thread as DefaultThread,
   type ThreadProps,
 } from "@liveblocks/react-ui";
-import type { Editor } from "@tiptap/react";
+import { type Editor, useEditorState } from "@tiptap/react";
 import React, {
   type ComponentType,
   type HTMLAttributes,
@@ -28,7 +28,6 @@ import React, {
 import { createPortal } from "react-dom";
 
 import { classNames } from "../classnames";
-import type { ThreadPluginState } from "../types";
 import { THREADS_PLUGIN_KEY } from "../types";
 
 type ThreadPanelComponents = {
@@ -61,7 +60,22 @@ export function FloatingThreads({
 }: FloatingThreadsProps) {
 
   const Thread = components?.Thread ?? DefaultThread;
-  const pluginState = editor ? THREADS_PLUGIN_KEY.getState(editor.state) as ThreadPluginState : null;
+
+  const { pluginState } = useEditorState({
+    editor,
+    selector: (ctx) => {
+      if (!ctx?.editor?.state) return { pluginState: undefined };
+      const state = THREADS_PLUGIN_KEY.getState(ctx.editor.state);
+      return {
+        pluginState: state,
+      };
+    },
+    equalityFn: (prev, next) => {
+      if (!prev || !next) return false;
+      return prev.pluginState?.selectedThreadPos === next.pluginState?.selectedThreadPos &&
+        prev.pluginState?.selectedThreadId === next.pluginState?.selectedThreadId;
+    },
+  }) ?? { pluginState: undefined };
 
   const [activeThread, setActiveThread] = useState<ThreadData | null>(null);
 


### PR DESCRIPTION
Fix for #2055 

Uses Tiptap's useEditorState with a selector to properly select the editor state when updates happen.
