### PR TITLE
Use #private fields

### DIFF
--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -1488,12 +1488,12 @@ export function getBearerTokenFromAuthValue(authValue: AuthValue): string {
  * backend.
  */
 class HttpClient {
-  private _baseUrl: string;
-  private _fetchPolyfill: typeof fetch;
+  #baseUrl: string;
+  #fetchPolyfill: typeof fetch;
 
   constructor(baseUrl: string, fetchPolyfill: typeof fetch) {
-    this._baseUrl = baseUrl;
-    this._fetchPolyfill = fetchPolyfill;
+    this.#baseUrl = baseUrl;
+    this.#fetchPolyfill = fetchPolyfill;
   }
 
   // ------------------------------------------------------------------
@@ -1513,7 +1513,7 @@ class HttpClient {
    *   5. ...but silently return `{}` if that parsing fails
    *   6. Throw HttpError if response is an error
    */
-  private async rawFetch(
+  async #rawFetch(
     endpoint: URLSafeString,
     authValue: AuthValue,
     options?: RequestInit,
@@ -1523,8 +1523,8 @@ class HttpClient {
       raise("This client can only be used to make /v2/c/* requests");
     }
 
-    const url = urljoin(this._baseUrl, endpoint, params);
-    return await this._fetchPolyfill(url, {
+    const url = urljoin(this.#baseUrl, endpoint, params);
+    return await this.#fetchPolyfill(url, {
       ...options,
       headers: {
         // These headers are default, but can be overriden by custom headers
@@ -1554,13 +1554,13 @@ class HttpClient {
    *   5. ...but silently return `{}` if that parsing fails (🤔)
    *   6. Throw HttpError if response is an error
    */
-  private async fetch<T extends JsonObject>(
+  async #fetch<T extends JsonObject>(
     endpoint: URLSafeString,
     authValue: AuthValue,
     options?: RequestInit,
     params?: QueryParams
   ): Promise<T> {
-    const response = await this.rawFetch(endpoint, authValue, options, params);
+    const response = await this.#rawFetch(endpoint, authValue, options, params);
 
     if (!response.ok) {
       let error: HttpError;
@@ -1595,7 +1595,7 @@ class HttpClient {
     params?: QueryParams,
     options?: Omit<RequestInit, "body" | "method" | "headers">
   ): Promise<Response> {
-    return await this.rawFetch(endpoint, authValue, options, params);
+    return await this.#rawFetch(endpoint, authValue, options, params);
   }
 
   /**
@@ -1608,7 +1608,7 @@ class HttpClient {
     authValue: AuthValue,
     body?: JsonObject
   ): Promise<Response> {
-    return await this.rawFetch(endpoint, authValue, {
+    return await this.#rawFetch(endpoint, authValue, {
       method: "POST",
       body: JSON.stringify(body),
     });
@@ -1623,7 +1623,7 @@ class HttpClient {
     endpoint: URLSafeString,
     authValue: AuthValue
   ): Promise<Response> {
-    return await this.rawFetch(endpoint, authValue, { method: "DELETE" });
+    return await this.#rawFetch(endpoint, authValue, { method: "DELETE" });
   }
 
   /**
@@ -1636,7 +1636,7 @@ class HttpClient {
     params?: QueryParams,
     options?: Omit<RequestInit, "body" | "method" | "headers">
   ): Promise<T> {
-    return await this.fetch<T>(endpoint, authValue, options, params);
+    return await this.#fetch<T>(endpoint, authValue, options, params);
   }
 
   /**
@@ -1650,7 +1650,7 @@ class HttpClient {
     options?: Omit<RequestInit, "body" | "method" | "headers">,
     params?: QueryParams
   ): Promise<T> {
-    return await this.fetch<T>(
+    return await this.#fetch<T>(
       endpoint,
       authValue,
       {
@@ -1670,7 +1670,7 @@ class HttpClient {
     endpoint: URLSafeString,
     authValue: AuthValue
   ): Promise<T> {
-    return await this.fetch<T>(endpoint, authValue, { method: "DELETE" });
+    return await this.#fetch<T>(endpoint, authValue, { method: "DELETE" });
   }
 
   /**
@@ -1684,7 +1684,7 @@ class HttpClient {
     params?: QueryParams,
     options?: Omit<RequestInit, "body" | "method" | "headers">
   ): Promise<T> {
-    return await this.fetch<T>(
+    return await this.#fetch<T>(
       endpoint,
       authValue,
       {

--- a/packages/liveblocks-core/src/comments/comment-body.ts
+++ b/packages/liveblocks-core/src/comments/comment-body.ts
@@ -311,25 +311,20 @@ function escapeHtml(
 
 // Adapted from https://github.com/Janpot/escape-html-template-tag
 export class HtmlSafeString {
-  private _strings: readonly string[];
-  private _values: readonly (
-    | string
-    | string[]
-    | HtmlSafeString
-    | HtmlSafeString[]
-  )[];
+  #strings: readonly string[];
+  #values: readonly (string | string[] | HtmlSafeString | HtmlSafeString[])[];
 
   constructor(
     strings: readonly string[],
     values: readonly (string | string[] | HtmlSafeString | HtmlSafeString[])[]
   ) {
-    this._strings = strings;
-    this._values = values;
+    this.#strings = strings;
+    this.#values = values;
   }
 
   toString(): string {
-    return this._strings.reduce((result, str, i) => {
-      return result + escapeHtml(nn(this._values[i - 1])) + str;
+    return this.#strings.reduce((result, str, i) => {
+      return result + escapeHtml(nn(this.#values[i - 1])) + str;
     });
   }
 }
@@ -399,8 +394,8 @@ function escapeMarkdown(
 
 // Adapted from https://github.com/Janpot/escape-html-template-tag
 export class MarkdownSafeString {
-  private _strings: readonly string[];
-  private _values: readonly (
+  #strings: readonly string[];
+  #values: readonly (
     | string
     | string[]
     | MarkdownSafeString
@@ -416,13 +411,13 @@ export class MarkdownSafeString {
       | MarkdownSafeString[]
     )[]
   ) {
-    this._strings = strings;
-    this._values = values;
+    this.#strings = strings;
+    this.#values = values;
   }
 
   toString(): string {
-    return this._strings.reduce((result, str, i) => {
-      return result + escapeMarkdown(nn(this._values[i - 1])) + str;
+    return this.#strings.reduce((result, str, i) => {
+      return result + escapeMarkdown(nn(this.#values[i - 1])) + str;
     });
   }
 }

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -967,9 +967,8 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
  * from the outside.
  */
 export class ManagedSocket<T extends BaseAuthResult> {
-  /** @internal */
-  private machine: FSM<Context, Event, State>;
-  private cleanups: (() => void)[];
+  #machine: FSM<Context, Event, State>;
+  #cleanups: (() => void)[];
 
   public readonly events: {
     /**
@@ -1010,14 +1009,14 @@ export class ManagedSocket<T extends BaseAuthResult> {
       delegates,
       { waitForActorId, enableDebugLogging }
     );
-    this.machine = machine;
+    this.#machine = machine;
     this.events = events;
-    this.cleanups = cleanups;
+    this.#cleanups = cleanups;
   }
 
   getStatus(): Status {
     try {
-      return toNewConnectionStatus(this.machine);
+      return toNewConnectionStatus(this.#machine);
     } catch {
       return "initial";
     }
@@ -1027,7 +1026,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * Returns the current auth authValue.
    */
   get authValue(): T | null {
-    return this.machine.context.authValue as T | null;
+    return this.#machine.context.authValue as T | null;
   }
 
   /**
@@ -1035,7 +1034,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * if the machine is idle at the moment, otherwise this is a no-op.
    */
   public connect(): void {
-    this.machine.send({ type: "CONNECT" });
+    this.#machine.send({ type: "CONNECT" });
   }
 
   /**
@@ -1043,7 +1042,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * the socket, potentially obtaining a new authValue first, if needed.
    */
   public reconnect(): void {
-    this.machine.send({ type: "RECONNECT" });
+    this.#machine.send({ type: "RECONNECT" });
   }
 
   /**
@@ -1051,7 +1050,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * a no-op if there is no active connection.
    */
   public disconnect(): void {
-    this.machine.send({ type: "DISCONNECT" });
+    this.#machine.send({ type: "DISCONNECT" });
   }
 
   /**
@@ -1060,10 +1059,10 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * letting the instance get garbage collected.
    */
   public destroy(): void {
-    this.machine.stop();
+    this.#machine.stop();
 
     let cleanup: (() => void) | undefined;
-    while ((cleanup = this.cleanups.pop())) {
+    while ((cleanup = this.#cleanups.pop())) {
       cleanup();
     }
   }
@@ -1073,7 +1072,7 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * message if this is somehow impossible.
    */
   public send(data: string): void {
-    const socket = this.machine.context?.socket;
+    const socket = this.#machine.context?.socket;
     if (socket === null) {
       console.warn("Cannot send: not connected yet", data);
     } else if (socket.readyState !== 1 /* WebSocket.OPEN */) {
@@ -1088,6 +1087,6 @@ export class ManagedSocket<T extends BaseAuthResult> {
    * Not ideal to keep exposed :(
    */
   public _privateSendMachineEvent(event: Event): void {
-    this.machine.send(event);
+    this.#machine.send(event);
   }
 }

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -127,13 +127,10 @@ type ParentInfo =
 
 export abstract class AbstractCrdt {
   //                  ^^^^^^^^^^^^ TODO: Make this an interface
-  /** @internal */
-  private __pool?: ManagedPool;
-  /** @internal */
-  private __id?: string;
+  #pool?: ManagedPool;
+  #id?: string;
 
-  /** @internal */
-  private _parent: ParentInfo = NoParent;
+  #parent: ParentInfo = NoParent;
 
   /** @internal */
   _getParentKeyOrThrow(): string {
@@ -171,21 +168,21 @@ export abstract class AbstractCrdt {
 
   /** @internal */
   protected get _pool(): ManagedPool | undefined {
-    return this.__pool;
+    return this.#pool;
   }
 
   get roomId(): string | null {
-    return this.__pool ? this.__pool.roomId : null;
+    return this.#pool ? this.#pool.roomId : null;
   }
 
   /** @internal */
   get _id(): string | undefined {
-    return this.__id;
+    return this.#id;
   }
 
   /** @internal */
   get parent(): ParentInfo {
-    return this._parent;
+    return this.#parent;
   }
 
   /** @internal */
@@ -228,13 +225,13 @@ export abstract class AbstractCrdt {
           throw new Error("Cannot set parent: node already has a parent");
         } else {
           // Ignore
-          this._parent = HasParent(newParentNode, newParentKey);
+          this.#parent = HasParent(newParentNode, newParentKey);
           return;
         }
 
       case "Orphaned":
       case "NoParent": {
-        this._parent = HasParent(newParentNode, newParentKey);
+        this.#parent = HasParent(newParentNode, newParentKey);
         return;
       }
 
@@ -245,14 +242,14 @@ export abstract class AbstractCrdt {
 
   /** @internal */
   _attach(id: string, pool: ManagedPool): void {
-    if (this.__id || this.__pool) {
+    if (this.#id || this.#pool) {
       throw new Error("Cannot attach node: already attached");
     }
 
     pool.addNode(id, crdtAsLiveNode(this));
 
-    this.__id = id;
-    this.__pool = pool;
+    this.#id = id;
+    this.#pool = pool;
   }
 
   /** @internal */
@@ -260,18 +257,18 @@ export abstract class AbstractCrdt {
 
   /** @internal */
   _detach(): void {
-    if (this.__pool && this.__id) {
-      this.__pool.deleteNode(this.__id);
+    if (this.#pool && this.#id) {
+      this.#pool.deleteNode(this.#id);
     }
 
     switch (this.parent.type) {
       case "HasParent": {
-        this._parent = Orphaned(this.parent.key, this.parent.pos);
+        this.#parent = Orphaned(this.parent.key, this.parent.pos);
         break;
       }
 
       case "NoParent": {
-        this._parent = NoParent;
+        this.#parent = NoParent;
         break;
       }
 
@@ -284,7 +281,7 @@ export abstract class AbstractCrdt {
         assertNever(this.parent, "Unknown state");
     }
 
-    this.__pool = undefined;
+    this.#pool = undefined;
   }
 
   /** @internal */
@@ -300,20 +297,12 @@ export abstract class AbstractCrdt {
   /** @internal */
   abstract _serialize(): SerializedCrdt;
 
-  /**
-   * @internal
-   *
-   * This caches the result of the last .toImmutable() call for this Live node.
-   */
-  private _cachedImmutable?: Immutable;
+  /** This caches the result of the last .toImmutable() call for this Live node. */
+  #cachedImmutable?: Immutable;
 
-  /** @internal */
-  private _cachedTreeNodeKey?: string | number;
-  /**
-   * @internal
-   * This caches the result of the last .toTreeNode() call for this Live node.
-   */
-  private _cachedTreeNode?: DevTools.LsonTreeNode;
+  #cachedTreeNodeKey?: string | number;
+  /** This caches the result of the last .toTreeNode() call for this Live node. */
+  #cachedTreeNode?: DevTools.LsonTreeNode;
 
   /**
    * @internal
@@ -324,11 +313,11 @@ export abstract class AbstractCrdt {
    */
   invalidate(): void {
     if (
-      this._cachedImmutable !== undefined ||
-      this._cachedTreeNode !== undefined
+      this.#cachedImmutable !== undefined ||
+      this.#cachedTreeNode !== undefined
     ) {
-      this._cachedImmutable = undefined;
-      this._cachedTreeNode = undefined;
+      this.#cachedImmutable = undefined;
+      this.#cachedTreeNode = undefined;
 
       if (this.parent.type === "HasParent") {
         this.parent.node.invalidate();
@@ -345,13 +334,13 @@ export abstract class AbstractCrdt {
    * Return an snapshot of this Live tree for use in DevTools.
    */
   toTreeNode(key: string): DevTools.LsonTreeNode {
-    if (this._cachedTreeNode === undefined || this._cachedTreeNodeKey !== key) {
-      this._cachedTreeNodeKey = key;
-      this._cachedTreeNode = this._toTreeNode(key);
+    if (this.#cachedTreeNode === undefined || this.#cachedTreeNodeKey !== key) {
+      this.#cachedTreeNodeKey = key;
+      this.#cachedTreeNode = this._toTreeNode(key);
     }
 
     // Return cached version
-    return this._cachedTreeNode;
+    return this.#cachedTreeNode;
   }
 
   /** @internal */
@@ -361,12 +350,12 @@ export abstract class AbstractCrdt {
    * Return an immutable snapshot of this Live node and its children.
    */
   toImmutable(): Immutable {
-    if (this._cachedImmutable === undefined) {
-      this._cachedImmutable = this._toImmutable();
+    if (this.#cachedImmutable === undefined) {
+      this.#cachedImmutable = this._toImmutable();
     }
 
     // Return cached version
-    return this._cachedImmutable;
+    return this.#cachedImmutable;
   }
 
   /**

--- a/packages/liveblocks-core/src/crdts/LiveRegister.ts
+++ b/packages/liveblocks-core/src/crdts/LiveRegister.ts
@@ -17,16 +17,15 @@ import { AbstractCrdt } from "./AbstractCrdt";
  * INTERNAL
  */
 export class LiveRegister<TValue extends Json> extends AbstractCrdt {
-  /** @internal */
-  _data: TValue;
+  #data: TValue;
 
   constructor(data: TValue) {
     super();
-    this._data = data;
+    this.#data = data;
   }
 
   get data(): TValue {
-    return this._data;
+    return this.#data;
   }
 
   /** @internal */
@@ -99,13 +98,13 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
       type: "Json",
       id: this._id ?? nanoid(),
       key,
-      payload: this._data,
+      payload: this.#data,
     };
   }
 
   /** @internal */
   _toImmutable(): Immutable {
-    return this._data;
+    return this.#data;
   }
 
   clone(): TValue {

--- a/packages/liveblocks-core/src/lib/SortedList.ts
+++ b/packages/liveblocks-core/src/lib/SortedList.ts
@@ -32,12 +32,12 @@ function bisectRight<T>(arr: readonly T[], x: T, lt: (a: T, b: T) => boolean) {
  * [{ id: 1 }, { id: 4 }, { id: 5 }, { id: 9 }])
  */
 export class SortedList<T> {
-  private _data: T[];
-  private _lt: (a: T, b: T) => boolean;
+  #data: T[];
+  #lt: (a: T, b: T) => boolean;
 
   private constructor(alreadySortedList: T[], lt: (a: T, b: T) => boolean) {
-    this._lt = lt;
-    this._data = alreadySortedList;
+    this.#lt = lt;
+    this.#data = alreadySortedList;
   }
 
   public static from<T>(arr: T[], lt: (a: T, b: T) => boolean): SortedList<T> {
@@ -59,15 +59,15 @@ export class SortedList<T> {
    * Clones the sorted list to a new instance.
    */
   public clone(): SortedList<T> {
-    return new SortedList(this._data.slice(), this._lt);
+    return new SortedList(this.#data.slice(), this.#lt);
   }
 
   /**
    * Adds a new item to the sorted list, such that it remains sorted.
    */
   add(value: T): void {
-    const idx = bisectRight(this._data, value, this._lt);
-    this._data.splice(idx, 0, value);
+    const idx = bisectRight(this.#data, value, this.#lt);
+    this.#data.splice(idx, 0, value);
   }
 
   /**
@@ -76,20 +76,20 @@ export class SortedList<T> {
    * removed if the element exists in the sorted list multiple times.
    */
   remove(value: T): boolean {
-    const idx = this._data.indexOf(value);
+    const idx = this.#data.indexOf(value);
     if (idx >= 0) {
-      this._data.splice(idx, 1);
+      this.#data.splice(idx, 1);
       return true;
     }
     return false;
   }
 
   get length(): number {
-    return this._data.length;
+    return this.#data.length;
   }
 
   *filter(predicate: (value: T) => boolean): IterableIterator<T> {
-    for (const item of this._data) {
+    for (const item of this.#data) {
       if (predicate(item)) {
         yield item;
       }
@@ -97,6 +97,6 @@ export class SortedList<T> {
   }
 
   [Symbol.iterator](): IterableIterator<T> {
-    return this._data[Symbol.iterator]();
+    return this.#data[Symbol.iterator]();
   }
 }

--- a/packages/liveblocks-core/src/refs/ManagedOthers.ts
+++ b/packages/liveblocks-core/src/refs/ManagedOthers.ts
@@ -35,33 +35,33 @@ function makeUser<P extends JsonObject, U extends BaseUserMeta>(
 export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
   // Track mutable state internally, but signal to the outside when the
   // observable derived state changes only
-  private readonly internal: MutableSignal<{
+  readonly #internal: MutableSignal<{
     connections: Map</* connectionId */ number, Connection<U>>;
     presences: Map</* connectionId */ number, P>;
   }>;
-  private readonly userCache: Map</* connectionId */ number, User<P, U>>;
+  readonly #userCache: Map</* connectionId */ number, User<P, U>>;
 
   // The "clean" signal that is exposed to the outside world
   public readonly signal: DerivedSignal<readonly User<P, U>[]>;
 
   constructor() {
-    this.internal = new MutableSignal({
+    this.#internal = new MutableSignal({
       connections: new Map</* connectionId */ number, Connection<U>>(),
       presences: new Map</* connectionId */ number, P>(),
     });
 
     this.signal = DerivedSignal.from(
-      this.internal,
+      this.#internal,
       (_ignore): readonly User<P, U>[] =>
         compact(
-          Array.from(this.internal.get().presences.keys()).map((connectionId) =>
-            this.getUser(Number(connectionId))
+          Array.from(this.#internal.get().presences.keys()).map(
+            (connectionId) => this.getUser(Number(connectionId))
           )
         )
     );
 
     // Others
-    this.userCache = new Map();
+    this.#userCache = new Map();
   }
 
   // Shorthand for .signal.get()
@@ -70,20 +70,19 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
   }
 
   public connectionIds(): IterableIterator<number> {
-    return this.internal.get().connections.keys();
+    return this.#internal.get().connections.keys();
   }
 
   clearOthers(): void {
-    this.internal.mutate((state) => {
+    this.#internal.mutate((state) => {
       state.connections.clear();
       state.presences.clear();
-      this.userCache.clear();
+      this.#userCache.clear();
     });
   }
 
-  /** @internal */
-  _getUser(connectionId: number): User<P, U> | undefined {
-    const state = this.internal.get();
+  #_getUser(connectionId: number): User<P, U> | undefined {
+    const state = this.#internal.get();
     const conn = state.connections.get(connectionId);
     const presence = state.presences.get(connectionId);
     if (conn !== undefined && presence !== undefined) {
@@ -93,23 +92,22 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
   }
 
   getUser(connectionId: number): User<P, U> | undefined {
-    const cachedUser = this.userCache.get(connectionId);
+    const cachedUser = this.#userCache.get(connectionId);
     if (cachedUser) {
       return cachedUser;
     }
 
-    const computedUser = this._getUser(connectionId);
+    const computedUser = this.#_getUser(connectionId);
     if (computedUser) {
-      this.userCache.set(connectionId, computedUser);
+      this.#userCache.set(connectionId, computedUser);
       return computedUser;
     }
 
     return undefined;
   }
 
-  /** @internal */
-  _invalidateUser(connectionId: number): void {
-    this.userCache.delete(connectionId);
+  #invalidateUser(connectionId: number): void {
+    this.#userCache.delete(connectionId);
   }
 
   /**
@@ -122,7 +120,7 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
     metaUserInfo: U["info"],
     scopes: string[]
   ): void {
-    this.internal.mutate((state) => {
+    this.#internal.mutate((state) => {
       state.connections.set(
         connectionId,
         freeze({
@@ -135,7 +133,7 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
       if (!state.presences.has(connectionId)) {
         return false;
       }
-      return this._invalidateUser(connectionId);
+      return this.#invalidateUser(connectionId);
     });
   }
 
@@ -144,10 +142,10 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
    * the presence information.
    */
   removeConnection(connectionId: number): void {
-    this.internal.mutate((state) => {
+    this.#internal.mutate((state) => {
       state.connections.delete(connectionId);
       state.presences.delete(connectionId);
-      this._invalidateUser(connectionId);
+      this.#invalidateUser(connectionId);
     });
   }
 
@@ -156,12 +154,12 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
    * its known presence data is overwritten.
    */
   setOther(connectionId: number, presence: P): void {
-    this.internal.mutate((state) => {
+    this.#internal.mutate((state) => {
       state.presences.set(connectionId, freeze(compactObject(presence)));
       if (!state.connections.has(connectionId)) {
         return false;
       }
-      return this._invalidateUser(connectionId);
+      return this.#invalidateUser(connectionId);
     });
   }
 
@@ -171,7 +169,7 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
    * full .setOther() call first.
    */
   patchOther(connectionId: number, patch: Partial<P>): void {
-    this.internal.mutate((state) => {
+    this.#internal.mutate((state) => {
       const oldPresence = state.presences.get(connectionId);
       if (oldPresence === undefined) {
         return false;
@@ -183,7 +181,7 @@ export class ManagedOthers<P extends JsonObject, U extends BaseUserMeta> {
       }
 
       state.presences.set(connectionId, freeze(newPresence));
-      return this._invalidateUser(connectionId);
+      return this.#invalidateUser(connectionId);
     });
   }
 }

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -162,10 +162,8 @@ type U = DU;
  * Interact with the Liveblocks API from your Node.js backend.
  */
 export class Liveblocks {
-  /** @internal */
-  private readonly _secret: string;
-  /** @internal */
-  private readonly _baseUrl: URL;
+  readonly #secret: string;
+  readonly #baseUrl: URL;
 
   /**
    * Interact with the Liveblocks API from your Node.js backend.
@@ -174,15 +172,14 @@ export class Liveblocks {
     const options_ = options as Record<string, unknown>;
     const secret = options_.secret;
     assertSecretKey(secret, "secret");
-    this._secret = secret;
-    this._baseUrl = new URL(getBaseUrl(options.baseUrl));
+    this.#secret = secret;
+    this.#baseUrl = new URL(getBaseUrl(options.baseUrl));
   }
 
-  /** @internal */
-  private async post(path: URLSafeString, json: Json): Promise<Response> {
-    const url = urljoin(this._baseUrl, path);
+  async #post(path: URLSafeString, json: Json): Promise<Response> {
+    const url = urljoin(this.#baseUrl, path);
     const headers = {
-      Authorization: `Bearer ${this._secret}`,
+      Authorization: `Bearer ${this.#secret}`,
       "Content-Type": "application/json",
     };
     const fetch = await fetchPolyfill();
@@ -194,11 +191,10 @@ export class Liveblocks {
     return res;
   }
 
-  /** @internal */
-  private async put(path: URLSafeString, json: Json): Promise<Response> {
-    const url = urljoin(this._baseUrl, path);
+  async #put(path: URLSafeString, json: Json): Promise<Response> {
+    const url = urljoin(this.#baseUrl, path);
     const headers = {
-      Authorization: `Bearer ${this._secret}`,
+      Authorization: `Bearer ${this.#secret}`,
       "Content-Type": "application/json",
     };
     const fetch = await fetchPolyfill();
@@ -209,37 +205,34 @@ export class Liveblocks {
     });
   }
 
-  /** @internal */
-  private async putBinary(
+  async #putBinary(
     path: URLSafeString,
     body: Uint8Array,
     params?: QueryParams
   ): Promise<Response> {
-    const url = urljoin(this._baseUrl, path, params);
+    const url = urljoin(this.#baseUrl, path, params);
     const headers = {
-      Authorization: `Bearer ${this._secret}`,
+      Authorization: `Bearer ${this.#secret}`,
       "Content-Type": "application/octet-stream",
     };
     const fetch = await fetchPolyfill();
     return await fetch(url, { method: "PUT", headers, body });
   }
 
-  /** @internal */
-  private async delete(path: URLSafeString): Promise<Response> {
-    const url = urljoin(this._baseUrl, path);
+  async #delete(path: URLSafeString): Promise<Response> {
+    const url = urljoin(this.#baseUrl, path);
     const headers = {
-      Authorization: `Bearer ${this._secret}`,
+      Authorization: `Bearer ${this.#secret}`,
     };
     const fetch = await fetchPolyfill();
     const res = await fetch(url, { method: "DELETE", headers });
     return res;
   }
 
-  /** @internal */
-  async get(path: URLSafeString, params?: QueryParams): Promise<Response> {
-    const url = urljoin(this._baseUrl, path, params);
+  async #get(path: URLSafeString, params?: QueryParams): Promise<Response> {
+    const url = urljoin(this.#baseUrl, path, params);
     const headers = {
-      Authorization: `Bearer ${this._secret}`,
+      Authorization: `Bearer ${this.#secret}`,
     };
     const fetch = await fetchPolyfill();
     const res = await fetch(url, { method: "GET", headers });
@@ -274,7 +267,7 @@ export class Liveblocks {
     >
   ): Session {
     const options = rest[0];
-    return new Session(this.post.bind(this), userId, options?.userInfo);
+    return new Session(this.#post.bind(this), userId, options?.userInfo);
   }
 
   /**
@@ -330,7 +323,7 @@ export class Liveblocks {
     // assertStringArrayOrUndefined(groupsIds, "groupIds"); // TODO: Check if this is a legal userId value too
 
     try {
-      const resp = await this.post(path, {
+      const resp = await this.#post(path, {
         userId,
         groupIds,
 
@@ -346,7 +339,7 @@ export class Liveblocks {
       return {
         status: 503 /* Service Unavailable */,
         body: `Call to ${urljoin(
-          this._baseUrl,
+          this.#baseUrl,
           path
         )} failed. See "error" for more information.`,
         error: er as Error | undefined,
@@ -440,7 +433,7 @@ export class Liveblocks {
       query,
     };
 
-    const res = await this.get(path, queryParams);
+    const res = await this.#get(path, queryParams);
 
     if (!res.ok) {
       const text = await res.text();
@@ -493,7 +486,7 @@ export class Liveblocks {
   ): Promise<RoomData> {
     const { defaultAccesses, groupsAccesses, usersAccesses, metadata } = params;
 
-    const res = await this.post(url`/v2/rooms`, {
+    const res = await this.#post(url`/v2/rooms`, {
       id: roomId,
       defaultAccesses,
       groupsAccesses,
@@ -527,7 +520,7 @@ export class Liveblocks {
    * @returns The room with the given id.
    */
   public async getRoom(roomId: string): Promise<RoomData> {
-    const res = await this.get(url`/v2/rooms/${roomId}`);
+    const res = await this.#get(url`/v2/rooms/${roomId}`);
 
     if (!res.ok) {
       const text = await res.text();
@@ -576,7 +569,7 @@ export class Liveblocks {
   ): Promise<RoomData> {
     const { defaultAccesses, groupsAccesses, usersAccesses, metadata } = params;
 
-    const res = await this.post(url`/v2/rooms/${roomId}`, {
+    const res = await this.#post(url`/v2/rooms/${roomId}`, {
       defaultAccesses,
       groupsAccesses,
       usersAccesses,
@@ -608,7 +601,7 @@ export class Liveblocks {
    * @param roomId The id of the room to delete.
    */
   public async deleteRoom(roomId: string): Promise<void> {
-    const res = await this.delete(url`/v2/rooms/${roomId}`);
+    const res = await this.#delete(url`/v2/rooms/${roomId}`);
 
     if (!res.ok) {
       const text = await res.text();
@@ -624,7 +617,7 @@ export class Liveblocks {
   public async getActiveUsers(
     roomId: string
   ): Promise<{ data: RoomUser<U>[] }> {
-    const res = await this.get(url`/v2/rooms/${roomId}/active_users`);
+    const res = await this.#get(url`/v2/rooms/${roomId}/active_users`);
 
     if (!res.ok) {
       const text = await res.text();
@@ -640,7 +633,7 @@ export class Liveblocks {
    * @param message The message to broadcast. It can be any JSON serializable value.
    */
   public async broadcastEvent(roomId: string, message: E): Promise<void> {
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/broadcast_event`,
       message
     );
@@ -688,7 +681,7 @@ export class Liveblocks {
     roomId: string,
     format: "plain-lson" | "json" = "plain-lson"
   ): Promise<PlainLsonObject | ToSimplifiedJson<S>> {
-    const res = await this.get(url`/v2/rooms/${roomId}/storage`, { format });
+    const res = await this.#get(url`/v2/rooms/${roomId}/storage`, { format });
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -708,7 +701,7 @@ export class Liveblocks {
     roomId: string,
     document: PlainLsonObject
   ): Promise<PlainLsonObject> {
-    const res = await this.post(url`/v2/rooms/${roomId}/storage`, document);
+    const res = await this.#post(url`/v2/rooms/${roomId}/storage`, document);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -721,7 +714,7 @@ export class Liveblocks {
    * @param roomId The id of the room to delete the storage from.
    */
   public async deleteStorageDocument(roomId: string): Promise<void> {
-    const res = await this.delete(url`/v2/rooms/${roomId}/storage`);
+    const res = await this.#delete(url`/v2/rooms/${roomId}/storage`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -752,7 +745,7 @@ export class Liveblocks {
 
     const path = url`v2/rooms/${roomId}/ydoc`;
 
-    const res = await this.get(path, {
+    const res = await this.#get(path, {
       formatting: format ? "true" : undefined,
       key,
       type,
@@ -779,7 +772,7 @@ export class Liveblocks {
       guid?: string;
     } = {}
   ): Promise<void> {
-    const res = await this.putBinary(url`/v2/rooms/${roomId}/ydoc`, update, {
+    const res = await this.#putBinary(url`/v2/rooms/${roomId}/ydoc`, update, {
       guid: params.guid,
     });
     if (!res.ok) {
@@ -801,7 +794,7 @@ export class Liveblocks {
       guid?: string;
     } = {}
   ): Promise<ArrayBuffer> {
-    const res = await this.get(url`/v2/rooms/${roomId}/ydoc-binary`, {
+    const res = await this.#get(url`/v2/rooms/${roomId}/ydoc-binary`, {
       guid: params.guid,
     });
     if (!res.ok) {
@@ -822,7 +815,7 @@ export class Liveblocks {
    * @returns The created schema.
    */
   public async createSchema(name: string, body: string): Promise<Schema> {
-    const res = await this.post(url`/v2/schemas`, {
+    const res = await this.#post(url`/v2/schemas`, {
       name,
       body,
     });
@@ -849,7 +842,7 @@ export class Liveblocks {
    * @returns The schema with the given id.
    */
   public async getSchema(schemaId: string): Promise<Schema> {
-    const res = await this.get(url`/v2/schemas/${schemaId}`);
+    const res = await this.#get(url`/v2/schemas/${schemaId}`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -874,7 +867,7 @@ export class Liveblocks {
    * @returns The updated schema. The version of the schema will be incremented.
    */
   public async updateSchema(schemaId: string, body: string): Promise<Schema> {
-    const res = await this.put(url`/v2/schemas/${schemaId}`, {
+    const res = await this.#put(url`/v2/schemas/${schemaId}`, {
       body,
     });
     if (!res.ok) {
@@ -900,7 +893,7 @@ export class Liveblocks {
    * @param schemaId Id of the schema - this is the combination of the schema name and version of the schema to update. For example, `my-schema@1`.
    */
   public async deleteSchema(schemaId: string): Promise<void> {
-    const res = await this.delete(url`/v2/schemas/${schemaId}`);
+    const res = await this.#delete(url`/v2/schemas/${schemaId}`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -913,7 +906,7 @@ export class Liveblocks {
    * @returns
    */
   public async getSchemaByRoomId(roomId: string): Promise<Schema> {
-    const res = await this.get(url`/v2/rooms/${roomId}/schema`);
+    const res = await this.#get(url`/v2/rooms/${roomId}/schema`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -943,7 +936,7 @@ export class Liveblocks {
     roomId: string,
     schemaId: string
   ): Promise<{ schema: string }> {
-    const res = await this.post(url`/v2/rooms/${roomId}/schema`, {
+    const res = await this.#post(url`/v2/rooms/${roomId}/schema`, {
       schema: schemaId,
     });
     if (!res.ok) {
@@ -958,7 +951,7 @@ export class Liveblocks {
    * @param roomId The id of the room to detach the schema from.
    */
   public async detachSchemaFromRoom(roomId: string): Promise<void> {
-    const res = await this.delete(url`/v2/rooms/${roomId}/schema`);
+    const res = await this.#delete(url`/v2/rooms/${roomId}/schema`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -1021,7 +1014,7 @@ export class Liveblocks {
       query = objectToQuery(params.query);
     }
 
-    const res = await this.get(url`/v2/rooms/${roomId}/threads`, {
+    const res = await this.#get(url`/v2/rooms/${roomId}/threads`, {
       query,
     });
     if (!res.ok) {
@@ -1047,7 +1040,7 @@ export class Liveblocks {
   }): Promise<ThreadData<M>> {
     const { roomId, threadId } = params;
 
-    const res = await this.get(url`/v2/rooms/${roomId}/threads/${threadId}`);
+    const res = await this.#get(url`/v2/rooms/${roomId}/threads/${threadId}`);
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);
@@ -1071,7 +1064,7 @@ export class Liveblocks {
   }): Promise<ThreadParticipants> {
     const { roomId, threadId } = params;
 
-    const res = await this.get(
+    const res = await this.#get(
       url`/v2/rooms/${roomId}/threads/${threadId}/participants`
     );
     if (!res.ok) {
@@ -1096,7 +1089,7 @@ export class Liveblocks {
   }): Promise<CommentData> {
     const { roomId, threadId, commentId } = params;
 
-    const res = await this.get(
+    const res = await this.#get(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${commentId}`
     );
     if (!res.ok) {
@@ -1127,7 +1120,7 @@ export class Liveblocks {
   }): Promise<CommentData> {
     const { roomId, threadId, data } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments`,
       {
         ...data,
@@ -1161,7 +1154,7 @@ export class Liveblocks {
   }): Promise<CommentData> {
     const { roomId, threadId, commentId, data } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${commentId}`,
       {
         ...data,
@@ -1189,7 +1182,7 @@ export class Liveblocks {
   }): Promise<void> {
     const { roomId, threadId, commentId } = params;
 
-    const res = await this.delete(
+    const res = await this.#delete(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${commentId}`
     );
     if (!res.ok) {
@@ -1213,7 +1206,7 @@ export class Liveblocks {
   ): Promise<ThreadData<M>> {
     const { roomId, data } = params;
 
-    const res = await this.post(url`/v2/rooms/${roomId}/threads`, {
+    const res = await this.#post(url`/v2/rooms/${roomId}/threads`, {
       ...data,
       comment: {
         ...data.comment,
@@ -1240,7 +1233,9 @@ export class Liveblocks {
   }): Promise<void> {
     const { roomId, threadId } = params;
 
-    const res = await this.delete(url`/v2/rooms/${roomId}/threads/${threadId}`);
+    const res = await this.#delete(
+      url`/v2/rooms/${roomId}/threads/${threadId}`
+    );
 
     if (!res.ok) {
       const text = await res.text();
@@ -1264,7 +1259,7 @@ export class Liveblocks {
   }): Promise<ThreadData<M>> {
     const { roomId, threadId } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-resolved`,
       {}
     );
@@ -1293,7 +1288,7 @@ export class Liveblocks {
   }): Promise<ThreadData<M>> {
     const { roomId, threadId } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-unresolved`,
       {}
     );
@@ -1326,7 +1321,7 @@ export class Liveblocks {
   }): Promise<M> {
     const { roomId, threadId, data } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/metadata`,
       {
         ...data,
@@ -1363,7 +1358,7 @@ export class Liveblocks {
     };
   }): Promise<CommentUserReaction> {
     const { roomId, threadId, commentId, data } = params;
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${commentId}/add-reaction`,
       {
         ...data,
@@ -1401,7 +1396,7 @@ export class Liveblocks {
   }): Promise<void> {
     const { roomId, threadId, data } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${params.commentId}/remove-reaction`,
       {
         ...data,
@@ -1426,7 +1421,7 @@ export class Liveblocks {
   }): Promise<InboxNotificationData> {
     const { userId, inboxNotificationId } = params;
 
-    const res = await this.get(
+    const res = await this.#get(
       url`/v2/users/${userId}/inbox-notifications/${inboxNotificationId}`
     );
     if (!res.ok) {
@@ -1478,7 +1473,7 @@ export class Liveblocks {
       query = objectToQuery(params.query);
     }
 
-    const res = await this.get(url`/v2/users/${userId}/inbox-notifications`, {
+    const res = await this.#get(url`/v2/users/${userId}/inbox-notifications`, {
       query,
     });
     if (!res.ok) {
@@ -1506,7 +1501,7 @@ export class Liveblocks {
   }): Promise<RoomNotificationSettings> {
     const { userId, roomId } = params;
 
-    const res = await this.get(
+    const res = await this.#get(
       url`/v2/rooms/${roomId}/users/${userId}/notification-settings`
     );
     if (!res.ok) {
@@ -1530,7 +1525,7 @@ export class Liveblocks {
   }): Promise<RoomNotificationSettings> {
     const { userId, roomId, data } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${roomId}/users/${userId}/notification-settings`,
       data
     );
@@ -1553,7 +1548,7 @@ export class Liveblocks {
   }): Promise<void> {
     const { userId, roomId } = params;
 
-    const res = await this.delete(
+    const res = await this.#delete(
       url`/v2/rooms/${roomId}/users/${userId}/notification-settings`
     );
     if (!res.ok) {
@@ -1573,7 +1568,7 @@ export class Liveblocks {
   }): Promise<RoomData> {
     const { currentRoomId, newRoomId } = params;
 
-    const res = await this.post(
+    const res = await this.#post(
       url`/v2/rooms/${currentRoomId}/update-room-id`,
       {
         newRoomId,
@@ -1601,7 +1596,7 @@ export class Liveblocks {
     subjectId: string;
     activityData: DAD[K];
   }): Promise<void> {
-    const res = await this.post(url`/v2/inbox-notifications/trigger`, params);
+    const res = await this.#post(url`/v2/inbox-notifications/trigger`, params);
 
     if (!res.ok) {
       const text = await res.text();
@@ -1620,7 +1615,7 @@ export class Liveblocks {
   }): Promise<void> {
     const { userId, inboxNotificationId } = params;
 
-    const res = await this.delete(
+    const res = await this.#delete(
       url`/v2/users/${userId}/inbox-notifications/${inboxNotificationId}`
     );
     if (!res.ok) {
@@ -1638,7 +1633,9 @@ export class Liveblocks {
   }): Promise<void> {
     const { userId } = params;
 
-    const res = await this.delete(url`/v2/users/${userId}/inbox-notifications`);
+    const res = await this.#delete(
+      url`/v2/users/${userId}/inbox-notifications`
+    );
     if (!res.ok) {
       const text = await res.text();
       throw new LiveblocksError(res.status, text);

--- a/packages/liveblocks-node/src/webhooks.ts
+++ b/packages/liveblocks-node/src/webhooks.ts
@@ -3,8 +3,8 @@ import * as sha256 from "fast-sha256";
 import type { IncomingHttpHeaders } from "http";
 
 export class WebhookHandler {
-  private secretBuffer: Buffer;
-  private static secretPrefix = "whsec_";
+  #secretBuffer: Buffer;
+  static #secretPrefix = "whsec_";
 
   constructor(
     /**
@@ -16,11 +16,11 @@ export class WebhookHandler {
     if (!secret) throw new Error("Secret is required");
     if (typeof secret !== "string") throw new Error("Secret must be a string");
 
-    if (secret.startsWith(WebhookHandler.secretPrefix) === false)
+    if (secret.startsWith(WebhookHandler.#secretPrefix) === false)
       throw new Error("Invalid secret, must start with whsec_");
 
-    const secretKey = secret.slice(WebhookHandler.secretPrefix.length);
-    this.secretBuffer = Buffer.from(secretKey, "base64");
+    const secretKey = secret.slice(WebhookHandler.#secretPrefix.length);
+    this.#secretBuffer = Buffer.from(secretKey, "base64");
   }
 
   /**
@@ -29,7 +29,8 @@ export class WebhookHandler {
   public verifyRequest(request: WebhookRequest): WebhookEvent {
     const { headers, rawBody } = request;
 
-    const { webhookId, timestamp, rawSignatures } = this.verifyHeaders(headers);
+    const { webhookId, timestamp, rawSignatures } =
+      this.#verifyHeaders(headers);
 
     if (typeof rawBody !== "string") {
       throw new Error(
@@ -37,9 +38,9 @@ export class WebhookHandler {
       );
     }
 
-    this.verifyTimestamp(timestamp);
+    this.#verifyTimestamp(timestamp);
 
-    const signature = this.sign(`${webhookId}.${timestamp}.${rawBody}`);
+    const signature = this.#sign(`${webhookId}.${timestamp}.${rawBody}`);
 
     const expectedSignatures = rawSignatures
       .split(" ")
@@ -58,7 +59,7 @@ export class WebhookHandler {
 
     const event: WebhookEvent = JSON.parse(rawBody) as WebhookEvent;
 
-    this.verifyWebhookEventType(event);
+    this.#verifyWebhookEventType(event);
 
     return event;
   }
@@ -66,7 +67,7 @@ export class WebhookHandler {
   /**
    * Verifies the headers and returns the webhookId, timestamp and rawSignatures
    */
-  private verifyHeaders(headers: IncomingHttpHeaders | Headers) {
+  #verifyHeaders(headers: IncomingHttpHeaders | Headers) {
     const usingNativeHeaders =
       typeof Headers !== "undefined" && headers instanceof Headers;
     const normalizedHeaders = usingNativeHeaders
@@ -98,16 +99,16 @@ export class WebhookHandler {
    * @param content
    * @returns `string`
    */
-  private sign(content: string): string {
+  #sign(content: string): string {
     const encoder = new TextEncoder();
     const toSign = encoder.encode(content);
-    return base64.encode(sha256.hmac(this.secretBuffer, toSign));
+    return base64.encode(sha256.hmac(this.#secretBuffer, toSign));
   }
 
   /**
    * Verifies that the timestamp is not too old or in the future
    */
-  private verifyTimestamp(timestampHeader: string) {
+  #verifyTimestamp(timestampHeader: string) {
     const now = Math.floor(Date.now() / 1000);
     const timestamp = parseInt(timestampHeader, 10);
 
@@ -130,9 +131,7 @@ export class WebhookHandler {
    * Ensures that the event is a known event type
    * or throws and prompts the user to upgrade to a higher version of @liveblocks/node
    */
-  private verifyWebhookEventType(
-    event: WebhookEvent
-  ): asserts event is WebhookEvent {
+  #verifyWebhookEventType(event: WebhookEvent): asserts event is WebhookEvent {
     if (
       event &&
       event.type &&

--- a/packages/liveblocks-react/src/ThreadDB.ts
+++ b/packages/liveblocks-react/src/ThreadDB.ts
@@ -52,26 +52,26 @@ export type ReadonlyThreadDB<M extends BaseMetadata> = Omit<
  *
  */
 export class ThreadDB<M extends BaseMetadata> {
-  private _byId: Map<string, ThreadDataWithDeleteInfo<M>>;
-  private _asc: SortedList<ThreadData<M>>;
-  private _desc: SortedList<ThreadData<M>>;
-  private _version: number; // The version is auto-incremented on every mutation and can be used as a reliable indicator to tell if the contents of the thread pool has changed
+  #byId: Map<string, ThreadDataWithDeleteInfo<M>>;
+  #asc: SortedList<ThreadData<M>>;
+  #desc: SortedList<ThreadData<M>>;
+  #version: number; // The version is auto-incremented on every mutation and can be used as a reliable indicator to tell if the contents of the thread pool has changed
 
   constructor() {
-    this._asc = SortedList.from<ThreadData<M>>([], (t1, t2) => {
+    this.#asc = SortedList.from<ThreadData<M>>([], (t1, t2) => {
       const d1 = t1.createdAt;
       const d2 = t2.createdAt;
       return d1 < d2 ? true : d1 === d2 ? t1.id < t2.id : false;
     });
 
-    this._desc = SortedList.from<ThreadData<M>>([], (t1, t2) => {
+    this.#desc = SortedList.from<ThreadData<M>>([], (t1, t2) => {
       const d2 = t2.updatedAt;
       const d1 = t1.updatedAt;
       return d2 < d1 ? true : d2 === d1 ? t2.id < t1.id : false;
     });
 
-    this._byId = new Map();
-    this._version = 0;
+    this.#byId = new Map();
+    this.#version = 0;
   }
 
   //
@@ -80,16 +80,16 @@ export class ThreadDB<M extends BaseMetadata> {
 
   public clone(): ThreadDB<M> {
     const newPool = new ThreadDB<M>();
-    newPool._byId = new Map(this._byId);
-    newPool._asc = this._asc.clone();
-    newPool._desc = this._desc.clone();
-    newPool._version = this._version;
+    newPool.#byId = new Map(this.#byId);
+    newPool.#asc = this.#asc.clone();
+    newPool.#desc = this.#desc.clone();
+    newPool.#version = this.#version;
     return newPool;
   }
 
   /** Gets the transaction count for this DB. Increments any time the DB is modified. */
   public get version() {
-    return this._version;
+    return this.#version;
   }
 
   /** Returns an existing thread by ID. Will never return a deleted thread. */
@@ -102,7 +102,7 @@ export class ThreadDB<M extends BaseMetadata> {
   public getEvenIfDeleted(
     threadId: string
   ): ThreadDataWithDeleteInfo<M> | undefined {
-    return this._byId.get(threadId);
+    return this.#byId.get(threadId);
   }
 
   /** Adds or updates a thread in the DB. If the newly given thread is a deleted one, it will get deleted. */
@@ -111,21 +111,21 @@ export class ThreadDB<M extends BaseMetadata> {
 
     const id = thread.id;
 
-    const toRemove = this._byId.get(id);
+    const toRemove = this.#byId.get(id);
     if (toRemove) {
       // Don't do anything if the existing thread is already deleted!
       if (toRemove.deletedAt) return;
 
-      this._asc.remove(toRemove);
-      this._desc.remove(toRemove);
+      this.#asc.remove(toRemove);
+      this.#desc.remove(toRemove);
     }
 
     if (!thread.deletedAt) {
-      this._asc.add(thread);
-      this._desc.add(thread);
+      this.#asc.add(thread);
+      this.#desc.add(thread);
     }
-    this._byId.set(id, thread);
-    this.touch();
+    this.#byId.set(id, thread);
+    this.#touch();
   }
 
   /** Like .upsert(), except it won't update if a thread by this ID already exists. */
@@ -143,7 +143,7 @@ export class ThreadDB<M extends BaseMetadata> {
    * queries, but it can still be accessed via `.getEvenIfDeleted()`.
    */
   public delete(threadId: string, deletedAt: Date): void {
-    const existing = this._byId.get(threadId);
+    const existing = this.#byId.get(threadId);
     if (existing && !existing.deletedAt) {
       this.upsert({ ...existing, deletedAt, updatedAt: deletedAt });
     }
@@ -166,7 +166,7 @@ export class ThreadDB<M extends BaseMetadata> {
     query: ThreadsQuery<M>,
     direction: "asc" | "desc"
   ): ThreadData<M>[] {
-    const index = direction === "desc" ? this._desc : this._asc;
+    const index = direction === "desc" ? this.#desc : this.#asc;
     const crit: ((thread: ThreadData<M>) => boolean)[] = [];
     if (roomId !== undefined) {
       crit.push((t) => t.roomId === roomId);
@@ -179,7 +179,7 @@ export class ThreadDB<M extends BaseMetadata> {
   // Private APIs
   //
 
-  private touch() {
-    ++this._version;
+  #touch() {
+    ++this.#version;
   }
 }

--- a/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
+++ b/packages/liveblocks-react/src/__tests__/_MockWebSocket.ts
@@ -19,7 +19,7 @@ enum WebSocketErrorCodes {
 export default class MockWebSocket {
   public readyState: number;
 
-  private static nextActor = 0;
+  static #nextActor = 0;
   public static readonly instances: MockWebSocket[] = [];
 
   public readonly isMock = true;
@@ -36,7 +36,7 @@ export default class MockWebSocket {
 
   constructor(public url: string) {
     MockWebSocket.instances.push(this);
-    const actor = MockWebSocket.nextActor++;
+    const actor = MockWebSocket.#nextActor++;
 
     this.readyState = 0 /* CONNECTING */;
 
@@ -63,7 +63,7 @@ export default class MockWebSocket {
 
   public static reset() {
     MockWebSocket.instances.length = 0;
-    MockWebSocket.nextActor = 0;
+    MockWebSocket.#nextActor = 0;
   }
 
   addEventListener(event: "open", callback: (event: Event) => void): void;

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -328,30 +328,30 @@ const ASYNC_LOADING = Object.freeze({ isLoading: true });
  */
 export class PaginatedResource {
   public readonly observable: Observable<void>;
-  private _eventSource: EventSource<void>;
-  private _fetchPage: (cursor?: string) => Promise<string | null>;
-  private _paginationState: PaginationState | null; // Should be null while in loading or error state!
-  private _pendingFetchMore: Promise<void> | null;
+  #eventSource: EventSource<void>;
+  #fetchPage: (cursor?: string) => Promise<string | null>;
+  #paginationState: PaginationState | null; // Should be null while in loading or error state!
+  #pendingFetchMore: Promise<void> | null;
 
   constructor(fetchPage: (cursor?: string) => Promise<string | null>) {
-    this._paginationState = null;
-    this._fetchPage = fetchPage;
-    this._eventSource = makeEventSource<void>();
-    this._pendingFetchMore = null;
-    this.observable = this._eventSource.observable;
+    this.#paginationState = null;
+    this.#fetchPage = fetchPage;
+    this.#eventSource = makeEventSource<void>();
+    this.#pendingFetchMore = null;
+    this.observable = this.#eventSource.observable;
 
     autobind(this);
   }
 
-  private patchPaginationState(patch: PaginationStatePatch): void {
-    const state = this._paginationState;
+  #patchPaginationState(patch: PaginationStatePatch): void {
+    const state = this.#paginationState;
     if (state === null) return;
-    this._paginationState = { ...state, ...patch };
-    this._eventSource.notify();
+    this.#paginationState = { ...state, ...patch };
+    this.#eventSource.notify();
   }
 
-  private async _fetchMore(): Promise<void> {
-    const state = this._paginationState;
+  async #fetchMore(): Promise<void> {
+    const state = this.#paginationState;
     if (!state?.cursor) {
       // Do nothing if we don't have a cursor to work with. It means:
       // - We don't have a cursor yet (we haven't loaded the first page yet); or
@@ -360,16 +360,16 @@ export class PaginatedResource {
       return;
     }
 
-    this.patchPaginationState({ isFetchingMore: true });
+    this.#patchPaginationState({ isFetchingMore: true });
     try {
-      const nextCursor = await this._fetchPage(state.cursor);
-      this.patchPaginationState({
+      const nextCursor = await this.#fetchPage(state.cursor);
+      this.#patchPaginationState({
         cursor: nextCursor,
         fetchMoreError: undefined,
         isFetchingMore: false,
       });
     } catch (err) {
-      this.patchPaginationState({
+      this.#patchPaginationState({
         isFetchingMore: false,
         fetchMoreError: err as Error,
       });
@@ -381,18 +381,18 @@ export class PaginatedResource {
     // 1) the pagination state has not be initialized
     // 2) the cursor is null, i.e., there are no more pages to fetch
     // 3) a request to fetch more is currently in progress
-    const state = this._paginationState;
+    const state = this.#paginationState;
     if (state?.cursor === null) {
       return noop;
     }
 
     // Case (3)
-    if (!this._pendingFetchMore) {
-      this._pendingFetchMore = this._fetchMore().finally(() => {
-        this._pendingFetchMore = null;
+    if (!this.#pendingFetchMore) {
+      this.#pendingFetchMore = this.#fetchMore().finally(() => {
+        this.#pendingFetchMore = null;
       });
     }
-    return this._pendingFetchMore;
+    return this.#pendingFetchMore;
   }
 
   public get(): AsyncResult<{
@@ -401,7 +401,7 @@ export class PaginatedResource {
     hasFetchedAll: boolean;
     isFetchingMore: boolean;
   }> {
-    const usable = this._cachedPromise;
+    const usable = this.#cachedPromise;
     if (usable === null || usable.status === "pending") {
       return ASYNC_LOADING;
     }
@@ -410,7 +410,7 @@ export class PaginatedResource {
       return { isLoading: false, error: usable.reason };
     }
 
-    const state = this._paginationState!;
+    const state = this.#paginationState!;
     return {
       isLoading: false,
       data: {
@@ -422,17 +422,17 @@ export class PaginatedResource {
     };
   }
 
-  private _cachedPromise: UsablePromise<void> | null = null;
+  #cachedPromise: UsablePromise<void> | null = null;
 
   public waitUntilLoaded(): UsablePromise<void> {
-    if (this._cachedPromise) {
-      return this._cachedPromise;
+    if (this.#cachedPromise) {
+      return this.#cachedPromise;
     }
 
     // Wrap the request to load room threads (and notifications) in an auto-retry function so that if the request fails,
     // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error
     const initialFetcher = autoRetry(
-      () => this._fetchPage(/* cursor */ undefined),
+      () => this.#fetchPage(/* cursor */ undefined),
       5,
       [5000, 5000, 10000, 15000]
     );
@@ -440,7 +440,7 @@ export class PaginatedResource {
     const promise = usify(
       initialFetcher.then((cursor) => {
         // Initial fetch completed
-        this._paginationState = {
+        this.#paginationState = {
           cursor,
           isFetchingMore: false,
           fetchMoreError: undefined,
@@ -450,38 +450,38 @@ export class PaginatedResource {
 
     // TODO for later: Maybe move this into the .then() above too?
     promise.then(
-      () => this._eventSource.notify(),
+      () => this.#eventSource.notify(),
       () => {
-        this._eventSource.notify();
+        this.#eventSource.notify();
 
         // Wait for 5 seconds before removing the request from the cache
         setTimeout(() => {
-          this._cachedPromise = null;
-          this._eventSource.notify();
+          this.#cachedPromise = null;
+          this.#eventSource.notify();
         }, 5_000);
       }
     );
 
-    this._cachedPromise = promise;
+    this.#cachedPromise = promise;
     return promise;
   }
 }
 
 export class SinglePageResource {
   public readonly observable: Observable<void>;
-  private _eventSource: EventSource<void>;
-  private _fetchPage: () => Promise<void>;
+  #eventSource: EventSource<void>;
+  #fetchPage: () => Promise<void>;
 
   constructor(fetchPage: () => Promise<void>) {
-    this._fetchPage = fetchPage;
-    this._eventSource = makeEventSource<void>();
-    this.observable = this._eventSource.observable;
+    this.#fetchPage = fetchPage;
+    this.#eventSource = makeEventSource<void>();
+    this.observable = this.#eventSource.observable;
 
     autobind(this);
   }
 
   public get(): AsyncResult<undefined> {
-    const usable = this._cachedPromise;
+    const usable = this.#cachedPromise;
     if (usable === null || usable.status === "pending") {
       return ASYNC_LOADING;
     }
@@ -496,17 +496,17 @@ export class SinglePageResource {
     };
   }
 
-  private _cachedPromise: UsablePromise<void> | null = null;
+  #cachedPromise: UsablePromise<void> | null = null;
 
   public waitUntilLoaded(): UsablePromise<void> {
-    if (this._cachedPromise) {
-      return this._cachedPromise;
+    if (this.#cachedPromise) {
+      return this.#cachedPromise;
     }
 
     // Wrap the request to load room threads (and notifications) in an auto-retry function so that if the request fails,
     // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error
     const initialFetcher = autoRetry(
-      () => this._fetchPage(),
+      () => this.#fetchPage(),
       5,
       [5000, 5000, 10000, 15000]
     );
@@ -515,19 +515,19 @@ export class SinglePageResource {
 
     // TODO for later: Maybe move this into the .then() above too?
     promise.then(
-      () => this._eventSource.notify(),
+      () => this.#eventSource.notify(),
       () => {
-        this._eventSource.notify();
+        this.#eventSource.notify();
 
         // Wait for 5 seconds before removing the request from the cache
         setTimeout(() => {
-          this._cachedPromise = null;
-          this._eventSource.notify();
+          this.#cachedPromise = null;
+          this.#eventSource.notify();
         }, 5_000);
       }
     );
 
-    this._cachedPromise = promise;
+    this.#cachedPromise = promise;
     return promise;
   }
 }
@@ -587,43 +587,42 @@ export type UmbrellaStoreState<M extends BaseMetadata> = {
 };
 
 export class UmbrellaStore<M extends BaseMetadata> {
-  private _client: Client<BaseUserMeta, M>;
-  private _syncSource: SyncSource;
+  #client: Client<BaseUserMeta, M>;
+  #syncSource: SyncSource;
 
   // Raw threads DB (without any optimistic updates applied)
-  private _rawThreadsDB: ThreadDB<M>;
-  private _prevVersion: number = -1;
+  #rawThreadsDB: ThreadDB<M>;
+  #prevVersion: number = -1;
 
-  private _store: Store<InternalState<M>>;
-  private _prevState: InternalState<M> | null = null;
-  private _stateCached: UmbrellaStoreState<M> | null = null;
+  #store: Store<InternalState<M>>;
+  #prevState: InternalState<M> | null = null;
+  #stateCached: UmbrellaStoreState<M> | null = null;
 
   // Notifications
-  private _notificationsLastRequestedAt: Date | null = null; // Keeps track of when we successfully requested an inbox notifications update for the last time. Will be `null` as long as the first successful fetch hasn't happened yet.
-  private _notifications: PaginatedResource;
+  #notificationsLastRequestedAt: Date | null = null; // Keeps track of when we successfully requested an inbox notifications update for the last time. Will be `null` as long as the first successful fetch hasn't happened yet.
+  #notifications: PaginatedResource;
 
   // Room Threads
-  private _roomThreadsLastRequestedAtByRoom = new Map<string, Date>();
-  private _roomThreads: Map<string, PaginatedResource> = new Map();
+  #roomThreadsLastRequestedAtByRoom = new Map<string, Date>();
+  #roomThreads: Map<string, PaginatedResource> = new Map();
 
   // User Threads
-  private _userThreadsLastRequestedAt: Date | null = null;
-  private _userThreads: Map<string, PaginatedResource> = new Map();
+  #userThreadsLastRequestedAt: Date | null = null;
+  #userThreads: Map<string, PaginatedResource> = new Map();
 
   // Room versions
-  private _roomVersions: Map<string, SinglePageResource> = new Map();
-  private _roomVersionsLastRequestedAtByRoom = new Map<string, Date>();
+  #roomVersions: Map<string, SinglePageResource> = new Map();
+  #roomVersionsLastRequestedAtByRoom = new Map<string, Date>();
 
   // Room notification settings
-  private _roomNotificationSettings: Map<string, SinglePageResource> =
-    new Map();
+  #roomNotificationSettings: Map<string, SinglePageResource> = new Map();
 
   constructor(client: OpaqueClient) {
-    this._client = client[kInternal].as<M>();
-    this._syncSource = this._client[kInternal].createSyncSource();
+    this.#client = client[kInternal].as<M>();
+    this.#syncSource = this.#client[kInternal].createSyncSource();
 
     const inboxFetcher = async (cursor?: string) => {
-      const result = await this._client.getInboxNotifications({ cursor });
+      const result = await this.#client.getInboxNotifications({ cursor });
 
       this.updateThreadsAndNotifications(
         result.threads,
@@ -631,22 +630,22 @@ export class UmbrellaStore<M extends BaseMetadata> {
       );
 
       // We initialize the `_lastRequestedNotificationsAt` date using the server timestamp after we've loaded the first page of inbox notifications.
-      if (this._notificationsLastRequestedAt === null) {
-        this._notificationsLastRequestedAt = result.requestedAt;
+      if (this.#notificationsLastRequestedAt === null) {
+        this.#notificationsLastRequestedAt = result.requestedAt;
       }
 
       const nextCursor = result.nextCursor;
       return nextCursor;
     };
-    this._notifications = new PaginatedResource(inboxFetcher);
-    this._notifications.observable.subscribe(() =>
+    this.#notifications = new PaginatedResource(inboxFetcher);
+    this.#notifications.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
-      this._store.set((store) => ({ ...store }))
+      this.#store.set((store) => ({ ...store }))
     );
 
-    this._rawThreadsDB = new ThreadDB();
-    this._store = createStore<InternalState<M>>({
+    this.#rawThreadsDB = new ThreadDB();
+    this.#store = createStore<InternalState<M>>({
       optimisticUpdates: [],
       permissionsByRoom: {},
       notificationsById: {},
@@ -663,21 +662,21 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // Don't return the raw internal state immediately! Return a new computed
     // cached state (with optimistic updates applied) instead, and cache that
     // until the next .set() call invalidates it.
-    const rawState = this._store.get();
+    const rawState = this.#store.get();
     if (
-      this._prevVersion !== this._rawThreadsDB.version || // Note: Version check is only needed temporarily, until we can get rid of the Zustand-like update model
-      this._prevState !== rawState ||
-      this._stateCached === null
+      this.#prevVersion !== this.#rawThreadsDB.version || // Note: Version check is only needed temporarily, until we can get rid of the Zustand-like update model
+      this.#prevState !== rawState ||
+      this.#stateCached === null
     ) {
-      this._stateCached = internalToExternalState(rawState, this._rawThreadsDB);
-      this._prevState = rawState;
-      this._prevVersion = this._rawThreadsDB.version;
+      this.#stateCached = internalToExternalState(rawState, this.#rawThreadsDB);
+      this.#prevState = rawState;
+      this.#prevVersion = this.#rawThreadsDB.version;
     }
-    return this._stateCached;
+    return this.#stateCached;
   }
 
   public batch(callback: () => void): void {
-    return this._store.batch(callback);
+    return this.#store.batch(callback);
   }
 
   public getFullState(): UmbrellaStoreState<M> {
@@ -695,7 +694,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   ): ThreadsAsyncResult<M> {
     const queryKey = makeRoomThreadsQueryKey(roomId, query);
 
-    const paginatedResource = this._roomThreads.get(queryKey);
+    const paginatedResource = this.#roomThreads.get(queryKey);
     if (paginatedResource === undefined) {
       return ASYNC_LOADING;
     }
@@ -728,7 +727,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   ): ThreadsAsyncResult<M> {
     const queryKey = makeUserThreadsQueryKey(query);
 
-    const paginatedResource = this._userThreads.get(queryKey);
+    const paginatedResource = this.#userThreads.get(queryKey);
     if (paginatedResource === undefined) {
       return ASYNC_LOADING;
     }
@@ -758,7 +757,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
   public getInboxNotificationsLoadingState(): InboxNotificationsAsyncResult {
-    const asyncResult = this._notifications.get();
+    const asyncResult = this.#notifications.get();
     if (asyncResult.isLoading || asyncResult.error) {
       return asyncResult;
     }
@@ -781,7 +780,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   ): RoomNotificationSettingsAsyncResult {
     const queryKey = makeNotificationSettingsQueryKey(roomId);
 
-    const resource = this._roomNotificationSettings.get(queryKey);
+    const resource = this.#roomNotificationSettings.get(queryKey);
     if (resource === undefined) {
       return ASYNC_LOADING;
     }
@@ -803,7 +802,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   ): AsyncResult<HistoryVersion[], "versions"> {
     const queryKey = makeVersionsQueryKey(roomId);
 
-    const resource = this._roomVersions.get(queryKey);
+    const resource = this.#roomVersions.get(queryKey);
     if (resource === undefined) {
       return ASYNC_LOADING;
     }
@@ -821,32 +820,32 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public subscribe(callback: () => void): () => void {
-    return this._store.subscribe(callback);
+    return this.#store.subscribe(callback);
   }
 
   public _getPermissions(roomId: string): Set<Permission> | undefined {
-    return this._store.get().permissionsByRoom[roomId];
+    return this.#store.get().permissionsByRoom[roomId];
   }
 
   // Direct low-level cache mutations ------------------------------------------------- {{{
 
-  private mutateThreadsDB(mutate: (db: ThreadDB<M>) => void): void {
-    const db = this._rawThreadsDB;
+  #mutateThreadsDB(mutate: (db: ThreadDB<M>) => void): void {
+    const db = this.#rawThreadsDB;
     const old = db.version;
     mutate(db);
 
     // Trigger a re-render only if anything changed in the DB
     if (old !== db.version) {
-      this._store.set((state) => ({ ...state }));
+      this.#store.set((state) => ({ ...state }));
     }
   }
 
-  private updateInboxNotificationsCache(
+  #updateInboxNotificationsCache(
     mapFn: (
       cache: Readonly<Record<string, InboxNotificationData>>
     ) => Readonly<Record<string, InboxNotificationData>>
   ): void {
-    this._store.set((state) => {
+    this.#store.set((state) => {
       const inboxNotifications = mapFn(state.notificationsById);
       return inboxNotifications !== state.notificationsById
         ? { ...state, notificationsById: inboxNotifications }
@@ -854,11 +853,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
     });
   }
 
-  private setNotificationSettings(
+  #setNotificationSettings(
     roomId: string,
     settings: RoomNotificationSettings
   ): void {
-    this._store.set((state) => ({
+    this.#store.set((state) => ({
       ...state,
       settingsByRoomId: {
         ...state.settingsByRoomId,
@@ -867,8 +866,8 @@ export class UmbrellaStore<M extends BaseMetadata> {
     }));
   }
 
-  private updateRoomVersions(roomId: string, versions: HistoryVersion[]): void {
-    this._store.set((state) => {
+  #updateRoomVersions(roomId: string, versions: HistoryVersion[]): void {
+    this.#store.set((state) => {
       const versionsById = Object.fromEntries(
         versions.map((version) => [version.id, version])
       );
@@ -887,14 +886,14 @@ export class UmbrellaStore<M extends BaseMetadata> {
     });
   }
 
-  private updateOptimisticUpdatesCache(
+  #updateOptimisticUpdatesCache(
     mapFn: (
       cache: readonly OptimisticUpdate<M>[]
     ) => readonly OptimisticUpdate<M>[]
   ): void {
-    this._store.set((state) => {
+    this.#store.set((state) => {
       const optimisticUpdates = mapFn(state.optimisticUpdates);
-      this._syncSource.setSyncStatus(
+      this.#syncSource.setSyncStatus(
         optimisticUpdates.length > 0 ? "synchronizing" : "synchronized"
       );
       return { ...state, optimisticUpdates };
@@ -907,7 +906,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   public force_set(
     callback: (currentState: InternalState<M>) => InternalState<M>
   ): void {
-    return this._store.set(callback);
+    return this.#store.set(callback);
   }
 
   /**
@@ -925,11 +924,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
     ) => Readonly<InboxNotificationData>
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
 
       // 2️⃣
-      this.updateInboxNotificationsCache((cache) => {
+      this.#updateInboxNotificationsCache((cache) => {
         const existing = cache[inboxNotificationId];
         if (!existing) {
           // If the inbox notification doesn't exist in the cache, we do not
@@ -957,9 +956,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     ) => Readonly<InboxNotificationData>
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
-      this.updateInboxNotificationsCache((cache) => mapValues(cache, mapFn)); // 2️⃣
+      this.#updateInboxNotificationsCache((cache) => mapValues(cache, mapFn)); // 2️⃣
     });
   }
 
@@ -972,11 +971,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
     optimisticUpdateId: string
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
 
       // 2️⃣
-      this.updateInboxNotificationsCache((cache) => {
+      this.#updateInboxNotificationsCache((cache) => {
         // Delete it
         const { [inboxNotificationId]: removed, ...newCache } = cache;
         return removed === undefined ? cache : newCache;
@@ -990,9 +989,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
    */
   public deleteAllInboxNotifications(optimisticUpdateId: string): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
-      this.updateInboxNotificationsCache(() => ({})); // 2️⃣ empty the cache
+      this.#updateInboxNotificationsCache(() => ({})); // 2️⃣ empty the cache
     });
   }
 
@@ -1004,9 +1003,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     thread: Readonly<ThreadDataWithDeleteInfo<M>>
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣j
-      this.mutateThreadsDB((db) => db.upsert(thread)); // 2️⃣
+      this.#mutateThreadsDB((db) => db.upsert(thread)); // 2️⃣
     });
   }
 
@@ -1020,7 +1019,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
    * - The thread ID in the cache was updated more recently than the optimistic
    *   update's timestamp (if given)
    */
-  private updateThread(
+  #updateThread(
     threadId: string,
     optimisticUpdateId: string | null,
     callback: (
@@ -1029,13 +1028,13 @@ export class UmbrellaStore<M extends BaseMetadata> {
     updatedAt?: Date // TODO We could look this up from the optimisticUpdate instead?
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       if (optimisticUpdateId !== null) {
         this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
       }
 
       // 2️⃣
-      this.mutateThreadsDB((db) => {
+      this.#mutateThreadsDB((db) => {
         const existing = db.get(threadId);
         if (!existing) return;
         if (!!updatedAt && existing.updatedAt > updatedAt) return;
@@ -1055,7 +1054,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     },
     updatedAt: Date // TODO We could look this up from the optimisticUpdate instead?
   ): void {
-    return this.updateThread(
+    return this.#updateThread(
       threadId,
       optimisticUpdateId,
       (thread) => ({ ...thread, ...compactObject(patch) }),
@@ -1070,7 +1069,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     reaction: CommentUserReaction,
     createdAt: Date // TODO We could look this up from the optimisticUpdate instead?
   ): void {
-    this.updateThread(
+    this.#updateThread(
       threadId,
       optimisticUpdateId,
       (thread) => applyAddReaction(thread, commentId, reaction),
@@ -1086,7 +1085,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     userId: string,
     removedAt: Date
   ): void {
-    this.updateThread(
+    this.#updateThread(
       threadId,
       optimisticUpdateId,
       (thread) =>
@@ -1107,7 +1106,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     threadId: string,
     optimisticUpdateId: string | null
   ): void {
-    return this.updateThread(
+    return this.#updateThread(
       threadId,
       optimisticUpdateId,
 
@@ -1125,23 +1124,23 @@ export class UmbrellaStore<M extends BaseMetadata> {
     optimisticUpdateId: string
   ): void {
     // Batch 1️⃣ + 2️⃣ + 3️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       // 1️⃣
       this.removeOptimisticUpdate(optimisticUpdateId);
 
       // If the associated thread is not found, we cannot create a comment under it
-      const existingThread = this._rawThreadsDB.get(newComment.threadId);
+      const existingThread = this.#rawThreadsDB.get(newComment.threadId);
       if (!existingThread) {
         return;
       }
 
       // 2️⃣ Update the thread instance by adding a comment under it
-      this.mutateThreadsDB((db) =>
+      this.#mutateThreadsDB((db) =>
         db.upsert(applyUpsertComment(existingThread, newComment))
       );
 
       // 3️⃣ Update the associated inbox notification (if any)
-      this.updateInboxNotificationsCache((cache) => {
+      this.#updateInboxNotificationsCache((cache) => {
         const existingNotification = Object.values(cache).find(
           (notification) =>
             notification.kind === "thread" &&
@@ -1171,7 +1170,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     optimisticUpdateId: string,
     editedComment: CommentData
   ): void {
-    return this.updateThread(threadId, optimisticUpdateId, (thread) =>
+    return this.#updateThread(threadId, optimisticUpdateId, (thread) =>
       applyUpsertComment(thread, editedComment)
     );
   }
@@ -1182,7 +1181,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     commentId: string,
     deletedAt: Date
   ): void {
-    return this.updateThread(
+    return this.#updateThread(
       threadId,
       optimisticUpdateId,
       (thread) => applyDeleteComment(thread, commentId, deletedAt),
@@ -1195,13 +1194,13 @@ export class UmbrellaStore<M extends BaseMetadata> {
     inboxNotification?: InboxNotificationData
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       // 1️⃣
-      this.mutateThreadsDB((db) => db.upsertIfNewer(thread));
+      this.#mutateThreadsDB((db) => db.upsertIfNewer(thread));
 
       // 2️⃣
       if (inboxNotification !== undefined) {
-        this.updateInboxNotificationsCache((cache) => ({
+        this.#updateInboxNotificationsCache((cache) => ({
           ...cache,
           [inboxNotification.id]: inboxNotification,
         }));
@@ -1226,14 +1225,14 @@ export class UmbrellaStore<M extends BaseMetadata> {
     deletedInboxNotifications: InboxNotificationDeleteInfo[] = []
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       // 1️⃣
-      this.mutateThreadsDB((db) =>
+      this.#mutateThreadsDB((db) =>
         applyThreadDeltaUpdates(db, { newThreads: threads, deletedThreads })
       );
 
       // 2️⃣
-      this.updateInboxNotificationsCache((cache) =>
+      this.#updateInboxNotificationsCache((cache) =>
         applyNotificationsUpdates(cache, {
           newInboxNotifications: inboxNotifications,
           deletedNotifications: deletedInboxNotifications,
@@ -1252,9 +1251,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     settings: Readonly<RoomNotificationSettings>
   ): void {
     // Batch 1️⃣ + 2️⃣
-    this._store.batch(() => {
+    this.#store.batch(() => {
       this.removeOptimisticUpdate(optimisticUpdateId); // 1️⃣
-      this.setNotificationSettings(roomId, settings); // 2️⃣
+      this.#setNotificationSettings(roomId, settings); // 2️⃣
     });
   }
 
@@ -1263,29 +1262,29 @@ export class UmbrellaStore<M extends BaseMetadata> {
   ): string {
     const id = nanoid();
     const newUpdate: OptimisticUpdate<M> = { ...optimisticUpdate, id };
-    this.updateOptimisticUpdatesCache((cache) => [...cache, newUpdate]);
+    this.#updateOptimisticUpdatesCache((cache) => [...cache, newUpdate]);
     return id;
   }
 
   public removeOptimisticUpdate(optimisticUpdateId: string): void {
-    this.updateOptimisticUpdatesCache((cache) =>
+    this.#updateOptimisticUpdatesCache((cache) =>
       cache.filter((ou) => ou.id !== optimisticUpdateId)
     );
   }
 
   public async fetchNotificationsDeltaUpdate(signal: AbortSignal) {
-    const lastRequestedAt = this._notificationsLastRequestedAt;
+    const lastRequestedAt = this.#notificationsLastRequestedAt;
     if (lastRequestedAt === null) {
       return;
     }
 
-    const result = await this._client.getInboxNotificationsSince({
+    const result = await this.#client.getInboxNotificationsSince({
       since: lastRequestedAt,
       signal,
     });
 
     if (lastRequestedAt < result.requestedAt) {
-      this._notificationsLastRequestedAt = result.requestedAt;
+      this.#notificationsLastRequestedAt = result.requestedAt;
     }
 
     this.updateThreadsAndNotifications(
@@ -1297,11 +1296,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   public waitUntilNotificationsLoaded(): UsablePromise<void> {
-    return this._notifications.waitUntilLoaded();
+    return this.#notifications.waitUntilLoaded();
   }
 
-  private updateRoomPermissions(permissions: Record<string, Permission[]>) {
-    const permissionsByRoom = { ...this._store.get().permissionsByRoom };
+  #updateRoomPermissions(permissions: Record<string, Permission[]>) {
+    const permissionsByRoom = { ...this.#store.get().permissionsByRoom };
 
     Object.entries(permissions).forEach(([roomId, newPermissions]) => {
       // Get the existing set of permissions for the room and only ever add permission to this set
@@ -1313,7 +1312,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       permissionsByRoom[roomId] = existingPermissions;
     });
 
-    this._store.set((state) => ({
+    this.#store.set((state) => ({
       ...state,
       permissionsByRoom,
     }));
@@ -1324,7 +1323,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     query: ThreadsQuery<M> | undefined
   ) {
     const threadsFetcher = async (cursor?: string) => {
-      const result = await this._client[kInternal].httpClient.getThreads({
+      const result = await this.#client[kInternal].httpClient.getThreads({
         roomId,
         cursor,
         query,
@@ -1334,10 +1333,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
         result.inboxNotifications
       );
 
-      this.updateRoomPermissions(result.permissionHints);
+      this.#updateRoomPermissions(result.permissionHints);
 
       const lastRequestedAt =
-        this._roomThreadsLastRequestedAtByRoom.get(roomId);
+        this.#roomThreadsLastRequestedAtByRoom.get(roomId);
 
       /**
        * We set the `lastRequestedAt` value for the room to the timestamp returned by the current request if:
@@ -1349,14 +1348,14 @@ export class UmbrellaStore<M extends BaseMetadata> {
         lastRequestedAt === undefined ||
         lastRequestedAt > result.requestedAt
       ) {
-        this._roomThreadsLastRequestedAtByRoom.set(roomId, result.requestedAt);
+        this.#roomThreadsLastRequestedAtByRoom.set(roomId, result.requestedAt);
       }
 
       return result.nextCursor;
     };
 
     const queryKey = makeRoomThreadsQueryKey(roomId, query);
-    let paginatedResource = this._roomThreads.get(queryKey);
+    let paginatedResource = this.#roomThreads.get(queryKey);
     if (paginatedResource === undefined) {
       paginatedResource = new PaginatedResource(threadsFetcher);
     }
@@ -1364,10 +1363,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
     paginatedResource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
-      this._store.set((store) => ({ ...store }))
+      this.#store.set((store) => ({ ...store }))
     );
 
-    this._roomThreads.set(queryKey, paginatedResource);
+    this.#roomThreads.set(queryKey, paginatedResource);
 
     return paginatedResource.waitUntilLoaded();
   }
@@ -1376,12 +1375,12 @@ export class UmbrellaStore<M extends BaseMetadata> {
     roomId: string,
     signal: AbortSignal
   ) {
-    const lastRequestedAt = this._roomThreadsLastRequestedAtByRoom.get(roomId);
+    const lastRequestedAt = this.#roomThreadsLastRequestedAtByRoom.get(roomId);
     if (lastRequestedAt === undefined) {
       return;
     }
 
-    const updates = await this._client[kInternal].httpClient.getThreadsSince({
+    const updates = await this.#client[kInternal].httpClient.getThreadsSince({
       roomId,
       since: lastRequestedAt,
       signal,
@@ -1394,11 +1393,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
       updates.inboxNotifications.deleted
     );
 
-    this.updateRoomPermissions(updates.permissionHints);
+    this.#updateRoomPermissions(updates.permissionHints);
 
     if (lastRequestedAt < updates.requestedAt) {
       // Update the `lastRequestedAt` value for the room to the timestamp returned by the current request
-      this._roomThreadsLastRequestedAtByRoom.set(roomId, updates.requestedAt);
+      this.#roomThreadsLastRequestedAtByRoom.set(roomId, updates.requestedAt);
     }
   }
 
@@ -1406,7 +1405,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     const queryKey = makeUserThreadsQueryKey(query);
 
     const threadsFetcher = async (cursor?: string) => {
-      const result = await this._client[
+      const result = await this.#client[
         kInternal
       ].httpClient.getUserThreads_experimental({
         cursor,
@@ -1417,17 +1416,17 @@ export class UmbrellaStore<M extends BaseMetadata> {
         result.inboxNotifications
       );
 
-      this.updateRoomPermissions(result.permissionHints);
+      this.#updateRoomPermissions(result.permissionHints);
 
       // We initialize the `_userThreadsLastRequestedAt` date using the server timestamp after we've loaded the first page of inbox notifications.
-      if (this._userThreadsLastRequestedAt === null) {
-        this._userThreadsLastRequestedAt = result.requestedAt;
+      if (this.#userThreadsLastRequestedAt === null) {
+        this.#userThreadsLastRequestedAt = result.requestedAt;
       }
 
       return result.nextCursor;
     };
 
-    let paginatedResource = this._userThreads.get(queryKey);
+    let paginatedResource = this.#userThreads.get(queryKey);
     if (paginatedResource === undefined) {
       paginatedResource = new PaginatedResource(threadsFetcher);
     }
@@ -1435,21 +1434,21 @@ export class UmbrellaStore<M extends BaseMetadata> {
     paginatedResource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
-      this._store.set((store) => ({ ...store }))
+      this.#store.set((store) => ({ ...store }))
     );
 
-    this._userThreads.set(queryKey, paginatedResource);
+    this.#userThreads.set(queryKey, paginatedResource);
 
     return paginatedResource.waitUntilLoaded();
   }
 
   public async fetchUserThreadsDeltaUpdate(signal: AbortSignal) {
-    const lastRequestedAt = this._userThreadsLastRequestedAt;
+    const lastRequestedAt = this.#userThreadsLastRequestedAt;
     if (lastRequestedAt === null) {
       return;
     }
 
-    const result = await this._client[
+    const result = await this.#client[
       kInternal
     ].httpClient.getUserThreadsSince_experimental({
       since: lastRequestedAt,
@@ -1457,7 +1456,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     });
 
     if (lastRequestedAt < result.requestedAt) {
-      this._notificationsLastRequestedAt = result.requestedAt;
+      this.#notificationsLastRequestedAt = result.requestedAt;
     }
 
     this.updateThreadsAndNotifications(
@@ -1467,15 +1466,15 @@ export class UmbrellaStore<M extends BaseMetadata> {
       result.inboxNotifications.deleted
     );
 
-    this.updateRoomPermissions(result.permissionHints);
+    this.#updateRoomPermissions(result.permissionHints);
   }
 
   public waitUntilRoomVersionsLoaded(roomId: string) {
     const queryKey = makeVersionsQueryKey(roomId);
-    let resource = this._roomVersions.get(queryKey);
+    let resource = this.#roomVersions.get(queryKey);
     if (resource === undefined) {
       const versionsFetcher = async () => {
-        const room = this._client.getRoom(roomId);
+        const room = this.#client.getRoom(roomId);
         if (room === null) {
           throw new HttpError(
             `Room '${roomId}' is not available on client`,
@@ -1484,16 +1483,16 @@ export class UmbrellaStore<M extends BaseMetadata> {
         }
 
         const result = await room[kInternal].listTextVersions();
-        this.updateRoomVersions(roomId, result.versions);
+        this.#updateRoomVersions(roomId, result.versions);
 
         const lastRequestedAt =
-          this._roomVersionsLastRequestedAtByRoom.get(roomId);
+          this.#roomVersionsLastRequestedAtByRoom.get(roomId);
 
         if (
           lastRequestedAt === undefined ||
           lastRequestedAt > result.requestedAt
         ) {
-          this._roomVersionsLastRequestedAtByRoom.set(
+          this.#roomVersionsLastRequestedAtByRoom.set(
             roomId,
             result.requestedAt
           );
@@ -1506,10 +1505,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
     resource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
-      this._store.set((store) => ({ ...store }))
+      this.#store.set((store) => ({ ...store }))
     );
 
-    this._roomVersions.set(queryKey, resource);
+    this.#roomVersions.set(queryKey, resource);
 
     return resource.waitUntilLoaded();
   }
@@ -1518,13 +1517,13 @@ export class UmbrellaStore<M extends BaseMetadata> {
     roomId: string,
     signal: AbortSignal
   ) {
-    const lastRequestedAt = this._roomVersionsLastRequestedAtByRoom.get(roomId);
+    const lastRequestedAt = this.#roomVersionsLastRequestedAtByRoom.get(roomId);
     if (lastRequestedAt === undefined) {
       return;
     }
 
     const room = nn(
-      this._client.getRoom(roomId),
+      this.#client.getRoom(roomId),
       `Room with id ${roomId} is not available on client`
     );
 
@@ -1533,20 +1532,20 @@ export class UmbrellaStore<M extends BaseMetadata> {
       signal,
     });
 
-    this.updateRoomVersions(roomId, updates.versions);
+    this.#updateRoomVersions(roomId, updates.versions);
 
     if (lastRequestedAt < updates.requestedAt) {
       // Update the `lastRequestedAt` value for the room to the timestamp returned by the current request
-      this._roomVersionsLastRequestedAtByRoom.set(roomId, updates.requestedAt);
+      this.#roomVersionsLastRequestedAtByRoom.set(roomId, updates.requestedAt);
     }
   }
 
   public waitUntilRoomNotificationSettingsLoaded(roomId: string) {
     const queryKey = makeNotificationSettingsQueryKey(roomId);
-    let resource = this._roomNotificationSettings.get(queryKey);
+    let resource = this.#roomNotificationSettings.get(queryKey);
     if (resource === undefined) {
       const notificationSettingsFetcher = async () => {
-        const room = this._client.getRoom(roomId);
+        const room = this.#client.getRoom(roomId);
         if (room === null) {
           throw new HttpError(
             `Room '${roomId}' is not available on client`,
@@ -1555,7 +1554,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
         }
 
         const result = await room.getNotificationSettings();
-        this.setNotificationSettings(roomId, result);
+        this.#setNotificationSettings(roomId, result);
       };
 
       resource = new SinglePageResource(notificationSettingsFetcher);
@@ -1564,10 +1563,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
     resource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
-      this._store.set((store) => ({ ...store }))
+      this.#store.set((store) => ({ ...store }))
     );
 
-    this._roomNotificationSettings.set(queryKey, resource);
+    this.#roomNotificationSettings.set(queryKey, resource);
 
     return resource.waitUntilLoaded();
   }
@@ -1577,11 +1576,11 @@ export class UmbrellaStore<M extends BaseMetadata> {
     signal: AbortSignal
   ) {
     const room = nn(
-      this._client.getRoom(roomId),
+      this.#client.getRoom(roomId),
       `Room with id ${roomId} is not available on client`
     );
     const result = await room.getNotificationSettings({ signal });
-    this.setNotificationSettings(roomId, result);
+    this.#setNotificationSettings(roomId, result);
   }
 }
 


### PR DESCRIPTION
Since #2116 is now merged, we can safely use private fields everywhere (truly private at runtime, and minifiable in builds), instead of using TypeScript-level private field identifiers. This should further reduce the bundle size, and has the added benefit of better runtime isolation.