### PR TITLE
Remove wrong `Timestamp` export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## Not published yet
+## 2.13.0 (Not published yet)
+
+### `@liveblocks/react-ui`
+
+- Remove `Timestamp` export mistakenly added to `@liveblocks/react-ui`, it
+  should be imported from `@liveblocks/react-ui/primitives` instead.
 
 ## 2.12.2
 

--- a/packages/liveblocks-react-ui/src/index.ts
+++ b/packages/liveblocks-react-ui/src/index.ts
@@ -40,5 +40,4 @@ export type {
 } from "./overrides";
 export { useOverrides } from "./overrides";
 export type { ComposerSubmitComment } from "./primitives";
-export { Timestamp } from "./primitives/Timestamp";
 export type { CommentAttachmentArgs } from "./types";


### PR DESCRIPTION
I just noticed that we currently export the `Timestamp` primitive from `@liveblocks/react-ui`, but it should only be exported from `@liveblocks/react-ui/primitives`. We didn't use it ourselves in other packages so no other changes than the removal.