### PR TITLE
Refactor umbrella store internals

### DIFF
--- a/packages/liveblocks-core/src/__tests__/resolvers.test.ts
+++ b/packages/liveblocks-core/src/__tests__/resolvers.test.ts
@@ -32,8 +32,8 @@ describe("resolvers", () => {
       });
 
       await Promise.all([
-        client[kInternal].usersStore.get("a"),
-        client[kInternal].usersStore.get("b"),
+        client[kInternal].usersStore.enqueue("a"),
+        client[kInternal].usersStore.enqueue("b"),
       ]);
 
       expect(client[kInternal].usersStore._cacheKeys()).toEqual(['"a"', '"b"']);
@@ -43,7 +43,7 @@ describe("resolvers", () => {
 
       expect(client[kInternal].usersStore._cacheKeys()).toEqual([]);
 
-      await client[kInternal].usersStore.get("a");
+      await client[kInternal].usersStore.enqueue("a");
 
       expect(client[kInternal].usersStore._cacheKeys()).toEqual(['"a"']);
 
@@ -61,8 +61,8 @@ describe("resolvers", () => {
       });
 
       await Promise.all([
-        client[kInternal].usersStore.get("a"),
-        client[kInternal].usersStore.get("b"),
+        client[kInternal].usersStore.enqueue("a"),
+        client[kInternal].usersStore.enqueue("b"),
       ]);
 
       expect(client[kInternal].usersStore._cacheKeys()).toEqual(['"a"', '"b"']);
@@ -73,9 +73,9 @@ describe("resolvers", () => {
       expect(client[kInternal].usersStore._cacheKeys()).toEqual(['"a"']);
 
       await Promise.all([
-        client[kInternal].usersStore.get("a"),
-        client[kInternal].usersStore.get("b"),
-        client[kInternal].usersStore.get("c"),
+        client[kInternal].usersStore.enqueue("a"),
+        client[kInternal].usersStore.enqueue("b"),
+        client[kInternal].usersStore.enqueue("c"),
       ]);
 
       expect(client[kInternal].usersStore._cacheKeys()).toEqual([
@@ -100,8 +100,8 @@ describe("resolvers", () => {
       });
 
       await Promise.all([
-        client[kInternal].roomsInfoStore.get("a"),
-        client[kInternal].roomsInfoStore.get("b"),
+        client[kInternal].roomsInfoStore.enqueue("a"),
+        client[kInternal].roomsInfoStore.enqueue("b"),
       ]);
 
       expect(client[kInternal].roomsInfoStore._cacheKeys()).toEqual([
@@ -114,7 +114,7 @@ describe("resolvers", () => {
 
       expect(client[kInternal].roomsInfoStore._cacheKeys()).toEqual([]);
 
-      await client[kInternal].roomsInfoStore.get("a");
+      await client[kInternal].roomsInfoStore.enqueue("a");
 
       expect(client[kInternal].roomsInfoStore._cacheKeys()).toEqual(['"a"']);
 
@@ -134,8 +134,8 @@ describe("resolvers", () => {
       });
 
       await Promise.all([
-        client[kInternal].roomsInfoStore.get("a"),
-        client[kInternal].roomsInfoStore.get("b"),
+        client[kInternal].roomsInfoStore.enqueue("a"),
+        client[kInternal].roomsInfoStore.enqueue("b"),
       ]);
 
       expect(client[kInternal].roomsInfoStore._cacheKeys()).toEqual([
@@ -149,9 +149,9 @@ describe("resolvers", () => {
       expect(client[kInternal].roomsInfoStore._cacheKeys()).toEqual(['"a"']);
 
       await Promise.all([
-        client[kInternal].roomsInfoStore.get("a"),
-        client[kInternal].roomsInfoStore.get("b"),
-        client[kInternal].roomsInfoStore.get("c"),
+        client[kInternal].roomsInfoStore.enqueue("a"),
+        client[kInternal].roomsInfoStore.enqueue("b"),
+        client[kInternal].roomsInfoStore.enqueue("c"),
       ]);
 
       expect(client[kInternal].roomsInfoStore._cacheKeys()).toEqual([

--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -975,7 +975,7 @@ export function createApiClient<M extends BaseMetadata>({
   }
 
   function getAttachmentUrl(options: { roomId: string; attachmentId: string }) {
-    const batch = getOrCreateAttachmentUrlsStore(options.roomId).getBatch();
+    const batch = getOrCreateAttachmentUrlsStore(options.roomId).batch;
     return batch.get(options.attachmentId);
   }
 

--- a/packages/liveblocks-core/src/lib/batch.ts
+++ b/packages/liveblocks-core/src/lib/batch.ts
@@ -175,7 +175,7 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
     return stringify(args);
   }
 
-  function setStateAndNotify(cacheKey: string, state: AsyncResult<O>) {
+  function update(cacheKey: string, state: AsyncResult<O>) {
     signal.mutate((cache) => {
       cache.set(cacheKey, state);
     });
@@ -206,30 +206,30 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
 
     try {
       // Set the state to loading.
-      setStateAndNotify(cacheKey, { isLoading: true });
+      update(cacheKey, { isLoading: true });
 
       // Wait for the batch to process this call.
       const result = await batch.get(input);
 
       // Set the state to the result.
-      setStateAndNotify(cacheKey, { isLoading: false, data: result });
+      update(cacheKey, { isLoading: false, data: result });
     } catch (error) {
       // // TODO: Differentiate whole batch errors from individual errors.
       // if (batch.error) {
       //   // If the whole batch errored, clear the state.
       //   // TODO: Keep track of retries and only clear the state a few times because it will be retried each time.
       //   //       Also implement exponential backoff to delay retries to avoid hammering `resolveUsers`.
-      //   setStateAndNotify(cacheKey, undefined);
+      //   update(cacheKey, undefined);
       // } else {
       //   // Otherwise, keep individual errors to avoid repeatedly loading the same error.
-      //   setStateAndNotify(cacheKey, {
+      //   update(cacheKey, {
       //     isLoading: false,
       //     error: error as Error,
       //   });
       // }
 
       // If there was an error (for various reasons), set the state to the error.
-      setStateAndNotify(cacheKey, {
+      update(cacheKey, {
         isLoading: false,
         error: error as Error,
       });
@@ -242,11 +242,7 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
     return cache.get(cacheKey);
   }
 
-  /**
-   * @internal
-   *
-   * Only for testing.
-   */
+  /** @internal - Only for testing */
   function _cacheKeys() {
     const cache = signal.get();
     return [...cache.keys()];

--- a/packages/liveblocks-core/src/lib/batch.ts
+++ b/packages/liveblocks-core/src/lib/batch.ts
@@ -22,7 +22,7 @@ export type BatchStore<O, I> = {
   /**
    * @internal
    */
-  getBatch: () => Batch<O, I>;
+  readonly batch: Batch<O, I>;
 
   /**
    * @internal
@@ -252,16 +252,13 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
     return [...cache.keys()];
   }
 
-  function getBatch() {
-    return batch;
-  }
-
   return {
     subscribe: signal.subscribe,
     enqueue,
     getItemState,
     invalidate,
-    getBatch,
+
+    batch,
     _cacheKeys,
   };
 }

--- a/packages/liveblocks-core/src/lib/batch.ts
+++ b/packages/liveblocks-core/src/lib/batch.ts
@@ -15,7 +15,7 @@ export type BatchCallback<O, I> = (
 
 export type BatchStore<O, I> = Observable<void> & {
   enqueue: (input: I) => Promise<void>;
-  getState: (input: I) => AsyncResult<O> | undefined;
+  getItemState: (input: I) => AsyncResult<O> | undefined;
   invalidate: (inputs?: I[]) => void;
 
   /**
@@ -238,7 +238,7 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
     }
   }
 
-  function getState(input: I): AsyncResult<O> | undefined {
+  function getItemState(input: I): AsyncResult<O> | undefined {
     const cacheKey = getCacheKey(input);
 
     return cache.get(cacheKey);
@@ -260,7 +260,7 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
   return {
     ...eventSource.observable,
     enqueue,
-    getState,
+    getItemState,
     invalidate,
     getBatch,
     _cacheKeys,

--- a/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
@@ -115,7 +115,7 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
     store.outputs.threads,
     useCallback(
       (state) =>
-        state.threadsDB
+        state
           .findMany(roomId, { resolved: false }, "asc")
           .map((thread) => thread.id),
       [roomId]
@@ -222,7 +222,7 @@ export function CommentPluginProvider({ children }: PropsWithChildren) {
       const threadIds = $getThreadIds(selection).filter((id) => {
         return store.outputs.threads
           .get()
-          .threadsDB.findMany(roomId, { resolved: false }, "asc")
+          .findMany(roomId, { resolved: false }, "asc")
           .some((thread) => thread.id === id);
       });
       setActiveThreads(threadIds);

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -218,7 +218,7 @@ export const useLiveblocksExtension = (
             const threadMap = new Map(
               store.outputs.threads
                 .get()
-                .threadsDB.findMany(roomId, { resolved: false }, "asc")
+                .findMany(roomId, { resolved: false }, "asc")
                 .map((thread) => [thread.id, true])
             );
             function isComment(mark: PMMark): mark is PMMark & {

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -31,10 +31,10 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore(NO_CLIENT);
 
     // Sync getters
-    expect(store.get_threads()).toEqual(expect.any(ThreadDB));
-    expect(store.get_notifications()).toEqual(empty1n);
-    expect(store.get_settings()).toEqual({}); // settings by room ID
-    expect(store.get_versions()).toEqual({}); // versions by room ID
+    expect(store.outputs.threads.get()).toEqual(expect.any(ThreadDB));
+    expect(store.outputs.notifications.get()).toEqual(empty1n);
+    expect(store.outputs.settingsByRoomId.get()).toEqual({}); // settings by room ID
+    expect(store.outputs.versionsByRoomId.get()).toEqual({}); // versions by room ID
 
     // Sync async-results getters
     expect(store.getInboxNotificationsLoadingState()).toEqual(loading);
@@ -48,8 +48,10 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore(NO_CLIENT);
 
     // IMPORTANT! Strict equality expected!
-    expect(store.get_threads()).toBe(store.get_threads());
-    expect(store.get_notifications()).toBe(store.get_notifications());
+    expect(store.outputs.threads.get()).toBe(store.outputs.threads.get());
+    expect(store.outputs.notifications.get()).toBe(
+      store.outputs.notifications.get()
+    );
 
     // Sync async-results getter
     // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -3,10 +3,6 @@ import { kInternal } from "@liveblocks/core";
 import { ThreadDB } from "../../ThreadDB";
 import { UmbrellaStore } from "../../umbrella-store";
 
-const empty1t = {
-  threadsDB: expect.any(ThreadDB),
-} as const;
-
 const empty1n = {
   sortedNotifications: [],
   notificationsById: {},
@@ -35,7 +31,7 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore(NO_CLIENT);
 
     // Sync getters
-    expect(store.get1_threads()).toEqual(empty1t);
+    expect(store.get1_threads()).toEqual(expect.any(ThreadDB));
     expect(store.get1_notifications()).toEqual(empty1n);
     expect(store.get2()).toEqual({}); // settings by room ID
     expect(store.get3()).toEqual({}); // versions by room ID

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/index.test.ts
@@ -31,10 +31,10 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore(NO_CLIENT);
 
     // Sync getters
-    expect(store.get1_threads()).toEqual(expect.any(ThreadDB));
-    expect(store.get1_notifications()).toEqual(empty1n);
-    expect(store.get2()).toEqual({}); // settings by room ID
-    expect(store.get3()).toEqual({}); // versions by room ID
+    expect(store.get_threads()).toEqual(expect.any(ThreadDB));
+    expect(store.get_notifications()).toEqual(empty1n);
+    expect(store.get_settings()).toEqual({}); // settings by room ID
+    expect(store.get_versions()).toEqual({}); // versions by room ID
 
     // Sync async-results getters
     expect(store.getInboxNotificationsLoadingState()).toEqual(loading);
@@ -48,8 +48,8 @@ describe("Umbrella Store", () => {
     const store = new UmbrellaStore(NO_CLIENT);
 
     // IMPORTANT! Strict equality expected!
-    expect(store.get1_threads()).toBe(store.get1_threads());
-    expect(store.get1_notifications()).toBe(store.get1_notifications());
+    expect(store.get_threads()).toBe(store.get_threads());
+    expect(store.get_notifications()).toBe(store.get_notifications());
 
     // Sync async-results getter
     // TODO Add check here for strict-equality of the OK-state, which currently isn't strictly-equal and the selectors/isEqual functions are still "working around" that

--- a/packages/liveblocks-react/src/__tests__/useHistoryVersions.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useHistoryVersions.test.tsx
@@ -165,22 +165,15 @@ describe("useHistoryVersions", () => {
       umbrellaStore,
     } = createContextsForTest();
 
-    umbrellaStore.force_set_versions((lut) => {
-      const room1Versions = new Map();
-      room1Versions.set("version_1", {
+    umbrellaStore.historyVersions.update("room-1", [
+      {
         type: "historyVersion",
         kind: "yjs",
         createdAt: new Date(),
         id: "version_1",
-        authors: [
-          {
-            id: "user-1",
-          },
-        ],
-      });
-
-      lut.set("room-1", room1Versions);
-    });
+        authors: [{ id: "user-1" }],
+      },
+    ]);
 
     const { result, unmount } = renderHook(() => useHistoryVersions(), {
       wrapper: ({ children }) => (

--- a/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useInboxNotifications.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { HttpError, nanoid, wait } from "@liveblocks/core";
+import { batch, HttpError, nanoid, wait } from "@liveblocks/core";
 import {
   act,
   fireEvent,
@@ -284,13 +284,12 @@ describe("useInboxNotifications", () => {
       umbrellaStore,
     } = createContextsForTest();
 
-    umbrellaStore.threads.upsert(thread1);
-    umbrellaStore.threads.upsert(thread2);
-
-    umbrellaStore.force_set_notifications((lut) => {
-      // Explicitly set the order to be reversed to test that the hook sorts the notifications
-      lut.set(oldInboxNotification.id, oldInboxNotification);
-      lut.set(newInboxNotification.id, newInboxNotification);
+    // Initialize the umbrella store with some data
+    batch(() => {
+      umbrellaStore.threads.upsert(thread1);
+      umbrellaStore.threads.upsert(thread2);
+      umbrellaStore.notifications.upsert(oldInboxNotification);
+      umbrellaStore.notifications.upsert(newInboxNotification);
     });
 
     const { result, unmount } = renderHook(() => useInboxNotifications(), {

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -420,7 +420,7 @@ function useInboxNotifications_withClient<T>(
   // is strong evidence that getInboxNotificationsLoadingState itself wants to
   // be a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   return useSyncExternalStoreWithSelector(
-    store.subscribe1_notifications,
+    store.subscribe_threads,
     store.getInboxNotificationsLoadingState,
     store.getInboxNotificationsLoadingState,
     selector,
@@ -572,7 +572,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
 ): ThreadData<M> {
   const { store } = getLiveblocksExtrasForClient<M>(client);
 
-  const getter = store.get1_both;
+  const getter = store.get_threadifications;
 
   const selector = useCallback(
     (state: ReturnType<typeof getter>) => {
@@ -598,7 +598,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
   );
 
   return useSyncExternalStoreWithSelector(
-    store.subscribe1_both, // Re-evaluate if we need to update any time the notification changes over time
+    store.subscribe_threadifications, // Re-evaluate if we need to update any time the notification changes over time
     getter,
     getter,
     selector
@@ -958,7 +958,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
   );
 
   return useSyncExternalStoreWithSelector(
-    store.subscribe1_threads,
+    store.subscribe_threads,
     getter,
     getter,
     identity,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -574,34 +574,34 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
 
   const getter = store.outputs.threadifications.get;
 
-  const selector = useCallback(
-    (state: ReturnType<typeof getter>) => {
-      const inboxNotification =
-        state.notificationsById[inboxNotificationId] ??
-        raise(`Inbox notification with ID "${inboxNotificationId}" not found`);
-
-      if (inboxNotification.kind !== "thread") {
-        raise(
-          `Inbox notification with ID "${inboxNotificationId}" is not of kind "thread"`
-        );
-      }
-
-      const thread =
-        state.threadsDB.get(inboxNotification.threadId) ??
-        raise(
-          `Thread with ID "${inboxNotification.threadId}" not found, this inbox notification might not be of kind "thread"`
-        );
-
-      return thread;
-    },
-    [inboxNotificationId]
-  );
-
   return useSyncExternalStoreWithSelector(
     store.outputs.threadifications.subscribe, // Re-evaluate if we need to update any time the notification changes over time
     getter,
     getter,
-    selector
+    useCallback(
+      (state) => {
+        const inboxNotification =
+          state.notificationsById[inboxNotificationId] ??
+          raise(
+            `Inbox notification with ID "${inboxNotificationId}" not found`
+          );
+
+        if (inboxNotification.kind !== "thread") {
+          raise(
+            `Inbox notification with ID "${inboxNotificationId}" is not of kind "thread"`
+          );
+        }
+
+        const thread =
+          state.threadsDB.get(inboxNotification.threadId) ??
+          raise(
+            `Thread with ID "${inboxNotification.threadId}" not found, this inbox notification might not be of kind "thread"`
+          );
+
+        return thread;
+      },
+      [inboxNotificationId]
+    )
   );
 }
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -54,6 +54,7 @@ import type {
   UseUserThreadsOptions,
 } from "./types";
 import { UmbrellaStore } from "./umbrella-store";
+import { useSignal } from "./use-signal";
 import { useSyncExternalStoreWithSelector } from "./use-sync-external-store-with-selector";
 
 /**
@@ -571,11 +572,8 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
   inboxNotificationId: string
 ): ThreadData<M> {
   const { store } = getLiveblocksExtrasForClient<M>(client);
-
-  return useSyncExternalStoreWithSelector(
-    store.outputs.threadifications.subscribe, // Re-evaluate if we need to update any time the notification changes over time
-    store.outputs.threadifications.get,
-    store.outputs.threadifications.get,
+  return useSignal(
+    store.outputs.threadifications,
     useCallback(
       (state) => {
         const inboxNotification =

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -637,9 +637,19 @@ function useUser_withClient<U extends BaseUserMeta>(
   );
 
   // Trigger a fetch if we don't have any data yet (whether initially or after an invalidation)
-  useEffect(() => {
-    void usersStore.enqueue(userId);
-  }, [usersStore, userId, result]);
+  useEffect(
+    () => void usersStore.enqueue(userId)
+
+    // NOTE: Deliberately *not* using a dependency array here!
+    //
+    // It is important to call usersStore.enqueue on *every* render.
+    // This is harmless though, on most renders, except:
+    // 1. The very first render, in which case we'll want to trigger evaluation
+    //    of the userId.
+    // 2. All other subsequent renders now are a no-op (from the implementation
+    //    of .enqueue)
+    // 3. If ever the userId gets invalidated, the user would be fetched again.
+  );
 
   return result;
 }
@@ -710,9 +720,19 @@ function useRoomInfo_withClient(
   );
 
   // Trigger a fetch if we don't have any data yet (whether initially or after an invalidation)
-  useEffect(() => {
-    void roomsInfoStore.enqueue(roomId);
-  }, [roomsInfoStore, roomId, result]);
+  useEffect(
+    () => void roomsInfoStore.enqueue(roomId)
+
+    // NOTE: Deliberately *not* using a dependency array here!
+    //
+    // It is important to call roomsInfoStore.enqueue on *every* render.
+    // This is harmless though, on most renders, except:
+    // 1. The very first render, in which case we'll want to trigger evaluation
+    //    of the roomId.
+    // 2. All other subsequent renders now are a no-op (from the implementation
+    //    of .enqueue)
+    // 3. If ever the roomId gets invalidated, the room info would be fetched again.
+  );
 
   return result;
 }

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -420,7 +420,7 @@ function useInboxNotifications_withClient<T>(
   // is strong evidence that getInboxNotificationsLoadingState itself wants to
   // be a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   return useSyncExternalStoreWithSelector(
-    store.subscribe_threads,
+    store.subscribe_notifications,
     store.getInboxNotificationsLoadingState,
     store.getInboxNotificationsLoadingState,
     selector,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -420,7 +420,7 @@ function useInboxNotifications_withClient<T>(
   // is strong evidence that getInboxNotificationsLoadingState itself wants to
   // be a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   return useSyncExternalStoreWithSelector(
-    store.subscribe_notifications,
+    store.outputs.notifications.subscribe,
     store.getInboxNotificationsLoadingState,
     store.getInboxNotificationsLoadingState,
     selector,
@@ -572,7 +572,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
 ): ThreadData<M> {
   const { store } = getLiveblocksExtrasForClient<M>(client);
 
-  const getter = store.get_threadifications;
+  const getter = store.outputs.threadifications.get;
 
   const selector = useCallback(
     (state: ReturnType<typeof getter>) => {
@@ -598,7 +598,7 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
   );
 
   return useSyncExternalStoreWithSelector(
-    store.subscribe_threadifications, // Re-evaluate if we need to update any time the notification changes over time
+    store.outputs.threadifications.subscribe, // Re-evaluate if we need to update any time the notification changes over time
     getter,
     getter,
     selector
@@ -958,7 +958,7 @@ function useUserThreads_experimental<M extends BaseMetadata>(
   );
 
   return useSyncExternalStoreWithSelector(
-    store.subscribe_threads,
+    store.outputs.threads.subscribe,
     getter,
     getter,
     identity,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -608,7 +608,7 @@ function useUser_withClient<U extends BaseUserMeta>(
   const usersStore = client[kInternal].usersStore;
 
   const getUserState = useCallback(
-    () => usersStore.getState(userId),
+    () => usersStore.getItemState(userId),
     [usersStore, userId]
   );
 
@@ -628,8 +628,6 @@ function useUser_withClient<U extends BaseUserMeta>(
 
   // Trigger a fetch if we don't have any data yet (whether initially or after an invalidation)
   useEffect(() => {
-    // NOTE: .get() will trigger any actual fetches, whereas .getState() will not,
-    // and it won't trigger a fetch if we already have data
     void usersStore.enqueue(userId);
   }, [usersStore, userId, result]);
 
@@ -643,7 +641,7 @@ function useUserSuspense_withClient<U extends BaseUserMeta>(
   const usersStore = client[kInternal].usersStore;
 
   const getUserState = useCallback(
-    () => usersStore.getState(userId),
+    () => usersStore.getItemState(userId),
     [usersStore, userId]
   );
   const userState = getUserState();
@@ -683,7 +681,7 @@ function useRoomInfo_withClient(
   const roomsInfoStore = client[kInternal].roomsInfoStore;
 
   const getRoomInfoState = useCallback(
-    () => roomsInfoStore.getState(roomId),
+    () => roomsInfoStore.getItemState(roomId),
     [roomsInfoStore, roomId]
   );
 
@@ -703,8 +701,6 @@ function useRoomInfo_withClient(
 
   // Trigger a fetch if we don't have any data yet (whether initially or after an invalidation)
   useEffect(() => {
-    // NOTE: .get() will trigger any actual fetches, whereas .getState() will not,
-    // and it won't trigger a fetch if we already have data
     void roomsInfoStore.enqueue(roomId);
   }, [roomsInfoStore, roomId, result]);
 
@@ -715,7 +711,7 @@ function useRoomInfoSuspense_withClient(client: OpaqueClient, roomId: string) {
   const roomsInfoStore = client[kInternal].roomsInfoStore;
 
   const getRoomInfoState = useCallback(
-    () => roomsInfoStore.getState(roomId),
+    () => roomsInfoStore.getItemState(roomId),
     [roomsInfoStore, roomId]
   );
   const roomInfoState = getRoomInfoState();

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -630,7 +630,7 @@ function useUser_withClient<U extends BaseUserMeta>(
   useEffect(() => {
     // NOTE: .get() will trigger any actual fetches, whereas .getState() will not,
     // and it won't trigger a fetch if we already have data
-    void usersStore.get(userId);
+    void usersStore.enqueue(userId);
   }, [usersStore, userId, result]);
 
   return result;
@@ -649,7 +649,7 @@ function useUserSuspense_withClient<U extends BaseUserMeta>(
   const userState = getUserState();
 
   if (!userState || userState.isLoading) {
-    throw usersStore.get(userId);
+    throw usersStore.enqueue(userId);
   }
 
   if (userState.error) {
@@ -705,7 +705,7 @@ function useRoomInfo_withClient(
   useEffect(() => {
     // NOTE: .get() will trigger any actual fetches, whereas .getState() will not,
     // and it won't trigger a fetch if we already have data
-    void roomsInfoStore.get(roomId);
+    void roomsInfoStore.enqueue(roomId);
   }, [roomsInfoStore, roomId, result]);
 
   return result;
@@ -721,7 +721,7 @@ function useRoomInfoSuspense_withClient(client: OpaqueClient, roomId: string) {
   const roomInfoState = getRoomInfoState();
 
   if (!roomInfoState || roomInfoState.isLoading) {
-    throw roomsInfoStore.get(roomId);
+    throw roomsInfoStore.enqueue(roomId);
   }
 
   if (roomInfoState.error) {

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -572,12 +572,10 @@ function useInboxNotificationThread_withClient<M extends BaseMetadata>(
 ): ThreadData<M> {
   const { store } = getLiveblocksExtrasForClient<M>(client);
 
-  const getter = store.outputs.threadifications.get;
-
   return useSyncExternalStoreWithSelector(
     store.outputs.threadifications.subscribe, // Re-evaluate if we need to update any time the notification changes over time
-    getter,
-    getter,
+    store.outputs.threadifications.get,
+    store.outputs.threadifications.get,
     useCallback(
       (state) => {
         const inboxNotification =

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -414,12 +414,22 @@ function useInboxNotifications_withClient<T>(
     };
   }, [poller]);
 
-  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
-  // why the getInboxNotificationsLoadingState getter should be paired with
-  // subscribe1 and not subscribe2 from the outside! (The reason is that
-  // getInboxNotificationsLoadingState internally uses `get1` not `get2`.) This
-  // is strong evidence that getInboxNotificationsLoadingState itself wants to
-  // be a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's
+  // not clear (unless you read the implementation of
+  // getInboxNotificationsLoadingState) why this getter should be paired with
+  // `store.outputs.notifications.subscribe`.
+  //
+  // Ideally refactor this to:
+  //
+  //   useSignal(
+  //     store.outputs.loadingNotifications,  // exposes { getNotifications }
+  //
+  //     useCallback(
+  //       ({ getNotifications }) => getNotifications(),
+  //       [options.query]
+  //     )
+  //   )
+  //
   return useSyncExternalStoreWithSelector(
     store.outputs.notifications.subscribe,
     store.getInboxNotificationsLoadingState,
@@ -938,12 +948,22 @@ function useUserThreads_experimental<M extends BaseMetadata>(
     };
   }, [poller]);
 
-  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
-  // why the getUserThreadsLoadingState getter should be paired with subscribe1
-  // and not subscribe2 from the outside! (The reason is that
-  // getUserThreadsLoadingState  internally uses `get1` not `get2`.) This is
-  // strong evidence that getUserThreadsLoadingState itself wants to be
-  // a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's
+  // not clear (unless you read the implementation of
+  // getUserThreadsLoadingState) why this getter should be paired with
+  // `store.outputs.threads.subscribe`.
+  //
+  // Ideally refactor this to:
+  //
+  //   useSignal(
+  //     store.outputs.loadingThreads,  // exposes { getUserThreads, getRoomThreads }
+  //
+  //     useCallback(
+  //       ({ getUserThreads }) => getUserThreads(options.query),
+  //       [options.query]
+  //     )
+  //   )
+  //
   const getter = useCallback(
     () => store.getUserThreadsLoadingState(options.query),
     [store, options.query]

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2609,6 +2609,8 @@ function useAttachmentUrlSuspense(attachmentId: string) {
   } as const;
 }
 
+const NO_PERMISSIONS = new Set();
+
 /**
  * @private For internal use only. Do not rely on this hook.
  */
@@ -2617,7 +2619,7 @@ function useRoomPermissions(roomId: string) {
   const store = getRoomExtrasForClient(client).store;
   return useSignal(
     store.permissionHints.signal,
-    (hints) => hints[roomId] ?? new Set()
+    (hints) => hints.get(roomId) ?? NO_PERMISSIONS
   );
 }
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -671,7 +671,7 @@ function RoomProviderInner<
       const { thread, inboxNotification: maybeNotification } = info;
 
       const existingThread = store
-        .get1_threads()
+        .get_threads()
         .getEvenIfDeleted(message.threadId);
 
       switch (message.type) {
@@ -1358,7 +1358,7 @@ function useThreads<M extends BaseMetadata>(
   );
 
   const state = useSyncExternalStoreWithSelector(
-    store.subscribe1_threads,
+    store.subscribe_threads,
     getter,
     getter,
     identity,
@@ -1487,7 +1487,7 @@ function useDeleteRoomThread(roomId: string): (threadId: string) => void {
 
       const userId = getCurrentUserId(client);
 
-      const existing = store.get1_threads().get(threadId);
+      const existing = store.get_threads().get(threadId);
       if (existing?.comments?.[0]?.userId !== userId) {
         throw new Error("Only the thread creator can delete the thread");
       }
@@ -1656,7 +1656,7 @@ function useEditRoomComment(
       const editedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const existing = store.get1_threads().getEvenIfDeleted(threadId);
+      const existing = store.get_threads().getEvenIfDeleted(threadId);
 
       if (existing === undefined) {
         console.warn(
@@ -1910,7 +1910,7 @@ function useMarkRoomThreadAsRead(roomId: string) {
     (threadId: string) => {
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
       const inboxNotification = Object.values(
-        store.get1_notifications().notificationsById
+        store.get_notifications().notificationsById
       ).find(
         (inboxNotification) =>
           inboxNotification.kind === "thread" &&
@@ -2159,7 +2159,7 @@ function useRoomNotificationSettings(): [
 
   // XXX_vincent Turn this into a useSignal
   const settings = useSyncExternalStoreWithSelector(
-    store.subscribe2,
+    store.subscribe_settings,
     getter,
     getter,
     identity,
@@ -2289,7 +2289,7 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
   // strong evidence that getRoomVersionsLoadingState itself wants to be
   // a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   const state = useSyncExternalStoreWithSelector(
-    store.subscribe3,
+    store.subscribe_versions,
     getter,
     getter,
     identity,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2550,12 +2550,11 @@ function useRoomAttachmentUrl(
     client[kInternal].httpClient.getOrCreateAttachmentUrlsStore(roomId);
 
   const getAttachmentUrlState = useCallback(
-    () => store.getState(attachmentId),
+    () => store.getItemState(attachmentId),
     [store, attachmentId]
   );
 
   useEffect(() => {
-    // NOTE: .get() will trigger any actual fetches, whereas .getState() will not
     void store.enqueue(attachmentId);
   }, [store, attachmentId]);
 
@@ -2579,7 +2578,7 @@ function useAttachmentUrlSuspense(attachmentId: string) {
   const { attachmentUrlsStore } = room[kInternal];
 
   const getAttachmentUrlState = useCallback(
-    () => attachmentUrlsStore.getState(attachmentId),
+    () => attachmentUrlsStore.getItemState(attachmentId),
     [attachmentUrlsStore, attachmentId]
   );
   const attachmentUrlState = getAttachmentUrlState();

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1346,12 +1346,22 @@ function useThreads<M extends BaseMetadata>(
     return () => poller.dec();
   }, [poller]);
 
-  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
-  // why the getRoomThreadsLoadingState getter should be paired with subscribe1
-  // and not subscribe2 from the outside! (The reason is that
-  // getRoomThreadsLoadingState internally uses `get1` not `get2`.) This is
-  // strong evidence that getRoomThreadsLoadingState itself wants to be
-  // a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's
+  // not clear (unless you read the implementation of
+  // getRoomThreadsLoadingState) why this getter should be paired with
+  // `store.outputs.threads.subscribe`.
+  //
+  // Ideally refactor this to:
+  //
+  //   useSignal(
+  //     store.outputs.loadingThreads,  // exposes { getUserThreads, getRoomThreads }
+  //
+  //     useCallback(
+  //       ({ getRoomThreads }) => getRoomThreads(room.id, options.query),
+  //       [options.query]
+  //     )
+  //   )
+  //
   const getter = useCallback(
     () => store.getRoomThreadsLoadingState(room.id, options.query),
     [store, room.id, options.query]
@@ -2145,19 +2155,27 @@ function useRoomNotificationSettings(): [
     };
   }, [poller]);
 
-  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
-  // why the getNotificationSettingsLoadingState getter should be paired with
-  // subscribe2 and not subscribe1 from the outside! (The reason is that
-  // getNotificationSettingsLoadingState internally uses `get2` not `get1`.)
-  // This is strong evidence that getNotificationSettingsLoadingState itself
-  // wants to be a Signal! Once we make it a Signal, we can simply use
-  // `useSignal()` here! ❤️
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's
+  // not clear (unless you read the implementation of
+  // getNotificationSettingsLoadingState) why this getter should be paired with
+  // `store.outputs.settingsByRoomId.subscribe`.
+  //
+  // Ideally refactor this to:
+  //
+  //   useSignal(
+  //     store.outputs.loadingSettings,  // exposes { getSettings }
+  //
+  //     useCallback(
+  //       ({ getSettings }) => getSettings(room.id),
+  //       [options.query]
+  //     )
+  //   )
+  //
   const getter = useCallback(
     () => store.getNotificationSettingsLoadingState(room.id),
     [store, room.id]
   );
 
-  // XXX_vincent Turn this into a useSignal
   const settings = useSyncExternalStoreWithSelector(
     store.outputs.settingsByRoomId.subscribe,
     getter,
@@ -2263,11 +2281,6 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
     return () => poller.dec();
   }, [poller]);
 
-  const getter = useCallback(
-    () => store.getRoomVersionsLoadingState(room.id),
-    [store, room.id]
-  );
-
   useEffect(
     () => {
       void store.waitUntilRoomVersionsLoaded(room.id);
@@ -2282,12 +2295,27 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
     //    *next* render after that, a *new* fetch/promise will get created.
   );
 
-  // XXX_vincent There is a disconnect between this getter and subscriber! It's unclear
-  // why the getRoomVersionsLoadingState getter should be paired with
-  // subscribe3 and not subscribe1 from the outside! (The reason is that
-  // getRoomVersionsLoadingState internally uses `get3` not `get1`.) This is
-  // strong evidence that getRoomVersionsLoadingState itself wants to be
-  // a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
+  // XXX_vincent There is a disconnect between this getter and subscriber! It's
+  // not clear (unless you read the implementation of
+  // getRoomVersionsLoadingState) why this getter should be paired with
+  // `store.outputs.versionsByRoomId.subscribe`.
+  //
+  // Ideally refactor this to:
+  //
+  //   useSignal(
+  //     store.outputs.loadingVersions,  // exposes { getVersions }
+  //
+  //     useCallback(
+  //       ({ getVersions }) => getVersions(room.id),
+  //       [options.query]
+  //     )
+  //   )
+  //
+  const getter = useCallback(
+    () => store.getRoomVersionsLoadingState(room.id),
+    [store, room.id]
+  );
+
   const state = useSyncExternalStoreWithSelector(
     store.outputs.versionsByRoomId.subscribe,
     getter,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -670,8 +670,8 @@ function RoomProviderInner<
       }
       const { thread, inboxNotification: maybeNotification } = info;
 
-      const existingThread = store
-        .get_threads()
+      const existingThread = store.outputs.threads
+        .get()
         .getEvenIfDeleted(message.threadId);
 
       switch (message.type) {
@@ -1358,7 +1358,7 @@ function useThreads<M extends BaseMetadata>(
   );
 
   const state = useSyncExternalStoreWithSelector(
-    store.subscribe_threads,
+    store.outputs.threads.subscribe,
     getter,
     getter,
     identity,
@@ -1487,7 +1487,7 @@ function useDeleteRoomThread(roomId: string): (threadId: string) => void {
 
       const userId = getCurrentUserId(client);
 
-      const existing = store.get_threads().get(threadId);
+      const existing = store.outputs.threads.get().get(threadId);
       if (existing?.comments?.[0]?.userId !== userId) {
         throw new Error("Only the thread creator can delete the thread");
       }
@@ -1656,7 +1656,7 @@ function useEditRoomComment(
       const editedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const existing = store.get_threads().getEvenIfDeleted(threadId);
+      const existing = store.outputs.threads.get().getEvenIfDeleted(threadId);
 
       if (existing === undefined) {
         console.warn(
@@ -1910,7 +1910,7 @@ function useMarkRoomThreadAsRead(roomId: string) {
     (threadId: string) => {
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
       const inboxNotification = Object.values(
-        store.get_notifications().notificationsById
+        store.outputs.notifications.get().notificationsById
       ).find(
         (inboxNotification) =>
           inboxNotification.kind === "thread" &&
@@ -2159,7 +2159,7 @@ function useRoomNotificationSettings(): [
 
   // XXX_vincent Turn this into a useSignal
   const settings = useSyncExternalStoreWithSelector(
-    store.subscribe_settings,
+    store.outputs.settingsByRoomId.subscribe,
     getter,
     getter,
     identity,
@@ -2289,7 +2289,7 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
   // strong evidence that getRoomVersionsLoadingState itself wants to be
   // a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   const state = useSyncExternalStoreWithSelector(
-    store.subscribe_versions,
+    store.outputs.versionsByRoomId.subscribe,
     getter,
     getter,
     identity,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -672,7 +672,7 @@ function RoomProviderInner<
 
       const existingThread = store
         .get1_threads()
-        .threadsDB.getEvenIfDeleted(message.threadId);
+        .getEvenIfDeleted(message.threadId);
 
       switch (message.type) {
         case ServerMsgCode.COMMENT_EDITED:
@@ -1487,7 +1487,7 @@ function useDeleteRoomThread(roomId: string): (threadId: string) => void {
 
       const userId = getCurrentUserId(client);
 
-      const existing = store.get1_threads().threadsDB.get(threadId);
+      const existing = store.get1_threads().get(threadId);
       if (existing?.comments?.[0]?.userId !== userId) {
         throw new Error("Only the thread creator can delete the thread");
       }
@@ -1656,9 +1656,7 @@ function useEditRoomComment(
       const editedAt = new Date();
 
       const { store, onMutationFailure } = getRoomExtrasForClient(client);
-      const existing = store
-        .get1_threads()
-        .threadsDB.getEvenIfDeleted(threadId);
+      const existing = store.get1_threads().getEvenIfDeleted(threadId);
 
       if (existing === undefined) {
         console.warn(

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2556,7 +2556,7 @@ function useRoomAttachmentUrl(
 
   useEffect(() => {
     // NOTE: .get() will trigger any actual fetches, whereas .getState() will not
-    void store.get(attachmentId);
+    void store.enqueue(attachmentId);
   }, [store, attachmentId]);
 
   return useSyncExternalStoreWithSelector(
@@ -2585,7 +2585,7 @@ function useAttachmentUrlSuspense(attachmentId: string) {
   const attachmentUrlState = getAttachmentUrlState();
 
   if (!attachmentUrlState || attachmentUrlState.isLoading) {
-    throw attachmentUrlsStore.get(attachmentId);
+    throw attachmentUrlsStore.enqueue(attachmentId);
   }
 
   if (attachmentUrlState.error) {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -974,46 +974,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
     autobind(this);
   }
 
-  public get_threadifications(): CleanThreadifications<M> {
-    return this.outputs.threadifications.get();
-  }
-
-  public subscribe_threadifications(callback: () => void): () => void {
-    return this.outputs.threadifications.subscribe(callback);
-  }
-
-  public get_threads(): ReadonlyThreadDB<M> {
-    return this.outputs.threads.get();
-  }
-
-  public subscribe_threads(callback: () => void): () => void {
-    return this.outputs.threads.subscribe(callback);
-  }
-
-  public get_notifications(): CleanNotifications {
-    return this.outputs.notifications.get();
-  }
-
-  public subscribe_notifications(callback: () => void): () => void {
-    return this.outputs.notifications.subscribe(callback);
-  }
-
-  public get_settings(): SettingsByRoomId {
-    return this.outputs.settingsByRoomId.get();
-  }
-
-  public subscribe_settings(callback: () => void): () => void {
-    return this.outputs.settingsByRoomId.subscribe(callback);
-  }
-
-  public get_versions(): VersionsByRoomId {
-    return this.outputs.versionsByRoomId.get();
-  }
-
-  public subscribe_versions(callback: () => void): () => void {
-    return this.outputs.versionsByRoomId.subscribe(callback);
-  }
-
   /**
    * Returns the async result of the given query and room id. If the query is success,
    * then it will return the threads that match that provided query and room id.
@@ -1035,7 +995,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return asyncResult;
     }
 
-    const threads = this.get_threads().findMany(roomId, query ?? {}, "asc");
+    const threads = this.outputs.threads
+      .get()
+      .findMany(roomId, query ?? {}, "asc");
 
     const page = asyncResult.data;
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
@@ -1064,7 +1026,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return asyncResult;
     }
 
-    const threads = this.get_threads().findMany(
+    const threads = this.outputs.threads.get().findMany(
       undefined, // Do _not_ filter by roomId
       query ?? {},
       "desc"
@@ -1093,7 +1055,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return {
       isLoading: false,
-      inboxNotifications: this.get_notifications().sortedNotifications,
+      inboxNotifications: this.outputs.notifications.get().sortedNotifications,
       hasFetchedAll: page.hasFetchedAll,
       isFetchingMore: page.isFetchingMore,
       fetchMoreError: page.fetchMoreError,
@@ -1121,7 +1083,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return {
       isLoading: false,
-      settings: nn(this.get_settings()[roomId]),
+      settings: nn(this.outputs.settingsByRoomId.get()[roomId]),
     };
   }
 
@@ -1143,7 +1105,9 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return {
       isLoading: false,
-      versions: Object.values(this.get_versions()[roomId] ?? {}),
+      versions: Object.values(
+        this.outputs.versionsByRoomId.get()[roomId] ?? {}
+      ),
     };
   }
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -974,43 +974,43 @@ export class UmbrellaStore<M extends BaseMetadata> {
     autobind(this);
   }
 
-  public get1_both(): CleanThreadifications<M> {
+  public get_threadifications(): CleanThreadifications<M> {
     return this.outputs.threadifications.get();
   }
 
-  public subscribe1_both(callback: () => void): () => void {
+  public subscribe_threadifications(callback: () => void): () => void {
     return this.outputs.threadifications.subscribe(callback);
   }
 
-  public get1_threads(): ReadonlyThreadDB<M> {
+  public get_threads(): ReadonlyThreadDB<M> {
     return this.outputs.threads.get();
   }
 
-  public subscribe1_threads(callback: () => void): () => void {
+  public subscribe_threads(callback: () => void): () => void {
     return this.outputs.threads.subscribe(callback);
   }
 
-  public get1_notifications(): CleanNotifications {
+  public get_notifications(): CleanNotifications {
     return this.outputs.notifications.get();
   }
 
-  public subscribe1_notifications(callback: () => void): () => void {
+  public subscribe_notifications(callback: () => void): () => void {
     return this.outputs.notifications.subscribe(callback);
   }
 
-  public get2(): SettingsByRoomId {
+  public get_settings(): SettingsByRoomId {
     return this.outputs.settingsByRoomId.get();
   }
 
-  public subscribe2(callback: () => void): () => void {
+  public subscribe_settings(callback: () => void): () => void {
     return this.outputs.settingsByRoomId.subscribe(callback);
   }
 
-  public get3(): VersionsByRoomId {
+  public get_versions(): VersionsByRoomId {
     return this.outputs.versionsByRoomId.get();
   }
 
-  public subscribe3(callback: () => void): () => void {
+  public subscribe_versions(callback: () => void): () => void {
     return this.outputs.versionsByRoomId.subscribe(callback);
   }
 
@@ -1035,7 +1035,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return asyncResult;
     }
 
-    const threads = this.get1_threads().findMany(roomId, query ?? {}, "asc");
+    const threads = this.get_threads().findMany(roomId, query ?? {}, "asc");
 
     const page = asyncResult.data;
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
@@ -1064,7 +1064,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
       return asyncResult;
     }
 
-    const threads = this.get1_threads().findMany(
+    const threads = this.get_threads().findMany(
       undefined, // Do _not_ filter by roomId
       query ?? {},
       "desc"
@@ -1093,7 +1093,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return {
       isLoading: false,
-      inboxNotifications: this.get1_notifications().sortedNotifications,
+      inboxNotifications: this.get_notifications().sortedNotifications,
       hasFetchedAll: page.hasFetchedAll,
       isFetchingMore: page.isFetchingMore,
       fetchMoreError: page.fetchMoreError,
@@ -1121,7 +1121,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return {
       isLoading: false,
-      settings: nn(this.get2()[roomId]),
+      settings: nn(this.get_settings()[roomId]),
     };
   }
 
@@ -1143,7 +1143,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
     // TODO Memoize this value to ensure stable result, so we won't have to use the selector and isEqual functions!
     return {
       isLoading: false,
-      versions: Object.values(this.get3()[roomId] ?? {}),
+      versions: Object.values(this.get_versions()[roomId] ?? {}),
     };
   }
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -683,6 +683,12 @@ function createStore_forNotifications() {
     });
   }
 
+  function upsert(notification: InboxNotificationData) {
+    signal.mutate((lut) => {
+      lut.set(notification.id, notification);
+    });
+  }
+
   return {
     signal: signal.asReadonly(),
 
@@ -693,11 +699,9 @@ function createStore_forNotifications() {
     applyDelta,
     clear,
     updateAssociatedNotification,
+    upsert,
 
     // XXX_vincent Remove this eventually
-    force_set: (
-      mutationCallback: (lut: NotificationsLUT) => void | undefined | boolean
-    ) => signal.mutate(mutationCallback),
     invalidate: () => signal.mutate(),
   };
 }
@@ -742,9 +746,7 @@ function createStore_forHistoryVersions() {
     // Mutations
     update,
 
-    // XXX_vincent Remove these eventually
-    force_set: (callback: (lut: VersionsLUT) => void | boolean) =>
-      signal.mutate(callback),
+    // XXX_vincent Remove this eventually
     invalidate: () => signal.mutate(),
   };
 }
@@ -1162,26 +1164,6 @@ export class UmbrellaStore<M extends BaseMetadata> {
       isLoading: false,
       versions: Object.values(this.get3()[roomId] ?? {}),
     };
-  }
-
-  /** @internal - Only call this method from unit tests. */
-  public force_set_versions(
-    callback: (lut: VersionsLUT) => void | boolean
-  ): void {
-    batch(() => {
-      this.historyVersions.force_set(callback);
-      this.invalidateEntireStore();
-    });
-  }
-
-  /** @internal - Only call this method from unit tests. */
-  public force_set_notifications(
-    callback: (lut: NotificationsLUT) => void | undefined | boolean
-  ): void {
-    batch(() => {
-      this.notifications.force_set(callback);
-      this.invalidateEntireStore();
-    });
   }
 
   /**


### PR DESCRIPTION
This PR cleans up a few internals about both the umbrella and the batch store. I'll continue this a bit in the new year. We're close to a big removal of complexity, just didn't get it done today. This is all prepwork that should be good to go on its own though.