### PR TITLE
Support zustand v5 in @liveblocks/zustand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.12.2 (Not published yet)
+
+### `@liveblocks/zustand`
+
+- Add support for Zustand v5
+
 ## 2.12.1
 
 ### `@liveblocks/react-ui`

--- a/e2e/next-sandbox/package.json
+++ b/e2e/next-sandbox/package.json
@@ -27,7 +27,7 @@
     "react-error-boundary": "^4.0.13",
     "react-redux": "^8.1.3",
     "redux": "^4.2.1",
-    "zustand": "^4.1.3"
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30161,7 +30161,7 @@
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
         "msw": "^0.36.4",
-        "zustand": "5.0.1"
+        "zustand": "^5.0.1"
       },
       "peerDependencies": {
         "zustand": "^5.0.1"
@@ -38912,7 +38912,7 @@
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
         "msw": "^0.36.4",
-        "zustand": "5.0.1"
+        "zustand": "^5.0.1"
       },
       "dependencies": {
         "@mswjs/cookies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "react-error-boundary": "^4.0.13",
         "react-redux": "^8.1.3",
         "redux": "^4.2.1",
-        "zustand": "^4.1.3"
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
@@ -55,6 +55,35 @@
         "@types/jest": "^29.5.5",
         "@types/lodash": "^4.14.199",
         "lodash": "^4.17.21"
+      }
+    },
+    "e2e/next-sandbox/node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -36771,7 +36800,15 @@
         "react-error-boundary": "^4.0.13",
         "react-redux": "^8.1.3",
         "redux": "^4.2.1",
-        "zustand": "^4.1.3"
+        "zustand": "^5.0.1"
+      },
+      "dependencies": {
+        "zustand": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+          "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+          "requires": {}
+        }
       }
     },
     "@liveblocks/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30132,10 +30132,10 @@
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
         "msw": "^0.36.4",
-        "zustand": "^4.1.3"
+        "zustand": "5.0.1"
       },
       "peerDependencies": {
-        "zustand": "^4.1.3"
+        "zustand": "^5.0.1"
       }
     },
     "packages/liveblocks-zustand/node_modules/@mswjs/cookies": {
@@ -30292,6 +30292,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/liveblocks-zustand/node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "schema-lang/codemirror-language": {
@@ -38845,7 +38875,7 @@
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
         "msw": "^0.36.4",
-        "zustand": "^4.1.3"
+        "zustand": "5.0.1"
       },
       "dependencies": {
         "@mswjs/cookies": {
@@ -38945,6 +38975,13 @@
         "type-fest": {
           "version": "1.4.0",
           "dev": true
+        },
+        "zustand": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+          "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+          "dev": true,
+          "requires": {}
         }
       }
     },

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -38,14 +38,14 @@
     "@liveblocks/core": "2.12.1"
   },
   "peerDependencies": {
-    "zustand": "^4.1.3"
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@testing-library/jest-dom": "^6.4.6",
     "msw": "^0.36.4",
-    "zustand": "^4.1.3"
+    "zustand": "5.0.1"
   },
   "sideEffects": false,
   "bugs": {

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -45,7 +45,7 @@
     "@liveblocks/jest-config": "*",
     "@testing-library/jest-dom": "^6.4.6",
     "msw": "^0.36.4",
-    "zustand": "5.0.1"
+    "zustand": "^5.0.1"
   },
   "sideEffects": false,
   "bugs": {

--- a/packages/liveblocks-zustand/src/__tests__/index.test.ts
+++ b/packages/liveblocks-zustand/src/__tests__/index.test.ts
@@ -16,7 +16,7 @@ import { ClientMsgCode, OpCode, ServerMsgCode } from "@liveblocks/core";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import type { StateCreator } from "zustand";
-import create from "zustand";
+import { create } from "zustand";
 
 import type { Mapping, WithLiveblocks } from "..";
 import { liveblocks as liveblocksMiddleware } from "..";

--- a/packages/liveblocks-zustand/test-d/basic.test-d.ts
+++ b/packages/liveblocks-zustand/test-d/basic.test-d.ts
@@ -5,7 +5,7 @@ import {
 } from "@liveblocks/zustand";
 import { devtools, persist } from "zustand/middleware";
 
-import create from "zustand";
+import { create } from "zustand";
 
 import { expectError, expectType } from "tsd";
 

--- a/packages/liveblocks-zustand/test-d/slices.test-d.ts
+++ b/packages/liveblocks-zustand/test-d/slices.test-d.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import create from "zustand";
+import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { createClient } from "@liveblocks/client";
 import { liveblocks as liveblocksMiddleware } from "@liveblocks/zustand";


### PR DESCRIPTION
Add support of `Zustand` v5 in `@liveblocks/zustand`.

No big breaking changes compared to support of v4. We still have the same TypeScript complaints than before,

### After merge & release

- [ ] Update example `zustand-flowchart` with new `@liveblocks/zustand` version and `zustand` v5 version
- [ ] Update example `zustand-todo-list` with new `@liveblocks/zustand` version and `zustand` v5 version
- [ ] Update example `zustand-whiteboard` with new `@liveblocks/zustand` version and `zustand` v5 version

Fixes [LB-1386](https://linear.app/liveblocks/issue/LB-1386/evaluate-and-support-zustand-v5-in-liveblockszustand)