### PR TITLE
Refactor more store internals to signals

### DIFF
--- a/packages/liveblocks-core/src/lib/__tests__/signals/MutableSignal.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/signals/MutableSignal.test.ts
@@ -18,7 +18,7 @@ it("signals always notify watchers whenever mutated (because we cannot tell if t
 
   const counter = new MutableSignal<S>({ counter: 0 });
 
-  const inc = (state: S) => state.counter++;
+  const inc = (state: S) => void state.counter++;
 
   const makeOdd = (state: S) => {
     if ((state.counter & 1) === 0) {
@@ -62,6 +62,7 @@ it("signals throw when used with an async mutation function", () => {
   type S = { counter: 0 };
   const counter = new MutableSignal<S>({ counter: 0 });
   const asyncInc = (state: S) => Promise.resolve(state.counter++);
+  // @ts-expect-error deliberately pass an async function
   expect(() => counter.mutate(asyncInc)).toThrow(
     "does not support async callbacks"
   );
@@ -90,7 +91,7 @@ it("when chained, derived signals will think the value changed", () => {
   expect(count.get()).toEqual(3);
   expect(str.get()).toEqual("cherry,apple,banana");
 
-  fruits.mutate((arr) => arr.sort());
+  fruits.mutate((arr) => void arr.sort());
 
   expect(count.get()).toEqual(3);
   expect(str.get()).toEqual("apple,banana,cherry");
@@ -118,7 +119,7 @@ it("when batched, derived signals will only update the value changed", () => {
   const unsub = list.subscribe(watcher);
 
   // Without batching...
-  fruits.mutate((f) => f.push("🍎"));
+  fruits.mutate((f) => void f.push("🍎"));
   count.set(3);
 
   expect(evaled).toHaveBeenCalledTimes(2); // ...it's called 2 times
@@ -128,7 +129,7 @@ it("when batched, derived signals will only update the value changed", () => {
 
   // But with batching...
   batch(() => {
-    fruits.mutate((f) => f.push("🍍"));
+    fruits.mutate((f) => void f.push("🍍"));
     count.set(2);
   });
 

--- a/packages/liveblocks-core/src/lib/signals.ts
+++ b/packages/liveblocks-core/src/lib/signals.ts
@@ -211,6 +211,10 @@ abstract class AbstractSignal<T> implements ISignal<T>, Observable<void> {
   removeSink(sink: DerivedSignal<unknown>): void {
     this[kSinks].delete(sink);
   }
+
+  asReadonly(): ISignal<T> {
+    return this;
+  }
 }
 
 // NOTE: This class is pretty similar to the Signal.State proposal

--- a/packages/liveblocks-core/src/lib/signals.ts
+++ b/packages/liveblocks-core/src/lib/signals.ts
@@ -424,7 +424,7 @@ export class MutableSignal<T extends object> extends AbstractSignal<T> {
    * If the callback explicitly returns `false`, it's assumed that the state
    * was not changed.
    */
-  mutate(callback?: (state: T) => unknown): void {
+  mutate(callback?: (state: T) => void | boolean): void {
     batch(() => {
       const result = callback ? callback(this.#state) : true;
       if (result !== null && typeof result === "object" && "then" in result) {

--- a/packages/liveblocks-core/src/lib/signals.ts
+++ b/packages/liveblocks-core/src/lib/signals.ts
@@ -175,9 +175,8 @@ abstract class AbstractSignal<T> implements ISignal<T>, Observable<void> {
   public [kTrigger](): void {
     this.#eventSource.notify();
 
-    // While Signals are being triggered in the current rolldown, we can
-    // enqueue more signals to trigger (which will get added to the current
-    // rolldown)
+    // While Signals are being triggered in the current unroll, we can enqueue
+    // more signals to trigger (which will get added to the current unroll)
     for (const sink of this[kSinks]) {
       enqueueTrigger(sink);
     }

--- a/packages/liveblocks-react/src/ThreadDB.ts
+++ b/packages/liveblocks-react/src/ThreadDB.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   BaseMetadata,
-  batch,
   ThreadData,
   ThreadDataWithDeleteInfo,
   ThreadDeleteInfo,
 } from "@liveblocks/core";
-import { MutableSignal, SortedList } from "@liveblocks/core";
+import { batch, MutableSignal, SortedList } from "@liveblocks/core";
 
 import { makeThreadsFilter } from "./lib/querying";
 import type { ThreadsQuery } from "./types";

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/applyThreadDeltaUpdates.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/applyThreadDeltaUpdates.test.tsx
@@ -1,7 +1,6 @@
 import type { ThreadData, ThreadDeleteInfo } from "@liveblocks/core";
 
 import { ThreadDB } from "../../ThreadDB";
-import { applyThreadDeltaUpdates } from "../../umbrella-store";
 import { dummyThreadData } from "../_dummies";
 
 describe("applyThreadDeltaUpdates", () => {
@@ -34,7 +33,7 @@ describe("applyThreadDeltaUpdates", () => {
   it("should add a new thread if it doesn't exist already", () => {
     const db = new ThreadDB();
 
-    applyThreadDeltaUpdates(db, {
+    db.applyDelta({
       newThreads: [thread1],
       deletedThreads: [],
     });
@@ -54,12 +53,10 @@ describe("applyThreadDeltaUpdates", () => {
     db.upsert(thread1);
 
     // Simulate updates with the newer version of thread1
-    const updates = {
+    db.applyDelta({
       newThreads: [thread1Updated],
       deletedThreads: [],
-    };
-
-    applyThreadDeltaUpdates(db, updates);
+    });
 
     // Expected output should reflect the updated properties of thread1Updated
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread1Updated]);
@@ -69,12 +66,10 @@ describe("applyThreadDeltaUpdates", () => {
     const db = new ThreadDB();
     db.upsert(thread1);
 
-    const updates = {
+    db.applyDelta({
       newThreads: [],
       deletedThreads: [thread1DeleteInfo], // Mark thread1 as deleted
-    };
-
-    applyThreadDeltaUpdates(db, updates);
+    });
 
     expect(db.findMany(undefined, {}, "asc")).toEqual([]);
     expect(db.getEvenIfDeleted(thread1.id)).toEqual({
@@ -91,12 +86,10 @@ describe("applyThreadDeltaUpdates", () => {
 
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread1]);
 
-    const updates = {
+    db.applyDelta({
       newThreads: [],
       deletedThreads: [thread2DeleteInfo], // Attempt to delete non-existing thread2
-    };
-
-    applyThreadDeltaUpdates(db, updates);
+    });
 
     // Output should remain unchanged
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread1]);
@@ -108,12 +101,10 @@ describe("applyThreadDeltaUpdates", () => {
 
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread1]);
 
-    const updates = {
+    db.applyDelta({
       newThreads: [thread2], // Add thread2
       deletedThreads: [thread1DeleteInfo], // Delete thread1
-    };
-
-    applyThreadDeltaUpdates(db, updates);
+    });
 
     // Thread2 was added, and thread 1 deleted
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread2]);
@@ -136,12 +127,10 @@ describe("applyThreadDeltaUpdates", () => {
     expect(fn).toHaveBeenCalledTimes(2);
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread1, thread2]);
 
-    const updates = {
+    db.applyDelta({
       newThreads: [],
       deletedThreads: [],
-    };
-
-    applyThreadDeltaUpdates(db, updates);
+    });
 
     expect(db.findMany(undefined, {}, "asc")).toEqual([thread1, thread2]);
 

--- a/packages/liveblocks-react/src/__tests__/useHistoryVersions.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useHistoryVersions.test.tsx
@@ -165,22 +165,22 @@ describe("useHistoryVersions", () => {
       umbrellaStore,
     } = createContextsForTest();
 
-    umbrellaStore.force_set_versions((state) => ({
-      ...state,
-      "room-1": {
-        version_1: {
-          type: "historyVersion",
-          kind: "yjs",
-          createdAt: new Date(),
-          id: "version_1",
-          authors: [
-            {
-              id: "user-1",
-            },
-          ],
-        },
-      },
-    }));
+    umbrellaStore.force_set_versions((lut) => {
+      const room1Versions = new Map();
+      room1Versions.set("version_1", {
+        type: "historyVersion",
+        kind: "yjs",
+        createdAt: new Date(),
+        id: "version_1",
+        authors: [
+          {
+            id: "user-1",
+          },
+        ],
+      });
+
+      lut.set("room-1", room1Versions);
+    });
 
     const { result, unmount } = renderHook(() => useHistoryVersions(), {
       wrapper: ({ children }) => (

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -287,12 +287,11 @@ describe("useInboxNotifications", () => {
     umbrellaStore.threads.upsert(thread1);
     umbrellaStore.threads.upsert(thread2);
 
-    umbrellaStore.force_set_notifications((prev) => ({
-      ...prev,
+    umbrellaStore.force_set_notifications((lut) => {
       // Explicitly set the order to be reversed to test that the hook sorts the notifications
-      [oldInboxNotification.id]: oldInboxNotification,
-      [newInboxNotification.id]: newInboxNotification,
-    }));
+      lut.set(oldInboxNotification.id, oldInboxNotification);
+      lut.set(newInboxNotification.id, newInboxNotification);
+    });
 
     const { result, unmount } = renderHook(() => useInboxNotifications(), {
       wrapper: ({ children }) => (

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -284,8 +284,8 @@ describe("useInboxNotifications", () => {
       umbrellaStore,
     } = createContextsForTest();
 
-    umbrellaStore.baseThreadsDB.upsert(thread1);
-    umbrellaStore.baseThreadsDB.upsert(thread2);
+    umbrellaStore.threads.upsert(thread1);
+    umbrellaStore.threads.upsert(thread2);
 
     umbrellaStore.force_set_notifications((prev) => ({
       ...prev,

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1453,7 +1453,7 @@ describe("useThreads", () => {
       umbrellaStore,
     } = createContextsForTest();
 
-    const db = umbrellaStore.baseThreadsDB;
+    const db = umbrellaStore.threads;
     db.upsert(thread1);
     db.upsert(thread2WithDeletedAt);
     umbrellaStore.force_set_versions((state) => ({ ...state }));

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -1456,7 +1456,7 @@ describe("useThreads", () => {
     const db = umbrellaStore.threads;
     db.upsert(thread1);
     db.upsert(thread2WithDeletedAt);
-    umbrellaStore.force_set_versions((state) => ({ ...state }));
+    umbrellaStore.invalidateEntireStore();
 
     const { result, unmount } = renderHook(
       () => useThreads({ query: { metadata: {} } }),

--- a/packages/liveblocks-react/src/lib/itertools.ts
+++ b/packages/liveblocks-react/src/lib/itertools.ts
@@ -1,0 +1,15 @@
+/**
+ * Like Array.prototype.find(), but for iterables.
+ *
+ * Returns the first item in the iterable for which the predicate holds.
+ * Returns undefined if item matches the predicate.
+ */
+export function find<T>(
+  it: Iterable<T>,
+  predicate: (value: T) => boolean
+): T | undefined {
+  for (const item of it) {
+    if (predicate(item)) return item;
+  }
+  return undefined;
+}

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -413,7 +413,7 @@ function useInboxNotifications_withClient<T>(
     };
   }, [poller]);
 
-  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
   // why the getInboxNotificationsLoadingState getter should be paired with
   // subscribe1 and not subscribe2 from the outside! (The reason is that
   // getInboxNotificationsLoadingState internally uses `get1` not `get2`.) This
@@ -946,7 +946,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
     };
   }, [poller]);
 
-  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
   // why the getUserThreadsLoadingState getter should be paired with subscribe1
   // and not subscribe2 from the outside! (The reason is that
   // getUserThreadsLoadingState  internally uses `get1` not `get2`.) This is

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -479,10 +479,10 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
       client.markInboxNotificationAsRead(inboxNotificationId).then(
         () => {
           // Replace the optimistic update by the real thing
-          store.updateInboxNotification(
+          store.markInboxNotificationRead(
             inboxNotificationId,
-            optimisticUpdateId,
-            (inboxNotification) => ({ ...inboxNotification, readAt })
+            readAt,
+            optimisticUpdateId
           );
         },
         () => {
@@ -507,10 +507,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
     client.markAllInboxNotificationsAsRead().then(
       () => {
         // Replace the optimistic update by the real thing
-        store.updateAllInboxNotifications(
-          optimisticUpdateId,
-          (inboxNotification) => ({ ...inboxNotification, readAt })
-        );
+        store.markAllInboxNotificationsRead(optimisticUpdateId, readAt);
       },
       () => {
         // TODO: Broadcast errors to client

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -470,7 +470,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
       const { store } = getLiveblocksExtrasForClient(client);
 
       const readAt = new Date();
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "mark-inbox-notification-as-read",
         inboxNotificationId,
         readAt,
@@ -487,7 +487,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
         },
         () => {
           // TODO: Broadcast errors to client
-          store.removeOptimisticUpdate(optimisticUpdateId);
+          store.optimisticUpdates.remove(optimisticUpdateId);
         }
       );
     },
@@ -499,7 +499,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
   return useCallback(() => {
     const { store } = getLiveblocksExtrasForClient(client);
     const readAt = new Date();
-    const optimisticUpdateId = store.addOptimisticUpdate({
+    const optimisticUpdateId = store.optimisticUpdates.add({
       type: "mark-all-inbox-notifications-as-read",
       readAt,
     });
@@ -514,7 +514,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
       },
       () => {
         // TODO: Broadcast errors to client
-        store.removeOptimisticUpdate(optimisticUpdateId);
+        store.optimisticUpdates.remove(optimisticUpdateId);
       }
     );
   }, [client]);
@@ -526,7 +526,7 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
       const { store } = getLiveblocksExtrasForClient(client);
 
       const deletedAt = new Date();
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "delete-inbox-notification",
         inboxNotificationId,
         deletedAt,
@@ -542,7 +542,7 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
         },
         () => {
           // TODO: Broadcast errors to client
-          store.removeOptimisticUpdate(optimisticUpdateId);
+          store.optimisticUpdates.remove(optimisticUpdateId);
         }
       );
     },
@@ -554,7 +554,7 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
   return useCallback(() => {
     const { store } = getLiveblocksExtrasForClient(client);
     const deletedAt = new Date();
-    const optimisticUpdateId = store.addOptimisticUpdate({
+    const optimisticUpdateId = store.optimisticUpdates.add({
       type: "delete-all-inbox-notifications",
       deletedAt,
     });
@@ -566,7 +566,7 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
       },
       () => {
         // TODO: Broadcast errors to client
-        store.removeOptimisticUpdate(optimisticUpdateId);
+        store.optimisticUpdates.remove(optimisticUpdateId);
       }
     );
   }, [client]);

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -470,7 +470,7 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
       const { store } = getLiveblocksExtrasForClient(client);
 
       const readAt = new Date();
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "mark-inbox-notification-as-read",
         inboxNotificationId,
         readAt,
@@ -482,12 +482,12 @@ function useMarkInboxNotificationAsRead_withClient(client: OpaqueClient) {
           store.markInboxNotificationRead(
             inboxNotificationId,
             readAt,
-            optimisticUpdateId
+            optimisticId
           );
         },
         () => {
           // TODO: Broadcast errors to client
-          store.optimisticUpdates.remove(optimisticUpdateId);
+          store.optimisticUpdates.remove(optimisticId);
         }
       );
     },
@@ -499,7 +499,7 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
   return useCallback(() => {
     const { store } = getLiveblocksExtrasForClient(client);
     const readAt = new Date();
-    const optimisticUpdateId = store.optimisticUpdates.add({
+    const optimisticId = store.optimisticUpdates.add({
       type: "mark-all-inbox-notifications-as-read",
       readAt,
     });
@@ -507,11 +507,11 @@ function useMarkAllInboxNotificationsAsRead_withClient(client: OpaqueClient) {
     client.markAllInboxNotificationsAsRead().then(
       () => {
         // Replace the optimistic update by the real thing
-        store.markAllInboxNotificationsRead(optimisticUpdateId, readAt);
+        store.markAllInboxNotificationsRead(optimisticId, readAt);
       },
       () => {
         // TODO: Broadcast errors to client
-        store.optimisticUpdates.remove(optimisticUpdateId);
+        store.optimisticUpdates.remove(optimisticId);
       }
     );
   }, [client]);
@@ -523,7 +523,7 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
       const { store } = getLiveblocksExtrasForClient(client);
 
       const deletedAt = new Date();
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "delete-inbox-notification",
         inboxNotificationId,
         deletedAt,
@@ -532,14 +532,11 @@ function useDeleteInboxNotification_withClient(client: OpaqueClient) {
       client.deleteInboxNotification(inboxNotificationId).then(
         () => {
           // Replace the optimistic update by the real thing
-          store.deleteInboxNotification(
-            inboxNotificationId,
-            optimisticUpdateId
-          );
+          store.deleteInboxNotification(inboxNotificationId, optimisticId);
         },
         () => {
           // TODO: Broadcast errors to client
-          store.optimisticUpdates.remove(optimisticUpdateId);
+          store.optimisticUpdates.remove(optimisticId);
         }
       );
     },
@@ -551,7 +548,7 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
   return useCallback(() => {
     const { store } = getLiveblocksExtrasForClient(client);
     const deletedAt = new Date();
-    const optimisticUpdateId = store.optimisticUpdates.add({
+    const optimisticId = store.optimisticUpdates.add({
       type: "delete-all-inbox-notifications",
       deletedAt,
     });
@@ -559,11 +556,11 @@ function useDeleteAllInboxNotifications_withClient(client: OpaqueClient) {
     client.deleteAllInboxNotifications().then(
       () => {
         // Replace the optimistic update by the real thing
-        store.deleteAllInboxNotifications(optimisticUpdateId);
+        store.deleteAllInboxNotifications(optimisticId);
       },
       () => {
         // TODO: Broadcast errors to client
-        store.optimisticUpdates.remove(optimisticUpdateId);
+        store.optimisticUpdates.remove(optimisticId);
       }
     );
   }, [client]);

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -413,13 +413,12 @@ function useInboxNotifications_withClient<T>(
     };
   }, [poller]);
 
-  // TODO(vincent+nimesh) There is a disconnect between this getter and
-  // subscriber! It's unclear why the getInboxNotificationsLoadingState getter
-  // should be paired with subscribe1 and not subscribe2 from the outside! (The
-  // reason is that getInboxNotificationsLoadingState internally uses `get1`
-  // not `get2`.) This is strong evidence that
-  // getInboxNotificationsLoadingState itself wants to be a Signal! Once we
-  // make it a Signal, we can simply use `useSignal()` here! ❤️
+  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // why the getInboxNotificationsLoadingState getter should be paired with
+  // subscribe1 and not subscribe2 from the outside! (The reason is that
+  // getInboxNotificationsLoadingState internally uses `get1` not `get2`.) This
+  // is strong evidence that getInboxNotificationsLoadingState itself wants to
+  // be a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   return useSyncExternalStoreWithSelector(
     store.subscribe1_threads,
     store.getInboxNotificationsLoadingState,
@@ -953,11 +952,11 @@ function useUserThreads_experimental<M extends BaseMetadata>(
     };
   }, [poller]);
 
-  // TODO(vincent+nimesh) There is a disconnect between this getter and
-  // subscriber! It's unclear why the getUserThreadsLoadingState getter should
-  // be paired with subscribe1 and not subscribe2 from the outside! (The reason
-  // is that getUserThreadsLoadingState  internally uses `get1` not `get2`.)
-  // This is strong evidence that getUserThreadsLoadingState itself wants to be
+  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // why the getUserThreadsLoadingState getter should be paired with subscribe1
+  // and not subscribe2 from the outside! (The reason is that
+  // getUserThreadsLoadingState  internally uses `get1` not `get2`.) This is
+  // strong evidence that getUserThreadsLoadingState itself wants to be
   // a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   const getter = useCallback(
     () => store.getUserThreadsLoadingState(options.query),

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1947,10 +1947,10 @@ function useMarkRoomThreadAsRead(roomId: string) {
         .then(
           () => {
             // Replace the optimistic update by the real thing
-            store.updateInboxNotification(
+            store.markInboxNotificationRead(
               inboxNotification.id,
-              optimisticUpdateId,
-              (inboxNotification) => ({ ...inboxNotification, readAt: now })
+              now,
+              optimisticUpdateId
             );
           },
           (err: Error) => {

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -255,7 +255,7 @@ function makeRoomExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
     optimisticUpdateId: string,
     createPublicError: (error: Error) => CommentsError<M>
   ) {
-    store.removeOptimisticUpdate(optimisticUpdateId);
+    store.optimisticUpdates.remove(optimisticUpdateId);
 
     if (innerError instanceof HttpError) {
       const error = handleApiError(innerError);
@@ -1432,7 +1432,7 @@ function useCreateRoomThread<M extends BaseMetadata>(
       };
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "create-thread",
         thread: newThread,
         roomId,
@@ -1492,7 +1492,7 @@ function useDeleteRoomThread(roomId: string): (threadId: string) => void {
         throw new Error("Only the thread creator can delete the thread");
       }
 
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "delete-thread",
         roomId,
         threadId,
@@ -1533,7 +1533,7 @@ function useEditRoomThreadMetadata<M extends BaseMetadata>(roomId: string) {
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "edit-thread-metadata",
         metadata,
         threadId,
@@ -1604,7 +1604,7 @@ function useCreateRoomComment(
       };
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "create-comment",
         comment,
       });
@@ -1683,7 +1683,7 @@ function useEditRoomComment(
         return;
       }
 
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "edit-comment",
         comment: {
           ...comment,
@@ -1744,7 +1744,7 @@ function useDeleteRoomComment(roomId: string) {
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
 
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "delete-comment",
         threadId,
         commentId,
@@ -1797,7 +1797,7 @@ function useAddRoomCommentReaction<M extends BaseMetadata>(roomId: string) {
 
       const { store, onMutationFailure } = getRoomExtrasForClient<M>(client);
 
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "add-reaction",
         threadId,
         commentId,
@@ -1862,7 +1862,7 @@ function useRemoveRoomCommentReaction(roomId: string) {
       const removedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "remove-reaction",
         threadId,
         commentId,
@@ -1933,7 +1933,7 @@ function useMarkRoomThreadAsRead(roomId: string) {
 
       const now = new Date();
 
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "mark-inbox-notification-as-read",
         inboxNotificationId: inboxNotification.id,
         readAt: now,
@@ -1991,7 +1991,7 @@ function useMarkRoomThreadAsResolved(roomId: string) {
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "mark-thread-as-resolved",
         threadId,
         updatedAt,
@@ -2046,7 +2046,7 @@ function useMarkRoomThreadAsUnresolved(roomId: string) {
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "mark-thread-as-unresolved",
         threadId,
         updatedAt,
@@ -2344,7 +2344,7 @@ function useUpdateRoomNotificationSettings() {
   return useCallback(
     (settings: Partial<RoomNotificationSettings>) => {
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.addOptimisticUpdate({
+      const optimisticUpdateId = store.optimisticUpdates.add({
         type: "update-notification-settings",
         roomId: room.id,
         settings,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -668,7 +668,7 @@ function RoomProviderInner<
         store.deleteThread(message.threadId, null);
         return;
       }
-      const { thread, inboxNotification } = info;
+      const { thread, inboxNotification: maybeNotification } = info;
 
       const existingThread = store
         .get1_threads()
@@ -684,10 +684,17 @@ function RoomProviderInner<
           // If the thread doesn't exist in the local cache, we do not update it with the server data as an optimistic update could have deleted the thread locally.
           if (!existingThread) break;
 
-          store.updateThreadAndNotification(thread, inboxNotification);
+          store.updateThreadifications(
+            [thread],
+            maybeNotification ? [maybeNotification] : []
+          );
           break;
+
         case ServerMsgCode.COMMENT_CREATED:
-          store.updateThreadAndNotification(thread, inboxNotification);
+          store.updateThreadifications(
+            [thread],
+            maybeNotification ? [maybeNotification] : []
+          );
           break;
         default:
           break;
@@ -2346,7 +2353,7 @@ function useUpdateRoomNotificationSettings() {
       room.updateNotificationSettings(settings).then(
         (settings) => {
           // Replace the optimistic update by the real thing
-          store.updateRoomNotificationSettings_confirmOptimisticUpdate(
+          store.updateRoomNotificationSettings(
             room.id,
             optimisticUpdateId,
             settings

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1545,12 +1545,7 @@ function useEditRoomThreadMetadata<M extends BaseMetadata>(roomId: string) {
         .then(
           (metadata) =>
             // Replace the optimistic update by the real thing
-            store.patchThread(
-              threadId,
-              optimisticId,
-              { metadata },
-              updatedAt
-            ),
+            store.patchThread(threadId, optimisticId, { metadata }, updatedAt),
           (err: Error) =>
             onMutationFailure(
               err,
@@ -1757,12 +1752,7 @@ function useDeleteRoomComment(roomId: string) {
         .then(
           () => {
             // Replace the optimistic update by the real thing
-            store.deleteComment(
-              threadId,
-              optimisticId,
-              commentId,
-              deletedAt
-            );
+            store.deleteComment(threadId, optimisticId, commentId, deletedAt);
           },
           (err: Error) =>
             onMutationFailure(
@@ -2353,11 +2343,7 @@ function useUpdateRoomNotificationSettings() {
       room.updateNotificationSettings(settings).then(
         (settings) => {
           // Replace the optimistic update by the real thing
-          store.updateRoomNotificationSettings(
-            room.id,
-            optimisticId,
-            settings
-          );
+          store.updateRoomNotificationSettings(room.id, optimisticId, settings);
         },
         (err: Error) =>
           onMutationFailure(

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -252,10 +252,10 @@ function makeRoomExtrasForClient<M extends BaseMetadata>(client: OpaqueClient) {
 
   function onMutationFailure(
     innerError: Error,
-    optimisticUpdateId: string,
+    optimisticId: string,
     createPublicError: (error: Error) => CommentsError<M>
   ) {
-    store.optimisticUpdates.remove(optimisticUpdateId);
+    store.optimisticUpdates.remove(optimisticId);
 
     if (innerError instanceof HttpError) {
       const error = handleApiError(innerError);
@@ -1432,7 +1432,7 @@ function useCreateRoomThread<M extends BaseMetadata>(
       };
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "create-thread",
         thread: newThread,
         roomId,
@@ -1452,12 +1452,12 @@ function useCreateRoomThread<M extends BaseMetadata>(
         .then(
           (thread) => {
             // Replace the optimistic update by the real thing
-            store.createThread(optimisticUpdateId, thread);
+            store.createThread(optimisticId, thread);
           },
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (err) =>
                 new CreateThreadError(err, {
                   roomId,
@@ -1492,7 +1492,7 @@ function useDeleteRoomThread(roomId: string): (threadId: string) => void {
         throw new Error("Only the thread creator can delete the thread");
       }
 
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "delete-thread",
         roomId,
         threadId,
@@ -1502,12 +1502,12 @@ function useDeleteRoomThread(roomId: string): (threadId: string) => void {
       client[kInternal].httpClient.deleteThread({ roomId, threadId }).then(
         () => {
           // Replace the optimistic update by the real thing
-          store.deleteThread(threadId, optimisticUpdateId);
+          store.deleteThread(threadId, optimisticId);
         },
         (err: Error) =>
           onMutationFailure(
             err,
-            optimisticUpdateId,
+            optimisticId,
             (err) => new DeleteThreadError(err, { roomId, threadId })
           )
       );
@@ -1533,7 +1533,7 @@ function useEditRoomThreadMetadata<M extends BaseMetadata>(roomId: string) {
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "edit-thread-metadata",
         metadata,
         threadId,
@@ -1547,14 +1547,14 @@ function useEditRoomThreadMetadata<M extends BaseMetadata>(roomId: string) {
             // Replace the optimistic update by the real thing
             store.patchThread(
               threadId,
-              optimisticUpdateId,
+              optimisticId,
               { metadata },
               updatedAt
             ),
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new EditThreadMetadataError(error, {
                   roomId,
@@ -1604,7 +1604,7 @@ function useCreateRoomComment(
       };
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "create-comment",
         comment,
       });
@@ -1616,12 +1616,12 @@ function useCreateRoomComment(
         .then(
           (newComment) => {
             // Replace the optimistic update by the real thing
-            store.createComment(newComment, optimisticUpdateId);
+            store.createComment(newComment, optimisticId);
           },
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (err) =>
                 new CreateCommentError(err, {
                   roomId,
@@ -1683,7 +1683,7 @@ function useEditRoomComment(
         return;
       }
 
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "edit-comment",
         comment: {
           ...comment,
@@ -1700,12 +1700,12 @@ function useEditRoomComment(
         .then(
           (editedComment) => {
             // Replace the optimistic update by the real thing
-            store.editComment(threadId, optimisticUpdateId, editedComment);
+            store.editComment(threadId, optimisticId, editedComment);
           },
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new EditCommentError(error, {
                   roomId,
@@ -1744,7 +1744,7 @@ function useDeleteRoomComment(roomId: string) {
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
 
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "delete-comment",
         threadId,
         commentId,
@@ -1759,7 +1759,7 @@ function useDeleteRoomComment(roomId: string) {
             // Replace the optimistic update by the real thing
             store.deleteComment(
               threadId,
-              optimisticUpdateId,
+              optimisticId,
               commentId,
               deletedAt
             );
@@ -1767,7 +1767,7 @@ function useDeleteRoomComment(roomId: string) {
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new DeleteCommentError(error, {
                   roomId,
@@ -1797,7 +1797,7 @@ function useAddRoomCommentReaction<M extends BaseMetadata>(roomId: string) {
 
       const { store, onMutationFailure } = getRoomExtrasForClient<M>(client);
 
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "add-reaction",
         threadId,
         commentId,
@@ -1815,7 +1815,7 @@ function useAddRoomCommentReaction<M extends BaseMetadata>(roomId: string) {
             // Replace the optimistic update by the real thing
             store.addReaction(
               threadId,
-              optimisticUpdateId,
+              optimisticId,
               commentId,
               addedReaction,
               createdAt
@@ -1824,7 +1824,7 @@ function useAddRoomCommentReaction<M extends BaseMetadata>(roomId: string) {
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new AddReactionError(error, {
                   roomId,
@@ -1862,7 +1862,7 @@ function useRemoveRoomCommentReaction(roomId: string) {
       const removedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "remove-reaction",
         threadId,
         commentId,
@@ -1878,7 +1878,7 @@ function useRemoveRoomCommentReaction(roomId: string) {
             // Replace the optimistic update by the real thing
             store.removeReaction(
               threadId,
-              optimisticUpdateId,
+              optimisticId,
               commentId,
               emoji,
               userId,
@@ -1888,7 +1888,7 @@ function useRemoveRoomCommentReaction(roomId: string) {
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new RemoveReactionError(error, {
                   roomId,
@@ -1933,7 +1933,7 @@ function useMarkRoomThreadAsRead(roomId: string) {
 
       const now = new Date();
 
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "mark-inbox-notification-as-read",
         inboxNotificationId: inboxNotification.id,
         readAt: now,
@@ -1950,13 +1950,13 @@ function useMarkRoomThreadAsRead(roomId: string) {
             store.markInboxNotificationRead(
               inboxNotification.id,
               now,
-              optimisticUpdateId
+              optimisticId
             );
           },
           (err: Error) => {
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new MarkInboxNotificationAsReadError(error, {
                   inboxNotificationId: inboxNotification.id,
@@ -1991,7 +1991,7 @@ function useMarkRoomThreadAsResolved(roomId: string) {
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "mark-thread-as-resolved",
         threadId,
         updatedAt,
@@ -2004,7 +2004,7 @@ function useMarkRoomThreadAsResolved(roomId: string) {
             // Replace the optimistic update by the real thing
             store.patchThread(
               threadId,
-              optimisticUpdateId,
+              optimisticId,
               { resolved: true },
               updatedAt
             );
@@ -2012,7 +2012,7 @@ function useMarkRoomThreadAsResolved(roomId: string) {
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new MarkThreadAsResolvedError(error, {
                   roomId,
@@ -2046,7 +2046,7 @@ function useMarkRoomThreadAsUnresolved(roomId: string) {
       const updatedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "mark-thread-as-unresolved",
         threadId,
         updatedAt,
@@ -2059,7 +2059,7 @@ function useMarkRoomThreadAsUnresolved(roomId: string) {
             // Replace the optimistic update by the real thing
             store.patchThread(
               threadId,
-              optimisticUpdateId,
+              optimisticId,
               { resolved: false },
               updatedAt
             );
@@ -2067,7 +2067,7 @@ function useMarkRoomThreadAsUnresolved(roomId: string) {
           (err: Error) =>
             onMutationFailure(
               err,
-              optimisticUpdateId,
+              optimisticId,
               (error) =>
                 new MarkThreadAsUnresolvedError(error, {
                   roomId,
@@ -2344,7 +2344,7 @@ function useUpdateRoomNotificationSettings() {
   return useCallback(
     (settings: Partial<RoomNotificationSettings>) => {
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const optimisticUpdateId = store.optimisticUpdates.add({
+      const optimisticId = store.optimisticUpdates.add({
         type: "update-notification-settings",
         roomId: room.id,
         settings,
@@ -2355,14 +2355,14 @@ function useUpdateRoomNotificationSettings() {
           // Replace the optimistic update by the real thing
           store.updateRoomNotificationSettings(
             room.id,
-            optimisticUpdateId,
+            optimisticId,
             settings
           );
         },
         (err: Error) =>
           onMutationFailure(
             err,
-            optimisticUpdateId,
+            optimisticId,
             (error) =>
               new UpdateNotificationSettingsError(error, {
                 roomId: room.id,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1346,7 +1346,7 @@ function useThreads<M extends BaseMetadata>(
     return () => poller.dec();
   }, [poller]);
 
-  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
   // why the getRoomThreadsLoadingState getter should be paired with subscribe1
   // and not subscribe2 from the outside! (The reason is that
   // getRoomThreadsLoadingState internally uses `get1` not `get2`.) This is
@@ -2147,7 +2147,7 @@ function useRoomNotificationSettings(): [
     };
   }, [poller]);
 
-  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
   // why the getNotificationSettingsLoadingState getter should be paired with
   // subscribe2 and not subscribe1 from the outside! (The reason is that
   // getNotificationSettingsLoadingState internally uses `get2` not `get1`.)
@@ -2159,7 +2159,7 @@ function useRoomNotificationSettings(): [
     [store, room.id]
   );
 
-  // XXX Turn this into a useSignal
+  // XXX_vincent Turn this into a useSignal
   const settings = useSyncExternalStoreWithSelector(
     store.subscribe2,
     getter,
@@ -2284,7 +2284,7 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
     //    *next* render after that, a *new* fetch/promise will get created.
   );
 
-  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
   // why the getRoomVersionsLoadingState getter should be paired with
   // subscribe3 and not subscribe1 from the outside! (The reason is that
   // getRoomVersionsLoadingState internally uses `get3` not `get1`.) This is

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1339,7 +1339,7 @@ function useThreads<M extends BaseMetadata>(
     return () => poller.dec();
   }, [poller]);
 
-  // TODO(vincent+nimesh) There is a disconnect between this getter and subscriber! It's unclear
+  // XXX There is a disconnect between this getter and subscriber! It's unclear
   // why the getRoomThreadsLoadingState getter should be paired with subscribe1
   // and not subscribe2 from the outside! (The reason is that
   // getRoomThreadsLoadingState internally uses `get1` not `get2`.) This is
@@ -2150,19 +2150,19 @@ function useRoomNotificationSettings(): [
     };
   }, [poller]);
 
-  // TODO(vincent+nimesh) There is a disconnect between this getter and
-  // subscriber! It's unclear why the getNotificationSettingsLoadingState
-  // getter should be paired with subscribe2 and not subscribe1 from the
-  // outside! (The reason is that getNotificationSettingsLoadingState
-  // internally uses `get2` not `get1`.) This is strong evidence that
-  // getNotificationSettingsLoadingState itself wants to be a Signal! Once we
-  // make it a Signal, we can simply use `useSignal()` here! ❤️
+  // XXX There is a disconnect between this getter and subscriber! It's unclear
+  // why the getNotificationSettingsLoadingState getter should be paired with
+  // subscribe2 and not subscribe1 from the outside! (The reason is that
+  // getNotificationSettingsLoadingState internally uses `get2` not `get1`.)
+  // This is strong evidence that getNotificationSettingsLoadingState itself
+  // wants to be a Signal! Once we make it a Signal, we can simply use
+  // `useSignal()` here! ❤️
   const getter = useCallback(
     () => store.getNotificationSettingsLoadingState(room.id),
     [store, room.id]
   );
 
-  // TODO(vincent+nimesh) Turn this into a useSignal
+  // XXX Turn this into a useSignal
   const settings = useSyncExternalStoreWithSelector(
     store.subscribe2,
     getter,
@@ -2287,7 +2287,7 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
     //    *next* render after that, a *new* fetch/promise will get created.
   );
 
-  // TODO(vincent+nimesh) There is a disconnect between this getter and subscriber! It's unclear
+  // XXX There is a disconnect between this getter and subscriber! It's unclear
   // why the getRoomVersionsLoadingState getter should be paired with
   // subscribe3 and not subscribe1 from the outside! (The reason is that
   // getRoomVersionsLoadingState internally uses `get3` not `get1`.) This is

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2630,7 +2630,7 @@ function useRoomPermissions(roomId: string) {
   const client = useClient();
   const store = getRoomExtrasForClient(client).store;
   return useSignal(
-    store.permissionHintsByRoomId,
+    store.permissionHints.signal,
     (hints) => hints[roomId] ?? new Set()
   );
 }

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -635,7 +635,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   // threads and notifications separately, but the threadifications signal will
   // be updated whenever either of them change.
   //
-  // TODO(vincent+nimesh) APIs like getRoomThreadsLoadingState should really also be modeled as output signals.
+  // XXX APIs like getRoomThreadsLoadingState should really also be modeled as output signals.
   //
   readonly outputs: {
     readonly threadifications: DerivedSignal<CleanThreadifications<M>>;
@@ -685,7 +685,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return nextCursor;
     };
 
-    // TODO(vincent+nimesh) Looks like this should also be a Signal!
+    // XXX Looks like this should also be a Signal!
     this.#notifications = new PaginatedResource(inboxFetcher);
     this.#notifications.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
@@ -728,8 +728,8 @@ export class UmbrellaStore<M extends BaseMetadata> {
         applyOptimisticUpdates_forSettings(settings, updates)
     );
 
-    // TODO(vincent+nimesh) Not much of a "derived" state: it's just the same
-    // as the input This is a smell. We should be able to extract it out of the
+    // XXX Not much of a "derived" state: it's just the same as the input
+    // This is a smell. We should be able to extract it out of the
     // UmbrellaStore must like the permission hints signal.
     const versionsByRoomId = DerivedSignal.from(
       this.baseVersionsByRoomId,
@@ -891,7 +891,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
-  // TODO(vincent+nimesh) This should really be a derived Signal!
+  // XXX This should really be a derived Signal!
   public getNotificationSettingsLoadingState(
     roomId: string
   ): RoomNotificationSettingsAsyncResult {
@@ -1454,7 +1454,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       paginatedResource = new PaginatedResource(threadsFetcher);
     }
 
-    // TODO(vincent+nimesh) Looks like this should also be a Signal!
+    // XXX Looks like this should also be a Signal!
     paginatedResource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
@@ -1526,7 +1526,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       paginatedResource = new PaginatedResource(threadsFetcher);
     }
 
-    // TODO(vincent+nimesh) Looks like this should also be a Signal!
+    // XXX Looks like this should also be a Signal!
     paginatedResource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
@@ -1538,10 +1538,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return paginatedResource.waitUntilLoaded();
   }
 
-  // TODO(vincent+nimesh) We should really be going over all call sites, and replace this call
+  // XXX We should really be going over all call sites, and replace this call
   // with a more specific invalidation!
   private invalidateEntireStore() {
-    // TODO(vincent+nimesh) Of course this now looks stupid, but it's the exact equivalent of
+    // XXX Of course this now looks stupid, but it's the exact equivalent of
     // what we're been doing all along
     batch(() => {
       this.baseVersionsByRoomId.set((store) => ({ ...store }));
@@ -1612,7 +1612,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       resource = new SinglePageResource(versionsFetcher);
     }
 
-    // TODO(vincent+nimesh) Looks like this should also be a Signal!
+    // XXX Looks like this should also be a Signal!
     resource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
@@ -1671,7 +1671,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       resource = new SinglePageResource(notificationSettingsFetcher);
     }
 
-    // TODO(vincent+nimesh) Looks like this should also be a Signal!
+    // XXX Looks like this should also be a Signal!
     resource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -450,10 +450,9 @@ export class PaginatedResource {
     );
 
     // NOTE: However tempting it may be, we cannot simply move this block into
-    // the promise definition above, how tempting that may be. The reason is
-    // that we should not call notify() before the UsablePromise is actually in
-    // resolved status. While still inside the .then() block, the UsablePromise
-    // is still in pending status.
+    // the promise definition above. The reason is that we should not call
+    // notify() before the UsablePromise is actually in resolved status. While
+    // still inside the .then() block, the UsablePromise is still in pending status.
     promise.then(
       () => this.#eventSource.notify(),
       () => {
@@ -514,10 +513,9 @@ class SinglePageResource {
     const promise = usify(initialFetcher);
 
     // NOTE: However tempting it may be, we cannot simply move this block into
-    // the promise definition above, how tempting that may be. The reason is
-    // that we should not call notify() before the UsablePromise is actually in
-    // resolved status. While still inside the .then() block, the UsablePromise
-    // is still in pending status.
+    // the promise definition above. The reason is that we should not call
+    // notify() before the UsablePromise is actually in resolved status. While
+    // still inside the .then() block, the UsablePromise is still in pending status.
     promise.then(
       () => this.#eventSource.notify(),
       () => {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1573,7 +1573,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
   // XXX_vincent We should really be going over all call sites, and replace this call
   // with a more specific invalidation!
-  private invalidateEntireStore() {
+  public invalidateEntireStore() {
     // XXX_vincent Of course this now looks stupid, but it's the exact equivalent of
     // what we're been doing all along
     batch(() => {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -674,10 +674,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     const inboxFetcher = async (cursor?: string) => {
       const result = await this.#client.getInboxNotifications({ cursor });
 
-      this.updateThreadsAndNotifications(
-        result.threads,
-        result.inboxNotifications
-      );
+      this.updateThreadifications(result.threads, result.inboxNotifications);
 
       // We initialize the `_lastRequestedNotificationsAt` date using the server timestamp after we've loaded the first page of inbox notifications.
       if (this.#notificationsLastRequestedAt === null) {
@@ -1283,7 +1280,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     });
   }
 
-  public updateThreadsAndNotifications(
+  public updateThreadifications(
     threads: ThreadData<M>[],
     inboxNotifications: InboxNotificationData[],
     deletedThreads: ThreadDeleteInfo[] = [],
@@ -1354,7 +1351,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       this.#notificationsLastRequestedAt = result.requestedAt;
     }
 
-    this.updateThreadsAndNotifications(
+    this.updateThreadifications(
       result.threads.updated,
       result.inboxNotifications.updated,
       result.threads.deleted,
@@ -1394,10 +1391,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
         cursor,
         query,
       });
-      this.updateThreadsAndNotifications(
-        result.threads,
-        result.inboxNotifications
-      );
+      this.updateThreadifications(result.threads, result.inboxNotifications);
 
       this.#updatePermissionHints(result.permissionHints);
 
@@ -1453,7 +1447,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       signal,
     });
 
-    this.updateThreadsAndNotifications(
+    this.updateThreadifications(
       updates.threads.updated,
       updates.inboxNotifications.updated,
       updates.threads.deleted,
@@ -1478,10 +1472,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
         cursor,
         query,
       });
-      this.updateThreadsAndNotifications(
-        result.threads,
-        result.inboxNotifications
-      );
+      this.updateThreadifications(result.threads, result.inboxNotifications);
 
       this.#updatePermissionHints(result.permissionHints);
 
@@ -1541,7 +1532,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       this.#notificationsLastRequestedAt = result.requestedAt;
     }
 
-    this.updateThreadsAndNotifications(
+    this.updateThreadifications(
       result.threads.updated,
       result.inboxNotifications.updated,
       result.threads.deleted,

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1,3 +1,4 @@
+// XXX Rename optimisticUpdateId → optimisticId everywhere
 import type {
   AsyncResult,
   BaseMetadata,

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -472,7 +472,7 @@ export class PaginatedResource {
   }
 }
 
-export class SinglePageResource {
+class SinglePageResource {
   public readonly observable: Observable<void>;
   #eventSource: EventSource<void>;
   #fetchPage: () => Promise<void>;

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -695,7 +695,7 @@ function createStore_forNotifications() {
     clear,
     updateAssociatedNotification,
 
-    // XXX Remove this eventually
+    // XXX_vincent Remove this eventually
     force_set: (
       mutationCallback: (lut: NotificationsLUT) => void | undefined | boolean
     ) => signal.mutate(mutationCallback),
@@ -718,7 +718,7 @@ function createStore_forRoomNotificationSettings() {
     // Mutations
     update,
 
-    // XXX Remove this eventually
+    // XXX_vincent Remove this eventually
     invalidate: () => signal.mutate(),
   };
 }
@@ -743,7 +743,7 @@ function createStore_forHistoryVersions() {
     // Mutations
     update,
 
-    // XXX Remove these eventually
+    // XXX_vincent Remove these eventually
     force_set: (callback: (lut: VersionsLUT) => void | boolean) =>
       signal.mutate(callback),
     invalidate: () => signal.mutate(),
@@ -777,7 +777,7 @@ function createStore_forPermissionHints() {
     // Mutations
     update,
 
-    // XXX Remove this eventually
+    // XXX_vincent Remove this eventually
     invalidate: () => signal.set((store) => ({ ...store })),
   };
 }
@@ -816,7 +816,7 @@ function createStore_forOptimistic<M extends BaseMetadata>(
     add,
     remove,
 
-    // XXX Remove this eventually
+    // XXX_vincent Remove this eventually
     invalidate: () => signal.set((store) => [...store]),
   };
 }
@@ -851,7 +851,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   // Input signals.
   // (Can be mutated directly.)
   //
-  // XXX Now that we have createStore_forX, we should probably also change
+  // XXX_vincent Now that we have createStore_forX, we should probably also change
   // `threads` to this pattern, ie create a createStore_forThreads helper as
   // well. It almost works like that already anyway!
   readonly threads: ThreadDB<M>; // Exposes its signal under `.signal` prop
@@ -869,7 +869,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   // threads and notifications separately, but the threadifications signal will
   // be updated whenever either of them change.
   //
-  // XXX APIs like getRoomThreadsLoadingState should really also be modeled as output signals.
+  // XXX_vincent APIs like getRoomThreadsLoadingState should really also be modeled as output signals.
   //
   readonly outputs: {
     readonly threadifications: DerivedSignal<CleanThreadifications<M>>;
@@ -918,7 +918,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return nextCursor;
     };
 
-    // XXX Looks like this should also be a Signal!
+    // XXX_vincent Looks like this should also be a Signal!
     this.#notifications = new PaginatedResource(inboxFetcher);
     this.#notifications.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
@@ -1112,7 +1112,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
   }
 
   // NOTE: This will read the async result, but WILL NOT start loading at the moment!
-  // XXX This should really be a derived Signal!
+  // XXX_vincent This should really be a derived Signal!
   public getNotificationSettingsLoadingState(
     roomId: string
   ): RoomNotificationSettingsAsyncResult {
@@ -1402,7 +1402,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     deletedNotifications: InboxNotificationDeleteInfo[] = []
   ): void {
     batch(() => {
-      // XXX Make these signatures look the same
+      // XXX_vincent Make these signatures look the same
       this.threads.applyDelta({ newThreads: threads, deletedThreads });
       this.notifications.applyDelta(notifications, deletedNotifications);
     });
@@ -1490,7 +1490,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       paginatedResource = new PaginatedResource(threadsFetcher);
     }
 
-    // XXX Looks like this should also be a Signal!
+    // XXX_vincent Looks like this should also be a Signal!
     paginatedResource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
@@ -1559,7 +1559,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       paginatedResource = new PaginatedResource(threadsFetcher);
     }
 
-    // XXX Looks like this should also be a Signal!
+    // XXX_vincent Looks like this should also be a Signal!
     paginatedResource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
@@ -1571,10 +1571,10 @@ export class UmbrellaStore<M extends BaseMetadata> {
     return paginatedResource.waitUntilLoaded();
   }
 
-  // XXX We should really be going over all call sites, and replace this call
+  // XXX_vincent We should really be going over all call sites, and replace this call
   // with a more specific invalidation!
   private invalidateEntireStore() {
-    // XXX Of course this now looks stupid, but it's the exact equivalent of
+    // XXX_vincent Of course this now looks stupid, but it's the exact equivalent of
     // what we're been doing all along
     batch(() => {
       this.historyVersions.invalidate();
@@ -1645,7 +1645,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       resource = new SinglePageResource(versionsFetcher);
     }
 
-    // XXX Looks like this should also be a Signal!
+    // XXX_vincent Looks like this should also be a Signal!
     resource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.
@@ -1704,7 +1704,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       resource = new SinglePageResource(notificationSettingsFetcher);
     }
 
-    // XXX Looks like this should also be a Signal!
+    // XXX_vincent Looks like this should also be a Signal!
     resource.observable.subscribe(() =>
       // Note that the store itself does not change, but it's only vehicle at
       // the moment to trigger a re-render, so we'll do a no-op update here.

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -1236,10 +1236,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     optimisticId: string,
     thread: Readonly<ThreadDataWithDeleteInfo<M>>
   ): void {
-    // Batch 1️⃣ + 2️⃣
     batch(() => {
-      this.optimisticUpdates.remove(optimisticId); // 1️⃣j
-      this.threads.upsert(thread); // 2️⃣
+      this.optimisticUpdates.remove(optimisticId);
+      this.threads.upsert(thread);
     });
   }
 
@@ -1261,21 +1260,16 @@ export class UmbrellaStore<M extends BaseMetadata> {
     ) => Readonly<ThreadDataWithDeleteInfo<M>>,
     updatedAt?: Date // TODO We could look this up from the optimisticUpdate instead?
   ): void {
-    // Batch 1️⃣ + 2️⃣
     batch(() => {
       if (optimisticId !== null) {
-        this.optimisticUpdates.remove(optimisticId); // 1️⃣
+        this.optimisticUpdates.remove(optimisticId);
       }
 
-      // 2️⃣
-      {
-        const db = this.threads;
-        const existing = db.get(threadId);
-        if (!existing) return;
-        if (!!updatedAt && existing.updatedAt > updatedAt) return;
-
-        db.upsert(callback(existing));
-      }
+      const db = this.threads;
+      const existing = db.get(threadId);
+      if (!existing) return;
+      if (!!updatedAt && existing.updatedAt > updatedAt) return;
+      db.upsert(callback(existing));
     });
   }
 
@@ -1417,10 +1411,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     optimisticId: string,
     settings: Readonly<RoomNotificationSettings>
   ): void {
-    // Batch 1️⃣ + 2️⃣
     batch(() => {
-      this.optimisticUpdates.remove(optimisticId); // 1️⃣
-      this.roomNotificationSettings.update(roomId, settings); // 2️⃣
+      this.optimisticUpdates.remove(optimisticId);
+      this.roomNotificationSettings.update(roomId, settings);
     });
   }
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -449,7 +449,11 @@ export class PaginatedResource {
       })
     );
 
-    // TODO for later: Maybe move this into the .then() above too?
+    // NOTE: However tempting it may be, we cannot simply move this block into
+    // the promise definition above, how tempting that may be. The reason is
+    // that we should not call notify() before the UsablePromise is actually in
+    // resolved status. While still inside the .then() block, the UsablePromise
+    // is still in pending status.
     promise.then(
       () => this.#eventSource.notify(),
       () => {
@@ -514,7 +518,11 @@ export class SinglePageResource {
 
     const promise = usify(initialFetcher);
 
-    // TODO for later: Maybe move this into the .then() above too?
+    // NOTE: However tempting it may be, we cannot simply move this block into
+    // the promise definition above, how tempting that may be. The reason is
+    // that we should not call notify() before the UsablePromise is actually in
+    // resolved status. While still inside the .then() block, the UsablePromise
+    // is still in pending status.
     promise.then(
       () => this.#eventSource.notify(),
       () => {


### PR DESCRIPTION
Next steps of refactoring of the umbrella store internals. Like last time, there is more refactoring to do here and I'm not done yet, but this PR is a good midpoint that should not change any existing behavior and should be good to merge as-is.

Some of the ideas we had in the past are starting to take shape now slowly. The most important one here being that I've started to isolate each "chunk" of the umbrella store into its own ministore.

Each ministore has:

- A single signal for the data it's managing
- A bunch of mutations that make sense for that particular data structure

The umbrella store just holds together these ministores mostly.

I want to eventually split these up into separate modules for even clearer separation of concerns, but I decided not to yet, to avoid unnecessarily complex merge conflicts with Aurel's current WIP. We can break them out later.
