### PR TITLE
Implement conditional signal subscriptions

### DIFF
--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -13,6 +13,7 @@ import { Batch, createBatchStore } from "./lib/batch";
 import { chunk } from "./lib/chunk";
 import { createCommentId, createThreadId } from "./lib/createIds";
 import type { DateToString } from "./lib/DateToString";
+import { DefaultMap } from "./lib/DefaultMap";
 import type { Json, JsonObject } from "./lib/Json";
 import { objectToQuery } from "./lib/objectToQuery";
 import type { QueryParams, URLSafeString } from "./lib/url";
@@ -928,50 +929,39 @@ export function createApiClient<M extends BaseMetadata>({
     }
   }
 
-  const getAttachmentUrlsBatchStoreByRoom: Map<
+  const attachmentUrlsBatchStoresByRoom = new DefaultMap<
     string,
     BatchStore<string, string>
-  > = new Map();
+  >((roomId) => {
+    const batch = new Batch<string, string>(
+      async (batchedAttachmentIds) => {
+        const attachmentIds = batchedAttachmentIds.flat();
+        const { urls } = await httpClient.post<{
+          urls: (string | null)[];
+        }>(
+          url`/v2/c/rooms/${roomId}/attachments/presigned-urls`,
+          await authManager.getAuthValue({
+            requestedScope: "comments:read",
+            roomId,
+          }),
+          { attachmentIds }
+        );
+
+        return urls.map(
+          (url) =>
+            url ??
+            new Error("There was an error while getting this attachment's URL")
+        );
+      },
+      { delay: 50 }
+    );
+    return createBatchStore(batch);
+  });
 
   function getOrCreateAttachmentUrlsStore(
     roomId: string
   ): BatchStore<string, string> {
-    let store = getAttachmentUrlsBatchStoreByRoom.get(roomId);
-    if (store === undefined) {
-      const batch = new Batch<string, string>(
-        async (batchedAttachmentIds) => {
-          const attachmentIds = batchedAttachmentIds.flat();
-          const { urls } = await httpClient.post<{
-            urls: (string | null)[];
-          }>(
-            url`/v2/c/rooms/${roomId}/attachments/presigned-urls`,
-            await authManager.getAuthValue({
-              requestedScope: "comments:read",
-              roomId,
-            }),
-            {
-              attachmentIds,
-            }
-          );
-
-          return urls.map(
-            (url) =>
-              url ??
-              new Error(
-                "There was an error while getting this attachment's URL"
-              )
-          );
-        },
-        {
-          delay: 50,
-        }
-      );
-
-      store = createBatchStore(batch);
-
-      getAttachmentUrlsBatchStoreByRoom.set(roomId, store);
-    }
-    return store;
+    return attachmentUrlsBatchStoresByRoom.getOrCreate(roomId);
   }
 
   function getAttachmentUrl(options: { roomId: string; attachmentId: string }) {
@@ -1013,16 +1003,9 @@ export function createApiClient<M extends BaseMetadata>({
     );
   }
 
-  const markInboxNotificationsAsReadBatchByRoom: Map<
-    string,
-    Batch<string, string>
-  > = new Map();
-  function getOrCreateMarkInboxNotificationsAsReadBatch(
-    roomId: string
-  ): Batch<string, string> {
-    let batch = markInboxNotificationsAsReadBatchByRoom.get(roomId);
-    if (batch === undefined) {
-      batch = new Batch<string, string>(
+  const markAsReadBatchesByRoom = new DefaultMap<string, Batch<string, string>>(
+    (roomId) =>
+      new Batch<string, string>(
         async (batchedInboxNotificationIds) => {
           const inboxNotificationIds = batchedInboxNotificationIds.flat();
           // This method (and the following batch handling) isn't the same as the one in
@@ -1041,21 +1024,15 @@ export function createApiClient<M extends BaseMetadata>({
           );
           return inboxNotificationIds;
         },
-        {
-          delay: 50,
-        }
-      );
-
-      markInboxNotificationsAsReadBatchByRoom.set(roomId, batch);
-    }
-    return batch;
-  }
+        { delay: 50 }
+      )
+  );
 
   async function markRoomInboxNotificationAsRead(options: {
     roomId: string;
     inboxNotificationId: string;
   }) {
-    const batch = getOrCreateMarkInboxNotificationsAsReadBatch(options.roomId);
+    const batch = markAsReadBatchesByRoom.getOrCreate(options.roomId);
     return batch.get(options.inboxNotificationId);
   }
 

--- a/packages/liveblocks-core/src/lib/DefaultMap.ts
+++ b/packages/liveblocks-core/src/lib/DefaultMap.ts
@@ -1,0 +1,71 @@
+/**
+ * Like ES6 map, but takes a default factory function which will be used
+ * to create entries for missing keys on the fly.
+ *
+ * Useful for code like:
+ *
+ *   const map = new DefaultMap(() => []);
+ *   map.getOrCreate('foo').push('hello');
+ *   map.getOrCreate('foo').push('world');
+ *   map.getOrCreate('foo')
+ *   // ['hello', 'world']
+ *
+ */
+export class DefaultMap<K, V> extends Map<K, V> {
+  #_factoryFn?: (key: K) => V;
+
+  constructor(
+    factoryFn?: (key: K) => V,
+    entries?: readonly (readonly [K, V])[] | null
+  ) {
+    super(entries);
+    this.#_factoryFn = factoryFn;
+  }
+
+  get #factoryFn() {
+    if (this.#_factoryFn === undefined) {
+      throw new Error("DefaultMap used without a factory function");
+    }
+    return this.#_factoryFn;
+  }
+
+  /**
+   * Gets the value at the given key, or creates it.
+   *
+   * Difference from normal Map: if the key does not exist, it will be created
+   * on the fly using the factory function, and that value will get returned
+   * instead of `undefined`.
+   */
+  getOrCreate(key: K, factoryFn?: (key: K) => V): V {
+    let value = super.get(key);
+    if (value === undefined) {
+      value = factoryFn !== undefined ? factoryFn(key) : this.#factoryFn(key);
+      this.set(key, value);
+    }
+    return value;
+  }
+
+  /**
+   * Sets the value at the given key.
+   *
+   * Difference from normal Map: if the second arg is a function, it will be
+   * called with the current value as its argument and the return value will be
+   * set instead. If the returned value is `undefined`, it will remove the key,
+   * meaning the next time the key is accessed it will get re-created by the
+   * factory function.
+   */
+  set(key: K, value: V): this;
+  set(key: K, valueFn: (prev: V) => V | undefined): this;
+  set(key: K, value: V | ((prev: V) => V | undefined)): this {
+    if (typeof value === "function") {
+      value = (value as (prev: V) => V)(this.get(key) ?? this.#factoryFn(key));
+    }
+
+    if (value === undefined) {
+      super.delete(key);
+      return this;
+    } else {
+      return super.set(key, value);
+    }
+  }
+}

--- a/packages/liveblocks-core/src/lib/DefaultMap.ts
+++ b/packages/liveblocks-core/src/lib/DefaultMap.ts
@@ -36,16 +36,18 @@ export class DefaultMap<K, V> extends Map<K, V> {
    * instead of `undefined`.
    */
   getOrCreate(key: K, defaultFn?: (key: K) => V): V {
-    let value = super.get(key);
-    if (value === undefined) {
+    if (super.has(key)) {
+      // eslint-disable-next-line no-restricted-syntax
+      return super.get(key)!;
+    } else {
       const fn =
         defaultFn ??
         this.#defaultFn ??
         raise("DefaultMap used without a factory function");
 
-      value = fn(key);
+      const value = fn(key);
       this.set(key, value);
+      return value;
     }
-    return value;
   }
 }

--- a/packages/liveblocks-core/src/lib/DefaultMap.ts
+++ b/packages/liveblocks-core/src/lib/DefaultMap.ts
@@ -14,6 +14,10 @@
 export class DefaultMap<K, V> extends Map<K, V> {
   #_factoryFn?: (key: K) => V;
 
+  /**
+   * If the factory function is not provided to the constructor, it has to be
+   * provided in each .getOrCreate() call individually.
+   */
   constructor(
     factoryFn?: (key: K) => V,
     entries?: readonly (readonly [K, V])[] | null
@@ -43,29 +47,5 @@ export class DefaultMap<K, V> extends Map<K, V> {
       this.set(key, value);
     }
     return value;
-  }
-
-  /**
-   * Sets the value at the given key.
-   *
-   * Difference from normal Map: if the second arg is a function, it will be
-   * called with the current value as its argument and the return value will be
-   * set instead. If the returned value is `undefined`, it will remove the key,
-   * meaning the next time the key is accessed it will get re-created by the
-   * factory function.
-   */
-  set(key: K, value: V): this;
-  set(key: K, valueFn: (prev: V) => V | undefined): this;
-  set(key: K, value: V | ((prev: V) => V | undefined)): this {
-    if (typeof value === "function") {
-      value = (value as (prev: V) => V)(this.get(key) ?? this.#factoryFn(key));
-    }
-
-    if (value === undefined) {
-      super.delete(key);
-      return this;
-    } else {
-      return super.set(key, value);
-    }
   }
 }

--- a/packages/liveblocks-core/src/lib/__tests__/DefaultMap.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/DefaultMap.test.ts
@@ -1,0 +1,126 @@
+import { DefaultMap } from "../DefaultMap";
+
+describe("DefaultMap", () => {
+  test("cannot be used without factory function", () => {
+    const map = new DefaultMap<string, Set<string>>(/* no factory given */);
+    map.getOrCreate("apple", () => new Set()).add("hello");
+    //                       ^^^^^^^^^^^^^^^
+    //                       Key-specific factory function given, so it's fine
+    //                       to not have a central factory
+
+    // Just happens to work because "apple" was already created
+    map.getOrCreate("apple").add("world");
+
+    expect(() => map.getOrCreate("banana")).toThrow(
+      /used without a factory function/
+    );
+  });
+
+  test("getOrCreate method", () => {
+    const map1 = new DefaultMap(() => new Set());
+    map1.getOrCreate("foo").add("hello");
+    map1.getOrCreate("foo").add("world");
+    map1.getOrCreate("bar").add("bye");
+    expect(new Map(map1)).toEqual(
+      new Map([
+        ["foo", new Set(["hello", "world"])],
+        ["bar", new Set(["bye"])],
+      ])
+    );
+
+    const map2 = new DefaultMap<string, string[]>((key) => [key + "!"]);
+    map2.getOrCreate("foo").push("hello");
+    map2.getOrCreate("foo").push("world");
+    map2.getOrCreate("bar").push("bye");
+    expect(new Map(map2)).toEqual(
+      new Map([
+        ["foo", ["foo!", "hello", "world"]],
+        ["bar", ["bar!", "bye"]],
+      ])
+    );
+  });
+
+  test("getOrCreate method (w/ specific factory)", () => {
+    const map = new DefaultMap((key: string) => new Set([key]));
+    map.getOrCreate("foo").add("hello");
+    map.getOrCreate("foo").add("world");
+
+    // Using a custom factory function, just for this "bar" key
+    map.getOrCreate("bar", () => new Set()).add("bye");
+
+    expect(new Map(map)).toEqual(
+      new Map([
+        ["foo", new Set(["foo", "hello", "world"])],
+        ["bar", new Set(["bye"])],
+      ])
+    );
+  });
+
+  test("set (classic)", () => {
+    const m = new DefaultMap<string, number>(() => 0);
+    m.set("foo", 5);
+    m.set("bar", 1);
+    m.set("qux", 0);
+    expect(new Map(m)).toEqual(
+      new Map([
+        ["foo", 5],
+        ["bar", 1],
+        ["qux", 0],
+      ])
+    );
+  });
+
+  test("set (with setter function)", () => {
+    const inc = (n: number): number => n + 1;
+
+    const m = new DefaultMap<string, number>(() => 0);
+    m.set("foo", inc);
+    m.set("foo", inc);
+    m.set("bar", inc);
+    expect(new Map(m)).toEqual(
+      new Map([
+        ["foo", 2],
+        ["bar", 1],
+      ])
+    );
+  });
+
+  test("set (with setter function that deletes)", () => {
+    const inc = (n: number): number => n + 1;
+    const dec = (n: number): number | undefined =>
+      n === 1 ? undefined : n - 1;
+
+    const m = new DefaultMap<string, number>(() => 0);
+    m.set("foo", inc);
+    m.set("foo", inc);
+    m.set("foo", dec);
+    m.set("foo", dec);
+
+    m.set("bar", inc);
+
+    m.set("qux", inc);
+    m.set("qux", dec);
+    m.set("qux", dec);
+
+    expect(new Map(m)).toEqual(
+      new Map([
+        // NOTE: No entry for "foo"! Not even "0", due to the implementation of
+        // the dec setter function.
+        ["bar", 1],
+        ["qux", -1],
+      ])
+    );
+
+    // Doing it the opposite way would keep the explicit "0" entry
+    m.set("foo", dec);
+    m.set("foo", inc);
+
+    expect(new Map(m)).toEqual(
+      new Map([
+        ["foo", 0],
+        ["bar", 1],
+        ["qux", -1],
+      ])
+    );
+  });
+});

--- a/packages/liveblocks-core/src/lib/__tests__/DefaultMap.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/DefaultMap.test.ts
@@ -42,6 +42,25 @@ describe("DefaultMap", () => {
     );
   });
 
+  test("getOrCreate method with explicit nullish values", () => {
+    const map = new DefaultMap(() => new Set());
+
+    // @ts-expect-error Deliberately setting 'foo' to undefined
+    map.set("foo", undefined);
+    // @ts-expect-error Deliberately setting 'bar' to null
+    map.set("bar", null);
+
+    // Basic assertions that it's just like a normal Map
+    expect(map.has("foo")).toEqual(true);
+    expect(map.get("foo")).toEqual(undefined);
+    expect(map.has("bar")).toEqual(true);
+    expect(map.get("bar")).toEqual(null);
+
+    expect(map.getOrCreate("foo")).toEqual(undefined); // Not a Set!
+    expect(map.getOrCreate("bar")).toEqual(null); // Not a Set!
+    expect(map.getOrCreate("qux")).toEqual(new Set());
+  });
+
   test("getOrCreate method (w/ specific factory)", () => {
     const map = new DefaultMap((key: string) => new Set([key]));
     map.getOrCreate("foo").add("hello");
@@ -86,6 +105,7 @@ describe("DefaultMap (properties)", () => {
           for (const [key, value] of tuples) {
             expected.set(key, value);
             actual.set(key, value);
+            expect(actual.getOrCreate(key)).toEqual(expected.get(key));
           }
 
           expect(new Map(actual)).toEqual(expected);

--- a/packages/liveblocks-core/src/lib/__tests__/signals/DerivedSignal.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/signals/DerivedSignal.test.ts
@@ -1,5 +1,6 @@
 import { shallow } from "../../../lib/shallow";
 import { batch, DerivedSignal, Signal } from "../../../lib/signals";
+import { DefaultMap } from "../../DefaultMap";
 
 it("compute signal from other signals", () => {
   const greeting = new Signal("hi");
@@ -229,18 +230,22 @@ it("signals only notify watchers when their value changes (with shallow)", () =>
 
   expect(numEvals).toEqual(0);
 
+  // Get the render counter's value now first, otherwise it won't subscribe correctly
+  renderCounter.get();
+  expect(numEvals).toEqual(1);
+
   // Toggling uppercase has no effect when the list is still empty
   uppercase.set(false);
   uppercase.set(true);
-  expect(numEvals).toEqual(0);
+  expect(numEvals).toEqual(1);
 
   // Toggling uppercase has no effect
   fruits.set(["apple", "banana"]);
-  expect(numEvals).toEqual(1);
-  uppercase.set(true); // Was already true, so has no effect
-  expect(numEvals).toEqual(1);
-  uppercase.set(false);
   expect(numEvals).toEqual(2);
+  uppercase.set(true); // Was already true, so has no effect
+  expect(numEvals).toEqual(2);
+  uppercase.set(false);
+  expect(numEvals).toEqual(3);
 
   unsub();
 });
@@ -345,4 +350,106 @@ it("batch signal notifications and re-evaluations are as efficient as possible",
   expect(sorted.get()).toEqual([1, 2, 3]);
 
   unsub();
+});
+
+it("conditionally read from other signal", () => {
+  const index = new Signal(0); // Signal to read
+  const signals = [
+    new Signal("hi"),
+    new Signal("foo"),
+    new Signal("bar"),
+    new Signal("qux"),
+  ];
+
+  const derived = DerivedSignal.from(index, (idx) => signals[idx].get());
+
+  expect(derived.isDirty).toEqual(true);
+  expect(derived.get()).toEqual("hi");
+  expect(derived.get()).toEqual("hi");
+  expect(derived.isDirty).toEqual(false);
+
+  signals[2].set("lol"); // 'bar' -> 'lol'
+
+  // Isn't dirty, because derived did not depend on this value
+  expect(derived.isDirty).toEqual(false);
+
+  expect(derived.get()).toEqual("hi");
+
+  index.set(1); // Change to depend on different signal
+
+  expect(derived.get()).toEqual("foo");
+  expect(derived.isDirty).toEqual(false);
+
+  signals[1].set("baz"); // 'foo' -> 'baz'
+
+  // Now it _is_ dirty, because it depends on this signal now
+  expect(derived.isDirty).toEqual(true);
+  expect(derived.get()).toEqual("baz");
+  expect(derived.isDirty).toEqual(false);
+});
+
+it("conditionally read from nested signals", () => {
+  const map = new DefaultMap<string, Signal<number>>(() => new Signal(0));
+  const prefix = new Signal("pre");
+  const fn = jest.fn();
+
+  const derived = DerivedSignal.from(
+    prefix,
+    (prefix) => {
+      fn();
+      const arr = [];
+      for (const [key, signal] of map.entries()) {
+        if (key.startsWith(prefix)) {
+          arr.push(signal.get());
+        }
+      }
+      return arr;
+    },
+    shallow
+  );
+
+  // Populate map with lots of signals
+  for (let i = 0; i < 10_000; i++) {
+    map.getOrCreate("pre" + i);
+  }
+
+  expect(derived.get().length).toEqual(10_000);
+  expect(fn).toHaveBeenCalledTimes(1);
+  prefix.set("pre444");
+
+  expect(derived.get().toString()).toEqual("0,0,0,0,0,0,0,0,0,0,0");
+
+  expect(fn).toHaveBeenCalledTimes(2);
+
+  // Changing unrelated signals does not trigger re-evaluation
+  map.getOrCreate("pre1234").set(927);
+  map.getOrCreate("pre7623").set(28179);
+  map.getOrCreate("foobar123").set(238);
+  expect(fn).toHaveBeenCalledTimes(2);
+
+  expect(derived.get().toString()).toEqual("0,0,0,0,0,0,0,0,0,0,0");
+  expect(fn).toHaveBeenCalledTimes(2);
+
+  // But changing related signals *does* trigger re-evaluation
+  map.getOrCreate("pre4440").set(908);
+  map.getOrCreate("pre4441").set(1313);
+  map.getOrCreate("pre444").set(43);
+  expect(fn).toHaveBeenCalledTimes(2);
+
+  expect(derived.get().toString()).toEqual("43,908,1313,0,0,0,0,0,0,0,0");
+  expect(fn).toHaveBeenCalledTimes(3);
+
+  // Deletion is tricky though! It's not an explicit value change, just
+  // a reference removal, so this won't be detectable.
+  map.delete("pre4441");
+  map.getOrCreate("another");
+  expect(fn).toHaveBeenCalledTimes(3);
+
+  expect(derived.get().toString()).toEqual("43,908,1313,0,0,0,0,0,0,0,0");
+  expect(fn).toHaveBeenCalledTimes(3);
+
+  // In order to detect the deletion, any of the other signals must change to trigger re-evaluation
+  map.getOrCreate("pre4447").set(18);
+  expect(derived.get().toString()).toEqual("43,908,0,0,0,0,0,18,0,0");
+  expect(fn).toHaveBeenCalledTimes(4);
 });

--- a/packages/liveblocks-core/src/lib/__tests__/signals/DerivedSignal.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/signals/DerivedSignal.test.ts
@@ -228,10 +228,6 @@ it("signals only notify watchers when their value changes (with shallow)", () =>
   expect(value1).toBe(value3);
   expect(fn).not.toHaveBeenCalled();
 
-  expect(numEvals).toEqual(0);
-
-  // Get the render counter's value now first, otherwise it won't subscribe correctly
-  renderCounter.get();
   expect(numEvals).toEqual(1);
 
   // Toggling uppercase has no effect when the list is still empty
@@ -454,8 +450,11 @@ it("conditionally reading signals won't unregister old sinks (when using static 
     return cond ? x : y;
   });
 
-  const unsub = z.subscribe(notificationFn);
   expect(evalFn).toHaveBeenCalledTimes(0);
+  expect(notificationFn).toHaveBeenCalledTimes(0);
+
+  const unsub = z.subscribe(notificationFn);
+  expect(evalFn).toHaveBeenCalledTimes(1);
   expect(notificationFn).toHaveBeenCalledTimes(0);
 
   expect(z.get()).toEqual(42);
@@ -488,8 +487,12 @@ it("conditionally reading signals will unregister old sinks (when using dynamic 
     return cond.get() ? x.get() : y.get();
   });
 
-  const unsub = z.subscribe(notificationFn);
   expect(evalFn).toHaveBeenCalledTimes(0);
+  expect(notificationFn).toHaveBeenCalledTimes(0);
+
+  const unsub = z.subscribe(notificationFn);
+
+  expect(evalFn).toHaveBeenCalledTimes(1);
   expect(notificationFn).toHaveBeenCalledTimes(0);
 
   expect(z.get()).toEqual(42);

--- a/packages/liveblocks-core/src/lib/signals.ts
+++ b/packages/liveblocks-core/src/lib/signals.ts
@@ -53,6 +53,13 @@ const kTrigger = Symbol("kTrigger");
 //
 let signalsToTrigger: Set<AbstractSignal<any>> | null = null;
 
+//
+// If a derived signal is currently being computed, there is a global "signals
+// that have been read" registry that every call to `someSignal.get()` will
+// register itself under.
+//
+let trackedReads: Set<AbstractSignal<any>> | null = null;
+
 /**
  * Runs a callback function that is allowed to change multiple signals. At the
  * end of the batch, all changed signals will be notified (at most once).
@@ -233,6 +240,7 @@ export class Signal<T> extends AbstractSignal<T> {
   }
 
   get(): T {
+    trackedReads?.add(this);
     return this.#value;
   }
 
@@ -278,14 +286,15 @@ export class DerivedSignal<T> extends AbstractSignal<T> {
   #prevValue: T;
   #dirty: boolean; // When true, the value in #value may not be up-to-date and needs re-checking
 
-  readonly #parents: readonly ISignal<unknown>[];
+  #sources: Set<ISignal<unknown>>;
+  readonly #deps: readonly ISignal<unknown>[];
   readonly #transform: (...values: unknown[]) => T;
 
   // Overload 1
-  static from<Ts extends [unknown, ...unknown[]], V>(...args: [...signals: { [K in keyof Ts]: ISignal<Ts[K]> }, transform: (...values: Ts) => V]): DerivedSignal<V>; // prettier-ignore
+  static from<Ts extends unknown[], V>(...args: [...signals: { [K in keyof Ts]: ISignal<Ts[K]> }, transform: (...values: Ts) => V]): DerivedSignal<V>; // prettier-ignore
   // Overload 2
-  static from<Ts extends [unknown, ...unknown[]], V>(...args: [...signals: { [K in keyof Ts]: ISignal<Ts[K]> }, transform: (...values: Ts) => V, equals: (a: V, b: V) => boolean]): DerivedSignal<V>; // prettier-ignore
-  static from<Ts extends [unknown, ...unknown[]], V>(
+  static from<Ts extends unknown[], V>(...args: [...signals: { [K in keyof Ts]: ISignal<Ts[K]> }, transform: (...values: Ts) => V, equals: (a: V, b: V) => boolean]): DerivedSignal<V>; // prettier-ignore
+  static from<Ts extends unknown[], V>(
     // prettier-ignore
     ...args: [
       ...signals: { [K in keyof Ts]: ISignal<Ts[K]> },
@@ -310,30 +319,33 @@ export class DerivedSignal<T> extends AbstractSignal<T> {
   }
 
   private constructor(
-    parents: ISignal<unknown>[],
+    deps: ISignal<unknown>[],
     transform: (...values: unknown[]) => T,
     equals?: (a: T, b: T) => boolean
   ) {
     super(equals);
     this.#dirty = true;
     this.#prevValue = INITIAL as unknown as T;
-    this.#parents = parents;
+    this.#deps = deps;
+    this.#sources = new Set();
     this.#transform = transform;
 
-    for (const parent of parents) {
-      parent.addSink(this as DerivedSignal<unknown>);
-    }
+    // for (const parent of parents) {
+    //   parent.addSink(this as DerivedSignal<unknown>);
+    // }
   }
 
   [Symbol.dispose](): void {
-    for (const parent of this.#parents) {
-      parent.removeSink(this as DerivedSignal<unknown>);
+    for (const src of this.#sources) {
+      src.removeSink(this as DerivedSignal<unknown>);
     }
 
     // @ts-expect-error make disposed object completely unusable
     this.#prevValue = "(disposed)";
     // @ts-expect-error make disposed object completely unusable
-    this.#parents = "(disposed)";
+    this.#sources = "(disposed)";
+    // @ts-expect-error make disposed object completely unusable
+    this.#deps = "(disposed)";
     // @ts-expect-error make disposed object completely unusable
     this.#transform = "(disposed)";
   }
@@ -343,7 +355,31 @@ export class DerivedSignal<T> extends AbstractSignal<T> {
   }
 
   #recompute(): boolean {
-    const derived = this.#transform(...this.#parents.map((p) => p.get()));
+    const oldTrackedReads = trackedReads;
+
+    let derived;
+    trackedReads = new Set();
+    try {
+      derived = this.#transform(...this.#deps.map((p) => p.get()));
+    } finally {
+      const oldSources = this.#sources;
+      this.#sources = new Set();
+
+      for (const sig of trackedReads) {
+        this.#sources.add(sig);
+        oldSources.delete(sig);
+      }
+
+      for (const oldSource of oldSources) {
+        oldSource.removeSink(this as DerivedSignal<unknown>);
+      }
+      for (const newSource of this.#sources) {
+        newSource.addSink(this as DerivedSignal<unknown>);
+      }
+
+      trackedReads = oldTrackedReads;
+    }
+
     this.#dirty = false;
 
     // Only emit a change to watchers if the value actually changed
@@ -365,6 +401,7 @@ export class DerivedSignal<T> extends AbstractSignal<T> {
     if (this.#dirty) {
       this.#recompute();
     }
+    trackedReads?.add(this);
     return this.#prevValue;
   }
 
@@ -414,6 +451,7 @@ export class MutableSignal<T extends object> extends AbstractSignal<T> {
   }
 
   get(): T {
+    trackedReads?.add(this);
     return this.#state;
   }
 

--- a/packages/liveblocks-core/src/lib/signals.ts
+++ b/packages/liveblocks-core/src/lib/signals.ts
@@ -190,6 +190,14 @@ abstract class AbstractSignal<T> implements ISignal<T>, Observable<void> {
   }
 
   subscribe(callback: Callback<void>): UnsubscribeCallback {
+    // If this is the first subscriber, we need to perform an initial .get()
+    // now in case this is a DerivedSignal that has not been evaluated yet. The
+    // reason we need to do this is that the .get() itself will register this
+    // signal as sinks of the dependent signals, so we will actually get
+    // notified here when one of the dependent signals changes.
+    if (this.#eventSource.count() === 0) {
+      this.get();
+    }
     return this.#eventSource.subscribe(callback);
   }
 


### PR DESCRIPTION
This PR implements dynamic tracking of signals for `DerivedSignal`.

Previously:

```ts
const counter = new Signal(0);
const isEven = DerivedSignal.from(counter, n => n % 2 === 0);
const parity = DerivedSignal.from(isEven, even => even ? "even" : "odd");
```

This syntax is still convenient and succinct for simple signals, but because the dependent signals needed to be passed in at declaration time, they are static relationships.

This means that conditional or nesting of signal dependencies was not possible before. This PR makes signals automatically dependent on any signal consumed in the evaluation function.

For example, the above code can now also be written as:

```ts
const counter = new Signal(0);
const isEven = DerivedSignal.from(() => counter.get() % 2 === 0);
const parity = DerivedSignal.from(() => isEven.get() ? "even" : "odd");
```

The previous syntax where you can pass in signals statically and their values get passed into the evaluation function is still supported for convenience and backward-compatibility. You can use either way, or even combine the two approaches.

The syntax

```ts
DerivedSignal.from(signalX, signalY, signalZ, (x, y, z) => { ... });
```

is now just sugar for:

```ts
DerivedSignal.from(() => {
  const x = signalX.get();
  const y = signalY.get();
  const z = signalZ.get();
  ...
});
```

This syntax is both more powerful and more closely aligned with the [TC39 signals proposal (stage 1)](https://github.com/tc39/proposal-signals) as well.

It works through signal read tracking. Any time a derived signal's evaluation function is executed, all signals that are read from (= called `.get()` on) during its execution are being tracked and the derived signal is automatically registered as sinks of those dependent signals.

This makes it possible to keep track of a list of signals, and dynamically listen to a subset of them. Or to make a signal track a list of signals itself as values. We need this functionality to track user/room threads response statuses by querykeys, for example, which we'll implement in a future PR.