### PR TITLE
Fix type in emails doc

### DIFF
--- a/docs/pages/api-reference/liveblocks-emails.mdx
+++ b/docs/pages/api-reference/liveblocks-emails.mdx
@@ -157,7 +157,7 @@ replies mentions the user. A single comment with the latest mention is returned.
 
 ```js
 {
-  type: "unreadMentions",
+  type: "unreadMention",
   roomId: "my-room-id",
   comment: {/* Comment data */},
 }


### PR DESCRIPTION
Small fix: `unreadMentions` → `unreadMention`. 

Thanks