### PR TITLE
Add method to get unread inbox notifications count for rooms

### DIFF
--- a/examples/nextjs-comments-notifications/src/app/[room]/useRoomUnreadInboxNotifications.ts
+++ b/examples/nextjs-comments-notifications/src/app/[room]/useRoomUnreadInboxNotifications.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { InboxNotificationData } from "@liveblocks/client";
+import { useInboxNotifications } from "@liveblocks/react/suspense";
+
+/**
+ * Hook to get the count of unread inbox notifications in a room.
+ *
+ * @param roomId The room ID.
+ * @returns The count of unread inbox notifications in the room.
+ */
+export function useRoomUnreadInboxNotificationsCount(roomId: string) {
+  const [unreadCount, setUnreadCount] = useState<number | null>(null);
+  const { inboxNotifications, hasFetchedAll, fetchMore, isFetchingMore } =
+    useInboxNotifications();
+
+  // Until hasFetchedAll is true, fetch more notifications
+  useEffect(() => {
+    if (!hasFetchedAll && !isFetchingMore) {
+      fetchMore();
+    }
+  }, [hasFetchedAll, isFetchingMore]);
+
+  // Calculate unread count
+  useEffect(() => {
+    if (hasFetchedAll) {
+      const roomInboxNotifications = inboxNotifications.filter(
+        (notification) => notification.roomId === roomId
+      );
+      const unreadCount = roomInboxNotifications.filter(
+        isInboxNotificationUnread
+      ).length;
+
+      setUnreadCount(unreadCount);
+    }
+  }, [inboxNotifications, roomId, hasFetchedAll]);
+
+  return unreadCount;
+}
+
+function isInboxNotificationUnread(
+  inboxNotification: InboxNotificationData
+): boolean {
+  return (
+    !inboxNotification.readAt ||
+    inboxNotification.notifiedAt > inboxNotification.readAt
+  );
+}

--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -207,6 +207,12 @@ export interface RoomHttpApi<M extends BaseMetadata> {
     inboxNotificationId: string;
   }): Promise<string>;
 
+  getRoomUnreadInboxNotificationsCount({
+    roomId,
+  }: {
+    roomId: string;
+  }): Promise<number>;
+
   getNotificationSettings({
     roomId,
     signal,
@@ -982,6 +988,19 @@ export function createApiClient<M extends BaseMetadata>({
   /* -------------------------------------------------------------------------------------------------
    * Notifications (Room level)
    * -----------------------------------------------------------------------------------------------*/
+  async function getRoomUnreadInboxNotificationsCount(options: {
+    roomId: string;
+  }) {
+    const { count } = await httpClient.get<{ count: number }>(
+      url`/v2/c/rooms/${options.roomId}/inbox-notifications/count`,
+      await authManager.getAuthValue({
+        requestedScope: "comments:read",
+        roomId: options.roomId,
+      })
+    );
+    return count;
+  }
+
   async function getNotificationSettings(options: {
     roomId: string;
     signal?: AbortSignal;
@@ -1440,6 +1459,7 @@ export function createApiClient<M extends BaseMetadata>({
     // Room notifications
     markRoomInboxNotificationAsRead,
     updateNotificationSettings,
+    getRoomUnreadInboxNotificationsCount,
     getNotificationSettings,
     // Room text editor
     createTextMention,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -954,6 +954,14 @@ export type Room<
   getAttachmentUrl(attachmentId: string): Promise<string>;
 
   /**
+   * Gets the unread count of inbox notifications for the current user and room.
+   *
+   * @example
+   * const count = await room.getUnreadInboxNotificationsCount();
+   */
+  getUnreadInboxNotificationsCount(): Promise<number>;
+
+  /**
    * Gets the user's notification settings for the current room.
    *
    * @example
@@ -2922,6 +2930,10 @@ export function createRoom<
     return httpClient.getAttachmentUrl({ roomId, attachmentId });
   }
 
+  function getUnreadInboxNotificationsCount() {
+    return httpClient.getRoomUnreadInboxNotificationsCount({ roomId });
+  }
+
   function getNotificationSettings(
     options?: GetNotificationSettingsOptions
   ): Promise<RoomNotificationSettings> {
@@ -3076,6 +3088,7 @@ export function createRoom<
       getAttachmentUrl,
 
       // Notifications
+      getUnreadInboxNotificationsCount,
       getNotificationSettings,
       updateNotificationSettings,
       markInboxNotificationAsRead,


### PR DESCRIPTION
#### Descriptions

Adds `room.getUnreadInboxNotificationsCount`

Usage:
```ts
  const room = useRoom();
  const count = await room.getUnreadInboxNotificationsCount();
  
  // OR
  
  const room = client.getRoom("my-room");
  const count = await room.getUnreadInboxNotificationsCount();
```