### PR TITLE
Handle unsupported attachment previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.12.1 (Not published yet)
+
+### `@liveblocks/react-ui`
+
+- Prevent unsupported attachment previews from loading infinitely.
+
 ## 2.12.0
 
 This release adds support for tracking synchronization status of pending local

--- a/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
@@ -121,8 +121,10 @@ const AttachmentFileIcon = memo(({ mimeType }: { mimeType: string }) => {
 
 function AttachmentImagePreview({
   attachment,
+  markAsPreviewError,
 }: {
   attachment: CommentMixedAttachment;
+  markAsPreviewError: () => void;
 }) {
   const { url } = useAttachmentUrl(attachment.id);
   const [isLoaded, setLoaded] = useState(false);
@@ -139,7 +141,12 @@ function AttachmentImagePreview({
           className="lb-attachment-preview-media"
           data-hidden={!isLoaded ? "" : undefined}
         >
-          <img src={url} loading="lazy" onLoad={handleLoad} />
+          <img
+            src={url}
+            loading="lazy"
+            onLoad={handleLoad}
+            onError={markAsPreviewError}
+          />
         </div>
       ) : null}
     </>
@@ -148,8 +155,10 @@ function AttachmentImagePreview({
 
 function AttachmentVideoPreview({
   attachment,
+  markAsPreviewError,
 }: {
   attachment: CommentMixedAttachment;
+  markAsPreviewError: () => void;
 }) {
   const { url } = useAttachmentUrl(attachment.id);
   const [isLoaded, setLoaded] = useState(false);
@@ -166,7 +175,11 @@ function AttachmentVideoPreview({
           className="lb-attachment-preview-media"
           data-hidden={!isLoaded ? "" : undefined}
         >
-          <video src={url} onLoadedData={handleLoad} />
+          <video
+            src={url}
+            onLoadedData={handleLoad}
+            onError={markAsPreviewError}
+          />
         </div>
       ) : null}
     </>
@@ -176,8 +189,10 @@ function AttachmentVideoPreview({
 function AttachmentPreview({
   attachment,
   allowMediaPreview = true,
+  markAsPreviewError,
 }: {
   attachment: CommentMixedAttachment;
+  markAsPreviewError: () => void;
   allowMediaPreview?: boolean;
 }) {
   const isInsideRoom = useIsInsideRoom();
@@ -191,11 +206,21 @@ function AttachmentPreview({
     attachment.size <= MAX_DISPLAYED_MEDIA_SIZE
   ) {
     if (attachment.mimeType.startsWith("image/")) {
-      return <AttachmentImagePreview attachment={attachment} />;
+      return (
+        <AttachmentImagePreview
+          attachment={attachment}
+          markAsPreviewError={markAsPreviewError}
+        />
+      );
     }
 
     if (attachment.mimeType.startsWith("video/")) {
-      return <AttachmentVideoPreview attachment={attachment} />;
+      return (
+        <AttachmentVideoPreview
+          attachment={attachment}
+          markAsPreviewError={markAsPreviewError}
+        />
+      );
     }
   }
 
@@ -307,8 +332,18 @@ export function MediaAttachment({
   onKeyDown,
   ...props
 }: AttachmentProps) {
-  const { isUploading, isError, description, deleteLabel } =
-    useAttachmentContent(attachment, overrides);
+  const {
+    isUploading,
+    isError: isUploadError,
+    description,
+    deleteLabel,
+  } = useAttachmentContent(attachment, overrides);
+  const [isPreviewError, setIsPreviewError] = useState(false);
+  const isError = isUploadError || isPreviewError;
+
+  const markAsPreviewError = useCallback(() => {
+    setIsPreviewError(true);
+  }, []);
 
   const handleDeletePointerDown = useCallback(
     (event: PointerEvent<HTMLButtonElement>) => {
@@ -340,6 +375,7 @@ export function MediaAttachment({
           <AttachmentPreview
             attachment={attachment}
             allowMediaPreview={allowMediaPreview}
+            markAsPreviewError={markAsPreviewError}
           />
         )}
       </div>
@@ -372,13 +408,22 @@ export function FileAttachment({
   onClick,
   onDeleteClick,
   preventFocusOnDelete,
-  allowMediaPreview = true,
   className,
   onKeyDown,
   ...props
 }: AttachmentProps) {
-  const { isUploading, isError, description, deleteLabel } =
-    useAttachmentContent(attachment, overrides);
+  const {
+    isUploading,
+    isError: isUploadError,
+    description,
+    deleteLabel,
+  } = useAttachmentContent(attachment, overrides);
+  const [isPreviewError, setIsPreviewError] = useState(false);
+  const isError = isUploadError || isPreviewError;
+
+  const markAsPreviewError = useCallback(() => {
+    setIsPreviewError(true);
+  }, []);
 
   const handleDeletePointerDown = useCallback(
     (event: PointerEvent<HTMLButtonElement>) => {
@@ -409,7 +454,7 @@ export function FileAttachment({
         ) : (
           <AttachmentPreview
             attachment={attachment}
-            allowMediaPreview={allowMediaPreview}
+            markAsPreviewError={markAsPreviewError}
           />
         )}
       </div>

--- a/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
@@ -198,9 +198,9 @@ function AttachmentPreview({
   const isUploaded =
     attachment.type === "attachment" || attachment.status === "uploaded";
 
-  const markPreviewAsUnsupported = useCallback(() => {
+  function markPreviewAsUnsupported() {
     setUnsupportedPreview(true);
-  }, []);
+  }
 
   if (
     !isUnsupportedPreview &&

--- a/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
@@ -121,10 +121,10 @@ const AttachmentFileIcon = memo(({ mimeType }: { mimeType: string }) => {
 
 function AttachmentImagePreview({
   attachment,
-  markAsPreviewError,
+  markPreviewAsUnsupported,
 }: {
   attachment: CommentMixedAttachment;
-  markAsPreviewError: () => void;
+  markPreviewAsUnsupported: () => void;
 }) {
   const { url } = useAttachmentUrl(attachment.id);
   const [isLoaded, setLoaded] = useState(false);
@@ -145,7 +145,7 @@ function AttachmentImagePreview({
             src={url}
             loading="lazy"
             onLoad={handleLoad}
-            onError={markAsPreviewError}
+            onError={markPreviewAsUnsupported}
           />
         </div>
       ) : null}
@@ -155,10 +155,10 @@ function AttachmentImagePreview({
 
 function AttachmentVideoPreview({
   attachment,
-  markAsPreviewError,
+  markPreviewAsUnsupported,
 }: {
   attachment: CommentMixedAttachment;
-  markAsPreviewError: () => void;
+  markPreviewAsUnsupported: () => void;
 }) {
   const { url } = useAttachmentUrl(attachment.id);
   const [isLoaded, setLoaded] = useState(false);
@@ -178,7 +178,7 @@ function AttachmentVideoPreview({
           <video
             src={url}
             onLoadedData={handleLoad}
-            onError={markAsPreviewError}
+            onError={markPreviewAsUnsupported}
           />
         </div>
       ) : null}
@@ -189,17 +189,21 @@ function AttachmentVideoPreview({
 function AttachmentPreview({
   attachment,
   allowMediaPreview = true,
-  markAsPreviewError,
 }: {
   attachment: CommentMixedAttachment;
-  markAsPreviewError: () => void;
   allowMediaPreview?: boolean;
 }) {
+  const [isUnsupportedPreview, setUnsupportedPreview] = useState(false);
   const isInsideRoom = useIsInsideRoom();
   const isUploaded =
     attachment.type === "attachment" || attachment.status === "uploaded";
 
+  const markPreviewAsUnsupported = useCallback(() => {
+    setUnsupportedPreview(true);
+  }, []);
+
   if (
+    !isUnsupportedPreview &&
     allowMediaPreview &&
     isUploaded &&
     isInsideRoom &&
@@ -209,7 +213,7 @@ function AttachmentPreview({
       return (
         <AttachmentImagePreview
           attachment={attachment}
-          markAsPreviewError={markAsPreviewError}
+          markPreviewAsUnsupported={markPreviewAsUnsupported}
         />
       );
     }
@@ -218,7 +222,7 @@ function AttachmentPreview({
       return (
         <AttachmentVideoPreview
           attachment={attachment}
-          markAsPreviewError={markAsPreviewError}
+          markPreviewAsUnsupported={markPreviewAsUnsupported}
         />
       );
     }
@@ -332,18 +336,8 @@ export function MediaAttachment({
   onKeyDown,
   ...props
 }: AttachmentProps) {
-  const {
-    isUploading,
-    isError: isUploadError,
-    description,
-    deleteLabel,
-  } = useAttachmentContent(attachment, overrides);
-  const [isPreviewError, setIsPreviewError] = useState(false);
-  const isError = isUploadError || isPreviewError;
-
-  const markAsPreviewError = useCallback(() => {
-    setIsPreviewError(true);
-  }, []);
+  const { isUploading, isError, description, deleteLabel } =
+    useAttachmentContent(attachment, overrides);
 
   const handleDeletePointerDown = useCallback(
     (event: PointerEvent<HTMLButtonElement>) => {
@@ -375,7 +369,6 @@ export function MediaAttachment({
           <AttachmentPreview
             attachment={attachment}
             allowMediaPreview={allowMediaPreview}
-            markAsPreviewError={markAsPreviewError}
           />
         )}
       </div>
@@ -412,18 +405,8 @@ export function FileAttachment({
   onKeyDown,
   ...props
 }: AttachmentProps) {
-  const {
-    isUploading,
-    isError: isUploadError,
-    description,
-    deleteLabel,
-  } = useAttachmentContent(attachment, overrides);
-  const [isPreviewError, setIsPreviewError] = useState(false);
-  const isError = isUploadError || isPreviewError;
-
-  const markAsPreviewError = useCallback(() => {
-    setIsPreviewError(true);
-  }, []);
+  const { isUploading, isError, description, deleteLabel } =
+    useAttachmentContent(attachment, overrides);
 
   const handleDeletePointerDown = useCallback(
     (event: PointerEvent<HTMLButtonElement>) => {
@@ -452,10 +435,7 @@ export function FileAttachment({
         ) : isError ? (
           <WarningIcon />
         ) : (
-          <AttachmentPreview
-            attachment={attachment}
-            markAsPreviewError={markAsPreviewError}
-          />
+          <AttachmentPreview attachment={attachment} />
         )}
       </div>
       <div className="lb-attachment-details">

--- a/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Attachment.tsx
@@ -401,6 +401,7 @@ export function FileAttachment({
   onClick,
   onDeleteClick,
   preventFocusOnDelete,
+  allowMediaPreview = true,
   className,
   onKeyDown,
   ...props
@@ -435,7 +436,10 @@ export function FileAttachment({
         ) : isError ? (
           <WarningIcon />
         ) : (
-          <AttachmentPreview attachment={attachment} />
+          <AttachmentPreview
+            attachment={attachment}
+            allowMediaPreview={allowMediaPreview}
+          />
         )}
       </div>
       <div className="lb-attachment-details">


### PR DESCRIPTION
@nimeshnayaju noticed that `heic` attachments were loading infinitely in non-WebKit browsers, that's because we currently attempt to preview _any_ image/video even if they are unsupported by the current environment. This PR adds error handling to escape the loading state when we know that a preview won't be displayable.

Fixes LB-1385