### PR TITLE
Clarify `resolveUsers` doc

### DIFF
--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -424,6 +424,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
 
   /**
    * A function that returns user info from user IDs.
+   * You should return a list of user objects of the same size, in the same order.
    */
   resolveUsers?: (
     args: ResolveUsersArgs

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -432,6 +432,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
 
   /**
    * A function that returns room info from room IDs.
+   * You should return a list of room info objects of the same size, in the same order.
    */
   resolveRoomsInfo?: (
     args: ResolveRoomsInfoArgs

--- a/packages/liveblocks-core/src/comments/comment-body.ts
+++ b/packages/liveblocks-core/src/comments/comment-body.ts
@@ -127,6 +127,7 @@ export type StringifyCommentBodyOptions<U extends BaseUserMeta = DU> = {
 
   /**
    * A function that returns user info from user IDs.
+   * You should return a list of user objects of the same size, in the same order.
    */
   resolveUsers?: (
     args: ResolveUsersArgs

--- a/packages/liveblocks-emails/src/comment-body.tsx
+++ b/packages/liveblocks-emails/src/comment-body.tsx
@@ -139,6 +139,7 @@ export type ConvertCommentBodyAsReactOptions<U extends BaseUserMeta = DU> = {
   components?: Partial<ConvertCommentBodyAsReactComponents<U>>;
   /**
    * A function that returns user info from user IDs.
+   * You should return a list of user objects of the same size, in the same order.
    */
   resolveUsers?: (
     args: ResolveUsersArgs
@@ -272,6 +273,7 @@ export type ConvertCommentBodyAsHtmlOptions<U extends BaseUserMeta = DU> = {
   styles?: Partial<ConvertCommentBodyAsHtmlStyles>;
   /**
    * A function that returns user info from user IDs.
+   * You should return a list of user objects of the same size, in the same order.
    */
   resolveUsers?: (
     args: ResolveUsersArgs


### PR DESCRIPTION
#### Description

Specifies that ordering and count are necessary for the return of user objects in `resolveUsers`

```ts
  /**
   * A function that returns user info from user IDs.
   * You should return a list of user objects of the same size, in the same order.
   */
  resolveUsers?: (
    args: ResolveUsersArgs
  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
};
```