### PR TITLE
Fix two re-rendering regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## vNEXT (Not yet published)
 
-- ...
+- Fix regression: `useInboxNotifications` didn't rerender correctly under all
+  circumstances
+- Performance fix: avoid unneeded re-renders in `useThreads` and
+  `useInboxNotifications` hooks
 
 ## 2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## vNEXT (Not yet published)
 
-- Fix regression: `useInboxNotifications` didn't rerender correctly under all
-  circumstances
-- Performance fix: avoid unneeded re-renders in `useThreads` and
-  `useInboxNotifications` hooks
+- ...
 
 ## 2.15.0
 

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -420,7 +420,7 @@ function useInboxNotifications_withClient<T>(
   // is strong evidence that getInboxNotificationsLoadingState itself wants to
   // be a Signal! Once we make it a Signal, we can simply use `useSignal()` here! ❤️
   return useSyncExternalStoreWithSelector(
-    store.subscribe1_threads,
+    store.subscribe1_notifications,
     store.getInboxNotificationsLoadingState,
     store.getInboxNotificationsLoadingState,
     selector,

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -33,6 +33,7 @@ import {
   MutableSignal,
   nanoid,
   nn,
+  shallow,
   Signal,
   stringify,
 } from "@liveblocks/core";
@@ -617,7 +618,7 @@ function createStore_forNotifications() {
   }
 
   function markAllRead(readAt: Date) {
-    return signal.mutate((lut) => {
+    signal.mutate((lut) => {
       for (const n of lut.values()) {
         n.readAt = readAt;
       }
@@ -938,14 +939,22 @@ export class UmbrellaStore<M extends BaseMetadata> {
         applyOptimisticUpdates_forThreadifications(ts, ns, updates)
     );
 
-    const threads = DerivedSignal.from(threadifications, (s) => ({
-      threadsDB: s.threadsDB,
-    }));
+    const threads = DerivedSignal.from(
+      threadifications,
+      (s) => ({
+        threadsDB: s.threadsDB,
+      }),
+      shallow
+    );
 
-    const notifications = DerivedSignal.from(threadifications, (s) => ({
-      sortedNotifications: s.sortedNotifications,
-      notificationsById: s.notificationsById,
-    }));
+    const notifications = DerivedSignal.from(
+      threadifications,
+      (s) => ({
+        sortedNotifications: s.sortedNotifications,
+        notificationsById: s.notificationsById,
+      }),
+      shallow
+    );
 
     const settingsByRoomId = DerivedSignal.from(
       this.roomNotificationSettings.signal,


### PR DESCRIPTION
This PR fixes two re-rendering regressions I introduced with the 2.15.0 refactorings:

- A forgotten `shallow` caused unnecessary re-renders in `useThreads` and `useInboxNotifications`
- The `useInboxNotifications` only got re-rendered when threads changed (not when only notifications changed)

I found these after doing more cleanup (removing the noise made these issues stand out). I'm going to open a separate PR for that cleanup work, but wanted these fixes to stand out from that noise.
