### PR TITLE
Fix report text editor for `@liveblocks/react-tiptap` and `@liveblocks/react-lexical`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.13.2 (Not yet published)
+## Not yet published
+
+## 2.13.2
 
 ### `@liveblocks/react-lexical`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-## Not yet published
+## 2.13.2 (Not yet published)
+
+### `@liveblocks/react-lexical`
+
+- Fix report text editor function's call. Now we wait for the room's status to
+  be `connected` to report the text editor instead of reporting directly after
+  room creation / loading.
+
+### `@liveblocks/react-tiptap`
+
+- Fix report text editor function's call. Now we wait for the room's status to
+  be `connected` to report the text editor instead of reporting directly after
+  room creation / loading.
 
 ## 2.13.1
 

--- a/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/liveblocks-plugin-provider.tsx
@@ -4,6 +4,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import type { Provider } from "@lexical/yjs";
 import { kInternal, nn, TextEditorType } from "@liveblocks/core";
 import { useClient, useRoom, useSelf } from "@liveblocks/react";
+import { useReportTextEditor } from "@liveblocks/react/_private";
 import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import type { MutableRefObject } from "react";
 import React, {
@@ -205,10 +206,7 @@ export const LiveblocksPlugin = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    // Report that this is lexical and root is the rootKey
-    room[kInternal].reportTextEditor(TextEditorType.Lexical, "root");
-  }, [room]);
+  useReportTextEditor(TextEditorType.Lexical, "root");
 
   // Get user info or allow override from props
   const self = useSelf();

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -7,6 +7,7 @@ import {
 import {
   CreateThreadError,
   getUmbrellaStoreForClient,
+  useReportTextEditor,
 } from "@liveblocks/react/_private";
 import { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import type { AnyExtension, Content, Editor } from "@tiptap/core";
@@ -163,12 +164,11 @@ export const useLiveblocksExtension = (
     }
   }, [isEditorReady, yjsProvider, options.initialContent, editor]);
 
