### PR TITLE
Add offline text editor support to starter kit

### DIFF
--- a/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.module.css
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.module.css
@@ -25,6 +25,13 @@
   border-bottom: 1px solid var(--color-border);
   padding: var(--space-3) var(--space-8);
   z-index: var(--z-above);
+  transition: opacity 0.1s ease-out;
+}
+
+.editorHeader[data-disabled] {
+  pointer-events: none;
+  opacity: 0.68;
+  user-select: none;
 }
 
 .editorPanel {

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
@@ -46,7 +46,7 @@ function TiptapEditor() {
   // Set up editor with plugins, and place user info into Yjs awareness and cursors
   const editor = useEditor({
     immediatelyRender: false,
-    // Start read-only, enable in `<DisplayToolbar />` after `canWrite` is loaded
+    // Start read-only, updated after `canWrite` is loaded
     editable: false,
     editorProps: {
       attributes: {
@@ -144,9 +144,23 @@ function TiptapEditor() {
     ],
   });
 
+  // Check if user has write access in current room
+  const canWrite = useSelf((me) => me.canWrite) || false;
+  const disableToolbar = !editor || !canWrite;
+
+  // If canWrite changes, sync to Tiptap, as we're defaulting to false in the config
+  if (editor?.isEditable !== canWrite) {
+    editor?.setEditable(canWrite);
+  }
+
   return (
     <div className={styles.container}>
-      <DisplayToolbar editor={editor} />
+      <div
+        className={styles.editorHeader}
+        data-disabled={disableToolbar || undefined}
+      >
+        <Toolbar editor={editor} />
+      </div>
       <div className={styles.editorPanel}>
         {editor ? <SelectionMenu editor={editor} /> : null}
         <div className={styles.editorContainerOffset}>
@@ -162,26 +176,6 @@ function TiptapEditor() {
         </div>
       </div>
       {editor ? <WordCount editor={editor} /> : null}
-    </div>
-  );
-}
-
-function DisplayToolbar({ editor }: { editor: Editor | null }) {
-  // Check if user has write access in current room
-  const canWrite = useSelf((me) => me.canWrite) || false;
-  const disableToolbar = !editor || !canWrite;
-
-  // If canWrite changes, sync to Tiptap, as we're defaulting to false in the config
-  if (editor?.isEditable !== canWrite) {
-    editor?.setEditable(canWrite);
-  }
-
-  return (
-    <div
-      className={styles.editorHeader}
-      data-disabled={disableToolbar || undefined}
-    >
-      <Toolbar editor={editor} />
     </div>
   );
 }

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
@@ -149,8 +149,8 @@ function TiptapEditor() {
   const disableToolbar = !editor || !canWrite;
 
   // If canWrite changes, sync to Tiptap, as we're defaulting to false in the config
-  if (editor && editor?.isEditable !== canWrite) {
-    editor?.setEditable(canWrite);
+  if (editor && editor.isEditable !== canWrite) {
+    editor.setEditable(canWrite);
   }
 
   return (

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
@@ -149,7 +149,7 @@ function TiptapEditor() {
   const disableToolbar = !editor || !canWrite;
 
   // If canWrite changes, sync to Tiptap, as we're defaulting to false in the config
-  if (editor?.isEditable !== canWrite) {
+  if (editor && editor?.isEditable !== canWrite) {
     editor?.setEditable(canWrite);
   }
 

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/TextEditor.tsx
@@ -21,7 +21,6 @@ import { Editor, EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { EditorView } from "prosemirror-view";
 import { CommentIcon } from "@/icons";
-import { useInitialDocument } from "@/lib/hooks";
 import { DocumentSpinner } from "@/primitives/Spinner";
 import { useIsMobile } from "@/utils";
 import { CustomTaskItem } from "./CustomTaskItem";
@@ -40,9 +39,6 @@ export function TextEditor() {
 
 // Collaborative text editor with simple rich text and live cursors
 function TiptapEditor() {
-  const initialDocument = useInitialDocument();
-  console.log(initialDocument);
-
   const liveblocks = useLiveblocksExtension({
     offlineSupport_experimental: true,
   });
@@ -50,6 +46,7 @@ function TiptapEditor() {
   // Set up editor with plugins, and place user info into Yjs awareness and cursors
   const editor = useEditor({
     immediatelyRender: false,
+    // Start read-only, enable in `<DisplayToolbar />` after `canWrite` is loaded
     editable: false,
     editorProps: {
       attributes: {
@@ -58,7 +55,9 @@ function TiptapEditor() {
       },
     },
     extensions: [
+      // Add collaboration
       liveblocks,
+
       StarterKit.configure({
         blockquote: {
           HTMLAttributes: {

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/TextInlineAdvanced.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/TextInlineAdvanced.tsx
@@ -7,12 +7,12 @@ import { Popover } from "@/primitives/Popover";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarInlineAdvanced({ editor }: Props) {
   function toggleLink(link: string) {
-    editor.chain().focus().toggleLink({ href: link }).run();
+    editor?.chain().focus().toggleLink({ href: link }).run();
   }
 
   return (
@@ -20,9 +20,9 @@ export function ToolbarInlineAdvanced({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().toggleCode().run()}
-        disabled={!editor.can().chain().focus().toggleCode().run()}
-        data-active={editor.isActive("code") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleCode().run()}
+        disabled={!editor?.can().chain().focus().toggleCode().run()}
+        data-active={editor?.isActive("code") ? "is-active" : undefined}
         aria-label="Code"
       >
         <CodeIcon style={{ width: "18px" }} />
@@ -31,9 +31,9 @@ export function ToolbarInlineAdvanced({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().toggleHighlight().run()}
-        disabled={!editor.can().chain().focus().toggleHighlight().run()}
-        data-active={editor.isActive("highlight") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleHighlight().run()}
+        disabled={!editor?.can().chain().focus().toggleHighlight().run()}
+        data-active={editor?.isActive("highlight") ? "is-active" : undefined}
         aria-label="Highlight"
       >
         <HighlightIcon style={{ width: "18px" }} />
@@ -44,15 +44,15 @@ export function ToolbarInlineAdvanced({ editor }: Props) {
           <LinkPopover
             onSubmit={toggleLink}
             onRemoveLink={toggleLink}
-            showRemove={editor.getAttributes("link").href}
+            showRemove={editor?.getAttributes("link").href}
           />
         }
       >
         <Button
           variant="subtle"
           className={styles.toolbarButton}
-          disabled={!editor.can().chain().focus().setLink({ href: "" }).run()}
-          data-active={editor.isActive("link") ? "is-active" : undefined}
+          disabled={!editor?.can().chain().focus().setLink({ href: "" }).run()}
+          data-active={editor?.isActive("link") ? "is-active" : undefined}
           aria-label="Link"
         >
           <LinkIcon style={{ width: "17px" }} />

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/Toolbar.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/Toolbar.tsx
@@ -10,7 +10,7 @@ import { ToolbarThread } from "./ToolbarThread";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function Toolbar({ editor }: Props) {

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarAlignment.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarAlignment.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/primitives/Button";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarAlignment({ editor }: Props) {
@@ -18,10 +18,10 @@ export function ToolbarAlignment({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().setTextAlign("left").run()}
-        disabled={!editor.can().chain().focus().setTextAlign("left").run()}
+        onClick={() => editor?.chain().focus().setTextAlign("left").run()}
+        disabled={!editor?.can().chain().focus().setTextAlign("left").run()}
         data-active={
-          editor.isActive({ textAlign: "left" }) ? "is-active" : undefined
+          editor?.isActive({ textAlign: "left" }) ? "is-active" : undefined
         }
         aria-label="Align left"
       >
@@ -31,10 +31,10 @@ export function ToolbarAlignment({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().setTextAlign("center").run()}
-        disabled={!editor.can().chain().focus().setTextAlign("center").run()}
+        onClick={() => editor?.chain().focus().setTextAlign("center").run()}
+        disabled={!editor?.can().chain().focus().setTextAlign("center").run()}
         data-active={
-          editor.isActive({ textAlign: "center" }) ? "is-active" : undefined
+          editor?.isActive({ textAlign: "center" }) ? "is-active" : undefined
         }
         aria-label="Align center"
       >
@@ -44,10 +44,10 @@ export function ToolbarAlignment({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().setTextAlign("right").run()}
-        disabled={!editor.can().chain().focus().setTextAlign("right").run()}
+        onClick={() => editor?.chain().focus().setTextAlign("right").run()}
+        disabled={!editor?.can().chain().focus().setTextAlign("right").run()}
         data-active={
-          editor.isActive({ textAlign: "right" }) ? "is-active" : undefined
+          editor?.isActive({ textAlign: "right" }) ? "is-active" : undefined
         }
         aria-label="Align right"
       >
@@ -57,10 +57,10 @@ export function ToolbarAlignment({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().setTextAlign("justify").run()}
-        disabled={!editor.can().chain().focus().setTextAlign("justify").run()}
+        onClick={() => editor?.chain().focus().setTextAlign("justify").run()}
+        disabled={!editor?.can().chain().focus().setTextAlign("justify").run()}
         data-active={
-          editor.isActive({ textAlign: "justify" }) ? "is-active" : undefined
+          editor?.isActive({ textAlign: "justify" }) ? "is-active" : undefined
         }
         aria-label="Justify"
       >

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarBlock.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarBlock.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/primitives/Button";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarBlock({ editor }: Props) {
@@ -18,9 +18,9 @@ export function ToolbarBlock({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().focus().toggleBulletList().run()}
-        disabled={!editor.can().chain().focus().toggleBulletList().run()}
-        data-active={editor.isActive("bulletList") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleBulletList().run()}
+        disabled={!editor?.can().chain().focus().toggleBulletList().run()}
+        data-active={editor?.isActive("bulletList") ? "is-active" : undefined}
         aria-label="Unordered list"
       >
         <ListUnorderedIcon />
@@ -29,9 +29,9 @@ export function ToolbarBlock({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().focus().toggleOrderedList().run()}
-        disabled={!editor.can().chain().focus().toggleOrderedList().run()}
-        data-active={editor.isActive("orderedList") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleOrderedList().run()}
+        disabled={!editor?.can().chain().focus().toggleOrderedList().run()}
+        data-active={editor?.isActive("orderedList") ? "is-active" : undefined}
         aria-label="Ordered list"
       >
         <ListOrderedIcon />
@@ -40,9 +40,9 @@ export function ToolbarBlock({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().focus().toggleBlockquote().run()}
-        disabled={!editor.can().chain().focus().toggleBlockquote().run()}
-        data-active={editor.isActive("blockquote") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleBlockquote().run()}
+        disabled={!editor?.can().chain().focus().toggleBlockquote().run()}
+        data-active={editor?.isActive("blockquote") ? "is-active" : undefined}
         aria-label="Blockquote"
       >
         <BlockquoteIcon />
@@ -51,9 +51,9 @@ export function ToolbarBlock({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().focus().toggleTaskList().run()}
-        disabled={!editor.can().chain().focus().toggleTaskList().run()}
-        data-active={editor.isActive("taskList") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleTaskList().run()}
+        disabled={!editor?.can().chain().focus().toggleTaskList().run()}
+        data-active={editor?.isActive("taskList") ? "is-active" : undefined}
         aria-label="Task list"
       >
         <CheckboxIcon style={{ width: "16px" }} />

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarCommands.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarCommands.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/primitives/Button";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarCommands({ editor }: Props) {
@@ -13,9 +13,9 @@ export function ToolbarCommands({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().undo().run()}
-        disabled={!editor.can().chain().undo().run()}
-        data-active={editor.isActive("bulletList") ? "is-active" : undefined}
+        onClick={() => editor?.chain().undo().run()}
+        disabled={!editor?.can().chain().undo().run()}
+        data-active={editor?.isActive("bulletList") ? "is-active" : undefined}
         aria-label="Undo"
       >
         <UndoIcon />
@@ -24,9 +24,9 @@ export function ToolbarCommands({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().redo().run()}
-        disabled={!editor.can().chain().redo().run()}
-        data-active={editor.isActive("orderedList") ? "is-active" : undefined}
+        onClick={() => editor?.chain().redo().run()}
+        disabled={!editor?.can().chain().redo().run()}
+        data-active={editor?.isActive("orderedList") ? "is-active" : undefined}
         aria-label="Redo"
       >
         <RedoIcon />

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarHeadings.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarHeadings.tsx
@@ -11,7 +11,7 @@ const toolbarHeadings = [
 ];
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarHeadings({ editor }: Props) {
@@ -54,7 +54,11 @@ export function ToolbarHeadings({ editor }: Props) {
   );
 }
 
-function getCurrentHeading(editor: Editor) {
+function getCurrentHeading(editor: Editor | null) {
+  if (!editor) {
+    return "p";
+  }
+
   if (editor.isActive("heading", { level: 1 })) {
     return "h1";
   }

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarInline.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarInline.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/primitives/Button";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarInline({ editor }: Props) {
@@ -13,9 +13,9 @@ export function ToolbarInline({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        disabled={!editor.can().chain().focus().toggleBold().run()}
-        data-active={editor.isActive("bold") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleBold().run()}
+        disabled={!editor?.can().chain().focus().toggleBold().run()}
+        data-active={editor?.isActive("bold") ? "is-active" : undefined}
         aria-label="Bold"
       >
         <BoldIcon />
@@ -24,9 +24,9 @@ export function ToolbarInline({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        disabled={!editor.can().chain().focus().toggleItalic().run()}
-        data-active={editor.isActive("italic") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleItalic().run()}
+        disabled={!editor?.can().chain().focus().toggleItalic().run()}
+        data-active={editor?.isActive("italic") ? "is-active" : undefined}
         aria-label="Italic"
       >
         <ItalicIcon />
@@ -35,9 +35,9 @@ export function ToolbarInline({ editor }: Props) {
       <Button
         variant="subtle"
         className={styles.toolbarButton}
-        onClick={() => editor.chain().focus().toggleStrike().run()}
-        disabled={!editor.can().chain().focus().toggleStrike().run()}
-        data-active={editor.isActive("strike") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleStrike().run()}
+        disabled={!editor?.can().chain().focus().toggleStrike().run()}
+        data-active={editor?.isActive("strike") ? "is-active" : undefined}
         aria-label="Strikethrough"
       >
         <StrikethroughIcon />

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarMedia.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarMedia.tsx
@@ -7,12 +7,12 @@ import { Popover } from "@/primitives/Popover";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarMedia({ editor }: Props) {
   function addImage(url: string) {
-    if (!url.length) {
+    if (!url.length || !editor) {
       return;
     }
 
@@ -20,7 +20,7 @@ export function ToolbarMedia({ editor }: Props) {
   }
 
   function addYouTube(url: string) {
-    if (!url.length) {
+    if (!url.length || !editor) {
       return;
     }
 
@@ -32,9 +32,9 @@ export function ToolbarMedia({ editor }: Props) {
       <Button
         className={styles.toolbarButton}
         variant="subtle"
-        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-        disabled={!editor.can().chain().focus().toggleCodeBlock().run()}
-        data-active={editor.isActive("codeBlock") ? "is-active" : undefined}
+        onClick={() => editor?.chain().focus().toggleCodeBlock().run()}
+        disabled={!editor?.can().chain().focus().toggleCodeBlock().run()}
+        data-active={editor?.isActive("codeBlock") ? "is-active" : undefined}
         aria-label="Code block"
       >
         <CodeBlockIcon />
@@ -44,8 +44,8 @@ export function ToolbarMedia({ editor }: Props) {
         <Button
           className={styles.toolbarButton}
           variant="subtle"
-          disabled={!editor.can().chain().setImage({ src: "" }).run()}
-          data-active={editor.isActive("image") ? "is-active" : undefined}
+          disabled={!editor?.can().chain().setImage({ src: "" }).run()}
+          data-active={editor?.isActive("image") ? "is-active" : undefined}
           aria-label="Image"
         >
           <ImageIcon />
@@ -58,8 +58,8 @@ export function ToolbarMedia({ editor }: Props) {
         <Button
           className={styles.toolbarButton}
           variant="subtle"
-          disabled={!editor.can().chain().setImage({ src: "" }).run()}
-          data-active={editor.isActive("youtube") ? "is-active" : undefined}
+          disabled={!editor?.can().chain().setImage({ src: "" }).run()}
+          data-active={editor?.isActive("youtube") ? "is-active" : undefined}
           aria-label="YouTube"
         >
           <YouTubeIcon />

--- a/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarThread.tsx
+++ b/starter-kits/nextjs-starter-kit/components/TextEditor/ToolbarThread.tsx
@@ -7,14 +7,14 @@ import { Button } from "@/primitives/Button";
 import styles from "./Toolbar.module.css";
 
 type Props = {
-  editor: Editor;
+  editor: Editor | null;
 };
 
 export function ToolbarThread({ editor }: Props) {
   const wrapper = useRef<HTMLDivElement>(null);
 
   const handleClick = useCallback(async () => {
-    editor.chain().focus().addPendingComment().run();
+    editor?.chain().focus().addPendingComment().run();
   }, [editor]);
 
   return (
@@ -23,8 +23,8 @@ export function ToolbarThread({ editor }: Props) {
         variant="subtle"
         className={styles.toolbarButton}
         onClick={handleClick}
-        disabled={editor.isActive("lb-comment")}
-        data-active={editor.isActive("lb-comment") ? "is-active" : undefined}
+        disabled={editor?.isActive("lb-comment")}
+        data-active={editor?.isActive("lb-comment") ? "is-active" : undefined}
         aria-label="Add comment"
       >
         <CommentIcon />

--- a/starter-kits/nextjs-starter-kit/package-lock.json
+++ b/starter-kits/nextjs-starter-kit/package-lock.json
@@ -6,11 +6,11 @@
     "": {
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "^2.11.0",
-        "@liveblocks/node": "^2.11.0",
-        "@liveblocks/react": "^2.11.0",
-        "@liveblocks/react-tiptap": "^2.11.0",
-        "@liveblocks/react-ui": "^2.11.0",
+        "@liveblocks/client": "^2.12.2",
+        "@liveblocks/node": "^2.12.2",
+        "@liveblocks/react": "^2.12.2",
+        "@liveblocks/react-tiptap": "^2.12.2",
+        "@liveblocks/react-ui": "^2.12.2",
         "@radix-ui/react-dialog": "^1.0.2",
         "@radix-ui/react-popover": "^1.0.2",
         "@radix-ui/react-select": "^1.1.1",
@@ -250,40 +250,40 @@
       "license": "Apache-2.0"
     },
     "node_modules/@liveblocks/client": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-2.11.0.tgz",
-      "integrity": "sha512-ZRayUwwOzucYn4QqOTz0vcQSZlqGaP8TBROzE9Ye/PwfACNasyfa3roZqfizhBlYlYQQ/8qQlvGl2n3LPf8Byg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-2.12.2.tgz",
+      "integrity": "sha512-7hhlxLPT7D+IC5jrZpjyJub+zzT01TSlJXJg4HOrbnbzDbK9aALS0k7qbxvMDH3SFCOu8bbvs5aJ4nGfUi/LaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "2.11.0"
+        "@liveblocks/core": "2.12.2"
       }
     },
     "node_modules/@liveblocks/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-2WQlJvJ1NVJ/CpKhDNJJHXrh2Yzz6eXchqn64JqTHk5TLGbx1s4kaTahEXaAOXmu2abnJWnv06v1mhv3YXYg+A==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-2.12.2.tgz",
+      "integrity": "sha512-TZCG67beJpY0w7Ap99mu7tfC+q/0LmaUBanJKRmPR3/rbGAOzNxn1GMIjuMc4eU5YNmxG6IUuBziYu54E2edQw==",
       "license": "Apache-2.0"
     },
     "node_modules/@liveblocks/node": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-2.11.0.tgz",
-      "integrity": "sha512-NONbdZGXzcQQzL+6RNTp5NEpY/J7vDl1L7SSq9wWyl99YgtsQK+g5xJQmhQa1rc4FSHuicIZbGszyXYiad/bBQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-2.12.2.tgz",
+      "integrity": "sha512-xLlcnN2PwwdsTwB7MLpyPzBs9Mi5MyyimspKvZSXX4+8Ndr3i2UQjMJy2F/xh7JopvTKK2d6kv/0QgFRVBfOfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/core": "2.11.0",
+        "@liveblocks/core": "2.12.2",
         "@stablelib/base64": "^1.0.1",
         "fast-sha256": "^1.3.0",
         "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@liveblocks/react": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-2.11.0.tgz",
-      "integrity": "sha512-uAPEh9ZS03ANTnbbU5PTiFVusI05H7EqOH4aDVaKDrogkKi70RYbCek4PKY8TpK2vLhmutBxyVd3tp2uBwvTFQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-2.12.2.tgz",
+      "integrity": "sha512-XubQdaGwIs4KlDgc9ccjZ+rytVU3EMd7T7F30rHarPwdvOvjR5VYph8PsLBBhOZ5YjmOXlEDi6Ci1CDDH9kBiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
         "use-sync-external-store": "^1.2.2"
       },
       "peerDependencies": {
@@ -291,17 +291,17 @@
       }
     },
     "node_modules/@liveblocks/react-tiptap": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react-tiptap/-/react-tiptap-2.11.0.tgz",
-      "integrity": "sha512-byqtcZYEZQbBoSLepU84RS/Q7fnGQdeJXLs0bbmbyxzmr6qcdYsXu3Y01h3+x6TzmMLGQU6yDfQbtkZd6mX6Iw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react-tiptap/-/react-tiptap-2.12.2.tgz",
+      "integrity": "sha512-oP0iNSvTy2X/FULB9O6IYEc7R0+nn2RNpXVrAkTuDS3JzNUR7Wzf/8UFFphXLmPWF2mJTjgFm70EyRdmwu6NRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
-        "@liveblocks/react": "2.11.0",
-        "@liveblocks/react-ui": "2.11.0",
-        "@liveblocks/yjs": "2.11.0",
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
+        "@liveblocks/react": "2.12.2",
+        "@liveblocks/react-ui": "2.12.2",
+        "@liveblocks/yjs": "2.12.2",
         "@tiptap/core": "^2.7.2",
         "@tiptap/react": "^2.7.2",
         "@tiptap/suggestion": "^2.7.2",
@@ -320,15 +320,15 @@
       }
     },
     "node_modules/@liveblocks/react-ui": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react-ui/-/react-ui-2.11.0.tgz",
-      "integrity": "sha512-aBrgLWclSoV+3tOXxf45pL6Uaf8mRvHTmda79kwyCB/8yjqoeqNe2PThcELL8WWyaZsl7XU6Bgjpat3zY5rRHQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react-ui/-/react-ui-2.12.2.tgz",
+      "integrity": "sha512-Nk0yekKHUuc/pQOFJzNL5MAfROH7nZeBaUFR9RxUpXZFGLcIItacWSihiAx6zm1SVhwqe6ZvRzl6kQ3Rzrlpkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
-        "@liveblocks/react": "2.11.0",
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
+        "@liveblocks/react": "2.12.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.0",
@@ -379,14 +379,15 @@
       }
     },
     "node_modules/@liveblocks/yjs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/yjs/-/yjs-2.11.0.tgz",
-      "integrity": "sha512-o9RfjrVUMW4htHvHGwXxptZxnjC+evEvEkBqS2uPhOBBtOSMe15rWqzhoHqRXngkMUs8BIZ0EOkM5a0qsFIF0w==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/yjs/-/yjs-2.12.2.tgz",
+      "integrity": "sha512-n2SoGOZgCeIQ9W2DTLi8iHH73Xsub7miaNLLS7I4JsD5K+fE3sV5X3BUIqMIMsManbBrtlfRWzAu4s7A/x6GqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
-        "js-base64": "^3.7.7"
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
+        "js-base64": "^3.7.7",
+        "y-indexeddb": "^9.0.12"
       },
       "peerDependencies": {
         "yjs": "^13.6.1"
@@ -9306,6 +9307,26 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/y-prosemirror": {
       "version": "1.2.12",
       "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.12.tgz",
@@ -9515,50 +9536,50 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "@liveblocks/client": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-2.11.0.tgz",
-      "integrity": "sha512-ZRayUwwOzucYn4QqOTz0vcQSZlqGaP8TBROzE9Ye/PwfACNasyfa3roZqfizhBlYlYQQ/8qQlvGl2n3LPf8Byg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/client/-/client-2.12.2.tgz",
+      "integrity": "sha512-7hhlxLPT7D+IC5jrZpjyJub+zzT01TSlJXJg4HOrbnbzDbK9aALS0k7qbxvMDH3SFCOu8bbvs5aJ4nGfUi/LaQ==",
       "requires": {
-        "@liveblocks/core": "2.11.0"
+        "@liveblocks/core": "2.12.2"
       }
     },
     "@liveblocks/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-2WQlJvJ1NVJ/CpKhDNJJHXrh2Yzz6eXchqn64JqTHk5TLGbx1s4kaTahEXaAOXmu2abnJWnv06v1mhv3YXYg+A=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/core/-/core-2.12.2.tgz",
+      "integrity": "sha512-TZCG67beJpY0w7Ap99mu7tfC+q/0LmaUBanJKRmPR3/rbGAOzNxn1GMIjuMc4eU5YNmxG6IUuBziYu54E2edQw=="
     },
     "@liveblocks/node": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-2.11.0.tgz",
-      "integrity": "sha512-NONbdZGXzcQQzL+6RNTp5NEpY/J7vDl1L7SSq9wWyl99YgtsQK+g5xJQmhQa1rc4FSHuicIZbGszyXYiad/bBQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/node/-/node-2.12.2.tgz",
+      "integrity": "sha512-xLlcnN2PwwdsTwB7MLpyPzBs9Mi5MyyimspKvZSXX4+8Ndr3i2UQjMJy2F/xh7JopvTKK2d6kv/0QgFRVBfOfQ==",
       "requires": {
-        "@liveblocks/core": "2.11.0",
+        "@liveblocks/core": "2.12.2",
         "@stablelib/base64": "^1.0.1",
         "fast-sha256": "^1.3.0",
         "node-fetch": "^2.6.1"
       }
     },
     "@liveblocks/react": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-2.11.0.tgz",
-      "integrity": "sha512-uAPEh9ZS03ANTnbbU5PTiFVusI05H7EqOH4aDVaKDrogkKi70RYbCek4PKY8TpK2vLhmutBxyVd3tp2uBwvTFQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react/-/react-2.12.2.tgz",
+      "integrity": "sha512-XubQdaGwIs4KlDgc9ccjZ+rytVU3EMd7T7F30rHarPwdvOvjR5VYph8PsLBBhOZ5YjmOXlEDi6Ci1CDDH9kBiA==",
       "requires": {
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
         "use-sync-external-store": "^1.2.2"
       }
     },
     "@liveblocks/react-tiptap": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react-tiptap/-/react-tiptap-2.11.0.tgz",
-      "integrity": "sha512-byqtcZYEZQbBoSLepU84RS/Q7fnGQdeJXLs0bbmbyxzmr6qcdYsXu3Y01h3+x6TzmMLGQU6yDfQbtkZd6mX6Iw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react-tiptap/-/react-tiptap-2.12.2.tgz",
+      "integrity": "sha512-oP0iNSvTy2X/FULB9O6IYEc7R0+nn2RNpXVrAkTuDS3JzNUR7Wzf/8UFFphXLmPWF2mJTjgFm70EyRdmwu6NRw==",
       "requires": {
         "@floating-ui/react-dom": "^2.1.2",
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
-        "@liveblocks/react": "2.11.0",
-        "@liveblocks/react-ui": "2.11.0",
-        "@liveblocks/yjs": "2.11.0",
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
+        "@liveblocks/react": "2.12.2",
+        "@liveblocks/react-ui": "2.12.2",
+        "@liveblocks/yjs": "2.12.2",
         "@tiptap/core": "^2.7.2",
         "@tiptap/react": "^2.7.2",
         "@tiptap/suggestion": "^2.7.2",
@@ -9568,14 +9589,14 @@
       }
     },
     "@liveblocks/react-ui": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/react-ui/-/react-ui-2.11.0.tgz",
-      "integrity": "sha512-aBrgLWclSoV+3tOXxf45pL6Uaf8mRvHTmda79kwyCB/8yjqoeqNe2PThcELL8WWyaZsl7XU6Bgjpat3zY5rRHQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/react-ui/-/react-ui-2.12.2.tgz",
+      "integrity": "sha512-Nk0yekKHUuc/pQOFJzNL5MAfROH7nZeBaUFR9RxUpXZFGLcIItacWSihiAx6zm1SVhwqe6ZvRzl6kQ3Rzrlpkw==",
       "requires": {
         "@floating-ui/react-dom": "^2.1.2",
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
-        "@liveblocks/react": "2.11.0",
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
+        "@liveblocks/react": "2.12.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.0",
@@ -9606,13 +9627,14 @@
       }
     },
     "@liveblocks/yjs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@liveblocks/yjs/-/yjs-2.11.0.tgz",
-      "integrity": "sha512-o9RfjrVUMW4htHvHGwXxptZxnjC+evEvEkBqS2uPhOBBtOSMe15rWqzhoHqRXngkMUs8BIZ0EOkM5a0qsFIF0w==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@liveblocks/yjs/-/yjs-2.12.2.tgz",
+      "integrity": "sha512-n2SoGOZgCeIQ9W2DTLi8iHH73Xsub7miaNLLS7I4JsD5K+fE3sV5X3BUIqMIMsManbBrtlfRWzAu4s7A/x6GqA==",
       "requires": {
-        "@liveblocks/client": "2.11.0",
-        "@liveblocks/core": "2.11.0",
-        "js-base64": "^3.7.7"
+        "@liveblocks/client": "2.12.2",
+        "@liveblocks/core": "2.12.2",
+        "js-base64": "^3.7.7",
+        "y-indexeddb": "^9.0.12"
       }
     },
     "@next/env": {
@@ -14959,6 +14981,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "requires": {
+        "lib0": "^0.2.74"
+      }
     },
     "y-prosemirror": {
       "version": "1.2.12",

--- a/starter-kits/nextjs-starter-kit/package.json
+++ b/starter-kits/nextjs-starter-kit/package.json
@@ -10,11 +10,11 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@liveblocks/client": "^2.11.0",
-    "@liveblocks/node": "^2.11.0",
-    "@liveblocks/react": "^2.11.0",
-    "@liveblocks/react-tiptap": "^2.11.0",
-    "@liveblocks/react-ui": "^2.11.0",
+    "@liveblocks/client": "^2.12.2",
+    "@liveblocks/node": "^2.12.2",
+    "@liveblocks/react": "^2.12.2",
+    "@liveblocks/react-tiptap": "^2.12.2",
+    "@liveblocks/react-ui": "^2.12.2",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-popover": "^1.0.2",
     "@radix-ui/react-select": "^1.1.1",


### PR DESCRIPTION
- Upgrade to 2.12.2 to get offline support for text editor documents.
- The toolbar now shows for everyone, but is faded if you're read only. 
- This is to avoid a flash, as we need to wait for `canWrite` to load before we can show anything, and this way we can load the page instantly.