-  const reportTextEditorType = useCallback(
-    (field: string) => {
-      room[kInternal].reportTextEditor(TextEditorType.TipTap, field);
-    },
-    [room]
+  useReportTextEditor(
+    TextEditorType.TipTap,
+    options.field ?? DEFAULT_OPTIONS.field
   );
+
   const onCreateMention = useCallback(
     (userId: string, notificationId: string) => {
       try {
@@ -287,8 +287,6 @@ export const useLiveblocksExtension = (
           })
         );
       }
-
-      reportTextEditorType(options.field ?? DEFAULT_OPTIONS.field);
     },
     onDestroy() {
       this.storage.unsubs.forEach((unsub) => unsub());

--- a/packages/liveblocks-react/src/_private.ts
+++ b/packages/liveblocks-react/src/_private.ts
@@ -16,6 +16,7 @@ export {
   useMarkRoomThreadAsResolved,
   useMarkRoomThreadAsUnresolved,
   useRemoveRoomCommentReaction,
+  useReportTextEditor,
   useRoomAttachmentUrl,
   useRoomPermissions,
 } from "./room";

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -772,12 +772,15 @@ function useStatus(): Status {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
-/** @private - this an internal API do not rely on it */
+/** @private - Internal API, do not rely on it. */
 function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
   const isReported = React.useRef<boolean>(false);
   const room = useRoom();
 
   React.useEffect(() => {
+    // We use a "locker" reference to avoid to spam / harass our backend
+    // and to not add / remove subscribers in case when the text editor type
+    // has been already reported.
     if (isReported.current) {
       return;
     }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -786,7 +786,7 @@ function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
     }
 
     const unsubscribe = room.events.status.subscribe((status: Status): void => {
-      if (status === "connected") {
+      if (status === "connected" && !isReported.current) {
         isReported.current = true;
         void room[kInternal].reportTextEditor(editor, rootKey);
       }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -32,6 +32,7 @@ import type {
   OpaqueClient,
   Poller,
   RoomEventMessage,
+  TextEditorType,
   ToImmutable,
 } from "@liveblocks/core";
 import {
@@ -769,6 +770,27 @@ function useStatus(): Status {
   const getSnapshot = room.getStatus;
   const getServerSnapshot = room.getStatus;
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/** @private - this an internal API do not rely on it */
+function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
+  const isReported = React.useRef<boolean>(false);
+  const room = useRoom();
+
+  React.useEffect(() => {
+    if (isReported.current) {
+      return;
+    }
+
+    const unsubscribe = room.events.status.subscribe((status: Status): void => {
+      if (status === "connected") {
+        isReported.current = true;
+        room[kInternal].reportTextEditor(editor, rootKey);
+      }
+    });
+
+    return unsubscribe;
+  }, [room]);
 }
 
 /**
@@ -3172,6 +3194,7 @@ export {
   useRedo,
   useRemoveReaction,
   useRemoveRoomCommentReaction,
+  useReportTextEditor,
   _useRoom as useRoom,
   useRoomAttachmentUrl,
   _useRoomNotificationSettings as useRoomNotificationSettings,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -788,11 +788,8 @@ function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
     const unsubscribe = room.events.status.subscribe((status: Status): void => {
       if (status === "connected" && !isReported.current) {
         isReported.current = true;
-        room[kInternal].reportTextEditor(editor, rootKey).catch((err) => {
-          console.warn(
-            `Text editor reporting for room '${room.id}' failed: ${String(err)}`
-          );
-        });
+        // We not catch because this method never throw (e.g `rawPost`)
+        void room[kInternal].reportTextEditor(editor, rootKey);
       }
     });
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -785,12 +785,12 @@ function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
     const unsubscribe = room.events.status.subscribe((status: Status): void => {
       if (status === "connected") {
         isReported.current = true;
-        room[kInternal].reportTextEditor(editor, rootKey);
+        void room[kInternal].reportTextEditor(editor, rootKey);
       }
     });
 
     return unsubscribe;
-  }, [room]);
+  }, [room, editor, rootKey]);
 }
 
 /**

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -788,7 +788,7 @@ function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
     const unsubscribe = room.events.status.subscribe((status: Status): void => {
       if (status === "connected" && !isReported.current) {
         isReported.current = true;
-        // We not catch because this method never throw (e.g `rawPost`)
+        // We do not catch because this method never throw (e.g `rawPost`)
         void room[kInternal].reportTextEditor(editor, rootKey);
       }
     });

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -788,7 +788,11 @@ function useReportTextEditor(editor: TextEditorType, rootKey: string): void {
     const unsubscribe = room.events.status.subscribe((status: Status): void => {
       if (status === "connected" && !isReported.current) {
         isReported.current = true;
-        void room[kInternal].reportTextEditor(editor, rootKey);
+        room[kInternal].reportTextEditor(editor, rootKey).catch((err) => {
+          console.warn(
+            `Text editor reporting for room '${room.id}' failed: ${String(err)}`
+          );
+        });
       }
     });
 


### PR DESCRIPTION
This PRs fix calls to report text editors from either `@liveblocks/react-tiptap` or `@liveblocks/react-lexical` by implementing a new private hook (under `/_private`) named `useReportTextEditor()`.

This new hook will wait for the room's status be `connected` after loading / creation and then will only report the text editor to ensure when calling the endpoint with `client.reportTextEditor(...)` it will not fails because the room is not found. Also it "protects" by creating a new level of abstraction direct calls to `room[kInternal]`. 

Usage:
```tsx
import { useReportTextEditor } from "@liveblocks/react/_private";

export function LiveblocksTextEditor() {
   useReportTextEditor(TextEditorType.Lexical, "root");

   return <Whatever />
}
```

### 🏁 Checklist

- [x] Check in example
- [x] Update change log

--- 
Fixes [LB-1459](https://linear.app/liveblocks/issue/LB-1459/text-editor-not-in-dashboard-after-creation)