### PR TITLE
Upgrade TypeScript to 5.7 in all projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
       ],
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.3",
-        "dependency-cruiser": "^16.3.3",
-        "prettier": "^3.3.2",
+        "dependency-cruiser": "^16.9.0",
+        "prettier": "^3.4.2",
         "publint": "^0.2.8",
         "ts-morph": "^22.0.0",
         "tsd": "^0.31.1",
-        "tsup": "^8.1.0",
+        "tsup": "^8.3.5",
         "turbo": "^2.3.3",
         "typescript": "<4.8"
       },
@@ -2426,19 +2426,20 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.4.tgz",
-      "integrity": "sha512-Zrm+B33R4LWPLjDEVnEqt2+SLTATlru1q/xYKVn8oVTbiRBGmK2VIMoIYGJDGyftnGaC788IuzGFAlb7IQ0Y8A==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -2697,6 +2698,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
@@ -2711,6 +2729,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
@@ -8424,169 +8459,266 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.7.0.tgz",
-      "integrity": "sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
+      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.7.0.tgz",
-      "integrity": "sha512-/EBw0cuJ/KVHiU2qyVYUhogXz7W2vXxBzeE9xtVIMC+RyitlY2vvaoysMUqASpkUtoNIHlnKTu/l7mXOPgnKOA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
+      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.7.0.tgz",
-      "integrity": "sha512-4VXG1bgvClJdbEYYjQ85RkOtwN8sqI3uCxH0HC5w9fKdqzRzgG39K7GAehATGS8jghA7zNoS5CjSKkDEqWmNZg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
+      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.7.0.tgz",
-      "integrity": "sha512-/ImhO+T/RWJ96hUbxiCn2yWI0/MeQZV/aeukQQfhxiSXuZJfyqtdHPUPrc84jxCfXTxbJLmg4q+GBETeb61aNw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
+      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
+      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
+      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.7.0.tgz",
-      "integrity": "sha512-zhye8POvTyUXlKbfPBVqoHy3t43gIgffY+7qBFqFxNqVtltQLtWeHNAbrMnXiLIfYmxcoL/feuLDote2tx+Qbg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
+      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
+      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.7.0.tgz",
-      "integrity": "sha512-RAdr3OJnUum6Vs83cQmKjxdTg31zJnLLTkjhcFt0auxM6jw00GD6IPFF42uasYPr/wGC6TRm7FsQiJyk0qIEfg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
+      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.7.0.tgz",
-      "integrity": "sha512-nhWwYsiJwZGq7SyR3afS3EekEOsEAlrNMpPC4ZDKn5ooYSEjDLe9W/xGvoIV8/F/+HNIY6jY8lIdXjjxfxopXw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
+      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
+      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
+      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.7.0.tgz",
-      "integrity": "sha512-rlfy5RnQG1aop1BL/gjdH42M2geMUyVQqd52GJVirqYc787A/XVvl3kQ5NG/43KXgOgE9HXgCaEH05kzQ+hLoA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
+      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
+      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.7.0.tgz",
-      "integrity": "sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.7.0.tgz",
-      "integrity": "sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
+      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.7.0.tgz",
-      "integrity": "sha512-CPtgaQL1aaPc80m8SCVEoxFGHxKYIt3zQYC3AccL/SqqiWXblo3pgToHuBwR8eCP2Toa+X1WmTR/QKFMykws7g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
+      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.7.0.tgz",
-      "integrity": "sha512-pmioUlttNh9GXF5x2CzNa7Z8kmRTyhEzzAC+2WOOapjewMbl+3tGuAnxbwc5JyG8Jsz2+hf/QD/n5VjimOZ63g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
+      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.7.0.tgz",
-      "integrity": "sha512-SeZzC2QhhdBQUm3U0c8+c/P6UlRyBcLL2Xp5KX7z46WXZxzR8RJSIWL9wSUeBTgxog5LTPJuPj0WOT9lvrtP7Q==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
+      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -10156,9 +10288,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
-      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.11",
@@ -10787,9 +10920,10 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10830,9 +10964,13 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
@@ -12393,6 +12531,16 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/consola": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
+      "integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "dev": true,
@@ -13313,38 +13461,34 @@
       "license": "MIT"
     },
     "node_modules/dependency-cruiser": {
-      "version": "16.3.3",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-16.3.3.tgz",
-      "integrity": "sha512-+YHPbd6RqM1nLUUbRVkbYO6mVeeq+VEL+bBkR+KFkYVU20vs1D0TalZ9z/hDLxiYiYCSTctUaoWWaUrRc1I+mw==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-16.9.0.tgz",
+      "integrity": "sha512-Gc/xHNOBq1nk5i7FPCuexCD0m2OXB/WEfiSHfNYQaQaHZiZltnl5Ixp/ZG38Jvi8aEhKBQTHV4Aw6gmR7rWlOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "acorn": "8.11.3",
-        "acorn-jsx": "5.3.2",
-        "acorn-jsx-walk": "2.0.0",
-        "acorn-loose": "8.4.0",
-        "acorn-walk": "8.3.2",
-        "ajv": "8.16.0",
-        "chalk": "5.3.0",
-        "commander": "12.1.0",
-        "enhanced-resolve": "5.17.0",
-        "figures": "6.1.0",
-        "ignore": "5.3.1",
-        "indent-string": "5.0.0",
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "acorn-jsx-walk": "^2.0.0",
+        "acorn-loose": "^8.4.0",
+        "acorn-walk": "^8.3.4",
+        "ajv": "^8.17.1",
+        "commander": "^13.0.0",
+        "enhanced-resolve": "^5.18.0",
+        "ignore": "^7.0.0",
         "interpret": "^3.1.1",
-        "is-installed-globally": "1.0.0",
-        "json5": "2.2.3",
-        "lodash": "4.17.21",
-        "memoize": "10.0.0",
-        "picomatch": "4.0.2",
-        "prompts": "2.4.2",
+        "is-installed-globally": "^1.0.0",
+        "json5": "^2.2.3",
+        "memoize": "^10.0.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "prompts": "^2.4.2",
         "rechoir": "^0.8.0",
-        "safe-regex": "2.1.1",
-        "semver": "^7.6.2",
-        "semver-try-require": "7.0.0",
-        "teamcity-service-messages": "0.1.14",
-        "tsconfig-paths-webpack-plugin": "4.1.0",
-        "watskeburt": "4.0.2",
-        "wrap-ansi": "9.0.0"
+        "safe-regex": "^2.1.1",
+        "semver": "^7.6.3",
+        "teamcity-service-messages": "^0.1.14",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
+        "watskeburt": "^4.2.2"
       },
       "bin": {
         "depcruise": "bin/dependency-cruise.mjs",
@@ -13359,123 +13503,55 @@
       }
     },
     "node_modules/dependency-cruiser/node_modules/ajv": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/dependency-cruiser/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/chalk": {
-      "version": "5.3.0",
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/emoji-regex": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-      "dev": true
-    },
-    "node_modules/dependency-cruiser/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dependency-cruiser/node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/indent-string": {
-      "version": "5.0.0",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.0.tgz",
+      "integrity": "sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/is-unicode-supported": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">= 4"
       }
     },
     "node_modules/dependency-cruiser/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dependency-cruiser/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/dependency-cruiser/node_modules/picomatch": {
       "version": "4.0.2",
@@ -13490,64 +13566,16 @@
       }
     },
     "node_modules/dependency-cruiser/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/string-width": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz",
-      "integrity": "sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/dependency-cruiser/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/dequal": {
@@ -13845,10 +13873,11 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -15428,6 +15457,23 @@
       "version": "1.3.0",
       "license": "Unlicense"
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "devOptional": true,
@@ -15926,18 +15972,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -23554,30 +23588,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/semver-try-require": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver-try-require/-/semver-try-require-7.0.0.tgz",
-      "integrity": "sha512-LI7GzDuAZmNKOY0/LY4nB3ifh6kYMvBimFTHVpA6wNEl3gw59QrLbTAnJb7vQzPd1qXPz+BtKJZaYORXWMerrA==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.6.0"
-      },
-      "engines": {
-        "node": "^18.17||>=20"
-      }
-    },
-    "node_modules/semver-try-require/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "dev": true,
@@ -25456,6 +25466,55 @@
       "version": "1.0.3",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -25688,13 +25747,15 @@
       }
     },
     "node_modules/tsconfig-paths-webpack-plugin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
-      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
         "tsconfig-paths": "^4.1.2"
       },
       "engines": {
@@ -25706,6 +25767,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -25722,6 +25784,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -25731,6 +25794,7 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -25785,24 +25849,27 @@
       "license": "0BSD"
     },
     "node_modules/tsup": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.1.0.tgz",
-      "integrity": "sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.5.tgz",
+      "integrity": "sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bundle-require": "^4.0.0",
-        "cac": "^6.7.12",
-        "chokidar": "^3.5.1",
-        "debug": "^4.3.1",
-        "esbuild": "^0.21.4",
-        "execa": "^5.0.0",
-        "globby": "^11.0.3",
-        "joycon": "^3.0.1",
-        "postcss-load-config": "^4.0.1",
+        "bundle-require": "^5.0.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.1",
+        "consola": "^3.2.3",
+        "debug": "^4.3.7",
+        "esbuild": "^0.24.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
         "resolve-from": "^5.0.0",
-        "rollup": "^4.0.2",
+        "rollup": "^4.24.0",
         "source-map": "0.8.0-beta.0",
-        "sucrase": "^3.20.3",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.1",
+        "tinyglobby": "^0.2.9",
         "tree-kill": "^1.2.2"
       },
       "bin": {
@@ -25834,359 +25901,383 @@
       }
     },
     "node_modules/tsup/node_modules/@esbuild/android-arm": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.4.tgz",
-      "integrity": "sha512-E7H/yTd8kGQfY4z9t3nRPk/hrhaCajfA3YSQSBrst8B+3uTcgsi8N+ZWYCaeIDsiVs6m65JPCaQN/DxBRclF3A==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.4.tgz",
-      "integrity": "sha512-fYFnz+ObClJ3dNiITySBUx+oNalYUT18/AryMxfovLkYWbutXsct3Wz2ZWAcGGppp+RVVX5FiXeLYGi97umisA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/android-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.4.tgz",
-      "integrity": "sha512-mDqmlge3hFbEPbCWxp4fM6hqq7aZfLEHZAKGP9viq9wMUBVQx202aDIfc3l+d2cKhUJM741VrCXEzRFhPDKH3Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.4.tgz",
-      "integrity": "sha512-72eaIrDZDSiWqpmCzVaBD58c8ea8cw/U0fq/PPOTqE3c53D0xVMRt2ooIABZ6/wj99Y+h4ksT/+I+srCDLU9TA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.4.tgz",
-      "integrity": "sha512-uBsuwRMehGmw1JC7Vecu/upOjTsMhgahmDkWhGLWxIgUn2x/Y4tIwUZngsmVb6XyPSTXJYS4YiASKPcm9Zitag==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.4.tgz",
-      "integrity": "sha512-8JfuSC6YMSAEIZIWNL3GtdUT5NhUA/CMUCpZdDRolUXNAXEE/Vbpe6qlGLpfThtY5NwXq8Hi4nJy4YfPh+TwAg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.4.tgz",
-      "integrity": "sha512-8d9y9eQhxv4ef7JmXny7591P/PYsDFc4+STaxC1GBv0tMyCdyWfXu2jBuqRsyhY8uL2HU8uPyscgE2KxCY9imQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.4.tgz",
-      "integrity": "sha512-2rqFFefpYmpMs+FWjkzSgXg5vViocqpq5a1PSRgT0AvSgxoXmGF17qfGAzKedg6wAwyM7UltrKVo9kxaJLMF/g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.4.tgz",
-      "integrity": "sha512-/GLD2orjNU50v9PcxNpYZi+y8dJ7e7/LhQukN3S4jNDXCKkyyiyAz9zDw3siZ7Eh1tRcnCHAo/WcqKMzmi4eMQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.4.tgz",
-      "integrity": "sha512-pNftBl7m/tFG3t2m/tSjuYeWIffzwAZT9m08+9DPLizxVOsUl8DdFzn9HvJrTQwe3wvJnwTdl92AonY36w/25g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.4.tgz",
-      "integrity": "sha512-cSD2gzCK5LuVX+hszzXQzlWya6c7hilO71L9h4KHwqI4qeqZ57bAtkgcC2YioXjsbfAv4lPn3qe3b00Zt+jIfQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.4.tgz",
-      "integrity": "sha512-qtzAd3BJh7UdbiXCrg6npWLYU0YpufsV9XlufKhMhYMJGJCdfX/G6+PNd0+v877X1JG5VmjBLUiFB0o8EUSicA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.4.tgz",
-      "integrity": "sha512-yB8AYzOTaL0D5+2a4xEy7OVvbcypvDR05MsB/VVPVA7nL4hc5w5Dyd/ddnayStDgJE59fAgNEOdLhBxjfx5+dg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.4.tgz",
-      "integrity": "sha512-Y5AgOuVzPjQdgU59ramLoqSSiXddu7F3F+LI5hYy/d1UHN7K5oLzYBDZe23QmQJ9PIVUXwOdKJ/jZahPdxzm9w==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.4.tgz",
-      "integrity": "sha512-Iqc/l/FFwtt8FoTK9riYv9zQNms7B8u+vAI/rxKuN10HgQIXaPzKZc479lZ0x6+vKVQbu55GdpYpeNWzjOhgbA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.4.tgz",
-      "integrity": "sha512-Td9jv782UMAFsuLZINfUpoF5mZIbAj+jv1YVtE58rFtfvoKRiKSkRGQfHTgKamLVT/fO7203bHa3wU122V/Bdg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.4.tgz",
-      "integrity": "sha512-Awn38oSXxsPMQxaV0Ipb7W/gxZtk5Tx3+W+rAPdZkyEhQ6968r9NvtkjhnhbEgWXYbgV+JEONJ6PcdBS+nlcpA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.4.tgz",
-      "integrity": "sha512-IsUmQeCY0aU374R82fxIPu6vkOybWIMc3hVGZ3ChRwL9hA1TwY+tS0lgFWV5+F1+1ssuvvXt3HFqe8roCip8Hg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.4.tgz",
-      "integrity": "sha512-hsKhgZ4teLUaDA6FG/QIu2q0rI6I36tZVfM4DBZv3BG0mkMIdEnMbhc4xwLvLJSS22uWmaVkFkqWgIS0gPIm+A==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.4.tgz",
-      "integrity": "sha512-UUfMgMoXPoA/bvGUNfUBFLCh0gt9dxZYIx9W4rfJr7+hKe5jxxHmfOK8YSH4qsHLLN4Ck8JZ+v7Q5fIm1huErg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.4.tgz",
-      "integrity": "sha512-yIxbspZb5kGCAHWm8dexALQ9en1IYDfErzjSEq1KzXFniHv019VT3mNtTK7t8qdy4TwT6QYHI9sEZabONHg+aw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.4.tgz",
-      "integrity": "sha512-sywLRD3UK/qRJt0oBwdpYLBibk7KiRfbswmWRDabuncQYSlf8aLEEUor/oP6KRz8KEG+HoiVLBhPRD5JWjS8Sg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tsup/node_modules/bundle-require": {
-      "version": "4.0.1",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26196,45 +26287,141 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
-        "esbuild": ">=0.17"
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/tsup/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/tsup/node_modules/esbuild": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.4.tgz",
-      "integrity": "sha512-sFMcNNrj+Q0ZDolrp5pDhH0nRPN9hLIM3fRPwgbLYJeSHHgnXSnbV3xYgSVuOeLWH9c73VwmEverVzupIv5xuA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.4",
-        "@esbuild/android-arm": "0.21.4",
-        "@esbuild/android-arm64": "0.21.4",
-        "@esbuild/android-x64": "0.21.4",
-        "@esbuild/darwin-arm64": "0.21.4",
-        "@esbuild/darwin-x64": "0.21.4",
-        "@esbuild/freebsd-arm64": "0.21.4",
-        "@esbuild/freebsd-x64": "0.21.4",
-        "@esbuild/linux-arm": "0.21.4",
-        "@esbuild/linux-arm64": "0.21.4",
-        "@esbuild/linux-ia32": "0.21.4",
-        "@esbuild/linux-loong64": "0.21.4",
-        "@esbuild/linux-mips64el": "0.21.4",
-        "@esbuild/linux-ppc64": "0.21.4",
-        "@esbuild/linux-riscv64": "0.21.4",
-        "@esbuild/linux-s390x": "0.21.4",
-        "@esbuild/linux-x64": "0.21.4",
-        "@esbuild/netbsd-x64": "0.21.4",
-        "@esbuild/openbsd-x64": "0.21.4",
-        "@esbuild/sunos-x64": "0.21.4",
-        "@esbuild/win32-arm64": "0.21.4",
-        "@esbuild/win32-ia32": "0.21.4",
-        "@esbuild/win32-x64": "0.21.4"
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/tsup/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/tsup/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/tsup/node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/tsup/node_modules/resolve-from": {
@@ -26246,10 +26433,14 @@
       }
     },
     "node_modules/tsup/node_modules/rollup": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.7.0.tgz",
-      "integrity": "sha512-7Kw0dUP4BWH78zaZCqF1rPyQ8D5DSU6URG45v1dqS/faNsx9WXyess00uTOZxKr7oR/4TOjO1CPudT8L1UsEgw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+      "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -26258,19 +26449,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.7.0",
-        "@rollup/rollup-android-arm64": "4.7.0",
-        "@rollup/rollup-darwin-arm64": "4.7.0",
-        "@rollup/rollup-darwin-x64": "4.7.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.7.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.7.0",
-        "@rollup/rollup-linux-arm64-musl": "4.7.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.7.0",
-        "@rollup/rollup-linux-x64-gnu": "4.7.0",
-        "@rollup/rollup-linux-x64-musl": "4.7.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.7.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.7.0",
-        "@rollup/rollup-win32-x64-msvc": "4.7.0",
+        "@rollup/rollup-android-arm-eabi": "4.30.1",
+        "@rollup/rollup-android-arm64": "4.30.1",
+        "@rollup/rollup-darwin-arm64": "4.30.1",
+        "@rollup/rollup-darwin-x64": "4.30.1",
+        "@rollup/rollup-freebsd-arm64": "4.30.1",
+        "@rollup/rollup-freebsd-x64": "4.30.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+        "@rollup/rollup-linux-arm64-musl": "4.30.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-gnu": "4.30.1",
+        "@rollup/rollup-linux-x64-musl": "4.30.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+        "@rollup/rollup-win32-x64-msvc": "4.30.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -26306,6 +26503,21 @@
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/tunnel-agent": {
@@ -26994,10 +27206,11 @@
       }
     },
     "node_modules/watskeburt": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.0.2.tgz",
-      "integrity": "sha512-w7X8AGrBZExP5/3e3c1X/CUY8Yod/aiAazQCvrg7n8Un6piD+NFFK926G15zRq4+wu0XAEWpSsZ4C+fEfVOCYw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.2.2.tgz",
+      "integrity": "sha512-AOCg1UYxWpiHW1tUwqpJau8vzarZYTtzl2uu99UptBmbzx6kOzCGMfRLF6KIRX4PYekmryn89MzxlRNkL66YyA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "watskeburt": "dist/run-cli.js"
       },
@@ -34416,9 +34629,9 @@
       "integrity": "sha512-calbMa7Gcyo+/t23XBaqQqon8LlgE9regey4UVoikoenKBXvUnCUL3s9RP6USCxttfr0XWVICtYUuKMdehKqMw=="
     },
     "@esbuild/aix-ppc64": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.4.tgz",
-      "integrity": "sha512-Zrm+B33R4LWPLjDEVnEqt2+SLTATlru1q/xYKVn8oVTbiRBGmK2VIMoIYGJDGyftnGaC788IuzGFAlb7IQ0Y8A==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
       "dev": true,
       "optional": true
     },
@@ -34518,10 +34731,24 @@
       "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
       "optional": true
     },
+    "@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "dev": true,
+      "optional": true
+    },
     "@esbuild/netbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
       "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
@@ -40728,93 +40955,135 @@
       }
     },
     "@rollup/rollup-android-arm-eabi": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.7.0.tgz",
-      "integrity": "sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
+      "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-android-arm64": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.7.0.tgz",
-      "integrity": "sha512-/EBw0cuJ/KVHiU2qyVYUhogXz7W2vXxBzeE9xtVIMC+RyitlY2vvaoysMUqASpkUtoNIHlnKTu/l7mXOPgnKOA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
+      "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-arm64": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.7.0.tgz",
-      "integrity": "sha512-4VXG1bgvClJdbEYYjQ85RkOtwN8sqI3uCxH0HC5w9fKdqzRzgG39K7GAehATGS8jghA7zNoS5CjSKkDEqWmNZg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
+      "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-darwin-x64": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.7.0.tgz",
-      "integrity": "sha512-/ImhO+T/RWJ96hUbxiCn2yWI0/MeQZV/aeukQQfhxiSXuZJfyqtdHPUPrc84jxCfXTxbJLmg4q+GBETeb61aNw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
+      "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-arm64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
+      "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-x64": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
+      "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.7.0.tgz",
-      "integrity": "sha512-zhye8POvTyUXlKbfPBVqoHy3t43gIgffY+7qBFqFxNqVtltQLtWeHNAbrMnXiLIfYmxcoL/feuLDote2tx+Qbg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
+      "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
+      "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.7.0.tgz",
-      "integrity": "sha512-RAdr3OJnUum6Vs83cQmKjxdTg31zJnLLTkjhcFt0auxM6jw00GD6IPFF42uasYPr/wGC6TRm7FsQiJyk0qIEfg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
+      "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-arm64-musl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.7.0.tgz",
-      "integrity": "sha512-nhWwYsiJwZGq7SyR3afS3EekEOsEAlrNMpPC4ZDKn5ooYSEjDLe9W/xGvoIV8/F/+HNIY6jY8lIdXjjxfxopXw==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
+      "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
+      "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
+      "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.7.0.tgz",
-      "integrity": "sha512-rlfy5RnQG1aop1BL/gjdH42M2geMUyVQqd52GJVirqYc787A/XVvl3kQ5NG/43KXgOgE9HXgCaEH05kzQ+hLoA==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
+      "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
+      "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.7.0.tgz",
-      "integrity": "sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+      "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.7.0.tgz",
-      "integrity": "sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
+      "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.7.0.tgz",
-      "integrity": "sha512-CPtgaQL1aaPc80m8SCVEoxFGHxKYIt3zQYC3AccL/SqqiWXblo3pgToHuBwR8eCP2Toa+X1WmTR/QKFMykws7g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
+      "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.7.0.tgz",
-      "integrity": "sha512-pmioUlttNh9GXF5x2CzNa7Z8kmRTyhEzzAC+2WOOapjewMbl+3tGuAnxbwc5JyG8Jsz2+hf/QD/n5VjimOZ63g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
+      "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
       "dev": true,
       "optional": true
     },
     "@rollup/rollup-win32-x64-msvc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.7.0.tgz",
-      "integrity": "sha512-SeZzC2QhhdBQUm3U0c8+c/P6UlRyBcLL2Xp5KX7z46WXZxzR8RJSIWL9wSUeBTgxog5LTPJuPj0WOT9lvrtP7Q==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
+      "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
       "dev": true,
       "optional": true
     },
@@ -41812,9 +42081,9 @@
       }
     },
     "@types/estree": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
-      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "@types/geojson": {
       "version": "7946.0.11",
@@ -42298,9 +42567,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -42327,9 +42596,12 @@
       }
     },
     "acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "requires": {
+        "acorn": "^8.11.0"
+      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -43372,6 +43644,12 @@
         }
       }
     },
+    "consola": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
+      "integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+      "dev": true
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "dev": true
@@ -44161,109 +44439,69 @@
       "dev": true
     },
     "dependency-cruiser": {
-      "version": "16.3.3",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-16.3.3.tgz",
-      "integrity": "sha512-+YHPbd6RqM1nLUUbRVkbYO6mVeeq+VEL+bBkR+KFkYVU20vs1D0TalZ9z/hDLxiYiYCSTctUaoWWaUrRc1I+mw==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-16.9.0.tgz",
+      "integrity": "sha512-Gc/xHNOBq1nk5i7FPCuexCD0m2OXB/WEfiSHfNYQaQaHZiZltnl5Ixp/ZG38Jvi8aEhKBQTHV4Aw6gmR7rWlOw==",
       "dev": true,
       "requires": {
-        "acorn": "8.11.3",
-        "acorn-jsx": "5.3.2",
-        "acorn-jsx-walk": "2.0.0",
-        "acorn-loose": "8.4.0",
-        "acorn-walk": "8.3.2",
-        "ajv": "8.16.0",
-        "chalk": "5.3.0",
-        "commander": "12.1.0",
-        "enhanced-resolve": "5.17.0",
-        "figures": "6.1.0",
-        "ignore": "5.3.1",
-        "indent-string": "5.0.0",
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "acorn-jsx-walk": "^2.0.0",
+        "acorn-loose": "^8.4.0",
+        "acorn-walk": "^8.3.4",
+        "ajv": "^8.17.1",
+        "commander": "^13.0.0",
+        "enhanced-resolve": "^5.18.0",
+        "ignore": "^7.0.0",
         "interpret": "^3.1.1",
-        "is-installed-globally": "1.0.0",
-        "json5": "2.2.3",
-        "lodash": "4.17.21",
-        "memoize": "10.0.0",
-        "picomatch": "4.0.2",
-        "prompts": "2.4.2",
+        "is-installed-globally": "^1.0.0",
+        "json5": "^2.2.3",
+        "memoize": "^10.0.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "prompts": "^2.4.2",
         "rechoir": "^0.8.0",
-        "safe-regex": "2.1.1",
-        "semver": "^7.6.2",
-        "semver-try-require": "7.0.0",
-        "teamcity-service-messages": "0.1.14",
-        "tsconfig-paths-webpack-plugin": "4.1.0",
-        "watskeburt": "4.0.2",
-        "wrap-ansi": "9.0.0"
+        "safe-regex": "^2.1.1",
+        "semver": "^7.6.3",
+        "teamcity-service-messages": "^0.1.14",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
+        "watskeburt": "^4.2.2"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.16.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-          "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.4.1"
+            "require-from-string": "^2.0.2"
           }
-        },
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "dev": true
         },
         "commander": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+          "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
           "dev": true
-        },
-        "emoji-regex": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-          "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-          "dev": true
-        },
-        "figures": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-          "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-          "dev": true,
-          "requires": {
-            "is-unicode-supported": "^2.0.0"
-          }
         },
         "ignore": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-          "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "is-unicode-supported": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-          "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.0.tgz",
+          "integrity": "sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A==",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
           "dev": true
         },
         "picomatch": {
@@ -44273,41 +44511,10 @@
           "dev": true
         },
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
-        },
-        "string-width": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.0.0.tgz",
-          "integrity": "sha512-GPQHj7row82Hjo9hKZieKcHIhaAIKOJvFSIZXuCU9OASVZrMNUaZuz++SPVrBjnLsnk4k+z9f2EIypgxf2vNFw==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^10.3.0",
-            "get-east-asian-width": "^1.0.0",
-            "strip-ansi": "^7.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-          "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^6.2.1",
-            "string-width": "^7.0.0",
-            "strip-ansi": "^7.1.0"
-          }
         }
       }
     },
@@ -44502,9 +44709,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -45531,6 +45738,12 @@
     "fast-sha256": {
       "version": "1.3.0"
     },
+    "fast-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+      "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.16",
       "devOptional": true
@@ -45870,12 +46083,6 @@
     },
     "get-caller-file": {
       "version": "2.0.5"
-    },
-    "get-east-asian-width": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
-      "dev": true
     },
     "get-intrinsic": {
       "version": "1.2.6",
@@ -50772,23 +50979,6 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "semver-try-require": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver-try-require/-/semver-try-require-7.0.0.tgz",
-      "integrity": "sha512-LI7GzDuAZmNKOY0/LY4nB3ifh6kYMvBimFTHVpA6wNEl3gw59QrLbTAnJb7vQzPd1qXPz+BtKJZaYORXWMerrA==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-          "dev": true
-        }
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "dev": true
@@ -52041,6 +52231,37 @@
     "tiny-warning": {
       "version": "1.0.3"
     },
+    "tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+          "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+          "dev": true
+        }
+      }
+    },
     "tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -52210,13 +52431,14 @@
       }
     },
     "tsconfig-paths-webpack-plugin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.1.0.tgz",
-      "integrity": "sha512-xWFISjviPydmtmgeUAuXp4N1fky+VCtfhOkDUFIv5ea7p4wuTomI4QTrXvFBX2S4jZsmyTSrStQl+E+4w+RzxA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
         "tsconfig-paths": "^4.1.2"
       },
       "dependencies": {
@@ -52268,242 +52490,291 @@
       "version": "2.4.0"
     },
     "tsup": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.1.0.tgz",
-      "integrity": "sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.5.tgz",
+      "integrity": "sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==",
       "dev": true,
       "requires": {
-        "bundle-require": "^4.0.0",
-        "cac": "^6.7.12",
-        "chokidar": "^3.5.1",
-        "debug": "^4.3.1",
-        "esbuild": "^0.21.4",
-        "execa": "^5.0.0",
-        "globby": "^11.0.3",
-        "joycon": "^3.0.1",
-        "postcss-load-config": "^4.0.1",
+        "bundle-require": "^5.0.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.1",
+        "consola": "^3.2.3",
+        "debug": "^4.3.7",
+        "esbuild": "^0.24.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
         "resolve-from": "^5.0.0",
-        "rollup": "^4.0.2",
+        "rollup": "^4.24.0",
         "source-map": "0.8.0-beta.0",
-        "sucrase": "^3.20.3",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.1",
+        "tinyglobby": "^0.2.9",
         "tree-kill": "^1.2.2"
       },
       "dependencies": {
         "@esbuild/android-arm": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.4.tgz",
-          "integrity": "sha512-E7H/yTd8kGQfY4z9t3nRPk/hrhaCajfA3YSQSBrst8B+3uTcgsi8N+ZWYCaeIDsiVs6m65JPCaQN/DxBRclF3A==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+          "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
           "dev": true,
           "optional": true
         },
         "@esbuild/android-arm64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.4.tgz",
-          "integrity": "sha512-fYFnz+ObClJ3dNiITySBUx+oNalYUT18/AryMxfovLkYWbutXsct3Wz2ZWAcGGppp+RVVX5FiXeLYGi97umisA==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+          "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
           "dev": true,
           "optional": true
         },
         "@esbuild/android-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.4.tgz",
-          "integrity": "sha512-mDqmlge3hFbEPbCWxp4fM6hqq7aZfLEHZAKGP9viq9wMUBVQx202aDIfc3l+d2cKhUJM741VrCXEzRFhPDKH3Q==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+          "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
           "dev": true,
           "optional": true
         },
         "@esbuild/darwin-arm64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.4.tgz",
-          "integrity": "sha512-72eaIrDZDSiWqpmCzVaBD58c8ea8cw/U0fq/PPOTqE3c53D0xVMRt2ooIABZ6/wj99Y+h4ksT/+I+srCDLU9TA==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+          "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
           "dev": true,
           "optional": true
         },
         "@esbuild/darwin-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.4.tgz",
-          "integrity": "sha512-uBsuwRMehGmw1JC7Vecu/upOjTsMhgahmDkWhGLWxIgUn2x/Y4tIwUZngsmVb6XyPSTXJYS4YiASKPcm9Zitag==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+          "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
           "dev": true,
           "optional": true
         },
         "@esbuild/freebsd-arm64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.4.tgz",
-          "integrity": "sha512-8JfuSC6YMSAEIZIWNL3GtdUT5NhUA/CMUCpZdDRolUXNAXEE/Vbpe6qlGLpfThtY5NwXq8Hi4nJy4YfPh+TwAg==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+          "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
           "dev": true,
           "optional": true
         },
         "@esbuild/freebsd-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.4.tgz",
-          "integrity": "sha512-8d9y9eQhxv4ef7JmXny7591P/PYsDFc4+STaxC1GBv0tMyCdyWfXu2jBuqRsyhY8uL2HU8uPyscgE2KxCY9imQ==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+          "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-arm": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.4.tgz",
-          "integrity": "sha512-2rqFFefpYmpMs+FWjkzSgXg5vViocqpq5a1PSRgT0AvSgxoXmGF17qfGAzKedg6wAwyM7UltrKVo9kxaJLMF/g==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+          "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-arm64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.4.tgz",
-          "integrity": "sha512-/GLD2orjNU50v9PcxNpYZi+y8dJ7e7/LhQukN3S4jNDXCKkyyiyAz9zDw3siZ7Eh1tRcnCHAo/WcqKMzmi4eMQ==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+          "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-ia32": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.4.tgz",
-          "integrity": "sha512-pNftBl7m/tFG3t2m/tSjuYeWIffzwAZT9m08+9DPLizxVOsUl8DdFzn9HvJrTQwe3wvJnwTdl92AonY36w/25g==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+          "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-loong64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.4.tgz",
-          "integrity": "sha512-cSD2gzCK5LuVX+hszzXQzlWya6c7hilO71L9h4KHwqI4qeqZ57bAtkgcC2YioXjsbfAv4lPn3qe3b00Zt+jIfQ==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+          "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-mips64el": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.4.tgz",
-          "integrity": "sha512-qtzAd3BJh7UdbiXCrg6npWLYU0YpufsV9XlufKhMhYMJGJCdfX/G6+PNd0+v877X1JG5VmjBLUiFB0o8EUSicA==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+          "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-ppc64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.4.tgz",
-          "integrity": "sha512-yB8AYzOTaL0D5+2a4xEy7OVvbcypvDR05MsB/VVPVA7nL4hc5w5Dyd/ddnayStDgJE59fAgNEOdLhBxjfx5+dg==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+          "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-riscv64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.4.tgz",
-          "integrity": "sha512-Y5AgOuVzPjQdgU59ramLoqSSiXddu7F3F+LI5hYy/d1UHN7K5oLzYBDZe23QmQJ9PIVUXwOdKJ/jZahPdxzm9w==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+          "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-s390x": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.4.tgz",
-          "integrity": "sha512-Iqc/l/FFwtt8FoTK9riYv9zQNms7B8u+vAI/rxKuN10HgQIXaPzKZc479lZ0x6+vKVQbu55GdpYpeNWzjOhgbA==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+          "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
           "dev": true,
           "optional": true
         },
         "@esbuild/linux-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.4.tgz",
-          "integrity": "sha512-Td9jv782UMAFsuLZINfUpoF5mZIbAj+jv1YVtE58rFtfvoKRiKSkRGQfHTgKamLVT/fO7203bHa3wU122V/Bdg==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+          "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
           "dev": true,
           "optional": true
         },
         "@esbuild/netbsd-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.4.tgz",
-          "integrity": "sha512-Awn38oSXxsPMQxaV0Ipb7W/gxZtk5Tx3+W+rAPdZkyEhQ6968r9NvtkjhnhbEgWXYbgV+JEONJ6PcdBS+nlcpA==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+          "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
           "dev": true,
           "optional": true
         },
         "@esbuild/openbsd-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.4.tgz",
-          "integrity": "sha512-IsUmQeCY0aU374R82fxIPu6vkOybWIMc3hVGZ3ChRwL9hA1TwY+tS0lgFWV5+F1+1ssuvvXt3HFqe8roCip8Hg==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+          "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
           "dev": true,
           "optional": true
         },
         "@esbuild/sunos-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.4.tgz",
-          "integrity": "sha512-hsKhgZ4teLUaDA6FG/QIu2q0rI6I36tZVfM4DBZv3BG0mkMIdEnMbhc4xwLvLJSS22uWmaVkFkqWgIS0gPIm+A==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+          "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
           "dev": true,
           "optional": true
         },
         "@esbuild/win32-arm64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.4.tgz",
-          "integrity": "sha512-UUfMgMoXPoA/bvGUNfUBFLCh0gt9dxZYIx9W4rfJr7+hKe5jxxHmfOK8YSH4qsHLLN4Ck8JZ+v7Q5fIm1huErg==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+          "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
           "dev": true,
           "optional": true
         },
         "@esbuild/win32-ia32": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.4.tgz",
-          "integrity": "sha512-yIxbspZb5kGCAHWm8dexALQ9en1IYDfErzjSEq1KzXFniHv019VT3mNtTK7t8qdy4TwT6QYHI9sEZabONHg+aw==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+          "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
           "dev": true,
           "optional": true
         },
         "@esbuild/win32-x64": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.4.tgz",
-          "integrity": "sha512-sywLRD3UK/qRJt0oBwdpYLBibk7KiRfbswmWRDabuncQYSlf8aLEEUor/oP6KRz8KEG+HoiVLBhPRD5JWjS8Sg==",
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+          "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
           "dev": true,
           "optional": true
         },
         "bundle-require": {
-          "version": "4.0.1",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+          "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
           "dev": true,
           "requires": {
             "load-tsconfig": "^0.2.3"
           }
         },
-        "esbuild": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.4.tgz",
-          "integrity": "sha512-sFMcNNrj+Q0ZDolrp5pDhH0nRPN9hLIM3fRPwgbLYJeSHHgnXSnbV3xYgSVuOeLWH9c73VwmEverVzupIv5xuA==",
+        "chokidar": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+          "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
           "dev": true,
           "requires": {
-            "@esbuild/aix-ppc64": "0.21.4",
-            "@esbuild/android-arm": "0.21.4",
-            "@esbuild/android-arm64": "0.21.4",
-            "@esbuild/android-x64": "0.21.4",
-            "@esbuild/darwin-arm64": "0.21.4",
-            "@esbuild/darwin-x64": "0.21.4",
-            "@esbuild/freebsd-arm64": "0.21.4",
-            "@esbuild/freebsd-x64": "0.21.4",
-            "@esbuild/linux-arm": "0.21.4",
-            "@esbuild/linux-arm64": "0.21.4",
-            "@esbuild/linux-ia32": "0.21.4",
-            "@esbuild/linux-loong64": "0.21.4",
-            "@esbuild/linux-mips64el": "0.21.4",
-            "@esbuild/linux-ppc64": "0.21.4",
-            "@esbuild/linux-riscv64": "0.21.4",
-            "@esbuild/linux-s390x": "0.21.4",
-            "@esbuild/linux-x64": "0.21.4",
-            "@esbuild/netbsd-x64": "0.21.4",
-            "@esbuild/openbsd-x64": "0.21.4",
-            "@esbuild/sunos-x64": "0.21.4",
-            "@esbuild/win32-arm64": "0.21.4",
-            "@esbuild/win32-ia32": "0.21.4",
-            "@esbuild/win32-x64": "0.21.4"
+            "readdirp": "^4.0.1"
           }
+        },
+        "esbuild": {
+          "version": "0.24.2",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+          "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+          "dev": true,
+          "requires": {
+            "@esbuild/aix-ppc64": "0.24.2",
+            "@esbuild/android-arm": "0.24.2",
+            "@esbuild/android-arm64": "0.24.2",
+            "@esbuild/android-x64": "0.24.2",
+            "@esbuild/darwin-arm64": "0.24.2",
+            "@esbuild/darwin-x64": "0.24.2",
+            "@esbuild/freebsd-arm64": "0.24.2",
+            "@esbuild/freebsd-x64": "0.24.2",
+            "@esbuild/linux-arm": "0.24.2",
+            "@esbuild/linux-arm64": "0.24.2",
+            "@esbuild/linux-ia32": "0.24.2",
+            "@esbuild/linux-loong64": "0.24.2",
+            "@esbuild/linux-mips64el": "0.24.2",
+            "@esbuild/linux-ppc64": "0.24.2",
+            "@esbuild/linux-riscv64": "0.24.2",
+            "@esbuild/linux-s390x": "0.24.2",
+            "@esbuild/linux-x64": "0.24.2",
+            "@esbuild/netbsd-arm64": "0.24.2",
+            "@esbuild/netbsd-x64": "0.24.2",
+            "@esbuild/openbsd-arm64": "0.24.2",
+            "@esbuild/openbsd-x64": "0.24.2",
+            "@esbuild/sunos-x64": "0.24.2",
+            "@esbuild/win32-arm64": "0.24.2",
+            "@esbuild/win32-ia32": "0.24.2",
+            "@esbuild/win32-x64": "0.24.2"
+          }
+        },
+        "lilconfig": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+          "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+          "dev": true
+        },
+        "postcss-load-config": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+          "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+          "dev": true,
+          "requires": {
+            "lilconfig": "^3.1.1"
+          }
+        },
+        "readdirp": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+          "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
           "dev": true
         },
         "rollup": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.7.0.tgz",
-          "integrity": "sha512-7Kw0dUP4BWH78zaZCqF1rPyQ8D5DSU6URG45v1dqS/faNsx9WXyess00uTOZxKr7oR/4TOjO1CPudT8L1UsEgw==",
+          "version": "4.30.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+          "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
           "dev": true,
           "requires": {
-            "@rollup/rollup-android-arm-eabi": "4.7.0",
-            "@rollup/rollup-android-arm64": "4.7.0",
-            "@rollup/rollup-darwin-arm64": "4.7.0",
-            "@rollup/rollup-darwin-x64": "4.7.0",
-            "@rollup/rollup-linux-arm-gnueabihf": "4.7.0",
-            "@rollup/rollup-linux-arm64-gnu": "4.7.0",
-            "@rollup/rollup-linux-arm64-musl": "4.7.0",
-            "@rollup/rollup-linux-riscv64-gnu": "4.7.0",
-            "@rollup/rollup-linux-x64-gnu": "4.7.0",
-            "@rollup/rollup-linux-x64-musl": "4.7.0",
-            "@rollup/rollup-win32-arm64-msvc": "4.7.0",
-            "@rollup/rollup-win32-ia32-msvc": "4.7.0",
-            "@rollup/rollup-win32-x64-msvc": "4.7.0",
+            "@rollup/rollup-android-arm-eabi": "4.30.1",
+            "@rollup/rollup-android-arm64": "4.30.1",
+            "@rollup/rollup-darwin-arm64": "4.30.1",
+            "@rollup/rollup-darwin-x64": "4.30.1",
+            "@rollup/rollup-freebsd-arm64": "4.30.1",
+            "@rollup/rollup-freebsd-x64": "4.30.1",
+            "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+            "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+            "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+            "@rollup/rollup-linux-arm64-musl": "4.30.1",
+            "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+            "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+            "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+            "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+            "@rollup/rollup-linux-x64-gnu": "4.30.1",
+            "@rollup/rollup-linux-x64-musl": "4.30.1",
+            "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+            "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+            "@rollup/rollup-win32-x64-msvc": "4.30.1",
+            "@types/estree": "1.0.6",
             "fsevents": "~2.3.2"
           }
         },
@@ -52533,6 +52804,14 @@
             "tr46": "^1.0.1",
             "webidl-conversions": "^4.0.2"
           }
+        },
+        "yaml": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+          "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -52964,9 +53243,9 @@
       }
     },
     "watskeburt": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.0.2.tgz",
-      "integrity": "sha512-w7X8AGrBZExP5/3e3c1X/CUY8Yod/aiAazQCvrg7n8Un6piD+NFFK926G15zRq4+wu0XAEWpSsZ4C+fEfVOCYw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.2.2.tgz",
+      "integrity": "sha512-AOCg1UYxWpiHW1tUwqpJau8vzarZYTtzl2uu99UptBmbzx6kOzCGMfRLF6KIRX4PYekmryn89MzxlRNkL66YyA==",
       "dev": true
     },
     "wcwidth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "tsd": "^0.31.1",
         "tsup": "^8.3.5",
         "turbo": "^2.3.3",
-        "typescript": "<4.8"
+        "typescript": "^5.7.2"
       },
       "engines": {
         "node": ">=22.x"
@@ -16596,21 +16596,6 @@
         }
       }
     },
-    "node_modules/htmlnano/node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
@@ -24974,20 +24959,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylelint/node_modules/typescript": {
-      "version": "5.2.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/stylelint/node_modules/write-file-atomic": {
       "version": "5.0.1",
       "devOptional": true,
@@ -26740,14 +26711,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -27960,22 +27933,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/liveblocks-emails/node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/liveblocks-node": {
       "name": "@liveblocks/node",
       "version": "2.15.2",
@@ -28171,22 +28128,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/liveblocks-node-prosemirror/node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/liveblocks-node-prosemirror/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -28308,22 +28249,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/liveblocks-node/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/liveblocks-react": {
@@ -36856,14 +36781,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
           "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
           "dev": true
-        },
-        "typescript": {
-          "version": "5.6.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-          "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -37042,14 +36959,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
           "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
           "dev": true
-        },
-        "typescript": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-          "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -37171,14 +37080,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
           "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
           "dev": true
-        },
-        "typescript": {
-          "version": "5.6.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-          "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "undici-types": {
           "version": "6.19.8",
@@ -46458,13 +46359,6 @@
             "js-yaml": "^4.1.0",
             "parse-json": "^5.2.0"
           }
-        },
-        "typescript": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-          "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -51857,12 +51751,6 @@
           "version": "1.4.0",
           "devOptional": true
         },
-        "typescript": {
-          "version": "5.2.2",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "write-file-atomic": {
           "version": "5.0.1",
           "devOptional": true,
@@ -52945,7 +52833,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4"
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg=="
     },
     "typical": {
       "version": "4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11417,6 +11417,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
@@ -13812,6 +13818,21 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.787",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
@@ -15531,6 +15552,36 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -17786,6 +17837,40 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest": {
@@ -25640,18 +25725,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.1.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
-      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
+      "version": "29.2.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
+      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+      "license": "MIT",
       "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
+        "bs-logger": "^0.2.6",
+        "ejs": "^3.1.10",
+        "fast-json-stable-stringify": "^2.1.0",
         "jest-util": "^29.0.0",
         "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.6.3",
+        "yargs-parser": "^21.1.1"
       },
       "bin": {
         "ts-jest": "cli.js"
@@ -25683,6 +25770,18 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ts-morph": {
@@ -27946,7 +28045,7 @@
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@types/node": "^20.7.1",
+        "@types/node": "^20.17.12",
         "@types/node-fetch": "^2.6.6",
         "msw": "^2.7.0",
         "svix": "^0.75.0"
@@ -28168,10 +28267,14 @@
       "license": "MIT"
     },
     "packages/liveblocks-node/node_modules/@types/node": {
-      "version": "20.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
-      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
-      "dev": true
+      "version": "20.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+      "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "packages/liveblocks-node/node_modules/headers-polyfill": {
       "version": "4.0.2",
@@ -28250,6 +28353,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/liveblocks-node/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
@@ -30551,11 +30661,11 @@
     "shared/jest-config": {
       "name": "@liveblocks/jest-config",
       "dependencies": {
-        "@types/jest": "^29.5.12",
+        "@types/jest": "^29.5.14",
         "fast-check": "^3.19.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "ts-jest": "^29.1.5",
+        "ts-jest": "^29.2.5",
         "whatwg-fetch": "^3.6.20"
       }
     },
@@ -31320,7 +31430,18 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/is-git-clean": "1.1.2",
-        "@types/jscodeshift": "0.11.11"
+        "@types/jscodeshift": "0.11.11",
+        "@types/node": "^22.10.5"
+      }
+    },
+    "tools/liveblocks-codemod/node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
       }
     },
     "tools/liveblocks-codemod/node_modules/arrify": {
@@ -31519,6 +31640,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "tools/liveblocks-codemod/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "tools/liveblocks-codemod/node_modules/yargs-parser": {
       "version": "18.1.3",
@@ -35630,6 +35758,7 @@
         "@liveblocks/jest-config": "*",
         "@types/is-git-clean": "1.1.2",
         "@types/jscodeshift": "0.11.11",
+        "@types/node": "^22.10.5",
         "execa": "4.0.3",
         "globby": "11.0.1",
         "inquirer": "7.3.3",
@@ -35639,6 +35768,15 @@
         "picocolors": "1.0.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "22.10.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+          "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~6.20.0"
+          }
+        },
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -35778,6 +35916,12 @@
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
+        },
+        "undici-types": {
+          "version": "6.20.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+          "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+          "dev": true
         },
         "yargs-parser": {
           "version": "18.1.3",
@@ -36816,11 +36960,11 @@
     "@liveblocks/jest-config": {
       "version": "file:shared/jest-config",
       "requires": {
-        "@types/jest": "^29.5.12",
+        "@types/jest": "^29.5.14",
         "fast-check": "^3.19.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "ts-jest": "^29.1.5",
+        "ts-jest": "^29.2.5",
         "whatwg-fetch": "^3.6.20"
       }
     },
@@ -36870,7 +37014,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@stablelib/base64": "^1.0.1",
-        "@types/node": "^20.7.1",
+        "@types/node": "^20.17.12",
         "@types/node-fetch": "^2.6.6",
         "fast-sha256": "^1.3.0",
         "msw": "^2.7.0",
@@ -36905,10 +37049,13 @@
           "dev": true
         },
         "@types/node": {
-          "version": "20.7.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
-          "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
-          "dev": true
+          "version": "20.17.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+          "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~6.19.2"
+          }
         },
         "headers-polyfill": {
           "version": "4.0.2",
@@ -36958,6 +37105,12 @@
           "version": "4.31.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
           "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
+          "dev": true
+        },
+        "undici-types": {
+          "version": "6.19.8",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
           "dev": true
         }
       }
@@ -42793,6 +42946,11 @@
       "version": "2.0.0",
       "devOptional": true
     },
+    "async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+    },
     "asynciterator.prototype": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
@@ -44564,6 +44722,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.787",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
@@ -45684,6 +45850,32 @@
       "version": "6.0.1",
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -47088,6 +47280,28 @@
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "jake": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "requires": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest": {
@@ -52263,18 +52477,26 @@
       "version": "0.1.13"
     },
     "ts-jest": {
-      "version": "29.1.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
-      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
+      "version": "29.2.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
+      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
       "requires": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
+        "bs-logger": "^0.2.6",
+        "ejs": "^3.1.10",
+        "fast-json-stable-stringify": "^2.1.0",
         "jest-util": "^29.0.0",
         "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.6.3",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+        }
       }
     },
     "ts-morph": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2235,15 +2235,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@bundled-es-modules/js-levenshtein": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
-      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
-      "dev": true,
-      "dependencies": {
-        "js-levenshtein": "^1.1.6"
-      }
-    },
     "node_modules/@bundled-es-modules/statuses": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
@@ -2922,34 +2913,34 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
     },
     "node_modules/@inquirer/confirm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.1.tgz",
+      "integrity": "sha512-vVLSbGci+IKQvDOtzpPTCOiEJCNidHcAq9JYVoWTW0svb5FiwSLotkM+JXNXejfjnzVYV9n0DTBythl9+XgTxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
+        "@inquirer/core": "^10.1.2",
+        "@inquirer/type": "^3.0.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.2.tgz",
+      "integrity": "sha512-bHd96F3ezHg1mf/J0Rb4CV8ndCN0v28kUlrHqP7+ECm1C/A+paB7Xh2lbMk6x+kweQC+rZOxM/YeKikzxco8bQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.6",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.5",
-        "@types/wrap-ansi": "^3.0.0",
+        "@inquirer/figures": "^1.0.9",
+        "@inquirer/type": "^3.0.2",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
+        "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^6.2.0",
@@ -2957,29 +2948,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/@inquirer/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@inquirer/core/node_modules/cli-width": {
@@ -2993,13 +2961,13 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@inquirer/core/node_modules/signal-exit": {
@@ -3014,13 +2982,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/@inquirer/core/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -3038,9 +2999,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
-      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
+      "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3048,26 +3009,16 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.2.tgz",
+      "integrity": "sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4326,19 +4277,33 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.15.3",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.5",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.0.4",
+        "headers-polyfill": "3.2.5",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.0"
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -10222,31 +10187,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
-    "node_modules/@types/inquirer": {
-      "version": "7.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^6.4.0"
-      }
-    },
-    "node_modules/@types/inquirer/node_modules/rxjs": {
-      "version": "6.6.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@types/inquirer/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@types/is-git-clean": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/is-git-clean/-/is-git-clean-1.1.2.tgz",
@@ -10356,16 +10296,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "18.19.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.34.tgz",
@@ -10465,14 +10395,6 @@
         "@types/jest": "*"
       }
     },
-    "node_modules/@types/through": {
-      "version": "0.0.30",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -10491,13 +10413,6 @@
     },
     "node_modules/@types/webextension-polyfill": {
       "version": "0.10.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -10855,14 +10770,6 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
       "license": "MIT"
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.7.9",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
@@ -15834,19 +15741,6 @@
         "node": ">= 14.17"
       }
     },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -16560,11 +16454,6 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
       "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
       "dev": true
-    },
-    "node_modules/headers-utils": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -20052,29 +19941,31 @@
       }
     },
     "node_modules/msw": {
-      "version": "0.39.2",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.5.tgz",
+      "integrity": "sha512-nG3fpmBXxFbKSIdk6miPuL3KjU6WMxgoW4tG1YgnP1M+TRG3Qn7b7R0euKAHq4vpwARHb18ZyfZljSxsTnMX2w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.2.0",
-        "@mswjs/interceptors": "^0.15.1",
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.10",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "chalk": "^4.1.1",
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
-        "graphql": "^16.3.0",
-        "headers-polyfill": "^3.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "3.2.5",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.3.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -20086,6 +19977,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.4.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/msw/node_modules/chalk": {
@@ -20103,12 +20002,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/msw/node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "1.4.0",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -20346,25 +20254,6 @@
         "node": ">= 0.10.5"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-emoji": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
@@ -20441,11 +20330,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
-    "node_modules/node-match-path": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-3.0.0.tgz",
@@ -20459,22 +20343,6 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
-    },
-    "node_modules/node-request-interceptor": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "debug": "^4.3.0",
-        "headers-utils": "^1.2.0",
-        "strict-event-emitter": "^0.1.0"
-      }
-    },
-    "node_modules/node-request-interceptor/node_modules/strict-event-emitter": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/noop-logger": {
       "version": "0.1.1",
@@ -27187,15 +27055,6 @@
         "which-typed-array": "^1.1.2"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/webextension-polyfill": {
       "version": "0.10.0",
       "dev": true,
@@ -27685,11 +27544,7 @@
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
-        "@liveblocks/jest-config": "*",
-        "@types/ws": "^8.5.10",
-        "dotenv": "^16.4.5",
-        "msw": "^0.39.1",
-        "ws": "^8.17.1"
+        "@liveblocks/jest-config": "*"
       }
     },
     "packages/liveblocks-codemod": {
@@ -27727,98 +27582,8 @@
         "@types/ws": "^8.5.10",
         "dotenv": "^16.4.5",
         "eslint-plugin-rulesdir": "^0.2.2",
-        "msw": "^0.47.4",
+        "msw": "^1.3.5",
         "ws": "^8.17.1"
-      }
-    },
-    "packages/liveblocks-core/node_modules/@mswjs/interceptors": {
-      "version": "0.17.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.7.5",
-        "debug": "^4.3.3",
-        "headers-polyfill": "^3.1.0",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "packages/liveblocks-core/node_modules/chalk": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-core/node_modules/msw": {
-      "version": "0.47.4",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.0",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "outvariant": "^1.3.0",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.6",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.2.x <= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-core/node_modules/type-fest": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/liveblocks-devtools": {
@@ -27872,16 +27637,16 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "csstype": "3.0.2",
-        "msw": "^2.0.2"
+        "msw": "^2.7.0"
       },
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "packages/liveblocks-emails/node_modules/@mswjs/interceptors": {
-      "version": "0.35.8",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.35.8.tgz",
-      "integrity": "sha512-PFfqpHplKa7KMdoQdj5td03uG05VK2Ng1dG0sP4pT9h0dGSX2v9txYt/AnrzPb/vAmfyBBC0NQV7VaBEX+efgQ==",
+      "version": "0.37.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27910,23 +27675,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/liveblocks-emails/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "packages/liveblocks-emails/node_modules/csstype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
@@ -27942,29 +27690,30 @@
       "license": "MIT"
     },
     "packages/liveblocks-emails/node_modules/msw": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.9.tgz",
-      "integrity": "sha512-1m8xccT6ipN4PTqLinPwmzhxQREuxaEJYdx4nIbggxP8aM7r1e71vE7RtOUSQoAm1LydjGfZKy7370XD/tsuYg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+      "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/cookie": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
         "@bundled-es-modules/tough-cookie": "^0.1.6",
-        "@inquirer/confirm": "^3.0.0",
-        "@mswjs/interceptors": "^0.35.8",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.37.0",
+        "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
-        "chalk": "^4.1.2",
         "graphql": "^16.8.1",
         "headers-polyfill": "^4.0.2",
         "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.2",
+        "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
         "strict-event-emitter": "^0.5.1",
-        "type-fest": "^4.9.0",
+        "type-fest": "^4.26.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -27984,6 +27733,13 @@
           "optional": true
         }
       }
+    },
+    "packages/liveblocks-emails/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "packages/liveblocks-emails/node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -28036,7 +27792,7 @@
         "@liveblocks/jest-config": "*",
         "@types/node": "^20.7.1",
         "@types/node-fetch": "^2.6.6",
-        "msw": "^2.0.2",
+        "msw": "^2.7.0",
         "svix": "^0.75.0"
       }
     },
@@ -28084,7 +27840,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/node": "^20.14.8",
-        "msw": "^2.6.4"
+        "msw": "^2.7.0"
       },
       "peerDependencies": {
         "@tiptap/pm": "^2.9.1",
@@ -28095,61 +27851,10 @@
         "yjs": "^13.6.20"
       }
     },
-    "packages/liveblocks-node-prosemirror/node_modules/@inquirer/confirm": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
-      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.0",
-        "@inquirer/type": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
-    "packages/liveblocks-node-prosemirror/node_modules/@inquirer/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.8",
-        "@inquirer/type": "^3.0.1",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/liveblocks-node-prosemirror/node_modules/@inquirer/type": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
-      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      }
-    },
     "packages/liveblocks-node-prosemirror/node_modules/@mswjs/interceptors": {
-      "version": "0.36.10",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
-      "integrity": "sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==",
+      "version": "0.37.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -28188,33 +27893,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/liveblocks-node-prosemirror/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-node-prosemirror/node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "packages/liveblocks-node-prosemirror/node_modules/headers-polyfill": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
@@ -28223,9 +27901,9 @@
       "license": "MIT"
     },
     "packages/liveblocks-node-prosemirror/node_modules/msw": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.6.4.tgz",
-      "integrity": "sha512-Pm4LmWQeytDsNCR+A7gt39XAdtH6zQb6jnIKRig0FlvYOn8eksn3s1nXxUfz5KYUjbckof7Z4p2ewzgffPoCbg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+      "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -28234,17 +27912,17 @@
         "@bundled-es-modules/statuses": "^1.0.1",
         "@bundled-es-modules/tough-cookie": "^0.1.6",
         "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.36.5",
+        "@mswjs/interceptors": "^0.37.0",
         "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
-        "chalk": "^4.1.2",
         "graphql": "^16.8.1",
         "headers-polyfill": "^4.0.2",
         "is-node-process": "^1.2.0",
         "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
         "strict-event-emitter": "^0.5.1",
         "type-fest": "^4.26.1",
         "yargs": "^17.7.2"
@@ -28267,28 +27945,12 @@
         }
       }
     },
-    "packages/liveblocks-node-prosemirror/node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+    "packages/liveblocks-node-prosemirror/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "packages/liveblocks-node-prosemirror/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "license": "ISC"
     },
     "packages/liveblocks-node-prosemirror/node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -28333,41 +27995,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/liveblocks-node-prosemirror/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+    "packages/liveblocks-node/node_modules/@mswjs/interceptors": {
+      "version": "0.37.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/liveblocks-node/node_modules/@mswjs/cookies": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
-      "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "packages/liveblocks-node/node_modules/@mswjs/interceptors": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.7.tgz",
-      "integrity": "sha512-U7iFYs/qU/5jfz1VDpoYz3xqX9nzhsBXw7q923dv6GiGTy+m2ZLhD33L80R/shHOW/YWjeH6k16GbIHGw+bAng==",
-      "dev": true,
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/logger": "^0.3.0",
         "@open-draft/until": "^2.0.0",
         "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
+        "outvariant": "^1.4.3",
         "strict-event-emitter": "^0.5.1"
       },
       "engines": {
@@ -28378,29 +28017,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/liveblocks-node/node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/liveblocks-node/node_modules/@types/node": {
       "version": "20.7.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
       "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
       "dev": true
-    },
-    "packages/liveblocks-node/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
     },
     "packages/liveblocks-node/node_modules/headers-polyfill": {
       "version": "4.0.2",
@@ -28409,35 +28040,31 @@
       "dev": true
     },
     "packages/liveblocks-node/node_modules/msw": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.2.tgz",
-      "integrity": "sha512-loyQnNUDY1x05R/t2naVdtNhP+tfyf+ckEwtvRUuoK9JnDeoh3/ZN3Fu2ZtvO/iJ3IwwuLizWwWaxBxS3sDQUw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+      "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@bundled-es-modules/cookie": "^2.0.0",
-        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/cookie": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
-        "@mswjs/cookies": "^1.0.0",
-        "@mswjs/interceptors": "^0.25.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.37.0",
+        "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/until": "^2.1.0",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "@types/statuses": "^2.0.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.4.2",
-        "formdata-node": "4.4.1",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
-        "headers-polyfill": "^4.0.1",
-        "inquirer": "^8.2.0",
+        "headers-polyfill": "^4.0.2",
         "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.5.0",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "msw": "cli/index.js"
@@ -28446,11 +28073,10 @@
         "node": ">=18"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
+        "url": "https://github.com/sponsors/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.2.x"
+        "typescript": ">= 4.8.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -28458,22 +28084,47 @@
         }
       }
     },
+    "packages/liveblocks-node/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "packages/liveblocks-node/node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "packages/liveblocks-node/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
+      "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/liveblocks-node/node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/liveblocks-react": {
@@ -28493,7 +28144,7 @@
         "date-fns": "^3.6.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "itertools": "^2.3.2",
-        "msw": "1.3.2",
+        "msw": "^1.3.5",
         "react-error-boundary": "^4.0.13"
       },
       "peerDependencies": {
@@ -28520,7 +28171,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^1.3.5",
         "rollup": "3.28.0",
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
@@ -28571,106 +28222,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
     },
-    "packages/liveblocks-react-lexical/node_modules/@mswjs/cookies": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
-      "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/msw": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.27.2.tgz",
-      "integrity": "sha512-PjxQ06gi2mqNINzVKL/lVWiP6Dd2LDUT3QK9AS2vJMbz/Xa0FgKmd1RF7kyFKiwv6qEazVp74TS0Qc8yjXRUgA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.4",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.0",
-        "@types/inquirer": "^7.3.1",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.4.0",
-        "headers-utils": "^1.2.0",
-        "inquirer": "^7.3.3",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.1",
-        "node-match-path": "^0.6.1",
-        "node-request-interceptor": "^0.6.3",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.1.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      }
-    },
     "packages/liveblocks-react-lexical/node_modules/rollup": {
       "version": "3.28.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
@@ -28686,57 +28237,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/strict-event-emitter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
-      "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==",
-      "dev": true
-    },
-    "packages/liveblocks-react-lexical/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "packages/liveblocks-react-lexical/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/liveblocks-react-lexical/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/liveblocks-react-tiptap": {
@@ -28763,7 +28263,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^1.3.5",
         "rollup": "3.28.0",
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
@@ -28818,112 +28318,6 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
     },
-    "packages/liveblocks-react-tiptap/node_modules/@mswjs/cookies": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
-      "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/graphql": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.9.0.tgz",
-      "integrity": "sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/msw": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.27.2.tgz",
-      "integrity": "sha512-PjxQ06gi2mqNINzVKL/lVWiP6Dd2LDUT3QK9AS2vJMbz/Xa0FgKmd1RF7kyFKiwv6qEazVp74TS0Qc8yjXRUgA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.4",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.0",
-        "@types/inquirer": "^7.3.1",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.4.0",
-        "headers-utils": "^1.2.0",
-        "inquirer": "^7.3.3",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.1",
-        "node-match-path": "^0.6.1",
-        "node-request-interceptor": "^0.6.3",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.1.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      }
-    },
     "packages/liveblocks-react-tiptap/node_modules/rollup": {
       "version": "3.28.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
@@ -28939,62 +28333,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/strict-event-emitter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
-      "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/liveblocks-react-tiptap/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "packages/liveblocks-react-tiptap/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/liveblocks-react-tiptap/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/liveblocks-react-ui": {
@@ -29026,7 +28364,7 @@
         "emojibase": "^15.3.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^1.3.5",
         "rollup": "3.28.0",
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
@@ -29071,16 +28409,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
-    },
-    "packages/liveblocks-react-ui/node_modules/@mswjs/cookies": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
-      "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
     },
     "packages/liveblocks-react-ui/node_modules/@radix-ui/primitive": {
       "version": "1.1.0",
@@ -30096,96 +29424,6 @@
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
       "license": "MIT"
     },
-    "packages/liveblocks-react-ui/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-react-ui/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "packages/liveblocks-react-ui/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/liveblocks-react-ui/node_modules/inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/liveblocks-react-ui/node_modules/msw": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.27.2.tgz",
-      "integrity": "sha512-PjxQ06gi2mqNINzVKL/lVWiP6Dd2LDUT3QK9AS2vJMbz/Xa0FgKmd1RF7kyFKiwv6qEazVp74TS0Qc8yjXRUgA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.4",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.0",
-        "@types/inquirer": "^7.3.1",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.4.0",
-        "headers-utils": "^1.2.0",
-        "inquirer": "^7.3.3",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.1",
-        "node-match-path": "^0.6.1",
-        "node-request-interceptor": "^0.6.3",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.1.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      }
-    },
     "packages/liveblocks-react-ui/node_modules/react-remove-scroll": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
@@ -30247,18 +29485,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "packages/liveblocks-react-ui/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "packages/liveblocks-react-ui/node_modules/slate-react": {
       "version": "0.110.3",
       "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.110.3.tgz",
@@ -30277,64 +29503,6 @@
         "react": ">=18.2.0",
         "react-dom": ">=18.2.0",
         "slate": ">=0.99.0"
-      }
-    },
-    "packages/liveblocks-react-ui/node_modules/strict-event-emitter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
-      "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==",
-      "dev": true
-    },
-    "packages/liveblocks-react-ui/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "packages/liveblocks-react-ui/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/liveblocks-react-ui/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/liveblocks-react/node_modules/@mswjs/interceptors": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "3.2.5",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/liveblocks-react/node_modules/@testing-library/dom": {
@@ -30438,15 +29606,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "packages/liveblocks-react/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "packages/liveblocks-react/node_modules/chalk": {
       "version": "4.1.1",
       "dev": true,
@@ -30461,57 +29620,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "packages/liveblocks-react/node_modules/msw": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
-      "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.10",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "chalk": "^4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^16.8.1",
-        "headers-polyfill": "3.2.5",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "outvariant": "^1.4.0",
-        "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.4.3",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.2.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-react/node_modules/msw/node_modules/strict-event-emitter": {
-      "version": "0.4.6",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/liveblocks-react/node_modules/pretty-format": {
       "version": "27.5.1",
@@ -30545,17 +29653,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "packages/liveblocks-react/node_modules/type-fest": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/liveblocks-redux": {
       "name": "@liveblocks/redux",
       "version": "2.15.2",
@@ -30569,33 +29666,11 @@
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
         "@testing-library/jest-dom": "^6.4.6",
-        "msw": "^0.36.4",
+        "msw": "^1.3.5",
         "redux": "^4.1.2"
       },
       "peerDependencies": {
         "redux": "^4"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/@mswjs/cookies": {
-      "version": "0.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/@mswjs/interceptors": {
-      "version": "0.12.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.2",
-        "debug": "^4.3.2",
-        "headers-utils": "^3.0.2",
-        "outvariant": "^1.2.0",
-        "strict-event-emitter": "^0.2.0"
       }
     },
     "packages/liveblocks-redux/node_modules/@testing-library/jest-dom": {
@@ -30643,94 +29718,11 @@
         }
       }
     },
-    "packages/liveblocks-redux/node_modules/@types/inquirer": {
-      "version": "8.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^7.2.0"
-      }
-    },
     "packages/liveblocks-redux/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true
-    },
-    "packages/liveblocks-redux/node_modules/graphql": {
-      "version": "15.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/headers-utils": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/liveblocks-redux/node_modules/msw": {
-      "version": "0.36.8",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.7",
-        "@mswjs/interceptors": "^0.12.7",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/inquirer": "^8.1.3",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.5.1",
-        "headers-utils": "^3.0.2",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
-        "yargs": "^17.3.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-redux/node_modules/msw/node_modules/type-fest": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "packages/liveblocks-yjs": {
       "name": "@liveblocks/yjs",
@@ -30746,29 +29738,10 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
-        "msw": "^0.47.4"
+        "msw": "^1.3.5"
       },
       "peerDependencies": {
         "yjs": "^13.6.1"
-      }
-    },
-    "packages/liveblocks-yjs/node_modules/@mswjs/interceptors": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
-      "dev": true,
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "3.2.5",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/liveblocks-yjs/node_modules/@testing-library/jest-dom": {
@@ -30829,95 +29802,11 @@
         "node": ">=8"
       }
     },
-    "packages/liveblocks-yjs/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "packages/liveblocks-yjs/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "packages/liveblocks-yjs/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true
-    },
-    "packages/liveblocks-yjs/node_modules/msw": {
-      "version": "0.47.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.4.tgz",
-      "integrity": "sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.0",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "outvariant": "^1.3.0",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.6",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.2.x <= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/liveblocks-yjs/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "packages/liveblocks-zustand": {
       "name": "@liveblocks/zustand",
@@ -30931,33 +29820,11 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
-        "msw": "^0.36.4",
+        "msw": "^1.3.5",
         "zustand": "^5.0.1"
       },
       "peerDependencies": {
         "zustand": "^5.0.1"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/@mswjs/cookies": {
-      "version": "0.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/@mswjs/interceptors": {
-      "version": "0.12.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.2",
-        "debug": "^4.3.2",
-        "headers-utils": "^3.0.2",
-        "outvariant": "^1.2.0",
-        "strict-event-emitter": "^0.2.0"
       }
     },
     "packages/liveblocks-zustand/node_modules/@testing-library/jest-dom": {
@@ -31005,94 +29872,11 @@
         }
       }
     },
-    "packages/liveblocks-zustand/node_modules/@types/inquirer": {
-      "version": "8.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/through": "*",
-        "rxjs": "^7.2.0"
-      }
-    },
     "packages/liveblocks-zustand/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true
-    },
-    "packages/liveblocks-zustand/node_modules/graphql": {
-      "version": "15.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/headers-utils": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/liveblocks-zustand/node_modules/msw": {
-      "version": "0.36.4",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mswjs/cookies": "^0.1.6",
-        "@mswjs/interceptors": "^0.12.7",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/inquirer": "^8.1.3",
-        "@types/js-levenshtein": "^1.1.0",
-        "chalk": "4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.1",
-        "graphql": "^15.5.1",
-        "headers-utils": "^3.0.2",
-        "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.1",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
-        "yargs": "^17.3.0"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/liveblocks-zustand/node_modules/type-fest": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "packages/liveblocks-zustand/node_modules/zustand": {
       "version": "5.0.1",
@@ -35534,15 +34318,6 @@
         }
       }
     },
-    "@bundled-es-modules/js-levenshtein": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
-      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
-      "dev": true,
-      "requires": {
-        "js-levenshtein": "^1.1.6"
-      }
-    },
     "@bundled-es-modules/statuses": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
@@ -35873,53 +34648,32 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
     },
     "@inquirer/confirm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.1.tgz",
+      "integrity": "sha512-vVLSbGci+IKQvDOtzpPTCOiEJCNidHcAq9JYVoWTW0svb5FiwSLotkM+JXNXejfjnzVYV9n0DTBythl9+XgTxg==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
+        "@inquirer/core": "^10.1.2",
+        "@inquirer/type": "^3.0.2"
       }
     },
     "@inquirer/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.2.tgz",
+      "integrity": "sha512-bHd96F3ezHg1mf/J0Rb4CV8ndCN0v28kUlrHqP7+ECm1C/A+paB7Xh2lbMk6x+kweQC+rZOxM/YeKikzxco8bQ==",
       "dev": true,
       "requires": {
-        "@inquirer/figures": "^1.0.6",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.5",
-        "@types/wrap-ansi": "^3.0.0",
+        "@inquirer/figures": "^1.0.9",
+        "@inquirer/type": "^3.0.2",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
+        "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^6.2.0",
         "yoctocolors-cjs": "^2.1.2"
       },
       "dependencies": {
-        "@inquirer/type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-          "dev": true,
-          "requires": {
-            "mute-stream": "^1.0.0"
-          }
-        },
-        "@types/node": {
-          "version": "22.5.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-          "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~6.19.2"
-          }
-        },
         "cli-width": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -35927,21 +34681,15 @@
           "dev": true
         },
         "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+          "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
           "dev": true
         },
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
           "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
-        },
-        "undici-types": {
-          "version": "6.19.8",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
           "dev": true
         },
         "wrap-ansi": {
@@ -35958,27 +34706,17 @@
       }
     },
     "@inquirer/figures": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
-      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
+      "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
       "dev": true
     },
     "@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.2.tgz",
+      "integrity": "sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==",
       "dev": true,
-      "requires": {
-        "mute-stream": "^1.0.0"
-      },
-      "dependencies": {
-        "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-          "dev": true
-        }
-      }
+      "requires": {}
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -36731,11 +35469,7 @@
       "requires": {
         "@liveblocks/core": "2.15.2",
         "@liveblocks/eslint-config": "*",
-        "@liveblocks/jest-config": "*",
-        "@types/ws": "^8.5.10",
-        "dotenv": "^16.4.5",
-        "msw": "^0.39.1",
-        "ws": "^8.17.1"
+        "@liveblocks/jest-config": "*"
       }
     },
     "@liveblocks/codemirror-language": {
@@ -36934,62 +35668,8 @@
         "@types/ws": "^8.5.10",
         "dotenv": "^16.4.5",
         "eslint-plugin-rulesdir": "^0.2.2",
-        "msw": "^0.47.4",
+        "msw": "^1.3.5",
         "ws": "^8.17.1"
-      },
-      "dependencies": {
-        "@mswjs/interceptors": {
-          "version": "0.17.5",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@types/debug": "^4.1.7",
-            "@xmldom/xmldom": "^0.7.5",
-            "debug": "^4.3.3",
-            "headers-polyfill": "^3.1.0",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.2.4",
-            "web-encoding": "^1.1.5"
-          }
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "msw": {
-          "version": "0.47.4",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.2.2",
-            "@mswjs/interceptors": "^0.17.5",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "chalk": "4.1.1",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.2",
-            "graphql": "^15.0.0 || ^16.0.0",
-            "headers-polyfill": "^3.1.0",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
-            "outvariant": "^1.3.0",
-            "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.6",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "dev": true
-        }
       }
     },
     "@liveblocks/devtools": {
@@ -37879,13 +36559,13 @@
         "@liveblocks/jest-config": "*",
         "@liveblocks/node": "2.15.2",
         "csstype": "3.0.2",
-        "msw": "^2.0.2"
+        "msw": "^2.7.0"
       },
       "dependencies": {
         "@mswjs/interceptors": {
-          "version": "0.35.8",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.35.8.tgz",
-          "integrity": "sha512-PFfqpHplKa7KMdoQdj5td03uG05VK2Ng1dG0sP4pT9h0dGSX2v9txYt/AnrzPb/vAmfyBBC0NQV7VaBEX+efgQ==",
+          "version": "0.37.5",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+          "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
           "dev": true,
           "requires": {
             "@open-draft/deferred-promise": "^2.2.0",
@@ -37908,16 +36588,6 @@
           "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
           "dev": true
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "csstype": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
@@ -37931,29 +36601,36 @@
           "dev": true
         },
         "msw": {
-          "version": "2.4.9",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.9.tgz",
-          "integrity": "sha512-1m8xccT6ipN4PTqLinPwmzhxQREuxaEJYdx4nIbggxP8aM7r1e71vE7RtOUSQoAm1LydjGfZKy7370XD/tsuYg==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+          "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
           "dev": true,
           "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
+            "@bundled-es-modules/cookie": "^2.0.1",
             "@bundled-es-modules/statuses": "^1.0.1",
             "@bundled-es-modules/tough-cookie": "^0.1.6",
-            "@inquirer/confirm": "^3.0.0",
-            "@mswjs/interceptors": "^0.35.8",
+            "@inquirer/confirm": "^5.0.0",
+            "@mswjs/interceptors": "^0.37.0",
+            "@open-draft/deferred-promise": "^2.2.0",
             "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.6.0",
             "@types/statuses": "^2.0.4",
-            "chalk": "^4.1.2",
             "graphql": "^16.8.1",
             "headers-polyfill": "^4.0.2",
             "is-node-process": "^1.2.0",
-            "outvariant": "^1.4.2",
+            "outvariant": "^1.4.3",
             "path-to-regexp": "^6.3.0",
+            "picocolors": "^1.1.1",
             "strict-event-emitter": "^0.5.1",
-            "type-fest": "^4.9.0",
+            "type-fest": "^4.26.1",
             "yargs": "^17.7.2"
           }
+        },
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+          "dev": true
         },
         "strict-event-emitter": {
           "version": "0.5.1",
@@ -38066,28 +36743,22 @@
         "@types/node": "^20.7.1",
         "@types/node-fetch": "^2.6.6",
         "fast-sha256": "^1.3.0",
-        "msw": "^2.0.2",
+        "msw": "^2.7.0",
         "node-fetch": "^2.6.1",
         "svix": "^0.75.0"
       },
       "dependencies": {
-        "@mswjs/cookies": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
-          "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
-          "dev": true
-        },
         "@mswjs/interceptors": {
-          "version": "0.25.7",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.7.tgz",
-          "integrity": "sha512-U7iFYs/qU/5jfz1VDpoYz3xqX9nzhsBXw7q923dv6GiGTy+m2ZLhD33L80R/shHOW/YWjeH6k16GbIHGw+bAng==",
+          "version": "0.37.5",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+          "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
           "dev": true,
           "requires": {
             "@open-draft/deferred-promise": "^2.2.0",
             "@open-draft/logger": "^0.3.0",
             "@open-draft/until": "^2.0.0",
             "is-node-process": "^1.2.0",
-            "outvariant": "^1.2.1",
+            "outvariant": "^1.4.3",
             "strict-event-emitter": "^0.5.1"
           }
         },
@@ -38097,21 +36768,17 @@
           "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
           "dev": true
         },
+        "@types/cookie": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+          "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+          "dev": true
+        },
         "@types/node": {
           "version": "20.7.1",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
           "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
           "dev": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
         },
         "headers-polyfill": {
           "version": "4.0.2",
@@ -38120,35 +36787,36 @@
           "dev": true
         },
         "msw": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.2.tgz",
-          "integrity": "sha512-loyQnNUDY1x05R/t2naVdtNhP+tfyf+ckEwtvRUuoK9JnDeoh3/ZN3Fu2ZtvO/iJ3IwwuLizWwWaxBxS3sDQUw==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+          "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
           "dev": true,
           "requires": {
-            "@bundled-es-modules/cookie": "^2.0.0",
-            "@bundled-es-modules/js-levenshtein": "^2.0.1",
+            "@bundled-es-modules/cookie": "^2.0.1",
             "@bundled-es-modules/statuses": "^1.0.1",
-            "@mswjs/cookies": "^1.0.0",
-            "@mswjs/interceptors": "^0.25.1",
+            "@bundled-es-modules/tough-cookie": "^0.1.6",
+            "@inquirer/confirm": "^5.0.0",
+            "@mswjs/interceptors": "^0.37.0",
+            "@open-draft/deferred-promise": "^2.2.0",
             "@open-draft/until": "^2.1.0",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "@types/statuses": "^2.0.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.4.2",
-            "formdata-node": "4.4.1",
+            "@types/cookie": "^0.6.0",
+            "@types/statuses": "^2.0.4",
             "graphql": "^16.8.1",
-            "headers-polyfill": "^4.0.1",
-            "inquirer": "^8.2.0",
+            "headers-polyfill": "^4.0.2",
             "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.5.0",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
+            "outvariant": "^1.4.3",
+            "path-to-regexp": "^6.3.0",
+            "picocolors": "^1.1.1",
+            "strict-event-emitter": "^0.5.1",
+            "type-fest": "^4.26.1",
+            "yargs": "^17.7.2"
           }
+        },
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+          "dev": true
         },
         "strict-event-emitter": {
           "version": "0.5.1",
@@ -38157,10 +36825,18 @@
           "dev": true
         },
         "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "version": "4.31.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
+          "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
           "dev": true
+        },
+        "typescript": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+          "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -38194,48 +36870,14 @@
         "@liveblocks/jest-config": "*",
         "@liveblocks/node": "2.15.2",
         "@types/node": "^20.14.8",
-        "msw": "^2.6.4",
+        "msw": "^2.7.0",
         "yjs": "^13.6.20"
       },
       "dependencies": {
-        "@inquirer/confirm": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
-          "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
-          "dev": true,
-          "requires": {
-            "@inquirer/core": "^10.1.0",
-            "@inquirer/type": "^3.0.1"
-          }
-        },
-        "@inquirer/core": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
-          "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-          "dev": true,
-          "requires": {
-            "@inquirer/figures": "^1.0.8",
-            "@inquirer/type": "^3.0.1",
-            "ansi-escapes": "^4.3.2",
-            "cli-width": "^4.1.0",
-            "mute-stream": "^2.0.0",
-            "signal-exit": "^4.1.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^6.2.0",
-            "yoctocolors-cjs": "^2.1.2"
-          }
-        },
-        "@inquirer/type": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
-          "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-          "dev": true,
-          "requires": {}
-        },
         "@mswjs/interceptors": {
-          "version": "0.36.10",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
-          "integrity": "sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==",
+          "version": "0.37.5",
+          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
+          "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
           "dev": true,
           "requires": {
             "@open-draft/deferred-promise": "^2.2.0",
@@ -38267,22 +36909,6 @@
             "undici-types": "~6.19.2"
           }
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cli-width": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-          "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-          "dev": true
-        },
         "headers-polyfill": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
@@ -38290,41 +36916,35 @@
           "dev": true
         },
         "msw": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-2.6.4.tgz",
-          "integrity": "sha512-Pm4LmWQeytDsNCR+A7gt39XAdtH6zQb6jnIKRig0FlvYOn8eksn3s1nXxUfz5KYUjbckof7Z4p2ewzgffPoCbg==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.0.tgz",
+          "integrity": "sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==",
           "dev": true,
           "requires": {
             "@bundled-es-modules/cookie": "^2.0.1",
             "@bundled-es-modules/statuses": "^1.0.1",
             "@bundled-es-modules/tough-cookie": "^0.1.6",
             "@inquirer/confirm": "^5.0.0",
-            "@mswjs/interceptors": "^0.36.5",
+            "@mswjs/interceptors": "^0.37.0",
             "@open-draft/deferred-promise": "^2.2.0",
             "@open-draft/until": "^2.1.0",
             "@types/cookie": "^0.6.0",
             "@types/statuses": "^2.0.4",
-            "chalk": "^4.1.2",
             "graphql": "^16.8.1",
             "headers-polyfill": "^4.0.2",
             "is-node-process": "^1.2.0",
             "outvariant": "^1.4.3",
             "path-to-regexp": "^6.3.0",
+            "picocolors": "^1.1.1",
             "strict-event-emitter": "^0.5.1",
             "type-fest": "^4.26.1",
             "yargs": "^17.7.2"
           }
         },
-        "mute-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-          "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+        "picocolors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+          "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
           "dev": true
         },
         "strict-event-emitter": {
@@ -38352,17 +36972,6 @@
           "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
           "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
           "dev": true
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
         }
       }
     },
@@ -38385,26 +36994,10 @@
         "date-fns": "^3.6.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "itertools": "^2.3.2",
-        "msw": "1.3.2",
+        "msw": "^1.3.5",
         "react-error-boundary": "^4.0.13"
       },
       "dependencies": {
-        "@mswjs/interceptors": {
-          "version": "0.17.10",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-          "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@types/debug": "^4.1.7",
-            "@xmldom/xmldom": "^0.8.3",
-            "debug": "^4.3.3",
-            "headers-polyfill": "3.2.5",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.2.4",
-            "web-encoding": "^1.1.5"
-          }
-        },
         "@testing-library/dom": {
           "version": "9.3.4",
           "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
@@ -38466,51 +37059,12 @@
             "@types/react-dom": "^18.0.0"
           }
         },
-        "@xmldom/xmldom": {
-          "version": "0.8.10",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-          "dev": true
-        },
         "chalk": {
           "version": "4.1.1",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
-          }
-        },
-        "msw": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
-          "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.2.2",
-            "@mswjs/interceptors": "^0.17.10",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "chalk": "^4.1.1",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.2",
-            "graphql": "^16.8.1",
-            "headers-polyfill": "3.2.5",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.2.0",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
-            "outvariant": "^1.4.0",
-            "path-to-regexp": "^6.2.0",
-            "strict-event-emitter": "^0.4.3",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          },
-          "dependencies": {
-            "strict-event-emitter": {
-              "version": "0.4.6",
-              "dev": true
-            }
           }
         },
         "pretty-format": {
@@ -38537,10 +37091,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "dev": true
         }
       }
     },
@@ -38559,7 +37109,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^1.3.5",
         "rollup": "3.28.0",
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
@@ -38598,90 +37148,6 @@
           "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
           "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
         },
-        "@mswjs/cookies": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
-          "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "graphql": {
-          "version": "15.8.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-          "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^3.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.19",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.4.0",
-            "rxjs": "^6.6.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "msw": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-0.27.2.tgz",
-          "integrity": "sha512-PjxQ06gi2mqNINzVKL/lVWiP6Dd2LDUT3QK9AS2vJMbz/Xa0FgKmd1RF7kyFKiwv6qEazVp74TS0Qc8yjXRUgA==",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.1.4",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.0",
-            "@types/inquirer": "^7.3.1",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "^4.1.0",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.4.0",
-            "headers-utils": "^1.2.0",
-            "inquirer": "^7.3.3",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.1",
-            "node-match-path": "^0.6.1",
-            "node-request-interceptor": "^0.6.3",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.1.0",
-            "yargs": "^16.2.0"
-          }
-        },
         "rollup": {
           "version": "3.28.0",
           "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
@@ -38690,48 +37156,6 @@
           "requires": {
             "fsevents": "~2.3.2"
           }
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
-          "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
         }
       }
     },
@@ -38753,7 +37177,7 @@
         "@tiptap/suggestion": "^2.7.2",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^1.3.5",
         "rollup": "3.28.0",
         "stylelint": "^15.10.2",
         "stylelint-config-standard": "^34.0.0",
@@ -38793,90 +37217,6 @@
           "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
           "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
         },
-        "@mswjs/cookies": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
-          "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "graphql": {
-          "version": "15.9.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.9.0.tgz",
-          "integrity": "sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^3.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.19",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.4.0",
-            "rxjs": "^6.6.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "msw": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-0.27.2.tgz",
-          "integrity": "sha512-PjxQ06gi2mqNINzVKL/lVWiP6Dd2LDUT3QK9AS2vJMbz/Xa0FgKmd1RF7kyFKiwv6qEazVp74TS0Qc8yjXRUgA==",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.1.4",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.0",
-            "@types/inquirer": "^7.3.1",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "^4.1.0",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.4.0",
-            "headers-utils": "^1.2.0",
-            "inquirer": "^7.3.3",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.1",
-            "node-match-path": "^0.6.1",
-            "node-request-interceptor": "^0.6.3",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.1.0",
-            "yargs": "^16.2.0"
-          }
-        },
         "rollup": {
           "version": "3.28.0",
           "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
@@ -38885,48 +37225,6 @@
           "requires": {
             "fsevents": "~2.3.2"
           }
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "strict-event-emitter": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
-          "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
         }
       }
     },
@@ -38950,7 +37248,7 @@
         "emojibase": "^15.3.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "msw": "^0.27.1",
+        "msw": "^1.3.5",
         "react-virtuoso": "^4.12.0",
         "rollup": "3.28.0",
         "slate": "^0.110.2",
@@ -38992,16 +37290,6 @@
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
           "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
-        },
-        "@mswjs/cookies": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
-          "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
         },
         "@radix-ui/primitive": {
           "version": "1.1.0",
@@ -39469,80 +37757,6 @@
           "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
           "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "graphql": {
-          "version": "15.8.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-          "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.1.0",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^3.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.19",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.4.0",
-            "rxjs": "^6.6.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "msw": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-0.27.2.tgz",
-          "integrity": "sha512-PjxQ06gi2mqNINzVKL/lVWiP6Dd2LDUT3QK9AS2vJMbz/Xa0FgKmd1RF7kyFKiwv6qEazVp74TS0Qc8yjXRUgA==",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.1.4",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.0",
-            "@types/inquirer": "^7.3.1",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "^4.1.0",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.4.0",
-            "headers-utils": "^1.2.0",
-            "inquirer": "^7.3.3",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.1",
-            "node-match-path": "^0.6.1",
-            "node-request-interceptor": "^0.6.3",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.1.0",
-            "yargs": "^16.2.0"
-          }
-        },
         "react-remove-scroll": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
@@ -39577,15 +37791,6 @@
             "fsevents": "~2.3.2"
           }
         },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
         "slate-react": {
           "version": "0.110.3",
           "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.110.3.tgz",
@@ -39599,39 +37804,6 @@
             "scroll-into-view-if-needed": "^3.1.0",
             "tiny-invariant": "1.3.1"
           }
-        },
-        "strict-event-emitter": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
-          "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
         }
       }
     },
@@ -39644,30 +37816,10 @@
         "@liveblocks/jest-config": "*",
         "@reduxjs/toolkit": "^1.7.2",
         "@testing-library/jest-dom": "^6.4.6",
-        "msw": "^0.36.4",
+        "msw": "^1.3.5",
         "redux": "^4.1.2"
       },
       "dependencies": {
-        "@mswjs/cookies": {
-          "version": "0.1.7",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
-        },
-        "@mswjs/interceptors": {
-          "version": "0.12.7",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@xmldom/xmldom": "^0.7.2",
-            "debug": "^4.3.2",
-            "headers-utils": "^3.0.2",
-            "outvariant": "^1.2.0",
-            "strict-event-emitter": "^0.2.0"
-          }
-        },
         "@testing-library/jest-dom": {
           "version": "6.4.6",
           "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
@@ -39684,67 +37836,11 @@
             "redent": "^3.0.0"
           }
         },
-        "@types/inquirer": {
-          "version": "8.2.0",
-          "dev": true,
-          "requires": {
-            "@types/through": "*",
-            "rxjs": "^7.2.0"
-          }
-        },
         "dom-accessibility-api": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
           "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
           "dev": true
-        },
-        "graphql": {
-          "version": "15.8.0",
-          "dev": true
-        },
-        "headers-utils": {
-          "version": "3.0.2",
-          "dev": true
-        },
-        "msw": {
-          "version": "0.36.8",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.1.7",
-            "@mswjs/interceptors": "^0.12.7",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.1",
-            "@types/inquirer": "^8.1.3",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "4.1.1",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.5.1",
-            "headers-utils": "^3.0.2",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
-            "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.0",
-            "type-fest": "^1.2.2",
-            "yargs": "^17.3.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.1",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "type-fest": {
-              "version": "1.4.0",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -40198,26 +38294,10 @@
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
         "js-base64": "^3.7.7",
-        "msw": "^0.47.4",
+        "msw": "^1.3.5",
         "y-indexeddb": "^9.0.12"
       },
       "dependencies": {
-        "@mswjs/interceptors": {
-          "version": "0.17.10",
-          "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-          "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@types/debug": "^4.1.7",
-            "@xmldom/xmldom": "^0.8.3",
-            "debug": "^4.3.3",
-            "headers-polyfill": "3.2.5",
-            "outvariant": "^1.2.1",
-            "strict-event-emitter": "^0.2.4",
-            "web-encoding": "^1.1.5"
-          }
-        },
         "@testing-library/jest-dom": {
           "version": "6.4.6",
           "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
@@ -40246,60 +38326,10 @@
             }
           }
         },
-        "@xmldom/xmldom": {
-          "version": "0.8.10",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "dom-accessibility-api": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
           "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-          "dev": true
-        },
-        "msw": {
-          "version": "0.47.4",
-          "resolved": "https://registry.npmjs.org/msw/-/msw-0.47.4.tgz",
-          "integrity": "sha512-Psftt8Yfl0+l+qqg9OlmKEsxF8S/vtda0CmlR6y8wTaWrMMzuCDa55n2hEGC0ZRDwuV6FFWc/4CjoDsBpATKBw==",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.2.2",
-            "@mswjs/interceptors": "^0.17.5",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.1",
-            "@types/js-levenshtein": "^1.1.1",
-            "chalk": "4.1.1",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.2",
-            "graphql": "^15.0.0 || ^16.0.0",
-            "headers-polyfill": "^3.1.0",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.7",
-            "outvariant": "^1.3.0",
-            "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.6",
-            "type-fest": "^2.19.0",
-            "yargs": "^17.3.1"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -40312,30 +38342,10 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@testing-library/jest-dom": "^6.4.6",
-        "msw": "^0.36.4",
+        "msw": "^1.3.5",
         "zustand": "^5.0.1"
       },
       "dependencies": {
-        "@mswjs/cookies": {
-          "version": "0.1.6",
-          "dev": true,
-          "requires": {
-            "@types/set-cookie-parser": "^2.4.0",
-            "set-cookie-parser": "^2.4.6"
-          }
-        },
-        "@mswjs/interceptors": {
-          "version": "0.12.7",
-          "dev": true,
-          "requires": {
-            "@open-draft/until": "^1.0.3",
-            "@xmldom/xmldom": "^0.7.2",
-            "debug": "^4.3.2",
-            "headers-utils": "^3.0.2",
-            "outvariant": "^1.2.0",
-            "strict-event-emitter": "^0.2.0"
-          }
-        },
         "@testing-library/jest-dom": {
           "version": "6.4.6",
           "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
@@ -40352,66 +38362,10 @@
             "redent": "^3.0.0"
           }
         },
-        "@types/inquirer": {
-          "version": "8.1.3",
-          "dev": true,
-          "requires": {
-            "@types/through": "*",
-            "rxjs": "^7.2.0"
-          }
-        },
         "dom-accessibility-api": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
           "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-          "dev": true
-        },
-        "graphql": {
-          "version": "15.8.0",
-          "dev": true
-        },
-        "headers-utils": {
-          "version": "3.0.2",
-          "dev": true
-        },
-        "msw": {
-          "version": "0.36.4",
-          "dev": true,
-          "requires": {
-            "@mswjs/cookies": "^0.1.6",
-            "@mswjs/interceptors": "^0.12.7",
-            "@open-draft/until": "^1.0.3",
-            "@types/cookie": "^0.4.1",
-            "@types/inquirer": "^8.1.3",
-            "@types/js-levenshtein": "^1.1.0",
-            "chalk": "4.1.1",
-            "chokidar": "^3.4.2",
-            "cookie": "^0.4.1",
-            "graphql": "^15.5.1",
-            "headers-utils": "^3.0.2",
-            "inquirer": "^8.2.0",
-            "is-node-process": "^1.0.1",
-            "js-levenshtein": "^1.1.6",
-            "node-fetch": "^2.6.1",
-            "path-to-regexp": "^6.2.0",
-            "statuses": "^2.0.0",
-            "strict-event-emitter": "^0.2.0",
-            "type-fest": "^1.2.2",
-            "yargs": "^17.3.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.1",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
-          }
-        },
-        "type-fest": {
-          "version": "1.4.0",
           "dev": true
         },
         "zustand": {
@@ -40522,15 +38476,27 @@
       }
     },
     "@mswjs/interceptors": {
-      "version": "0.15.3",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
       "dev": true,
       "requires": {
         "@open-draft/until": "^1.0.3",
-        "@xmldom/xmldom": "^0.7.5",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.0.4",
+        "headers-polyfill": "3.2.5",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.0"
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "dependencies": {
+        "@xmldom/xmldom": {
+          "version": "0.8.10",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+          "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+          "dev": true
+        }
       }
     },
     "@next/env": {
@@ -43891,27 +41857,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
-    "@types/inquirer": {
-      "version": "7.3.3",
-      "dev": true,
-      "requires": {
-        "@types/through": "*",
-        "rxjs": "^6.4.0"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "6.6.7",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
     "@types/is-git-clean": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/is-git-clean/-/is-git-clean-1.1.2.tgz",
@@ -44009,15 +41954,6 @@
       "version": "0.7.31",
       "dev": true
     },
-    "@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "18.19.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.34.tgz",
@@ -44105,13 +42041,6 @@
         "@types/jest": "*"
       }
     },
-    "@types/through": {
-      "version": "0.0.30",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -44127,12 +42056,6 @@
     },
     "@types/webextension-polyfill": {
       "version": "0.10.0",
-      "dev": true
-    },
-    "@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true
     },
     "@types/ws": {
@@ -44374,10 +42297,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
-    },
-    "@xmldom/xmldom": {
-      "version": "0.7.9",
-      "dev": true
     },
     "@zxing/text-encoding": {
       "version": "0.9.0",
@@ -47828,16 +45747,6 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw=="
     },
-    "formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      }
-    },
     "fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -48301,10 +46210,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
       "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
-      "dev": true
-    },
-    "headers-utils": {
-      "version": "1.2.5",
       "dev": true
     },
     "hoist-non-react-statics": {
@@ -50547,27 +48452,29 @@
       }
     },
     "msw": {
-      "version": "0.39.2",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.5.tgz",
+      "integrity": "sha512-nG3fpmBXxFbKSIdk6miPuL3KjU6WMxgoW4tG1YgnP1M+TRG3Qn7b7R0euKAHq4vpwARHb18ZyfZljSxsTnMX2w==",
       "dev": true,
       "requires": {
-        "@mswjs/cookies": "^0.2.0",
-        "@mswjs/interceptors": "^0.15.1",
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.10",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "chalk": "^4.1.1",
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
-        "graphql": "^16.3.0",
-        "headers-polyfill": "^3.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "3.2.5",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
-        "path-to-regexp": "^6.2.0",
-        "statuses": "^2.0.0",
-        "strict-event-emitter": "^0.2.0",
-        "type-fest": "^1.2.2",
+        "outvariant": "^1.4.0",
+        "path-to-regexp": "^6.3.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
       "dependencies": {
@@ -50579,8 +48486,16 @@
             "supports-color": "^7.1.0"
           }
         },
+        "strict-event-emitter": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+          "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+          "dev": true
+        },
         "type-fest": {
-          "version": "1.4.0",
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
       }
@@ -50751,12 +48666,6 @@
         "minimatch": "^3.0.2"
       }
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
-    },
     "node-emoji": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
@@ -50808,10 +48717,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
-    "node-match-path": {
-      "version": "0.6.3",
-      "dev": true
-    },
     "node-object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-3.0.0.tgz",
@@ -50821,22 +48726,6 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
-    },
-    "node-request-interceptor": {
-      "version": "0.6.3",
-      "dev": true,
-      "requires": {
-        "@open-draft/until": "^1.0.3",
-        "debug": "^4.3.0",
-        "headers-utils": "^1.2.0",
-        "strict-event-emitter": "^0.1.0"
-      },
-      "dependencies": {
-        "strict-event-emitter": {
-          "version": "0.1.0",
-          "dev": true
-        }
-      }
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -55126,12 +53015,6 @@
           }
         }
       }
-    },
-    "web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true
     },
     "webextension-polyfill": {
       "version": "0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.3",
+        "@types/node": "^18.19.70",
         "dependency-cruiser": "^16.9.0",
         "prettier": "^3.4.2",
         "publint": "^0.2.8",
@@ -11419,9 +11420,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.34.tgz",
-      "integrity": "sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==",
+      "version": "18.19.70",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.70.tgz",
+      "integrity": "sha512-RE+K0+KZoEpDUbGGctnGdkrLFwi1eYKTlIHNl2Um98mUkGsm1u2Ff6Ltd0e8DktTtC98uy7rSj+hO8t/QuLoVQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -29351,7 +29353,6 @@
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@types/node": "^20.17.12",
         "@types/node-fetch": "^2.6.6",
         "msw": "^2.7.0",
         "svix": "^0.75.0"
@@ -29368,8 +29369,7 @@
       },
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
-        "@liveblocks/jest-config": "*",
-        "@types/node": "^20.14.8"
+        "@liveblocks/jest-config": "*"
       },
       "peerDependencies": {
         "@lexical/headless": "0.16.1",
@@ -29377,15 +29377,6 @@
         "@lexical/selection": "0.16.1",
         "@lexical/yjs": "0.16.1",
         "lexical": "0.16.1"
-      }
-    },
-    "packages/liveblocks-node-lexical/node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/liveblocks-node-prosemirror": {
@@ -29400,7 +29391,6 @@
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@types/node": "^20.14.8",
         "msw": "^2.7.0"
       },
       "peerDependencies": {
@@ -29443,16 +29433,6 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/liveblocks-node-prosemirror/node_modules/@types/node": {
-      "version": "20.17.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
-      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
     },
     "packages/liveblocks-node-prosemirror/node_modules/headers-polyfill": {
       "version": "4.0.3",
@@ -29533,13 +29513,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/liveblocks-node-prosemirror/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/liveblocks-node/node_modules/@mswjs/interceptors": {
       "version": "0.37.5",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
@@ -29571,16 +29544,6 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/liveblocks-node/node_modules/@types/node": {
-      "version": "20.17.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
-      "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
     },
     "packages/liveblocks-node/node_modules/headers-polyfill": {
       "version": "4.0.2",
@@ -29659,13 +29622,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "packages/liveblocks-node/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/liveblocks-react": {
       "name": "@liveblocks/react",
@@ -32459,17 +32415,10 @@
       "devDependencies": {
         "@types/command-line-args": "^5.2.0",
         "@types/degit": "^2.8.3",
-        "@types/node": "^17.0.39",
         "@types/prompts": "^2.4.1",
         "cross-env": "^7.0.3",
         "esbuild": "^0.15.12"
       }
-    },
-    "tools/create-liveblocks-app/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
     },
     "tools/create-liveblocks-app/node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -32736,18 +32685,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/is-git-clean": "1.1.2",
-        "@types/jscodeshift": "0.11.11",
-        "@types/node": "^22.10.5"
-      }
-    },
-    "tools/liveblocks-codemod/node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
+        "@types/jscodeshift": "0.11.11"
       }
     },
     "tools/liveblocks-codemod/node_modules/arrify": {
@@ -32946,13 +32884,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "tools/liveblocks-codemod/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "license": "MIT"
     },
     "tools/liveblocks-codemod/node_modules/yargs-parser": {
       "version": "18.1.3",
@@ -34999,7 +34930,7 @@
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "chalk": "^4.0.0",
         "jest-message-util": "^29.7.0",
         "jest-util": "^29.7.0",
@@ -35027,7 +34958,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -35099,7 +35030,7 @@
       "requires": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "jest-mock": "^29.7.0"
       }
     },
@@ -35127,7 +35058,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "jest-message-util": "^29.7.0",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
@@ -35155,7 +35086,7 @@
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -35277,7 +35208,7 @@
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       },
@@ -35653,7 +35584,6 @@
         "@liveblocks/jest-config": "*",
         "@types/is-git-clean": "1.1.2",
         "@types/jscodeshift": "0.11.11",
-        "@types/node": "^22.10.5",
         "execa": "4.0.3",
         "globby": "11.0.1",
         "inquirer": "7.3.3",
@@ -35663,15 +35593,6 @@
         "picocolors": "1.0.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "22.10.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-          "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~6.20.0"
-          }
-        },
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -35811,12 +35732,6 @@
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="
-        },
-        "undici-types": {
-          "version": "6.20.0",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-          "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-          "dev": true
         },
         "yargs-parser": {
           "version": "18.1.3",
@@ -36065,7 +35980,6 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@stablelib/base64": "^1.0.1",
-        "@types/node": "^20.17.12",
         "@types/node-fetch": "^2.6.6",
         "fast-sha256": "^1.3.0",
         "msw": "^2.7.0",
@@ -36098,15 +36012,6 @@
           "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
           "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
           "dev": true
-        },
-        "@types/node": {
-          "version": "20.17.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
-          "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~6.19.2"
-          }
         },
         "headers-polyfill": {
           "version": "4.0.2",
@@ -36157,12 +36062,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.31.0.tgz",
           "integrity": "sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==",
           "dev": true
-        },
-        "undici-types": {
-          "version": "6.19.8",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-          "dev": true
         }
       }
     },
@@ -36173,19 +36072,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@liveblocks/node": "2.15.2",
-        "@types/node": "^20.14.8",
         "yjs": "^13.6.18"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "20.14.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-          "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        }
       }
     },
     "@liveblocks/node-prosemirror": {
@@ -36195,7 +36082,6 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@liveblocks/node": "2.15.2",
-        "@types/node": "^20.14.8",
         "msw": "^2.7.0",
         "yjs": "^13.6.20"
       },
@@ -36225,15 +36111,6 @@
           "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
           "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
           "dev": true
-        },
-        "@types/node": {
-          "version": "20.17.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
-          "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~6.19.2"
-          }
         },
         "headers-polyfill": {
           "version": "4.0.3",
@@ -36283,12 +36160,6 @@
           "version": "4.26.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
           "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
-          "dev": true
-        },
-        "undici-types": {
-          "version": "6.19.8",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
           "dev": true
         }
       }
@@ -41769,7 +41640,7 @@
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.8.tgz",
       "integrity": "sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "^18.19.70"
       }
     },
     "@types/hoist-non-react-statics": {
@@ -41833,7 +41704,7 @@
     "@types/jsdom": {
       "version": "20.0.0",
       "requires": {
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
@@ -41884,9 +41755,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.19.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.34.tgz",
-      "integrity": "sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==",
+      "version": "18.19.70",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.70.tgz",
+      "integrity": "sha512-RE+K0+KZoEpDUbGGctnGdkrLFwi1eYKTlIHNl2Um98mUkGsm1u2Ff6Ltd0e8DktTtC98uy7rSj+hO8t/QuLoVQ==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -41897,7 +41768,7 @@
       "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "form-data": "^4.0.0"
       }
     },
@@ -41924,7 +41795,7 @@
       "version": "2.4.2",
       "dev": true,
       "requires": {
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "kleur": "^3.0.3"
       }
     },
@@ -41951,7 +41822,7 @@
       "version": "2.4.2",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "^18.19.70"
       }
     },
     "@types/stack-utils": {
@@ -41993,7 +41864,7 @@
       "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "^18.19.70"
       }
     },
     "@types/yargs": {
@@ -43461,7 +43332,6 @@
       "requires": {
         "@types/command-line-args": "^5.2.0",
         "@types/degit": "^2.8.3",
-        "@types/node": "^17.0.39",
         "@types/prompts": "^2.4.1",
         "ansi-colors": "^4.1.3",
         "command-line-args": "^5.2.1",
@@ -43477,12 +43347,6 @@
         "simple-git": "^3.16.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -46934,7 +46798,7 @@
         "@jest/expect": "^29.7.0",
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^1.0.0",
@@ -47081,7 +46945,7 @@
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
         "@types/jsdom": "^20.0.0",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0",
         "jsdom": "^20.0.0"
@@ -47095,7 +46959,7 @@
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
       }
@@ -47112,7 +46976,7 @@
       "requires": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
@@ -47186,7 +47050,7 @@
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "jest-util": "^29.7.0"
       }
     },
@@ -47247,7 +47111,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
@@ -47288,7 +47152,7 @@
         "@jest/test-result": "^29.7.0",
         "@jest/transform": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -47360,7 +47224,7 @@
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "requires": {
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
@@ -47412,7 +47276,7 @@
       "requires": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
@@ -47436,7 +47300,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "requires": {
-        "@types/node": "*",
+        "@types/node": "^18.19.70",
         "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4135,6 +4135,7 @@
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
       "integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -4762,6 +4763,26 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.9.3"
+      }
+    },
+    "node_modules/@parcel/config-default/node_modules/@parcel/runtime-js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
+      "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/diagnostic": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.9.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@parcel/core": {
@@ -5515,23 +5536,423 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
-      "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.3.tgz",
+      "integrity": "sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==",
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.8.3"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/cache": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
+      "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "lmdb": "2.5.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/codeframe": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
+      "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/diagnostic": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
+      "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
+      "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/fs-search": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
+      "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/hash": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
+      "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/markdown-ansi": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
+      "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/package-manager": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
+      "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/plugin": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
+      "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/types": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/types": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
+      "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.8.3",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/lmdb": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@parcel/runtime-js/node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/@parcel/runtime-js/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
@@ -5759,15 +6180,6 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.9.3"
-      }
-    },
-    "node_modules/@parcel/transformer-js/node_modules/@swc/helpers": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
@@ -6490,9 +6902,9 @@
       "integrity": "sha512-P75g48dqOGneJ+n0AcqnLE/TYflcaPc3B7h6EopnCBBYUDnCNBMwYmKAkaf5pnhsEB0ybPS6TU1C2DTGfqaW7A=="
     },
     "node_modules/@plasmohq/parcel-bundler": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-bundler/-/parcel-bundler-0.5.5.tgz",
-      "integrity": "sha512-QCMmmfic514CfdXMJ7JMWUnqDzIHKVKyYeqPpUDsXON6JvA1yTmO5mEQSls8+5u/HpocP9QmTskQOHu3RCNX9A==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-bundler/-/parcel-bundler-0.5.6.tgz",
+      "integrity": "sha512-kjwj5tQUhdAK00AxXOzgqJ2jryZg4X6aleYAcjbREPzVMqKEu1NrNSNy5VGAfNRG6NCT6ZYg39ZCyuUOR2lEsQ==",
       "license": "MIT",
       "dependencies": {
         "@parcel/core": "2.9.3",
@@ -6508,10 +6920,66 @@
         "parcel": ">= 2.7.0"
       }
     },
+    "node_modules/@plasmohq/parcel-compressor-utf8": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-compressor-utf8/-/parcel-compressor-utf8-0.1.1.tgz",
+      "integrity": "sha512-9zcF39XIBzauYLERoGNVSy7qR1MzEqjhQn16RrlCpZ1AyNMlBJ3B28SmnUpBQNgne8JOHTtcx6cUVm1IvM3J+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/plugin": "2.9.3"
+      },
+      "engines": {
+        "parcel": ">= 2.8.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-config": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-config/-/parcel-config-0.41.1.tgz",
+      "integrity": "sha512-peNpm+F1tVIZmDx8Mca8b3769cxc2IWS7q0+0Y4BLT1+2kis7X4b46IAYgOXtsDRZCb9pvxQhRhrVHpwGtdVLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/compressor-raw": "2.9.3",
+        "@parcel/config-default": "2.9.3",
+        "@parcel/core": "2.9.3",
+        "@parcel/optimizer-data-url": "2.9.3",
+        "@parcel/reporter-bundle-buddy": "2.9.3",
+        "@parcel/resolver-default": "2.9.3",
+        "@parcel/runtime-js": "2.8.3",
+        "@parcel/runtime-service-worker": "2.9.3",
+        "@parcel/source-map": "2.1.1",
+        "@parcel/transformer-babel": "2.9.3",
+        "@parcel/transformer-css": "2.9.3",
+        "@parcel/transformer-graphql": "2.9.3",
+        "@parcel/transformer-inline-string": "2.9.3",
+        "@parcel/transformer-js": "2.9.3",
+        "@parcel/transformer-less": "2.9.3",
+        "@parcel/transformer-postcss": "2.9.3",
+        "@parcel/transformer-raw": "2.9.3",
+        "@parcel/transformer-react-refresh-wrap": "2.9.3",
+        "@parcel/transformer-sass": "2.9.3",
+        "@parcel/transformer-svg-react": "2.9.3",
+        "@parcel/transformer-worklet": "2.9.3",
+        "@plasmohq/parcel-bundler": "0.5.6",
+        "@plasmohq/parcel-compressor-utf8": "0.1.1",
+        "@plasmohq/parcel-namer-manifest": "0.3.12",
+        "@plasmohq/parcel-optimizer-encapsulate": "0.0.8",
+        "@plasmohq/parcel-optimizer-es": "0.4.1",
+        "@plasmohq/parcel-packager": "0.6.15",
+        "@plasmohq/parcel-resolver": "0.14.1",
+        "@plasmohq/parcel-resolver-post": "0.4.5",
+        "@plasmohq/parcel-runtime": "0.25.1",
+        "@plasmohq/parcel-transformer-inject-env": "0.2.12",
+        "@plasmohq/parcel-transformer-inline-css": "0.3.11",
+        "@plasmohq/parcel-transformer-manifest": "0.20.1",
+        "@plasmohq/parcel-transformer-svelte": "0.6.0",
+        "@plasmohq/parcel-transformer-vue": "0.5.0"
+      }
+    },
     "node_modules/@plasmohq/parcel-core": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-core/-/parcel-core-0.1.8.tgz",
-      "integrity": "sha512-kMWuazvf925ZAn2yHzzrb4Zsje1titFmvi/C5cXrI0TH58eT7n6GUiRXiOYP4JgGDHs/pEygx3WPuyWVTNF2HQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-core/-/parcel-core-0.1.10.tgz",
+      "integrity": "sha512-XbJrqlgPNo+uQaukWayfRDZnAvdkYrmcydCOz0wfmuksTjDisyGkL3ZbWeX86QPN65CXFyou11/9h3+U9IsHfA==",
+      "license": "MIT",
       "dependencies": {
         "@parcel/cache": "2.9.3",
         "@parcel/core": "2.9.3",
@@ -6551,9 +7019,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-encapsulate": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-encapsulate/-/parcel-optimizer-encapsulate-0.0.7.tgz",
-      "integrity": "sha512-mA9kY5dwuebQ4vLX6A5yTFo0gZZNWKUHpF6yO0lYq3oP843MyRJS8SxAtzQb4vTlVWPk3SX6Yw81DgBo4I6Xiw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-encapsulate/-/parcel-optimizer-encapsulate-0.0.8.tgz",
+      "integrity": "sha512-iXDXoLtYBvV4rHhFw3O6nrS3dEWYe9k2m0i/Tvzg2lz4lUHFyvK5NN9RWqkOLfI8JviaqQzaaMKteJhLsX6z1A==",
       "license": "MIT",
       "dependencies": {
         "@parcel/core": "2.9.3",
@@ -6566,16 +7034,16 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-es/-/parcel-optimizer-es-0.4.0.tgz",
-      "integrity": "sha512-Iz1cTuw38wEbSQ36/dVKh5MyRA12/Ecrx90pqaIkoqA9ZSZuxuWWa7rPa3bVMFkzi28BpVHW1z9EnhVN4188kQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-es/-/parcel-optimizer-es-0.4.1.tgz",
+      "integrity": "sha512-2FvBq3L5wHyD+TNHpO0IVMJKX1XQ+uBruFVcRUgo+lDkIAyop7P8wpsY4iq3dOKXJrqjwBop9nzNcq0L/zaalQ==",
       "license": "MIT",
       "dependencies": {
         "@parcel/core": "2.9.3",
         "@parcel/plugin": "2.9.3",
         "@parcel/source-map": "2.1.1",
         "@parcel/utils": "2.9.3",
-        "@swc/core": "1.3.82",
+        "@swc/core": "1.3.96",
         "nullthrows": "1.1.1"
       },
       "engines": {
@@ -6583,13 +7051,14 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.82.tgz",
-      "integrity": "sha512-jpC1a18HMH67018Ij2jh+hT7JBFu7ZKcQVfrZ8K6JuEY+kjXmbea07P9MbQUZbAe0FB+xi3CqEVCP73MebodJQ==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.96.tgz",
+      "integrity": "sha512-zwE3TLgoZwJfQygdv2SdCK9mRLYluwDOM53I+dT6Z5ZvrgVENmY3txvWDvduzkV+/8IuvrRbVezMpxcojadRdQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/types": "^0.1.4"
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
       },
       "engines": {
         "node": ">=10"
@@ -6599,16 +7068,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.82",
-        "@swc/core-darwin-x64": "1.3.82",
-        "@swc/core-linux-arm-gnueabihf": "1.3.82",
-        "@swc/core-linux-arm64-gnu": "1.3.82",
-        "@swc/core-linux-arm64-musl": "1.3.82",
-        "@swc/core-linux-x64-gnu": "1.3.82",
-        "@swc/core-linux-x64-musl": "1.3.82",
-        "@swc/core-win32-arm64-msvc": "1.3.82",
-        "@swc/core-win32-ia32-msvc": "1.3.82",
-        "@swc/core-win32-x64-msvc": "1.3.82"
+        "@swc/core-darwin-arm64": "1.3.96",
+        "@swc/core-darwin-x64": "1.3.96",
+        "@swc/core-linux-arm-gnueabihf": "1.3.96",
+        "@swc/core-linux-arm64-gnu": "1.3.96",
+        "@swc/core-linux-arm64-musl": "1.3.96",
+        "@swc/core-linux-x64-gnu": "1.3.96",
+        "@swc/core-linux-x64-musl": "1.3.96",
+        "@swc/core-win32-arm64-msvc": "1.3.96",
+        "@swc/core-win32-ia32-msvc": "1.3.96",
+        "@swc/core-win32-x64-msvc": "1.3.96"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -6620,9 +7089,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.82.tgz",
-      "integrity": "sha512-JfsyDW34gVKD3uE0OUpUqYvAD3yseEaicnFP6pB292THtLJb0IKBBnK50vV/RzEJtc1bR3g1kNfxo2PeurZTrA==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.96.tgz",
+      "integrity": "sha512-8hzgXYVd85hfPh6mJ9yrG26rhgzCmcLO0h1TIl8U31hwmTbfZLzRitFQ/kqMJNbIBCwmNH1RU2QcJnL3d7f69A==",
       "cpu": [
         "arm64"
       ],
@@ -6636,9 +7105,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.82.tgz",
-      "integrity": "sha512-ogQWgNMq7qTpITjcP3dnzkFNj7bh6SwMr859GvtOTrE75H7L7jDWxESfH4f8foB/LGxBKiDNmxKhitCuAsZK4A==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.96.tgz",
+      "integrity": "sha512-mFp9GFfuPg+43vlAdQZl0WZpZSE8sEzqL7sr/7Reul5McUHP0BaLsEzwjvD035ESfkY8GBZdLpMinblIbFNljQ==",
       "cpu": [
         "x64"
       ],
@@ -6652,9 +7121,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.82.tgz",
-      "integrity": "sha512-7TMXG1lXlNhD0kUiEqs+YlGV4irAdBa2quuy+XI3oJf2fBK6dQfEq4xBy65B3khrorzQS3O0oDGQ+cmdpHExHA==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.96.tgz",
+      "integrity": "sha512-8UEKkYJP4c8YzYIY/LlbSo8z5Obj4hqcv/fUTHiEePiGsOddgGf7AWjh56u7IoN/0uEmEro59nc1ChFXqXSGyg==",
       "cpu": [
         "arm"
       ],
@@ -6668,9 +7137,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.82.tgz",
-      "integrity": "sha512-26JkOujbzcItPAmIbD5vHJxQVy5ihcSu3YHTKwope1h28sApZdtE7S3e2G3gsZRTIdsCQkXUtAQeqHxGWWR3pw==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.96.tgz",
+      "integrity": "sha512-c/IiJ0s1y3Ymm2BTpyC/xr6gOvoqAVETrivVXHq68xgNms95luSpbYQ28rqaZC8bQC8M5zdXpSc0T8DJu8RJGw==",
       "cpu": [
         "arm64"
       ],
@@ -6684,9 +7153,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.82.tgz",
-      "integrity": "sha512-8Izj9tuuMpoc3cqiPBRtwqpO1BZ/+sfZVsEhLxrbOFlcSb8LnKyMle1g3JMMUwI4EU75RGVIzZMn8A6GOKdJbA==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.96.tgz",
+      "integrity": "sha512-i5/UTUwmJLri7zhtF6SAo/4QDQJDH2fhYJaBIUhrICmIkRO/ltURmpejqxsM/ye9Jqv5zG7VszMC0v/GYn/7BQ==",
       "cpu": [
         "arm64"
       ],
@@ -6700,9 +7169,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.82.tgz",
-      "integrity": "sha512-0GSrIBScQwTaPv46T2qB7XnDYxndRCpwH4HMjh6FN+I+lfPUhTSJKW8AonqrqT1TbpFIgvzQs7EnTsD7AnSCow==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.96.tgz",
+      "integrity": "sha512-USdaZu8lTIkm4Yf9cogct/j5eqtdZqTgcTib4I+NloUW0E/hySou3eSyp3V2UAA1qyuC72ld1otXuyKBna0YKQ==",
       "cpu": [
         "x64"
       ],
@@ -6716,9 +7185,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.82.tgz",
-      "integrity": "sha512-KJUnaaepDKNzrEbwz4jv0iC3/t9x0NSoe06fnkAlhh2+NFKWKKJhVCOBTrpds8n7eylBDIXUlK34XQafjVMUdg==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.96.tgz",
+      "integrity": "sha512-QYErutd+G2SNaCinUVobfL7jWWjGTI0QEoQ6hqTp7PxCJS/dmKmj3C5ZkvxRYcq7XcZt7ovrYCTwPTHzt6lZBg==",
       "cpu": [
         "x64"
       ],
@@ -6732,9 +7201,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.82.tgz",
-      "integrity": "sha512-TR3MHKhDYIyGyFcyl2d/p1ftceXcubAhX5wRSOdtOyr5+K/v3jbyCCqN7bbqO5o43wQVCwwR/drHleYyDZvg8Q==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.96.tgz",
+      "integrity": "sha512-hjGvvAduA3Un2cZ9iNP4xvTXOO4jL3G9iakhFsgVhpkU73SGmK7+LN8ZVBEu4oq2SUcHO6caWvnZ881cxGuSpg==",
       "cpu": [
         "arm64"
       ],
@@ -6748,9 +7217,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.82.tgz",
-      "integrity": "sha512-ZX4HzVVt6hs84YUg70UvyBJnBOIspmQQM0iXSzBvOikk3zRoN7BnDwQH4GScvevCEBuou60+i4I6d5kHLOfh8Q==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.96.tgz",
+      "integrity": "sha512-Far2hVFiwr+7VPCM2GxSmbh3ikTpM3pDombE+d69hkedvYHYZxtTF+2LTKl/sXtpbUnsoq7yV/32c9R/xaaWfw==",
       "cpu": [
         "ia32"
       ],
@@ -6764,9 +7233,9 @@
       }
     },
     "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.82.tgz",
-      "integrity": "sha512-4mJMnex21kbQoaHeAmHnVwQN9/XAfPszJ6n9HI7SVH+aAHnbBIR0M59/b50/CJMjTj5niUGk7EwQ3nhVNOG32g==",
+      "version": "1.3.96",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.96.tgz",
+      "integrity": "sha512-4VbSAniIu0ikLf5mBX81FsljnfqjoVGleEkCQv4+zRlyZtO3FHoDPkeLVoy6WRlj7tyrRcfUJ4mDdPkbfTO14g==",
       "cpu": [
         "x64"
       ],
@@ -6779,21 +7248,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/@plasmohq/parcel-optimizer-es/node_modules/@swc/helpers": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-      "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@plasmohq/parcel-packager": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-packager/-/parcel-packager-0.6.14.tgz",
-      "integrity": "sha512-pFab9COfafx66CtOFWgLgKf4TUPLb5EiTO4ecRz1HDINSvPl48ci+3czmtSzOI4+b1uiqZYxUB3eeaMfh9XWpA==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-packager/-/parcel-packager-0.6.15.tgz",
+      "integrity": "sha512-c6Afk5l8EqxyZ/N7p8avWEBt5teTQPQsvZZpPHWhsAY9eonX+h8bFdmXym1oevaq5TySJOpNCSUdTvqqZtlSnQ==",
       "license": "MIT",
       "dependencies": {
         "@parcel/core": "2.9.3",
@@ -6806,15 +7264,545 @@
         "parcel": ">= 2.7.0"
       }
     },
+    "node_modules/@plasmohq/parcel-resolver": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver/-/parcel-resolver-0.14.1.tgz",
+      "integrity": "sha512-1nmmMI7N5rtpni2TpUyPkI8XU1wIk/lTDGNZXLxtkzOoFiFP2sc2xZq4OGhmnRYvWphZYrnhMjRrjNJmqOFqxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/core": "2.9.3",
+        "@parcel/hash": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/types": "2.9.3",
+        "fast-glob": "3.3.2",
+        "fs-extra": "11.1.1",
+        "got": "13.0.0"
+      },
+      "engines": {
+        "parcel": ">= 2.7.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver-post/-/parcel-resolver-post-0.4.5.tgz",
+      "integrity": "sha512-Y5la9wruh3fMHlUoWtVBcbSyvg2xZE1kSRp5BAjtfyZlKS2cT/vIbFTUkqk9nPvXLExBDNajIxTKk9ag/9WzpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/core": "2.9.3",
+        "@parcel/hash": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/types": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "tsup": "7.2.0",
+        "typescript": "5.2.2"
+      },
+      "engines": {
+        "parcel": ">= 2.7.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/bundle-require": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-4.2.1.tgz",
+      "integrity": "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==",
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.17"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/tsup": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-7.2.0.tgz",
+      "integrity": "sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^4.0.0",
+        "cac": "^6.7.12",
+        "chokidar": "^3.5.1",
+        "debug": "^4.3.1",
+        "esbuild": "^0.18.2",
+        "execa": "^5.0.0",
+        "globby": "^11.0.3",
+        "joycon": "^3.0.1",
+        "postcss-load-config": "^4.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^3.2.5",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.20.3",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@plasmohq/parcel-resolver-post/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@plasmohq/parcel-resolver/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-runtime": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-runtime/-/parcel-runtime-0.25.1.tgz",
+      "integrity": "sha512-asr4DMXJSKPilye0uiyZf51NUC3WZAr0Y6mzl+mtRGIcywuv42+X52qnZl9a9xYkVZeYlVJq62Kfk4+wPthakg==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/core": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@types/trusted-types": "2.0.7",
+        "react-refresh": "0.14.0"
+      },
+      "engines": {
+        "parcel": ">= 2.7.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-runtime/node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@plasmohq/parcel-transformer-inject-env": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inject-env/-/parcel-transformer-inject-env-0.2.11.tgz",
-      "integrity": "sha512-eGwwoaDbPPwrRcEgOi/BpLVGe5ttrBhs91NBcKMpE/D5gktfbJPD1zHG8MPtQdE4Iq23aG3JUbiT5clmdwtUhQ==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inject-env/-/parcel-transformer-inject-env-0.2.12.tgz",
+      "integrity": "sha512-QhM5Je0LyuAAJMAXeBEu4YvDirIPXuO2SoxHkwTMIwCMXpstPinnKiElrIoolqZjcxLmDCfsXerXZfbN6NhSlA==",
       "license": "MIT",
       "dependencies": {
         "@parcel/core": "2.9.3",
         "@parcel/plugin": "2.9.3",
         "@parcel/types": "2.9.3"
+      },
+      "engines": {
+        "parcel": ">= 2.7.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inline-css/-/parcel-transformer-inline-css-0.3.11.tgz",
+      "integrity": "sha512-EUSwEowFNSgC/F1q/V4H4NXJ23wwLzlmRI6lvIr6S0mIuG/FCga+lAV3IZ+yAuXqUM2VexX6JyYYpNVidrMSxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/core": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "browserslist": "4.22.1",
+        "lightningcss": "1.21.8"
+      },
+      "engines": {
+        "parcel": ">= 2.7.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.8.tgz",
+      "integrity": "sha512-jEqaL7m/ZckZJjlMAfycr1Kpz7f93k6n7KGF5SJjuPSm6DWI6h3ayLZmgRHgy1OfrwoCed6h4C/gHYPOd1OFMA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.21.8",
+        "lightningcss-darwin-x64": "1.21.8",
+        "lightningcss-freebsd-x64": "1.21.8",
+        "lightningcss-linux-arm-gnueabihf": "1.21.8",
+        "lightningcss-linux-arm64-gnu": "1.21.8",
+        "lightningcss-linux-arm64-musl": "1.21.8",
+        "lightningcss-linux-x64-gnu": "1.21.8",
+        "lightningcss-linux-x64-musl": "1.21.8",
+        "lightningcss-win32-x64-msvc": "1.21.8"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.8.tgz",
+      "integrity": "sha512-BOMoGfcgkk2f4ltzsJqmkjiqRtlZUK+UdwhR+P6VgIsnpQBV3G01mlL6GzYxYqxq+6/3/n/D+4oy2NeknmADZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-darwin-x64": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.8.tgz",
+      "integrity": "sha512-YhF64mcVDPKKufL4aNFBnVH7uvzE0bW3YUsPXdP4yUcT/8IXChypOZ/PE1pmt2RlbmsyVuuIIeZU4zTyZe5Amw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.21.8.tgz",
+      "integrity": "sha512-CV6A/vTG2Ryd3YpChEgfWWv4TXCAETo9TcHSNx0IP0dnKcnDEiAko4PIKhCqZL11IGdN1ZLBCVPw+vw5ZYwzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.8.tgz",
+      "integrity": "sha512-9PMbqh8n/Xq0F4/j2NR/hHM2HRDiFXFSF0iOvV67pNWKJkHIO6mR8jBw/88Aro5Ye/ILsX5OuWsxIVJDFv0NXA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.8.tgz",
+      "integrity": "sha512-JTM/TuMMllkzaXV7/eDjG4IJKLlCl+RfYZwtsVmC82gc0QX0O37csGAcY2OGleiuA4DnEo/Qea5WoFfZUNC6zg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.8.tgz",
+      "integrity": "sha512-01gWShXrgoIb8urzShpn1RWtZuaSyKSzF2hfO+flzlTPoACqcO3rgcu/3af4Cw54e8vKzL5hPRo4kROmgaOMLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.8.tgz",
+      "integrity": "sha512-yVB5vYJjJb/Aku0V9QaGYIntvK/1TJOlNB9GmkNpXX5bSSP2pYW4lWW97jxFMHO908M0zjEt1qyOLMyqojHL+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.8.tgz",
+      "integrity": "sha512-TYi+KNtBVK0+FZvxTX/d5XJb+tw3Jq+2Rr9hW359wp1afsi1Vkg+uVGgbn+m2dipa5XwpCseQq81ylMlXuyfPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-inline-css/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.21.8",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.8.tgz",
+      "integrity": "sha512-mww+kqbPx0/C44l2LEloECtRUuOFDjq9ftp+EHTPiCp2t+avy0sh8MaFwGsrKkj2XfZhaRhi4CPVKBoqF1Qlwg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-manifest": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-manifest/-/parcel-transformer-manifest-0.20.1.tgz",
+      "integrity": "sha512-fA2d+u7eAURr8Vyi1HAB8zwndBW2czi5YcLgZRVwEqHODYYIyNcmqMJHLt7TAQYTD+POG+z4WpM81AKdhcq8mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mischnic/json-sourcemap": "0.1.0",
+        "@parcel/core": "2.9.3",
+        "@parcel/diagnostic": "2.9.3",
+        "@parcel/fs": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/types": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "content-security-policy-parser": "0.4.1",
+        "json-schema-to-ts": "2.9.2",
+        "nullthrows": "1.1.1"
+      },
+      "engines": {
+        "parcel": ">= 2.7.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-manifest/node_modules/@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "license": "MIT"
+    },
+    "node_modules/@plasmohq/parcel-transformer-manifest/node_modules/@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^0.15.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-manifest/node_modules/@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@plasmohq/parcel-transformer-svelte": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-svelte/-/parcel-transformer-svelte-0.6.0.tgz",
+      "integrity": "sha512-5lZW6NBtzhJaCyjpKaZF1/YzY9CF+kbfNknvASJB/Cf6uJPJlrgdxoWiVJ8IWMs3DyLgAnJXTdIU+uwjwXP1wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/core": "2.9.3",
+        "@parcel/diagnostic": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/source-map": "2.1.1",
+        "@parcel/utils": "2.9.3",
+        "svelte": "4.2.2"
       },
       "engines": {
         "parcel": ">= 2.7.0"
@@ -6843,9 +7831,10 @@
       }
     },
     "node_modules/@plasmohq/storage": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/storage/-/storage-1.8.0.tgz",
-      "integrity": "sha512-8VEVKq2takNaR6SBpRaS2KdLMwsoH91eekap1QA2M4B2CcyprSbsEMuK6HogfcD5gRBzHJAhHqwBGL9PdUJm7w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@plasmohq/storage/-/storage-1.13.0.tgz",
+      "integrity": "sha512-ceFtWFDMXg6v9nePEVyTgMusFmnMK82eNBf9ac0nN0kjMZQ+5IVEaiAgnS/c+KS43b7W+NJPpCakh+flgLOpjg==",
+      "license": "MIT",
       "dependencies": {
         "pify": "6.1.0"
       },
@@ -11555,21 +12544,18 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.2.tgz",
-      "integrity": "sha512-QtQGAQJfHXiTrtRH8Q1gkarFLs56fDmfiMCptvRbo/AEQIImrW6u7EcUAOfkHHNE9dqZKH3227iRKRSp0KtfTw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
+      "integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal-json": "^1.0.0"
-      },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
@@ -11723,16 +12709,16 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.3.tgz",
+      "integrity": "sha512-pCO3aoRJ0MBiRMu8B7vUga0qL3L7gO1+SW7ku6qlSsMLwuhaawnuvZDyzJY/kyC63Un0XAB0OPUcfF1eTO/V+Q==",
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.3.tgz",
-      "integrity": "sha512-7RYKL+vZVCyAsMLi5SPu7QGauGGT8avnP/HO571ndEuV4MYdGXvLhtW67FuLPeEI8EiIY7zbbRR9x7x7HU0kgw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -11742,9 +12728,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.2.tgz",
-      "integrity": "sha512-HZoJwzC+rZ9lqEemTMiO0luOePoGYNBgsLLgegKR/cljiJvcDNhDZQkzC+NC5Oh0aHbdBNSOHpghwMuB5tqhjg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -11759,14 +12745,13 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.2.1.tgz",
-      "integrity": "sha512-YTB47kHwBW9zSG8LD77MIBAAQXjU2WjAkMHeeb7hUplVs6+IoM5I7uEVQNPMB7lj9r8I76UMdoMkGnCodHOLqg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.1.tgz",
+      "integrity": "sha512-eVZbtKM+4uehzrsj49KtCy3Pbg7kO1pJ3SKZ1SFrIH/0pnj9scuGGgUlNDf/7qS8WKtGdiJY5Kyhs/ivYPTB/g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "b4a": "^1.6.6",
-        "streamx": "^2.18.0"
+        "streamx": "^2.21.0"
       }
     },
     "node_modules/base": {
@@ -11880,7 +12865,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -11897,10 +12884,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -12156,6 +13143,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.1.2.tgz",
+      "integrity": "sha512-CAtbGEDulyjzs05RXy3uKcwqeztz/dMEuAc1Xu9NQBsbrhuGMneL0u9Dj5SoutLKBFYun8txxYIwhjtLNfUmCA==",
+      "license": "MIT"
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -12435,6 +13428,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -12461,6 +13455,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -12902,9 +13897,9 @@
       }
     },
     "node_modules/css-select/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "license": "BSD-2-Clause",
       "optional": true,
       "peer": true,
@@ -13329,27 +14324,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/deep-equal-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deep-equal-json/-/deep-equal-json-1.0.0.tgz",
-      "integrity": "sha512-x11iOxzQuLWG1faqBf8PYn3xSxkK41Wg38lUbch9f+nVmBeuI53PPXeRIDdHsW2/dP2GGKL9p8cLCahHToE7CA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/deep-equal-json/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
-    },
     "node_modules/deep-equal/node_modules/isarray": {
       "version": "2.0.5",
       "dev": true,
@@ -13582,15 +14556,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -15438,7 +16403,8 @@
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -17502,12 +18468,12 @@
       "license": "MIT"
     },
     "node_modules/is-reference": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "*"
+        "@types/estree": "^1.0.6"
       }
     },
     "node_modules/is-regex": {
@@ -19055,9 +20021,9 @@
       }
     },
     "node_modules/less": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
-      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.1.tgz",
+      "integrity": "sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "copy-anything": "^2.0.1",
@@ -20318,9 +21284,10 @@
       "license": "ISC"
     },
     "node_modules/node-abi": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-      "integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -20686,6 +21653,7 @@
     },
     "node_modules/object-is": {
       "version": "1.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -21568,6 +22536,233 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/plasmo": {
+      "version": "0.89.4",
+      "resolved": "https://registry.npmjs.org/plasmo/-/plasmo-0.89.4.tgz",
+      "integrity": "sha512-vsoMe8ts0tyW27fZxwQLqWR/58NKqRepLFrZMVBH4ceSIyPDryfPpXzVxmBDH43odbiUVFdh8BGAt2ri2vQuGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "1.7.2",
+        "@parcel/core": "2.9.3",
+        "@parcel/fs": "2.9.3",
+        "@parcel/package-manager": "2.9.3",
+        "@parcel/watcher": "2.2.0",
+        "@plasmohq/init": "0.7.0",
+        "@plasmohq/parcel-config": "0.41.1",
+        "@plasmohq/parcel-core": "0.1.10",
+        "buffer": "6.0.3",
+        "chalk": "5.3.0",
+        "change-case": "5.1.2",
+        "dotenv": "16.3.1",
+        "dotenv-expand": "10.0.0",
+        "events": "3.3.0",
+        "fast-glob": "3.3.2",
+        "fflate": "0.8.1",
+        "get-port": "7.0.0",
+        "got": "13.0.0",
+        "ignore": "5.2.4",
+        "inquirer": "9.2.12",
+        "is-path-inside": "4.0.0",
+        "json5": "2.2.3",
+        "mnemonic-id": "3.2.7",
+        "node-object-hash": "3.0.0",
+        "package-json": "8.1.1",
+        "process": "0.11.10",
+        "semver": "7.5.4",
+        "sharp": "0.32.6",
+        "tempy": "3.1.0",
+        "typescript": "5.2.2"
+      },
+      "bin": {
+        "plasmo": "bin/index.mjs"
+      }
+    },
+    "node_modules/plasmo/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/plasmo/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/plasmo/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/plasmo/node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/plasmo/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/plasmo/node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "license": "MIT"
+    },
+    "node_modules/plasmo/node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/plasmo/node_modules/inquirer": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
+      "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ljharb/through": "^2.3.11",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^5.3.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^4.1.0",
+        "external-editor": "^3.1.0",
+        "figures": "^5.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/plasmo/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/plasmo/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/plasmo/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/plasmo/node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/plasmo/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/plasmo/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
@@ -22011,9 +23206,10 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -22036,9 +23232,10 @@
       }
     },
     "node_modules/prebuild-install/node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -22558,7 +23755,8 @@
     "node_modules/queue-tick": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -23754,6 +24952,69 @@
         "node": ">=8"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sharp/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
+    },
+    "node_modules/sharp/node_modules/tar-fs": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -23883,6 +25144,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -23906,6 +25168,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -23913,7 +25176,8 @@
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -24431,9 +25695,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
-      "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
+      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
@@ -25162,6 +26426,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svelte": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
+      "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^3.2.1",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/svelte/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/svelte/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
@@ -25465,9 +26771,9 @@
       }
     },
     "node_modules/text-decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
-      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -31674,7 +32980,7 @@
       "dependencies": {
         "@dagrejs/dagre": "^1.0.4",
         "@liveblocks/core": "*",
-        "@plasmohq/storage": "^1.8.0",
+        "@plasmohq/storage": "^1.13.0",
         "@radix-ui/react-dialog": "^1.0.2",
         "@radix-ui/react-popover": "^1.0.3",
         "@radix-ui/react-select": "^1.2.0",
@@ -31683,7 +32989,7 @@
         "classnames": "^2.3.2",
         "fast-equals": "^5.0.1",
         "js-base64": "^3.7.5",
-        "plasmo": "^0.83.0",
+        "plasmo": "^0.89.4",
         "prism-react-renderer": "^2.0.6",
         "react": "18.2.0",
         "react-arborist": "^3.4.0",
@@ -31704,1417 +33010,6 @@
         "prettier-plugin-tailwindcss": "^0.5.4",
         "tailwindcss": "^3.2.4",
         "webextension-polyfill": "^0.10.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@lezer/common": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
-      "license": "MIT"
-    },
-    "tools/liveblocks-devtools/node_modules/@lezer/lr": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "tools/liveblocks-devtools/node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "tools/liveblocks-devtools/node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "tools/liveblocks-devtools/node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "tools/liveblocks-devtools/node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "tools/liveblocks-devtools/node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "tools/liveblocks-devtools/node_modules/@mischnic/json-sourcemap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
-      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^0.15.7",
-        "@lezer/lr": "^0.15.4",
-        "json5": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/codeframe": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
-      "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/codeframe/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/events": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
-      "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/fs-search": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
-      "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/logger": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
-      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/diagnostic": "2.8.3",
-        "@parcel/events": "2.8.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/logger/node_modules/@parcel/diagnostic": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
-      "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/markdown-ansi": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
-      "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/markdown-ansi/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.3.tgz",
-      "integrity": "sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/plugin": "2.8.3",
-        "@parcel/utils": "2.8.3",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.8.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/cache": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
-      "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/fs": "2.8.3",
-        "@parcel/logger": "2.8.3",
-        "@parcel/utils": "2.8.3",
-        "lmdb": "2.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.8.3"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/diagnostic": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
-      "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/fs": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
-      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/fs-search": "2.8.3",
-        "@parcel/types": "2.8.3",
-        "@parcel/utils": "2.8.3",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.8.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.8.3"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/hash": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
-      "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "xxhash-wasm": "^0.4.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/package-manager": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
-      "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/diagnostic": "2.8.3",
-        "@parcel/fs": "2.8.3",
-        "@parcel/logger": "2.8.3",
-        "@parcel/types": "2.8.3",
-        "@parcel/utils": "2.8.3",
-        "@parcel/workers": "2.8.3",
-        "semver": "^5.7.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.8.3"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/plugin": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
-      "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/types": "2.8.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/types": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
-      "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/cache": "2.8.3",
-        "@parcel/diagnostic": "2.8.3",
-        "@parcel/fs": "2.8.3",
-        "@parcel/package-manager": "2.8.3",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.8.3",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/utils": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
-      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/codeframe": "2.8.3",
-        "@parcel/diagnostic": "2.8.3",
-        "@parcel/hash": "2.8.3",
-        "@parcel/logger": "2.8.3",
-        "@parcel/markdown-ansi": "2.8.3",
-        "@parcel/source-map": "^2.1.1",
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/@parcel/workers": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
-      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/diagnostic": "2.8.3",
-        "@parcel/logger": "2.8.3",
-        "@parcel/types": "2.8.3",
-        "@parcel/utils": "2.8.3",
-        "chrome-trace-event": "^1.0.2",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.8.3"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@parcel/runtime-js/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-compressor-utf8": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-compressor-utf8/-/parcel-compressor-utf8-0.1.0.tgz",
-      "integrity": "sha512-UxljXY+cUVO0ZdszoQRfQjbRjyWYIhGKCjFD48yOcnbSkOZmS5MPPhKrT79x+PMGSK5T6fUXaDjzqbnMb45MZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/plugin": "2.9.3"
-      },
-      "engines": {
-        "parcel": ">= 2.8.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-config": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-config/-/parcel-config-0.41.0.tgz",
-      "integrity": "sha512-MHtuEyjSCqVT0J584KF4ZrnNF1KTGz3+0+wEBgYiiWEW+WW91/Hv/5pboBrPH4tu/knxSQjzE9zlY5Rq2xh9Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/compressor-raw": "2.9.3",
-        "@parcel/config-default": "2.9.3",
-        "@parcel/core": "2.9.3",
-        "@parcel/optimizer-data-url": "2.9.3",
-        "@parcel/reporter-bundle-buddy": "2.9.3",
-        "@parcel/resolver-default": "2.9.3",
-        "@parcel/runtime-js": "2.8.3",
-        "@parcel/runtime-service-worker": "2.9.3",
-        "@parcel/source-map": "2.1.1",
-        "@parcel/transformer-babel": "2.9.3",
-        "@parcel/transformer-css": "2.9.3",
-        "@parcel/transformer-graphql": "2.9.3",
-        "@parcel/transformer-inline-string": "2.9.3",
-        "@parcel/transformer-js": "2.9.3",
-        "@parcel/transformer-less": "2.9.3",
-        "@parcel/transformer-postcss": "2.9.3",
-        "@parcel/transformer-raw": "2.9.3",
-        "@parcel/transformer-react-refresh-wrap": "2.9.3",
-        "@parcel/transformer-sass": "2.9.3",
-        "@parcel/transformer-svg-react": "2.9.3",
-        "@parcel/transformer-worklet": "2.9.3",
-        "@plasmohq/parcel-bundler": "0.5.5",
-        "@plasmohq/parcel-compressor-utf8": "0.1.0",
-        "@plasmohq/parcel-namer-manifest": "0.3.12",
-        "@plasmohq/parcel-optimizer-encapsulate": "0.0.7",
-        "@plasmohq/parcel-optimizer-es": "0.4.0",
-        "@plasmohq/parcel-packager": "0.6.14",
-        "@plasmohq/parcel-resolver": "0.14.0",
-        "@plasmohq/parcel-resolver-post": "0.4.4",
-        "@plasmohq/parcel-runtime": "0.25.0",
-        "@plasmohq/parcel-transformer-inject-env": "0.2.11",
-        "@plasmohq/parcel-transformer-inline-css": "0.3.11",
-        "@plasmohq/parcel-transformer-manifest": "0.19.0",
-        "@plasmohq/parcel-transformer-svelte": "0.6.0",
-        "@plasmohq/parcel-transformer-vue": "0.5.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-resolver": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver/-/parcel-resolver-0.14.0.tgz",
-      "integrity": "sha512-OPGFiv2SxDEJl9sNPKfjkQ3QaqKOzSDx8E85Bq9FCOKCj+EWTPfoeUOAuMkHY/ArcvDBhWAo3Zu66f2U7iPEGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/core": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "fast-glob": "3.3.2",
-        "fs-extra": "11.1.1",
-        "got": "13.0.0"
-      },
-      "engines": {
-        "parcel": ">= 2.7.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-resolver-post": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver-post/-/parcel-resolver-post-0.4.4.tgz",
-      "integrity": "sha512-n39U5z2aGAfCDFydpvEDXx0MWtqYwh0+aX4QS49/IsmZMM1Ra+GnHs/gfeJz0jtN83EytlbwSoDcXRkORx9rIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/core": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "tsup": "7.2.0",
-        "typescript": "5.2.2"
-      },
-      "engines": {
-        "parcel": ">= 2.7.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-runtime": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-runtime/-/parcel-runtime-0.25.0.tgz",
-      "integrity": "sha512-jtb77WDCYhKDPi/jRweSNX9GEe/REQUQU50d18YkDpQDyo/enVTyWVeYqfo3Q21iGLX8x9E5nF2rXtIVtoOAmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/core": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@types/trusted-types": "2.0.7",
-        "react-refresh": "0.14.0"
-      },
-      "engines": {
-        "parcel": ">= 2.7.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-transformer-inline-css": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inline-css/-/parcel-transformer-inline-css-0.3.11.tgz",
-      "integrity": "sha512-EUSwEowFNSgC/F1q/V4H4NXJ23wwLzlmRI6lvIr6S0mIuG/FCga+lAV3IZ+yAuXqUM2VexX6JyYYpNVidrMSxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/core": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "browserslist": "4.22.1",
-        "lightningcss": "1.21.8"
-      },
-      "engines": {
-        "parcel": ">= 2.7.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-transformer-manifest": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-manifest/-/parcel-transformer-manifest-0.19.0.tgz",
-      "integrity": "sha512-cDmca0jPVFVnRQPqCWcsPPwre27/yAGxSF1+JmPVUeXZYMCrg5wdNepRDSw+/dDBO2VmNHh/Tv+Hgj1fLIM8CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mischnic/json-sourcemap": "0.1.0",
-        "@parcel/core": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "content-security-policy-parser": "0.4.1",
-        "json-schema-to-ts": "2.9.2",
-        "nullthrows": "1.1.1"
-      },
-      "engines": {
-        "parcel": ">= 2.7.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/@plasmohq/parcel-transformer-svelte": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-svelte/-/parcel-transformer-svelte-0.6.0.tgz",
-      "integrity": "sha512-5lZW6NBtzhJaCyjpKaZF1/YzY9CF+kbfNknvASJB/Cf6uJPJlrgdxoWiVJ8IWMs3DyLgAnJXTdIU+uwjwXP1wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@parcel/core": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/source-map": "2.1.1",
-        "@parcel/utils": "2.9.3",
-        "svelte": "4.2.2"
-      },
-      "engines": {
-        "parcel": ">= 2.7.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/bundle-require": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-4.2.1.tgz",
-      "integrity": "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==",
-      "license": "MIT",
-      "dependencies": {
-        "load-tsconfig": "^0.2.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.17"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/change-case": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.1.2.tgz",
-      "integrity": "sha512-CAtbGEDulyjzs05RXy3uKcwqeztz/dMEuAc1Xu9NQBsbrhuGMneL0u9Dj5SoutLKBFYun8txxYIwhjtLNfUmCA==",
-      "license": "MIT"
-    },
-    "tools/liveblocks-devtools/node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/fflate": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
-      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
-      "license": "MIT"
-    },
-    "tools/liveblocks-devtools/node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/inquirer": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
-      "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/through": "^2.3.11",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^5.3.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^4.1.0",
-        "external-editor": "^3.1.0",
-        "figures": "^5.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "1.0.0",
-        "ora": "^5.4.1",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.8.tgz",
-      "integrity": "sha512-jEqaL7m/ZckZJjlMAfycr1Kpz7f93k6n7KGF5SJjuPSm6DWI6h3ayLZmgRHgy1OfrwoCed6h4C/gHYPOd1OFMA==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.21.8",
-        "lightningcss-darwin-x64": "1.21.8",
-        "lightningcss-freebsd-x64": "1.21.8",
-        "lightningcss-linux-arm-gnueabihf": "1.21.8",
-        "lightningcss-linux-arm64-gnu": "1.21.8",
-        "lightningcss-linux-arm64-musl": "1.21.8",
-        "lightningcss-linux-x64-gnu": "1.21.8",
-        "lightningcss-linux-x64-musl": "1.21.8",
-        "lightningcss-win32-x64-msvc": "1.21.8"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-darwin-arm64": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.8.tgz",
-      "integrity": "sha512-BOMoGfcgkk2f4ltzsJqmkjiqRtlZUK+UdwhR+P6VgIsnpQBV3G01mlL6GzYxYqxq+6/3/n/D+4oy2NeknmADZw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-darwin-x64": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.8.tgz",
-      "integrity": "sha512-YhF64mcVDPKKufL4aNFBnVH7uvzE0bW3YUsPXdP4yUcT/8IXChypOZ/PE1pmt2RlbmsyVuuIIeZU4zTyZe5Amw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-freebsd-x64": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.21.8.tgz",
-      "integrity": "sha512-CV6A/vTG2Ryd3YpChEgfWWv4TXCAETo9TcHSNx0IP0dnKcnDEiAko4PIKhCqZL11IGdN1ZLBCVPw+vw5ZYwzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.8.tgz",
-      "integrity": "sha512-9PMbqh8n/Xq0F4/j2NR/hHM2HRDiFXFSF0iOvV67pNWKJkHIO6mR8jBw/88Aro5Ye/ILsX5OuWsxIVJDFv0NXA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.8.tgz",
-      "integrity": "sha512-JTM/TuMMllkzaXV7/eDjG4IJKLlCl+RfYZwtsVmC82gc0QX0O37csGAcY2OGleiuA4DnEo/Qea5WoFfZUNC6zg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.8.tgz",
-      "integrity": "sha512-01gWShXrgoIb8urzShpn1RWtZuaSyKSzF2hfO+flzlTPoACqcO3rgcu/3af4Cw54e8vKzL5hPRo4kROmgaOMLg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.8.tgz",
-      "integrity": "sha512-yVB5vYJjJb/Aku0V9QaGYIntvK/1TJOlNB9GmkNpXX5bSSP2pYW4lWW97jxFMHO908M0zjEt1qyOLMyqojHL+Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.8.tgz",
-      "integrity": "sha512-TYi+KNtBVK0+FZvxTX/d5XJb+tw3Jq+2Rr9hW359wp1afsi1Vkg+uVGgbn+m2dipa5XwpCseQq81ylMlXuyfPw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.21.8",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.8.tgz",
-      "integrity": "sha512-mww+kqbPx0/C44l2LEloECtRUuOFDjq9ftp+EHTPiCp2t+avy0sh8MaFwGsrKkj2XfZhaRhi4CPVKBoqF1Qlwg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "msgpackr": "^1.5.4",
-        "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.3",
-        "ordered-binary": "^1.2.4",
-        "weak-lru-cache": "^1.2.2"
-      },
-      "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/lmdb/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "license": "MIT"
-    },
-    "tools/liveblocks-devtools/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT"
-    },
-    "tools/liveblocks-devtools/node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
-      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build-optional-packages": "bin.js",
-        "node-gyp-build-optional-packages-optional": "optional.js",
-        "node-gyp-build-optional-packages-test": "build-test.js"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/plasmo": {
-      "version": "0.89.1",
-      "resolved": "https://registry.npmjs.org/plasmo/-/plasmo-0.89.1.tgz",
-      "integrity": "sha512-YBSi9QeXYo9UDcbpgNI+FBC19iWs9C66ucyZpop0MaW5rc+uv/6HHzINkw+NL2izfJ8bdEU0l3iCLhpBmeKP2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/spawn-async": "1.7.2",
-        "@parcel/core": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/watcher": "2.2.0",
-        "@plasmohq/init": "0.7.0",
-        "@plasmohq/parcel-config": "0.41.0",
-        "@plasmohq/parcel-core": "0.1.8",
-        "buffer": "6.0.3",
-        "chalk": "5.3.0",
-        "change-case": "5.1.2",
-        "dotenv": "16.3.1",
-        "dotenv-expand": "10.0.0",
-        "events": "3.3.0",
-        "fast-glob": "3.3.2",
-        "fflate": "0.8.1",
-        "get-port": "7.0.0",
-        "got": "13.0.0",
-        "ignore": "5.2.4",
-        "inquirer": "9.2.12",
-        "is-path-inside": "4.0.0",
-        "json5": "2.2.3",
-        "mnemonic-id": "3.2.7",
-        "node-object-hash": "3.0.0",
-        "package-json": "8.1.1",
-        "process": "0.11.10",
-        "semver": "7.5.4",
-        "sharp": "0.32.6",
-        "tempy": "3.1.0",
-        "typescript": "5.2.2"
-      },
-      "bin": {
-        "plasmo": "bin/index.mjs"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/sharp/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/svelte": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
-      "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.9.0",
-        "aria-query": "^5.3.0",
-        "axobject-query": "^3.2.1",
-        "code-red": "^1.0.3",
-        "css-tree": "^2.3.1",
-        "estree-walker": "^3.0.3",
-        "is-reference": "^3.0.1",
-        "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "periscopic": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/tsup": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-7.2.0.tgz",
-      "integrity": "sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-require": "^4.0.0",
-        "cac": "^6.7.12",
-        "chokidar": "^3.5.1",
-        "debug": "^4.3.1",
-        "esbuild": "^0.18.2",
-        "execa": "^5.0.0",
-        "globby": "^11.0.3",
-        "joycon": "^3.0.1",
-        "postcss-load-config": "^4.0.1",
-        "resolve-from": "^5.0.0",
-        "rollup": "^3.2.5",
-        "source-map": "0.8.0-beta.0",
-        "sucrase": "^3.20.3",
-        "tree-kill": "^1.2.2"
-      },
-      "bin": {
-        "tsup": "dist/cli-default.js",
-        "tsup-node": "dist/cli-node.js"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@swc/core": "^1",
-        "postcss": "^8.4.12",
-        "typescript": ">=4.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "license": "BSD-2-Clause"
-    },
-    "tools/liveblocks-devtools/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
-    "tools/liveblocks-devtools/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     }
   },
@@ -35959,7 +35854,7 @@
       "requires": {
         "@dagrejs/dagre": "^1.0.4",
         "@liveblocks/core": "*",
-        "@plasmohq/storage": "^1.8.0",
+        "@plasmohq/storage": "^1.13.0",
         "@radix-ui/react-dialog": "^1.0.2",
         "@radix-ui/react-popover": "^1.0.3",
         "@radix-ui/react-select": "^1.2.0",
@@ -35974,7 +35869,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "fast-equals": "^5.0.1",
         "js-base64": "^3.7.5",
-        "plasmo": "^0.83.0",
+        "plasmo": "^0.89.4",
         "postcss": "^8.4.20",
         "prettier-plugin-tailwindcss": "^0.5.4",
         "prism-react-renderer": "^2.0.6",
@@ -35987,850 +35882,6 @@
         "use-resize-observer": "^9.1.0",
         "webextension-polyfill": "^0.10.0",
         "yjs": "^13.6.14"
-      },
-      "dependencies": {
-        "@lezer/common": {
-          "version": "0.15.12",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-          "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
-        },
-        "@lezer/lr": {
-          "version": "0.15.8",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-          "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
-          "requires": {
-            "@lezer/common": "^0.15.0"
-          }
-        },
-        "@lmdb/lmdb-darwin-arm64": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-          "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
-          "optional": true
-        },
-        "@lmdb/lmdb-darwin-x64": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-          "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
-          "optional": true
-        },
-        "@lmdb/lmdb-linux-arm": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-          "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
-          "optional": true
-        },
-        "@lmdb/lmdb-linux-arm64": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-          "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
-          "optional": true
-        },
-        "@lmdb/lmdb-linux-x64": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-          "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
-          "optional": true
-        },
-        "@lmdb/lmdb-win32-x64": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-          "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
-          "optional": true
-        },
-        "@mischnic/json-sourcemap": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
-          "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
-          "requires": {
-            "@lezer/common": "^0.15.7",
-            "@lezer/lr": "^0.15.4",
-            "json5": "^2.2.1"
-          }
-        },
-        "@parcel/codeframe": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
-          "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
-          "requires": {
-            "chalk": "^4.1.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
-          }
-        },
-        "@parcel/events": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
-          "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w=="
-        },
-        "@parcel/fs-search": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
-          "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
-          "requires": {
-            "detect-libc": "^1.0.3"
-          }
-        },
-        "@parcel/logger": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
-          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
-          "requires": {
-            "@parcel/diagnostic": "2.8.3",
-            "@parcel/events": "2.8.3"
-          },
-          "dependencies": {
-            "@parcel/diagnostic": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
-              "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
-              "requires": {
-                "@mischnic/json-sourcemap": "^0.1.0",
-                "nullthrows": "^1.1.1"
-              }
-            }
-          }
-        },
-        "@parcel/markdown-ansi": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
-          "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
-          "requires": {
-            "chalk": "^4.1.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
-          }
-        },
-        "@parcel/runtime-js": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.3.tgz",
-          "integrity": "sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==",
-          "requires": {
-            "@parcel/plugin": "2.8.3",
-            "@parcel/utils": "2.8.3",
-            "nullthrows": "^1.1.1"
-          },
-          "dependencies": {
-            "@parcel/cache": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
-              "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
-              "requires": {
-                "@parcel/fs": "2.8.3",
-                "@parcel/logger": "2.8.3",
-                "@parcel/utils": "2.8.3",
-                "lmdb": "2.5.2"
-              }
-            },
-            "@parcel/diagnostic": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
-              "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
-              "requires": {
-                "@mischnic/json-sourcemap": "^0.1.0",
-                "nullthrows": "^1.1.1"
-              }
-            },
-            "@parcel/fs": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
-              "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
-              "requires": {
-                "@parcel/fs-search": "2.8.3",
-                "@parcel/types": "2.8.3",
-                "@parcel/utils": "2.8.3",
-                "@parcel/watcher": "^2.0.7",
-                "@parcel/workers": "2.8.3"
-              }
-            },
-            "@parcel/hash": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
-              "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
-              "requires": {
-                "detect-libc": "^1.0.3",
-                "xxhash-wasm": "^0.4.2"
-              }
-            },
-            "@parcel/package-manager": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
-              "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
-              "requires": {
-                "@parcel/diagnostic": "2.8.3",
-                "@parcel/fs": "2.8.3",
-                "@parcel/logger": "2.8.3",
-                "@parcel/types": "2.8.3",
-                "@parcel/utils": "2.8.3",
-                "@parcel/workers": "2.8.3",
-                "semver": "^5.7.1"
-              }
-            },
-            "@parcel/plugin": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
-              "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
-              "requires": {
-                "@parcel/types": "2.8.3"
-              }
-            },
-            "@parcel/types": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
-              "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
-              "requires": {
-                "@parcel/cache": "2.8.3",
-                "@parcel/diagnostic": "2.8.3",
-                "@parcel/fs": "2.8.3",
-                "@parcel/package-manager": "2.8.3",
-                "@parcel/source-map": "^2.1.1",
-                "@parcel/workers": "2.8.3",
-                "utility-types": "^3.10.0"
-              }
-            },
-            "@parcel/utils": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
-              "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
-              "requires": {
-                "@parcel/codeframe": "2.8.3",
-                "@parcel/diagnostic": "2.8.3",
-                "@parcel/hash": "2.8.3",
-                "@parcel/logger": "2.8.3",
-                "@parcel/markdown-ansi": "2.8.3",
-                "@parcel/source-map": "^2.1.1",
-                "chalk": "^4.1.0"
-              }
-            },
-            "@parcel/workers": {
-              "version": "2.8.3",
-              "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
-              "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
-              "requires": {
-                "@parcel/diagnostic": "2.8.3",
-                "@parcel/logger": "2.8.3",
-                "@parcel/types": "2.8.3",
-                "@parcel/utils": "2.8.3",
-                "chrome-trace-event": "^1.0.2",
-                "nullthrows": "^1.1.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "semver": {
-              "version": "5.7.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-              "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-            }
-          }
-        },
-        "@plasmohq/parcel-compressor-utf8": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-compressor-utf8/-/parcel-compressor-utf8-0.1.0.tgz",
-          "integrity": "sha512-UxljXY+cUVO0ZdszoQRfQjbRjyWYIhGKCjFD48yOcnbSkOZmS5MPPhKrT79x+PMGSK5T6fUXaDjzqbnMb45MZw==",
-          "requires": {
-            "@parcel/plugin": "2.9.3"
-          }
-        },
-        "@plasmohq/parcel-config": {
-          "version": "0.41.0",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-config/-/parcel-config-0.41.0.tgz",
-          "integrity": "sha512-MHtuEyjSCqVT0J584KF4ZrnNF1KTGz3+0+wEBgYiiWEW+WW91/Hv/5pboBrPH4tu/knxSQjzE9zlY5Rq2xh9Rg==",
-          "requires": {
-            "@parcel/compressor-raw": "2.9.3",
-            "@parcel/config-default": "2.9.3",
-            "@parcel/core": "2.9.3",
-            "@parcel/optimizer-data-url": "2.9.3",
-            "@parcel/reporter-bundle-buddy": "2.9.3",
-            "@parcel/resolver-default": "2.9.3",
-            "@parcel/runtime-js": "2.8.3",
-            "@parcel/runtime-service-worker": "2.9.3",
-            "@parcel/source-map": "2.1.1",
-            "@parcel/transformer-babel": "2.9.3",
-            "@parcel/transformer-css": "2.9.3",
-            "@parcel/transformer-graphql": "2.9.3",
-            "@parcel/transformer-inline-string": "2.9.3",
-            "@parcel/transformer-js": "2.9.3",
-            "@parcel/transformer-less": "2.9.3",
-            "@parcel/transformer-postcss": "2.9.3",
-            "@parcel/transformer-raw": "2.9.3",
-            "@parcel/transformer-react-refresh-wrap": "2.9.3",
-            "@parcel/transformer-sass": "2.9.3",
-            "@parcel/transformer-svg-react": "2.9.3",
-            "@parcel/transformer-worklet": "2.9.3",
-            "@plasmohq/parcel-bundler": "0.5.5",
-            "@plasmohq/parcel-compressor-utf8": "0.1.0",
-            "@plasmohq/parcel-namer-manifest": "0.3.12",
-            "@plasmohq/parcel-optimizer-encapsulate": "0.0.7",
-            "@plasmohq/parcel-optimizer-es": "0.4.0",
-            "@plasmohq/parcel-packager": "0.6.14",
-            "@plasmohq/parcel-resolver": "0.14.0",
-            "@plasmohq/parcel-resolver-post": "0.4.4",
-            "@plasmohq/parcel-runtime": "0.25.0",
-            "@plasmohq/parcel-transformer-inject-env": "0.2.11",
-            "@plasmohq/parcel-transformer-inline-css": "0.3.11",
-            "@plasmohq/parcel-transformer-manifest": "0.19.0",
-            "@plasmohq/parcel-transformer-svelte": "0.6.0",
-            "@plasmohq/parcel-transformer-vue": "0.5.0"
-          }
-        },
-        "@plasmohq/parcel-resolver": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver/-/parcel-resolver-0.14.0.tgz",
-          "integrity": "sha512-OPGFiv2SxDEJl9sNPKfjkQ3QaqKOzSDx8E85Bq9FCOKCj+EWTPfoeUOAuMkHY/ArcvDBhWAo3Zu66f2U7iPEGQ==",
-          "requires": {
-            "@parcel/core": "2.9.3",
-            "@parcel/hash": "2.9.3",
-            "@parcel/plugin": "2.9.3",
-            "@parcel/types": "2.9.3",
-            "fast-glob": "3.3.2",
-            "fs-extra": "11.1.1",
-            "got": "13.0.0"
-          }
-        },
-        "@plasmohq/parcel-resolver-post": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver-post/-/parcel-resolver-post-0.4.4.tgz",
-          "integrity": "sha512-n39U5z2aGAfCDFydpvEDXx0MWtqYwh0+aX4QS49/IsmZMM1Ra+GnHs/gfeJz0jtN83EytlbwSoDcXRkORx9rIQ==",
-          "requires": {
-            "@parcel/core": "2.9.3",
-            "@parcel/hash": "2.9.3",
-            "@parcel/plugin": "2.9.3",
-            "@parcel/types": "2.9.3",
-            "@parcel/utils": "2.9.3",
-            "tsup": "7.2.0",
-            "typescript": "5.2.2"
-          }
-        },
-        "@plasmohq/parcel-runtime": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-runtime/-/parcel-runtime-0.25.0.tgz",
-          "integrity": "sha512-jtb77WDCYhKDPi/jRweSNX9GEe/REQUQU50d18YkDpQDyo/enVTyWVeYqfo3Q21iGLX8x9E5nF2rXtIVtoOAmw==",
-          "requires": {
-            "@parcel/core": "2.9.3",
-            "@parcel/plugin": "2.9.3",
-            "@types/trusted-types": "2.0.7",
-            "react-refresh": "0.14.0"
-          }
-        },
-        "@plasmohq/parcel-transformer-inline-css": {
-          "version": "0.3.11",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inline-css/-/parcel-transformer-inline-css-0.3.11.tgz",
-          "integrity": "sha512-EUSwEowFNSgC/F1q/V4H4NXJ23wwLzlmRI6lvIr6S0mIuG/FCga+lAV3IZ+yAuXqUM2VexX6JyYYpNVidrMSxw==",
-          "requires": {
-            "@parcel/core": "2.9.3",
-            "@parcel/plugin": "2.9.3",
-            "@parcel/utils": "2.9.3",
-            "browserslist": "4.22.1",
-            "lightningcss": "1.21.8"
-          }
-        },
-        "@plasmohq/parcel-transformer-manifest": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-manifest/-/parcel-transformer-manifest-0.19.0.tgz",
-          "integrity": "sha512-cDmca0jPVFVnRQPqCWcsPPwre27/yAGxSF1+JmPVUeXZYMCrg5wdNepRDSw+/dDBO2VmNHh/Tv+Hgj1fLIM8CQ==",
-          "requires": {
-            "@mischnic/json-sourcemap": "0.1.0",
-            "@parcel/core": "2.9.3",
-            "@parcel/diagnostic": "2.9.3",
-            "@parcel/fs": "2.9.3",
-            "@parcel/plugin": "2.9.3",
-            "@parcel/types": "2.9.3",
-            "@parcel/utils": "2.9.3",
-            "content-security-policy-parser": "0.4.1",
-            "json-schema-to-ts": "2.9.2",
-            "nullthrows": "1.1.1"
-          }
-        },
-        "@plasmohq/parcel-transformer-svelte": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-svelte/-/parcel-transformer-svelte-0.6.0.tgz",
-          "integrity": "sha512-5lZW6NBtzhJaCyjpKaZF1/YzY9CF+kbfNknvASJB/Cf6uJPJlrgdxoWiVJ8IWMs3DyLgAnJXTdIU+uwjwXP1wg==",
-          "requires": {
-            "@parcel/core": "2.9.3",
-            "@parcel/diagnostic": "2.9.3",
-            "@parcel/plugin": "2.9.3",
-            "@parcel/source-map": "2.1.1",
-            "@parcel/utils": "2.9.3",
-            "svelte": "4.2.2"
-          }
-        },
-        "aria-query": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-          "requires": {
-            "dequal": "^2.0.3"
-          }
-        },
-        "browserslist": {
-          "version": "4.22.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-          "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001541",
-            "electron-to-chromium": "^1.4.535",
-            "node-releases": "^2.0.13",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "bundle-require": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-4.2.1.tgz",
-          "integrity": "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==",
-          "requires": {
-            "load-tsconfig": "^0.2.3"
-          }
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
-        },
-        "change-case": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.1.2.tgz",
-          "integrity": "sha512-CAtbGEDulyjzs05RXy3uKcwqeztz/dMEuAc1Xu9NQBsbrhuGMneL0u9Dj5SoutLKBFYun8txxYIwhjtLNfUmCA=="
-        },
-        "cli-width": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-          "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
-        },
-        "dotenv": {
-          "version": "16.3.1",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-          "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
-        },
-        "esbuild": {
-          "version": "0.18.20",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-          "requires": {
-            "@esbuild/android-arm": "0.18.20",
-            "@esbuild/android-arm64": "0.18.20",
-            "@esbuild/android-x64": "0.18.20",
-            "@esbuild/darwin-arm64": "0.18.20",
-            "@esbuild/darwin-x64": "0.18.20",
-            "@esbuild/freebsd-arm64": "0.18.20",
-            "@esbuild/freebsd-x64": "0.18.20",
-            "@esbuild/linux-arm": "0.18.20",
-            "@esbuild/linux-arm64": "0.18.20",
-            "@esbuild/linux-ia32": "0.18.20",
-            "@esbuild/linux-loong64": "0.18.20",
-            "@esbuild/linux-mips64el": "0.18.20",
-            "@esbuild/linux-ppc64": "0.18.20",
-            "@esbuild/linux-riscv64": "0.18.20",
-            "@esbuild/linux-s390x": "0.18.20",
-            "@esbuild/linux-x64": "0.18.20",
-            "@esbuild/netbsd-x64": "0.18.20",
-            "@esbuild/openbsd-x64": "0.18.20",
-            "@esbuild/sunos-x64": "0.18.20",
-            "@esbuild/win32-arm64": "0.18.20",
-            "@esbuild/win32-ia32": "0.18.20",
-            "@esbuild/win32-x64": "0.18.20"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        },
-        "estree-walker": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-          "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-          "requires": {
-            "@types/estree": "^1.0.0"
-          }
-        },
-        "fflate": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
-          "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="
-        },
-        "figures": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-          "requires": {
-            "escape-string-regexp": "^5.0.0",
-            "is-unicode-supported": "^1.2.0"
-          }
-        },
-        "fs-extra": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "9.2.12",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
-          "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
-          "requires": {
-            "@ljharb/through": "^2.3.11",
-            "ansi-escapes": "^4.3.2",
-            "chalk": "^5.3.0",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^4.1.0",
-            "external-editor": "^3.1.0",
-            "figures": "^5.0.0",
-            "lodash": "^4.17.21",
-            "mute-stream": "1.0.0",
-            "ora": "^5.4.1",
-            "run-async": "^3.0.0",
-            "rxjs": "^7.8.1",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-          "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="
-        },
-        "is-unicode-supported": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-          "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
-        },
-        "lightningcss": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.8.tgz",
-          "integrity": "sha512-jEqaL7m/ZckZJjlMAfycr1Kpz7f93k6n7KGF5SJjuPSm6DWI6h3ayLZmgRHgy1OfrwoCed6h4C/gHYPOd1OFMA==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "lightningcss-darwin-arm64": "1.21.8",
-            "lightningcss-darwin-x64": "1.21.8",
-            "lightningcss-freebsd-x64": "1.21.8",
-            "lightningcss-linux-arm-gnueabihf": "1.21.8",
-            "lightningcss-linux-arm64-gnu": "1.21.8",
-            "lightningcss-linux-arm64-musl": "1.21.8",
-            "lightningcss-linux-x64-gnu": "1.21.8",
-            "lightningcss-linux-x64-musl": "1.21.8",
-            "lightningcss-win32-x64-msvc": "1.21.8"
-          }
-        },
-        "lightningcss-darwin-arm64": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.8.tgz",
-          "integrity": "sha512-BOMoGfcgkk2f4ltzsJqmkjiqRtlZUK+UdwhR+P6VgIsnpQBV3G01mlL6GzYxYqxq+6/3/n/D+4oy2NeknmADZw==",
-          "optional": true
-        },
-        "lightningcss-darwin-x64": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.8.tgz",
-          "integrity": "sha512-YhF64mcVDPKKufL4aNFBnVH7uvzE0bW3YUsPXdP4yUcT/8IXChypOZ/PE1pmt2RlbmsyVuuIIeZU4zTyZe5Amw==",
-          "optional": true
-        },
-        "lightningcss-freebsd-x64": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.21.8.tgz",
-          "integrity": "sha512-CV6A/vTG2Ryd3YpChEgfWWv4TXCAETo9TcHSNx0IP0dnKcnDEiAko4PIKhCqZL11IGdN1ZLBCVPw+vw5ZYwzfA==",
-          "optional": true
-        },
-        "lightningcss-linux-arm-gnueabihf": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.8.tgz",
-          "integrity": "sha512-9PMbqh8n/Xq0F4/j2NR/hHM2HRDiFXFSF0iOvV67pNWKJkHIO6mR8jBw/88Aro5Ye/ILsX5OuWsxIVJDFv0NXA==",
-          "optional": true
-        },
-        "lightningcss-linux-arm64-gnu": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.8.tgz",
-          "integrity": "sha512-JTM/TuMMllkzaXV7/eDjG4IJKLlCl+RfYZwtsVmC82gc0QX0O37csGAcY2OGleiuA4DnEo/Qea5WoFfZUNC6zg==",
-          "optional": true
-        },
-        "lightningcss-linux-arm64-musl": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.8.tgz",
-          "integrity": "sha512-01gWShXrgoIb8urzShpn1RWtZuaSyKSzF2hfO+flzlTPoACqcO3rgcu/3af4Cw54e8vKzL5hPRo4kROmgaOMLg==",
-          "optional": true
-        },
-        "lightningcss-linux-x64-gnu": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.8.tgz",
-          "integrity": "sha512-yVB5vYJjJb/Aku0V9QaGYIntvK/1TJOlNB9GmkNpXX5bSSP2pYW4lWW97jxFMHO908M0zjEt1qyOLMyqojHL+Q==",
-          "optional": true
-        },
-        "lightningcss-linux-x64-musl": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.8.tgz",
-          "integrity": "sha512-TYi+KNtBVK0+FZvxTX/d5XJb+tw3Jq+2Rr9hW359wp1afsi1Vkg+uVGgbn+m2dipa5XwpCseQq81ylMlXuyfPw==",
-          "optional": true
-        },
-        "lightningcss-win32-x64-msvc": {
-          "version": "1.21.8",
-          "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.8.tgz",
-          "integrity": "sha512-mww+kqbPx0/C44l2LEloECtRUuOFDjq9ftp+EHTPiCp2t+avy0sh8MaFwGsrKkj2XfZhaRhi4CPVKBoqF1Qlwg==",
-          "optional": true
-        },
-        "lmdb": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-          "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
-          "requires": {
-            "@lmdb/lmdb-darwin-arm64": "2.5.2",
-            "@lmdb/lmdb-darwin-x64": "2.5.2",
-            "@lmdb/lmdb-linux-arm": "2.5.2",
-            "@lmdb/lmdb-linux-arm64": "2.5.2",
-            "@lmdb/lmdb-linux-x64": "2.5.2",
-            "@lmdb/lmdb-win32-x64": "2.5.2",
-            "msgpackr": "^1.5.4",
-            "node-addon-api": "^4.3.0",
-            "node-gyp-build-optional-packages": "5.0.3",
-            "ordered-binary": "^1.2.4",
-            "weak-lru-cache": "^1.2.2"
-          },
-          "dependencies": {
-            "node-addon-api": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-              "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
-            }
-          }
-        },
-        "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="
-        },
-        "node-addon-api": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
-        },
-        "node-gyp-build-optional-packages": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
-          "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA=="
-        },
-        "plasmo": {
-          "version": "https://registry.npmjs.org/plasmo/-/plasmo-0.89.1.tgz",
-          "integrity": "sha512-YBSi9QeXYo9UDcbpgNI+FBC19iWs9C66ucyZpop0MaW5rc+uv/6HHzINkw+NL2izfJ8bdEU0l3iCLhpBmeKP2A==",
-          "requires": {
-            "@expo/spawn-async": "1.7.2",
-            "@parcel/core": "2.9.3",
-            "@parcel/fs": "2.9.3",
-            "@parcel/package-manager": "2.9.3",
-            "@parcel/watcher": "2.2.0",
-            "@plasmohq/init": "0.7.0",
-            "@plasmohq/parcel-config": "0.41.0",
-            "@plasmohq/parcel-core": "0.1.8",
-            "buffer": "6.0.3",
-            "chalk": "5.3.0",
-            "change-case": "5.1.2",
-            "dotenv": "16.3.1",
-            "dotenv-expand": "10.0.0",
-            "events": "3.3.0",
-            "fast-glob": "3.3.2",
-            "fflate": "0.8.1",
-            "get-port": "7.0.0",
-            "got": "13.0.0",
-            "ignore": "5.2.4",
-            "inquirer": "9.2.12",
-            "is-path-inside": "4.0.0",
-            "json5": "2.2.3",
-            "mnemonic-id": "3.2.7",
-            "node-object-hash": "3.0.0",
-            "package-json": "8.1.1",
-            "process": "0.11.10",
-            "semver": "7.5.4",
-            "sharp": "0.32.6",
-            "tempy": "3.1.0",
-            "typescript": "5.2.2"
-          }
-        },
-        "react-refresh": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-          "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-        },
-        "run-async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="
-        },
-        "sharp": {
-          "version": "0.32.6",
-          "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-          "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-          "requires": {
-            "color": "^4.2.3",
-            "detect-libc": "^2.0.2",
-            "node-addon-api": "^6.1.0",
-            "prebuild-install": "^7.1.1",
-            "semver": "^7.5.4",
-            "simple-get": "^4.0.1",
-            "tar-fs": "^3.0.4",
-            "tunnel-agent": "^0.6.0"
-          },
-          "dependencies": {
-            "detect-libc": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-              "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
-        },
-        "svelte": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
-          "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
-          "requires": {
-            "@ampproject/remapping": "^2.2.1",
-            "@jridgewell/sourcemap-codec": "^1.4.15",
-            "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.9.0",
-            "aria-query": "^5.3.0",
-            "axobject-query": "^3.2.1",
-            "code-red": "^1.0.3",
-            "css-tree": "^2.3.1",
-            "estree-walker": "^3.0.3",
-            "is-reference": "^3.0.1",
-            "locate-character": "^3.0.0",
-            "magic-string": "^0.30.4",
-            "periscopic": "^3.1.0"
-          }
-        },
-        "tar-fs": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-          "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
-          "requires": {
-            "bare-fs": "^2.1.1",
-            "bare-path": "^2.1.0",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "tsup": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/tsup/-/tsup-7.2.0.tgz",
-          "integrity": "sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==",
-          "requires": {
-            "bundle-require": "^4.0.0",
-            "cac": "^6.7.12",
-            "chokidar": "^3.5.1",
-            "debug": "^4.3.1",
-            "esbuild": "^0.18.2",
-            "execa": "^5.0.0",
-            "globby": "^11.0.3",
-            "joycon": "^3.0.1",
-            "postcss-load-config": "^4.0.1",
-            "resolve-from": "^5.0.0",
-            "rollup": "^3.2.5",
-            "source-map": "0.8.0-beta.0",
-            "sucrase": "^3.20.3",
-            "tree-kill": "^1.2.2"
-          }
-        },
-        "typescript": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
       }
     },
     "@liveblocks/emails": {
@@ -39006,6 +38057,19 @@
         "@parcel/transformer-raw": "2.9.3",
         "@parcel/transformer-react-refresh-wrap": "2.9.3",
         "@parcel/transformer-svg": "2.9.3"
+      },
+      "dependencies": {
+        "@parcel/runtime-js": {
+          "version": "2.9.3",
+          "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
+          "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+          "requires": {
+            "@parcel/diagnostic": "2.9.3",
+            "@parcel/plugin": "2.9.3",
+            "@parcel/utils": "2.9.3",
+            "nullthrows": "^1.1.1"
+          }
+        }
       }
     },
     "@parcel/core": {
@@ -39463,14 +38527,235 @@
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
-      "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.8.3.tgz",
+      "integrity": "sha512-IRja0vNKwvMtPgIqkBQh0QtRn0XcxNC8HU1jrgWGRckzu10qJWO+5ULgtOeR4pv9krffmMPqywGXw6l/gvJKYQ==",
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/utils": "2.8.3",
         "nullthrows": "^1.1.1"
+      },
+      "dependencies": {
+        "@lmdb/lmdb-darwin-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+          "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+          "optional": true
+        },
+        "@lmdb/lmdb-darwin-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+          "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+          "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+          "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+          "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+          "optional": true
+        },
+        "@lmdb/lmdb-win32-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+          "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+          "optional": true
+        },
+        "@parcel/cache": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
+          "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
+          "requires": {
+            "@parcel/fs": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "lmdb": "2.5.2"
+          }
+        },
+        "@parcel/codeframe": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
+          "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/diagnostic": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
+          "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/events": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
+          "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w=="
+        },
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+          "requires": {
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/fs-search": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
+          "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
+          "requires": {
+            "detect-libc": "^1.0.3"
+          }
+        },
+        "@parcel/hash": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
+          "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "xxhash-wasm": "^0.4.2"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/markdown-ansi": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
+          "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/package-manager": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
+          "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/fs": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/workers": "2.8.3",
+            "semver": "^5.7.1"
+          }
+        },
+        "@parcel/plugin": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
+          "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
+          "requires": {
+            "@parcel/types": "2.8.3"
+          }
+        },
+        "@parcel/types": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
+          "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
+          "requires": {
+            "@parcel/cache": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/fs": "2.8.3",
+            "@parcel/package-manager": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "@parcel/workers": "2.8.3",
+            "utility-types": "^3.10.0"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "lmdb": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+          "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+          "requires": {
+            "@lmdb/lmdb-darwin-arm64": "2.5.2",
+            "@lmdb/lmdb-darwin-x64": "2.5.2",
+            "@lmdb/lmdb-linux-arm": "2.5.2",
+            "@lmdb/lmdb-linux-arm64": "2.5.2",
+            "@lmdb/lmdb-linux-x64": "2.5.2",
+            "@lmdb/lmdb-win32-x64": "2.5.2",
+            "msgpackr": "^1.5.4",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "5.0.3",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "node-gyp-build-optional-packages": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+          "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA=="
+        },
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+        }
       }
     },
     "@parcel/runtime-react-refresh": {
@@ -39605,16 +38890,6 @@
         "nullthrows": "^1.1.1",
         "regenerator-runtime": "^0.13.7",
         "semver": "^7.5.2"
-      },
-      "dependencies": {
-        "@swc/helpers": {
-          "version": "0.5.11",
-          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-          "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@parcel/transformer-json": {
@@ -39888,9 +39163,9 @@
       "integrity": "sha512-P75g48dqOGneJ+n0AcqnLE/TYflcaPc3B7h6EopnCBBYUDnCNBMwYmKAkaf5pnhsEB0ybPS6TU1C2DTGfqaW7A=="
     },
     "@plasmohq/parcel-bundler": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-bundler/-/parcel-bundler-0.5.5.tgz",
-      "integrity": "sha512-QCMmmfic514CfdXMJ7JMWUnqDzIHKVKyYeqPpUDsXON6JvA1yTmO5mEQSls8+5u/HpocP9QmTskQOHu3RCNX9A==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-bundler/-/parcel-bundler-0.5.6.tgz",
+      "integrity": "sha512-kjwj5tQUhdAK00AxXOzgqJ2jryZg4X6aleYAcjbREPzVMqKEu1NrNSNy5VGAfNRG6NCT6ZYg39ZCyuUOR2lEsQ==",
       "requires": {
         "@parcel/core": "2.9.3",
         "@parcel/diagnostic": "2.9.3",
@@ -39901,10 +39176,60 @@
         "nullthrows": "1.1.1"
       }
     },
+    "@plasmohq/parcel-compressor-utf8": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-compressor-utf8/-/parcel-compressor-utf8-0.1.1.tgz",
+      "integrity": "sha512-9zcF39XIBzauYLERoGNVSy7qR1MzEqjhQn16RrlCpZ1AyNMlBJ3B28SmnUpBQNgne8JOHTtcx6cUVm1IvM3J+g==",
+      "requires": {
+        "@parcel/plugin": "2.9.3"
+      }
+    },
+    "@plasmohq/parcel-config": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-config/-/parcel-config-0.41.1.tgz",
+      "integrity": "sha512-peNpm+F1tVIZmDx8Mca8b3769cxc2IWS7q0+0Y4BLT1+2kis7X4b46IAYgOXtsDRZCb9pvxQhRhrVHpwGtdVLg==",
+      "requires": {
+        "@parcel/compressor-raw": "2.9.3",
+        "@parcel/config-default": "2.9.3",
+        "@parcel/core": "2.9.3",
+        "@parcel/optimizer-data-url": "2.9.3",
+        "@parcel/reporter-bundle-buddy": "2.9.3",
+        "@parcel/resolver-default": "2.9.3",
+        "@parcel/runtime-js": "2.8.3",
+        "@parcel/runtime-service-worker": "2.9.3",
+        "@parcel/source-map": "2.1.1",
+        "@parcel/transformer-babel": "2.9.3",
+        "@parcel/transformer-css": "2.9.3",
+        "@parcel/transformer-graphql": "2.9.3",
+        "@parcel/transformer-inline-string": "2.9.3",
+        "@parcel/transformer-js": "2.9.3",
+        "@parcel/transformer-less": "2.9.3",
+        "@parcel/transformer-postcss": "2.9.3",
+        "@parcel/transformer-raw": "2.9.3",
+        "@parcel/transformer-react-refresh-wrap": "2.9.3",
+        "@parcel/transformer-sass": "2.9.3",
+        "@parcel/transformer-svg-react": "2.9.3",
+        "@parcel/transformer-worklet": "2.9.3",
+        "@plasmohq/parcel-bundler": "0.5.6",
+        "@plasmohq/parcel-compressor-utf8": "0.1.1",
+        "@plasmohq/parcel-namer-manifest": "0.3.12",
+        "@plasmohq/parcel-optimizer-encapsulate": "0.0.8",
+        "@plasmohq/parcel-optimizer-es": "0.4.1",
+        "@plasmohq/parcel-packager": "0.6.15",
+        "@plasmohq/parcel-resolver": "0.14.1",
+        "@plasmohq/parcel-resolver-post": "0.4.5",
+        "@plasmohq/parcel-runtime": "0.25.1",
+        "@plasmohq/parcel-transformer-inject-env": "0.2.12",
+        "@plasmohq/parcel-transformer-inline-css": "0.3.11",
+        "@plasmohq/parcel-transformer-manifest": "0.20.1",
+        "@plasmohq/parcel-transformer-svelte": "0.6.0",
+        "@plasmohq/parcel-transformer-vue": "0.5.0"
+      }
+    },
     "@plasmohq/parcel-core": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-core/-/parcel-core-0.1.8.tgz",
-      "integrity": "sha512-kMWuazvf925ZAn2yHzzrb4Zsje1titFmvi/C5cXrI0TH58eT7n6GUiRXiOYP4JgGDHs/pEygx3WPuyWVTNF2HQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-core/-/parcel-core-0.1.10.tgz",
+      "integrity": "sha512-XbJrqlgPNo+uQaukWayfRDZnAvdkYrmcydCOz0wfmuksTjDisyGkL3ZbWeX86QPN65CXFyou11/9h3+U9IsHfA==",
       "requires": {
         "@parcel/cache": "2.9.3",
         "@parcel/core": "2.9.3",
@@ -39937,9 +39262,9 @@
       }
     },
     "@plasmohq/parcel-optimizer-encapsulate": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-encapsulate/-/parcel-optimizer-encapsulate-0.0.7.tgz",
-      "integrity": "sha512-mA9kY5dwuebQ4vLX6A5yTFo0gZZNWKUHpF6yO0lYq3oP843MyRJS8SxAtzQb4vTlVWPk3SX6Yw81DgBo4I6Xiw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-encapsulate/-/parcel-optimizer-encapsulate-0.0.8.tgz",
+      "integrity": "sha512-iXDXoLtYBvV4rHhFw3O6nrS3dEWYe9k2m0i/Tvzg2lz4lUHFyvK5NN9RWqkOLfI8JviaqQzaaMKteJhLsX6z1A==",
       "requires": {
         "@parcel/core": "2.9.3",
         "@parcel/plugin": "2.9.3",
@@ -39948,112 +39273,103 @@
       }
     },
     "@plasmohq/parcel-optimizer-es": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-es/-/parcel-optimizer-es-0.4.0.tgz",
-      "integrity": "sha512-Iz1cTuw38wEbSQ36/dVKh5MyRA12/Ecrx90pqaIkoqA9ZSZuxuWWa7rPa3bVMFkzi28BpVHW1z9EnhVN4188kQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-optimizer-es/-/parcel-optimizer-es-0.4.1.tgz",
+      "integrity": "sha512-2FvBq3L5wHyD+TNHpO0IVMJKX1XQ+uBruFVcRUgo+lDkIAyop7P8wpsY4iq3dOKXJrqjwBop9nzNcq0L/zaalQ==",
       "requires": {
         "@parcel/core": "2.9.3",
         "@parcel/plugin": "2.9.3",
         "@parcel/source-map": "2.1.1",
         "@parcel/utils": "2.9.3",
-        "@swc/core": "1.3.82",
+        "@swc/core": "1.3.96",
         "nullthrows": "1.1.1"
       },
       "dependencies": {
         "@swc/core": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.82.tgz",
-          "integrity": "sha512-jpC1a18HMH67018Ij2jh+hT7JBFu7ZKcQVfrZ8K6JuEY+kjXmbea07P9MbQUZbAe0FB+xi3CqEVCP73MebodJQ==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.96.tgz",
+          "integrity": "sha512-zwE3TLgoZwJfQygdv2SdCK9mRLYluwDOM53I+dT6Z5ZvrgVENmY3txvWDvduzkV+/8IuvrRbVezMpxcojadRdQ==",
           "requires": {
-            "@swc/core-darwin-arm64": "1.3.82",
-            "@swc/core-darwin-x64": "1.3.82",
-            "@swc/core-linux-arm-gnueabihf": "1.3.82",
-            "@swc/core-linux-arm64-gnu": "1.3.82",
-            "@swc/core-linux-arm64-musl": "1.3.82",
-            "@swc/core-linux-x64-gnu": "1.3.82",
-            "@swc/core-linux-x64-musl": "1.3.82",
-            "@swc/core-win32-arm64-msvc": "1.3.82",
-            "@swc/core-win32-ia32-msvc": "1.3.82",
-            "@swc/core-win32-x64-msvc": "1.3.82",
-            "@swc/types": "^0.1.4"
+            "@swc/core-darwin-arm64": "1.3.96",
+            "@swc/core-darwin-x64": "1.3.96",
+            "@swc/core-linux-arm-gnueabihf": "1.3.96",
+            "@swc/core-linux-arm64-gnu": "1.3.96",
+            "@swc/core-linux-arm64-musl": "1.3.96",
+            "@swc/core-linux-x64-gnu": "1.3.96",
+            "@swc/core-linux-x64-musl": "1.3.96",
+            "@swc/core-win32-arm64-msvc": "1.3.96",
+            "@swc/core-win32-ia32-msvc": "1.3.96",
+            "@swc/core-win32-x64-msvc": "1.3.96",
+            "@swc/counter": "^0.1.1",
+            "@swc/types": "^0.1.5"
           }
         },
         "@swc/core-darwin-arm64": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.82.tgz",
-          "integrity": "sha512-JfsyDW34gVKD3uE0OUpUqYvAD3yseEaicnFP6pB292THtLJb0IKBBnK50vV/RzEJtc1bR3g1kNfxo2PeurZTrA==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.96.tgz",
+          "integrity": "sha512-8hzgXYVd85hfPh6mJ9yrG26rhgzCmcLO0h1TIl8U31hwmTbfZLzRitFQ/kqMJNbIBCwmNH1RU2QcJnL3d7f69A==",
           "optional": true
         },
         "@swc/core-darwin-x64": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.82.tgz",
-          "integrity": "sha512-ogQWgNMq7qTpITjcP3dnzkFNj7bh6SwMr859GvtOTrE75H7L7jDWxESfH4f8foB/LGxBKiDNmxKhitCuAsZK4A==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.96.tgz",
+          "integrity": "sha512-mFp9GFfuPg+43vlAdQZl0WZpZSE8sEzqL7sr/7Reul5McUHP0BaLsEzwjvD035ESfkY8GBZdLpMinblIbFNljQ==",
           "optional": true
         },
         "@swc/core-linux-arm-gnueabihf": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.82.tgz",
-          "integrity": "sha512-7TMXG1lXlNhD0kUiEqs+YlGV4irAdBa2quuy+XI3oJf2fBK6dQfEq4xBy65B3khrorzQS3O0oDGQ+cmdpHExHA==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.96.tgz",
+          "integrity": "sha512-8UEKkYJP4c8YzYIY/LlbSo8z5Obj4hqcv/fUTHiEePiGsOddgGf7AWjh56u7IoN/0uEmEro59nc1ChFXqXSGyg==",
           "optional": true
         },
         "@swc/core-linux-arm64-gnu": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.82.tgz",
-          "integrity": "sha512-26JkOujbzcItPAmIbD5vHJxQVy5ihcSu3YHTKwope1h28sApZdtE7S3e2G3gsZRTIdsCQkXUtAQeqHxGWWR3pw==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.96.tgz",
+          "integrity": "sha512-c/IiJ0s1y3Ymm2BTpyC/xr6gOvoqAVETrivVXHq68xgNms95luSpbYQ28rqaZC8bQC8M5zdXpSc0T8DJu8RJGw==",
           "optional": true
         },
         "@swc/core-linux-arm64-musl": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.82.tgz",
-          "integrity": "sha512-8Izj9tuuMpoc3cqiPBRtwqpO1BZ/+sfZVsEhLxrbOFlcSb8LnKyMle1g3JMMUwI4EU75RGVIzZMn8A6GOKdJbA==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.96.tgz",
+          "integrity": "sha512-i5/UTUwmJLri7zhtF6SAo/4QDQJDH2fhYJaBIUhrICmIkRO/ltURmpejqxsM/ye9Jqv5zG7VszMC0v/GYn/7BQ==",
           "optional": true
         },
         "@swc/core-linux-x64-gnu": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.82.tgz",
-          "integrity": "sha512-0GSrIBScQwTaPv46T2qB7XnDYxndRCpwH4HMjh6FN+I+lfPUhTSJKW8AonqrqT1TbpFIgvzQs7EnTsD7AnSCow==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.96.tgz",
+          "integrity": "sha512-USdaZu8lTIkm4Yf9cogct/j5eqtdZqTgcTib4I+NloUW0E/hySou3eSyp3V2UAA1qyuC72ld1otXuyKBna0YKQ==",
           "optional": true
         },
         "@swc/core-linux-x64-musl": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.82.tgz",
-          "integrity": "sha512-KJUnaaepDKNzrEbwz4jv0iC3/t9x0NSoe06fnkAlhh2+NFKWKKJhVCOBTrpds8n7eylBDIXUlK34XQafjVMUdg==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.96.tgz",
+          "integrity": "sha512-QYErutd+G2SNaCinUVobfL7jWWjGTI0QEoQ6hqTp7PxCJS/dmKmj3C5ZkvxRYcq7XcZt7ovrYCTwPTHzt6lZBg==",
           "optional": true
         },
         "@swc/core-win32-arm64-msvc": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.82.tgz",
-          "integrity": "sha512-TR3MHKhDYIyGyFcyl2d/p1ftceXcubAhX5wRSOdtOyr5+K/v3jbyCCqN7bbqO5o43wQVCwwR/drHleYyDZvg8Q==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.96.tgz",
+          "integrity": "sha512-hjGvvAduA3Un2cZ9iNP4xvTXOO4jL3G9iakhFsgVhpkU73SGmK7+LN8ZVBEu4oq2SUcHO6caWvnZ881cxGuSpg==",
           "optional": true
         },
         "@swc/core-win32-ia32-msvc": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.82.tgz",
-          "integrity": "sha512-ZX4HzVVt6hs84YUg70UvyBJnBOIspmQQM0iXSzBvOikk3zRoN7BnDwQH4GScvevCEBuou60+i4I6d5kHLOfh8Q==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.96.tgz",
+          "integrity": "sha512-Far2hVFiwr+7VPCM2GxSmbh3ikTpM3pDombE+d69hkedvYHYZxtTF+2LTKl/sXtpbUnsoq7yV/32c9R/xaaWfw==",
           "optional": true
         },
         "@swc/core-win32-x64-msvc": {
-          "version": "1.3.82",
-          "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.82.tgz",
-          "integrity": "sha512-4mJMnex21kbQoaHeAmHnVwQN9/XAfPszJ6n9HI7SVH+aAHnbBIR0M59/b50/CJMjTj5niUGk7EwQ3nhVNOG32g==",
+          "version": "1.3.96",
+          "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.96.tgz",
+          "integrity": "sha512-4VbSAniIu0ikLf5mBX81FsljnfqjoVGleEkCQv4+zRlyZtO3FHoDPkeLVoy6WRlj7tyrRcfUJ4mDdPkbfTO14g==",
           "optional": true
-        },
-        "@swc/helpers": {
-          "version": "0.5.11",
-          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-          "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.4.0"
-          }
         }
       }
     },
     "@plasmohq/parcel-packager": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-packager/-/parcel-packager-0.6.14.tgz",
-      "integrity": "sha512-pFab9COfafx66CtOFWgLgKf4TUPLb5EiTO4ecRz1HDINSvPl48ci+3czmtSzOI4+b1uiqZYxUB3eeaMfh9XWpA==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-packager/-/parcel-packager-0.6.15.tgz",
+      "integrity": "sha512-c6Afk5l8EqxyZ/N7p8avWEBt5teTQPQsvZZpPHWhsAY9eonX+h8bFdmXym1oevaq5TySJOpNCSUdTvqqZtlSnQ==",
       "requires": {
         "@parcel/core": "2.9.3",
         "@parcel/plugin": "2.9.3",
@@ -40062,14 +39378,318 @@
         "nullthrows": "1.1.1"
       }
     },
+    "@plasmohq/parcel-resolver": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver/-/parcel-resolver-0.14.1.tgz",
+      "integrity": "sha512-1nmmMI7N5rtpni2TpUyPkI8XU1wIk/lTDGNZXLxtkzOoFiFP2sc2xZq4OGhmnRYvWphZYrnhMjRrjNJmqOFqxw==",
+      "requires": {
+        "@parcel/core": "2.9.3",
+        "@parcel/hash": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/types": "2.9.3",
+        "fast-glob": "3.3.2",
+        "fs-extra": "11.1.1",
+        "got": "13.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        }
+      }
+    },
+    "@plasmohq/parcel-resolver-post": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-resolver-post/-/parcel-resolver-post-0.4.5.tgz",
+      "integrity": "sha512-Y5la9wruh3fMHlUoWtVBcbSyvg2xZE1kSRp5BAjtfyZlKS2cT/vIbFTUkqk9nPvXLExBDNajIxTKk9ag/9WzpA==",
+      "requires": {
+        "@parcel/core": "2.9.3",
+        "@parcel/hash": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/types": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "tsup": "7.2.0",
+        "typescript": "5.2.2"
+      },
+      "dependencies": {
+        "bundle-require": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-4.2.1.tgz",
+          "integrity": "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==",
+          "requires": {
+            "load-tsconfig": "^0.2.3"
+          }
+        },
+        "esbuild": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+          "requires": {
+            "@esbuild/android-arm": "0.18.20",
+            "@esbuild/android-arm64": "0.18.20",
+            "@esbuild/android-x64": "0.18.20",
+            "@esbuild/darwin-arm64": "0.18.20",
+            "@esbuild/darwin-x64": "0.18.20",
+            "@esbuild/freebsd-arm64": "0.18.20",
+            "@esbuild/freebsd-x64": "0.18.20",
+            "@esbuild/linux-arm": "0.18.20",
+            "@esbuild/linux-arm64": "0.18.20",
+            "@esbuild/linux-ia32": "0.18.20",
+            "@esbuild/linux-loong64": "0.18.20",
+            "@esbuild/linux-mips64el": "0.18.20",
+            "@esbuild/linux-ppc64": "0.18.20",
+            "@esbuild/linux-riscv64": "0.18.20",
+            "@esbuild/linux-s390x": "0.18.20",
+            "@esbuild/linux-x64": "0.18.20",
+            "@esbuild/netbsd-x64": "0.18.20",
+            "@esbuild/openbsd-x64": "0.18.20",
+            "@esbuild/sunos-x64": "0.18.20",
+            "@esbuild/win32-arm64": "0.18.20",
+            "@esbuild/win32-ia32": "0.18.20",
+            "@esbuild/win32-x64": "0.18.20"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
+        "source-map": {
+          "version": "0.8.0-beta.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+          "requires": {
+            "whatwg-url": "^7.0.0"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "tsup": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/tsup/-/tsup-7.2.0.tgz",
+          "integrity": "sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==",
+          "requires": {
+            "bundle-require": "^4.0.0",
+            "cac": "^6.7.12",
+            "chokidar": "^3.5.1",
+            "debug": "^4.3.1",
+            "esbuild": "^0.18.2",
+            "execa": "^5.0.0",
+            "globby": "^11.0.3",
+            "joycon": "^3.0.1",
+            "postcss-load-config": "^4.0.1",
+            "resolve-from": "^5.0.0",
+            "rollup": "^3.2.5",
+            "source-map": "0.8.0-beta.0",
+            "sucrase": "^3.20.3",
+            "tree-kill": "^1.2.2"
+          }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
+    "@plasmohq/parcel-runtime": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-runtime/-/parcel-runtime-0.25.1.tgz",
+      "integrity": "sha512-asr4DMXJSKPilye0uiyZf51NUC3WZAr0Y6mzl+mtRGIcywuv42+X52qnZl9a9xYkVZeYlVJq62Kfk4+wPthakg==",
+      "requires": {
+        "@parcel/core": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@types/trusted-types": "2.0.7",
+        "react-refresh": "0.14.0"
+      },
+      "dependencies": {
+        "react-refresh": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+          "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
+        }
+      }
+    },
     "@plasmohq/parcel-transformer-inject-env": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inject-env/-/parcel-transformer-inject-env-0.2.11.tgz",
-      "integrity": "sha512-eGwwoaDbPPwrRcEgOi/BpLVGe5ttrBhs91NBcKMpE/D5gktfbJPD1zHG8MPtQdE4Iq23aG3JUbiT5clmdwtUhQ==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inject-env/-/parcel-transformer-inject-env-0.2.12.tgz",
+      "integrity": "sha512-QhM5Je0LyuAAJMAXeBEu4YvDirIPXuO2SoxHkwTMIwCMXpstPinnKiElrIoolqZjcxLmDCfsXerXZfbN6NhSlA==",
       "requires": {
         "@parcel/core": "2.9.3",
         "@parcel/plugin": "2.9.3",
         "@parcel/types": "2.9.3"
+      }
+    },
+    "@plasmohq/parcel-transformer-inline-css": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-inline-css/-/parcel-transformer-inline-css-0.3.11.tgz",
+      "integrity": "sha512-EUSwEowFNSgC/F1q/V4H4NXJ23wwLzlmRI6lvIr6S0mIuG/FCga+lAV3IZ+yAuXqUM2VexX6JyYYpNVidrMSxw==",
+      "requires": {
+        "@parcel/core": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "browserslist": "4.22.1",
+        "lightningcss": "1.21.8"
+      },
+      "dependencies": {
+        "lightningcss": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.8.tgz",
+          "integrity": "sha512-jEqaL7m/ZckZJjlMAfycr1Kpz7f93k6n7KGF5SJjuPSm6DWI6h3ayLZmgRHgy1OfrwoCed6h4C/gHYPOd1OFMA==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "lightningcss-darwin-arm64": "1.21.8",
+            "lightningcss-darwin-x64": "1.21.8",
+            "lightningcss-freebsd-x64": "1.21.8",
+            "lightningcss-linux-arm-gnueabihf": "1.21.8",
+            "lightningcss-linux-arm64-gnu": "1.21.8",
+            "lightningcss-linux-arm64-musl": "1.21.8",
+            "lightningcss-linux-x64-gnu": "1.21.8",
+            "lightningcss-linux-x64-musl": "1.21.8",
+            "lightningcss-win32-x64-msvc": "1.21.8"
+          }
+        },
+        "lightningcss-darwin-arm64": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.8.tgz",
+          "integrity": "sha512-BOMoGfcgkk2f4ltzsJqmkjiqRtlZUK+UdwhR+P6VgIsnpQBV3G01mlL6GzYxYqxq+6/3/n/D+4oy2NeknmADZw==",
+          "optional": true
+        },
+        "lightningcss-darwin-x64": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.8.tgz",
+          "integrity": "sha512-YhF64mcVDPKKufL4aNFBnVH7uvzE0bW3YUsPXdP4yUcT/8IXChypOZ/PE1pmt2RlbmsyVuuIIeZU4zTyZe5Amw==",
+          "optional": true
+        },
+        "lightningcss-freebsd-x64": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.21.8.tgz",
+          "integrity": "sha512-CV6A/vTG2Ryd3YpChEgfWWv4TXCAETo9TcHSNx0IP0dnKcnDEiAko4PIKhCqZL11IGdN1ZLBCVPw+vw5ZYwzfA==",
+          "optional": true
+        },
+        "lightningcss-linux-arm-gnueabihf": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.8.tgz",
+          "integrity": "sha512-9PMbqh8n/Xq0F4/j2NR/hHM2HRDiFXFSF0iOvV67pNWKJkHIO6mR8jBw/88Aro5Ye/ILsX5OuWsxIVJDFv0NXA==",
+          "optional": true
+        },
+        "lightningcss-linux-arm64-gnu": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.8.tgz",
+          "integrity": "sha512-JTM/TuMMllkzaXV7/eDjG4IJKLlCl+RfYZwtsVmC82gc0QX0O37csGAcY2OGleiuA4DnEo/Qea5WoFfZUNC6zg==",
+          "optional": true
+        },
+        "lightningcss-linux-arm64-musl": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.8.tgz",
+          "integrity": "sha512-01gWShXrgoIb8urzShpn1RWtZuaSyKSzF2hfO+flzlTPoACqcO3rgcu/3af4Cw54e8vKzL5hPRo4kROmgaOMLg==",
+          "optional": true
+        },
+        "lightningcss-linux-x64-gnu": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.8.tgz",
+          "integrity": "sha512-yVB5vYJjJb/Aku0V9QaGYIntvK/1TJOlNB9GmkNpXX5bSSP2pYW4lWW97jxFMHO908M0zjEt1qyOLMyqojHL+Q==",
+          "optional": true
+        },
+        "lightningcss-linux-x64-musl": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.8.tgz",
+          "integrity": "sha512-TYi+KNtBVK0+FZvxTX/d5XJb+tw3Jq+2Rr9hW359wp1afsi1Vkg+uVGgbn+m2dipa5XwpCseQq81ylMlXuyfPw==",
+          "optional": true
+        },
+        "lightningcss-win32-x64-msvc": {
+          "version": "1.21.8",
+          "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.8.tgz",
+          "integrity": "sha512-mww+kqbPx0/C44l2LEloECtRUuOFDjq9ftp+EHTPiCp2t+avy0sh8MaFwGsrKkj2XfZhaRhi4CPVKBoqF1Qlwg==",
+          "optional": true
+        }
+      }
+    },
+    "@plasmohq/parcel-transformer-manifest": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-manifest/-/parcel-transformer-manifest-0.20.1.tgz",
+      "integrity": "sha512-fA2d+u7eAURr8Vyi1HAB8zwndBW2czi5YcLgZRVwEqHODYYIyNcmqMJHLt7TAQYTD+POG+z4WpM81AKdhcq8mg==",
+      "requires": {
+        "@mischnic/json-sourcemap": "0.1.0",
+        "@parcel/core": "2.9.3",
+        "@parcel/diagnostic": "2.9.3",
+        "@parcel/fs": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/types": "2.9.3",
+        "@parcel/utils": "2.9.3",
+        "content-security-policy-parser": "0.4.1",
+        "json-schema-to-ts": "2.9.2",
+        "nullthrows": "1.1.1"
+      },
+      "dependencies": {
+        "@lezer/common": {
+          "version": "0.15.12",
+          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+          "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
+        },
+        "@lezer/lr": {
+          "version": "0.15.8",
+          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+          "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+          "requires": {
+            "@lezer/common": "^0.15.0"
+          }
+        },
+        "@mischnic/json-sourcemap": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+          "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+          "requires": {
+            "@lezer/common": "^0.15.7",
+            "@lezer/lr": "^0.15.4",
+            "json5": "^2.2.1"
+          }
+        }
+      }
+    },
+    "@plasmohq/parcel-transformer-svelte": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@plasmohq/parcel-transformer-svelte/-/parcel-transformer-svelte-0.6.0.tgz",
+      "integrity": "sha512-5lZW6NBtzhJaCyjpKaZF1/YzY9CF+kbfNknvASJB/Cf6uJPJlrgdxoWiVJ8IWMs3DyLgAnJXTdIU+uwjwXP1wg==",
+      "requires": {
+        "@parcel/core": "2.9.3",
+        "@parcel/diagnostic": "2.9.3",
+        "@parcel/plugin": "2.9.3",
+        "@parcel/source-map": "2.1.1",
+        "@parcel/utils": "2.9.3",
+        "svelte": "4.2.2"
       }
     },
     "@plasmohq/parcel-transformer-vue": {
@@ -40091,9 +39711,9 @@
       }
     },
     "@plasmohq/storage": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@plasmohq/storage/-/storage-1.8.0.tgz",
-      "integrity": "sha512-8VEVKq2takNaR6SBpRaS2KdLMwsoH91eekap1QA2M4B2CcyprSbsEMuK6HogfcD5gRBzHJAhHqwBGL9PdUJm7w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@plasmohq/storage/-/storage-1.13.0.tgz",
+      "integrity": "sha512-ceFtWFDMXg6v9nePEVyTgMusFmnMK82eNBf9ac0nN0kjMZQ+5IVEaiAgnS/c+KS43b7W+NJPpCakh+flgLOpjg==",
       "requires": {
         "pify": "6.1.0"
       },
@@ -43019,17 +42639,14 @@
       "dev": true
     },
     "axobject-query": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.2.tgz",
-      "integrity": "sha512-QtQGAQJfHXiTrtRH8Q1gkarFLs56fDmfiMCptvRbo/AEQIImrW6u7EcUAOfkHHNE9dqZKH3227iRKRSp0KtfTw==",
-      "requires": {
-        "deep-equal-json": "^1.0.0"
-      }
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
+      "integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A=="
     },
     "b4a": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -43143,15 +42760,15 @@
       "version": "1.0.2"
     },
     "bare-events": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.3.tgz",
+      "integrity": "sha512-pCO3aoRJ0MBiRMu8B7vUga0qL3L7gO1+SW7ku6qlSsMLwuhaawnuvZDyzJY/kyC63Un0XAB0OPUcfF1eTO/V+Q==",
       "optional": true
     },
     "bare-fs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.3.tgz",
-      "integrity": "sha512-7RYKL+vZVCyAsMLi5SPu7QGauGGT8avnP/HO571ndEuV4MYdGXvLhtW67FuLPeEI8EiIY7zbbRR9x7x7HU0kgw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
       "optional": true,
       "requires": {
         "bare-events": "^2.0.0",
@@ -43160,9 +42777,9 @@
       }
     },
     "bare-os": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.2.tgz",
-      "integrity": "sha512-HZoJwzC+rZ9lqEemTMiO0luOePoGYNBgsLLgegKR/cljiJvcDNhDZQkzC+NC5Oh0aHbdBNSOHpghwMuB5tqhjg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
       "optional": true
     },
     "bare-path": {
@@ -43175,13 +42792,12 @@
       }
     },
     "bare-stream": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.2.1.tgz",
-      "integrity": "sha512-YTB47kHwBW9zSG8LD77MIBAAQXjU2WjAkMHeeb7hUplVs6+IoM5I7uEVQNPMB7lj9r8I76UMdoMkGnCodHOLqg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.1.tgz",
+      "integrity": "sha512-eVZbtKM+4uehzrsj49KtCy3Pbg7kO1pJ3SKZ1SFrIH/0pnj9scuGGgUlNDf/7qS8WKtGdiJY5Kyhs/ivYPTB/g==",
       "optional": true,
       "requires": {
-        "b4a": "^1.6.6",
-        "streamx": "^2.18.0"
+        "streamx": "^2.21.0"
       }
     },
     "base": {
@@ -43263,12 +42879,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.10",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
         "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "bs-logger": {
@@ -43420,6 +43038,11 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "change-case": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.1.2.tgz",
+      "integrity": "sha512-CAtbGEDulyjzs05RXy3uKcwqeztz/dMEuAc1Xu9NQBsbrhuGMneL0u9Dj5SoutLKBFYun8txxYIwhjtLNfUmCA=="
     },
     "char-regex": {
       "version": "1.0.2",
@@ -44124,9 +43747,9 @@
           }
         },
         "domutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+          "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
           "optional": true,
           "peer": true,
           "requires": {
@@ -44415,24 +44038,6 @@
         }
       }
     },
-    "deep-equal-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deep-equal-json/-/deep-equal-json-1.0.0.tgz",
-      "integrity": "sha512-x11iOxzQuLWG1faqBf8PYn3xSxkK41Wg38lUbch9f+nVmBeuI53PPXeRIDdHsW2/dP2GGKL9p8cLCahHToE7CA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
-      }
-    },
     "deep-extend": {
       "version": "0.6.0"
     },
@@ -44576,11 +44181,6 @@
           "dev": true
         }
       }
-    },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-libc": {
       "version": "1.0.3"
@@ -47074,11 +46674,11 @@
       "version": "1.0.1"
     },
     "is-reference": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
       "requires": {
-        "@types/estree": "*"
+        "@types/estree": "^1.0.6"
       }
     },
     "is-regex": {
@@ -48176,9 +47776,9 @@
       }
     },
     "less": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
-      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.1.tgz",
+      "integrity": "sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==",
       "requires": {
         "copy-anything": "^2.0.1",
         "errno": "^0.1.1",
@@ -48947,9 +48547,9 @@
       }
     },
     "node-abi": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-      "integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
       "requires": {
         "semver": "^7.3.5"
       }
@@ -49193,6 +48793,7 @@
     },
     "object-is": {
       "version": "1.1.5",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -49782,6 +49383,145 @@
         }
       }
     },
+    "plasmo": {
+      "version": "0.89.4",
+      "resolved": "https://registry.npmjs.org/plasmo/-/plasmo-0.89.4.tgz",
+      "integrity": "sha512-vsoMe8ts0tyW27fZxwQLqWR/58NKqRepLFrZMVBH4ceSIyPDryfPpXzVxmBDH43odbiUVFdh8BGAt2ri2vQuGw==",
+      "requires": {
+        "@expo/spawn-async": "1.7.2",
+        "@parcel/core": "2.9.3",
+        "@parcel/fs": "2.9.3",
+        "@parcel/package-manager": "2.9.3",
+        "@parcel/watcher": "2.2.0",
+        "@plasmohq/init": "0.7.0",
+        "@plasmohq/parcel-config": "0.41.1",
+        "@plasmohq/parcel-core": "0.1.10",
+        "buffer": "6.0.3",
+        "chalk": "5.3.0",
+        "change-case": "5.1.2",
+        "dotenv": "16.3.1",
+        "dotenv-expand": "10.0.0",
+        "events": "3.3.0",
+        "fast-glob": "3.3.2",
+        "fflate": "0.8.1",
+        "get-port": "7.0.0",
+        "got": "13.0.0",
+        "ignore": "5.2.4",
+        "inquirer": "9.2.12",
+        "is-path-inside": "4.0.0",
+        "json5": "2.2.3",
+        "mnemonic-id": "3.2.7",
+        "node-object-hash": "3.0.0",
+        "package-json": "8.1.1",
+        "process": "0.11.10",
+        "semver": "7.5.4",
+        "sharp": "0.32.6",
+        "tempy": "3.1.0",
+        "typescript": "5.2.2"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+        },
+        "cli-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+          "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
+        },
+        "dotenv": {
+          "version": "16.3.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+          "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        },
+        "fflate": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+          "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ=="
+        },
+        "figures": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+          "requires": {
+            "escape-string-regexp": "^5.0.0",
+            "is-unicode-supported": "^1.2.0"
+          }
+        },
+        "inquirer": {
+          "version": "9.2.12",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
+          "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
+          "requires": {
+            "@ljharb/through": "^2.3.11",
+            "ansi-escapes": "^4.3.2",
+            "chalk": "^5.3.0",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^4.1.0",
+            "external-editor": "^3.1.0",
+            "figures": "^5.0.0",
+            "lodash": "^4.17.21",
+            "mute-stream": "1.0.0",
+            "ora": "^5.4.1",
+            "run-async": "^3.0.0",
+            "rxjs": "^7.8.1",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+          "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="
+        },
+        "is-unicode-supported": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+          "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+        },
+        "mute-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="
+        },
+        "run-async": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "playwright": {
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
@@ -50013,9 +49753,9 @@
       }
     },
     "prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -50032,9 +49772,9 @@
       },
       "dependencies": {
         "detect-libc": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-          "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+          "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
         }
       }
     },
@@ -51161,6 +50901,54 @@
         "kind-of": "^6.0.2"
       }
     },
+    "sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "requires": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "detect-libc": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+          "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
+        },
+        "node-addon-api": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+        },
+        "tar-fs": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+          "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+          "requires": {
+            "bare-fs": "^2.1.1",
+            "bare-path": "^2.1.0",
+            "pump": "^3.0.0",
+            "tar-stream": "^3.1.5"
+          }
+        },
+        "tar-stream": {
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+          "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+          "requires": {
+            "b4a": "^1.6.4",
+            "fast-fifo": "^1.2.0",
+            "streamx": "^2.15.0"
+          }
+        }
+      }
+    },
     "shebang-command": {
       "version": "2.0.0",
       "requires": {
@@ -51634,9 +51422,9 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "streamx": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
-      "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
+      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
       "requires": {
         "bare-events": "^2.2.0",
         "fast-fifo": "^1.3.2",
@@ -52072,6 +51860,41 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0"
     },
+    "svelte": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
+      "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
+      "requires": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^3.2.1",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+          "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="
+        },
+        "estree-walker": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+          "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+          "requires": {
+            "@types/estree": "^1.0.0"
+          }
+        }
+      }
+    },
     "svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
@@ -52288,9 +52111,9 @@
       }
     },
     "text-decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
-      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
       "requires": {
         "b4a": "^1.6.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11220,52 +11220,38 @@
       }
     },
     "node_modules/ast-generator": {
-      "version": "0.1.0",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ast-generator/-/ast-generator-0.2.3.tgz",
+      "integrity": "sha512-a8Hobx1hzary7eIiSW3x21nRmlUYz1UJEAYfAFCbyym/zP3RglWj+8b0t7PNxheOaheD/ltRO5ZgckWjOmlqJQ==",
       "dev": true,
       "dependencies": {
-        "chalk": "<5",
-        "commander": "^10.0.0",
-        "prettier": "^2.8.7",
-        "tiny-invariant": "^1.3.1",
-        "typescript": "^4.9.5"
+        "commander": "^13.0.0",
+        "prettier": "^3.4.2",
+        "tiny-invariant": "^1.3.3"
       },
       "bin": {
         "generate-ast": "dist/index.js"
+      },
+      "peerDependencies": {
+        "typescript": "^4 || ^5"
       }
     },
     "node_modules/ast-generator/node_modules/commander": {
-      "version": "10.0.0",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/ast-generator/node_modules/prettier": {
-      "version": "2.8.8",
+    "node_modules/ast-generator/node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/ast-generator/node_modules/typescript": {
-      "version": "4.9.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
+      "license": "MIT"
     },
     "node_modules/ast-types": {
       "version": "0.14.2",
@@ -21961,9 +21947,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -29954,7 +29940,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/didyoumean": "^1.2.0",
-        "ast-generator": "^0.1.0",
+        "ast-generator": "^0.2.3",
         "peggy": "^2.0.1",
         "pkg": "^4.4.9",
         "ts-node": "^10.9.1",
@@ -38058,7 +38044,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/didyoumean": "^1.2.0",
-        "ast-generator": "^0.1.0",
+        "ast-generator": "^0.2.3",
         "didyoumean": "^1.2.2",
         "peggy": "^2.0.1",
         "pkg": "^4.4.9",
@@ -42592,26 +42578,26 @@
       "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
     },
     "ast-generator": {
-      "version": "0.1.0",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ast-generator/-/ast-generator-0.2.3.tgz",
+      "integrity": "sha512-a8Hobx1hzary7eIiSW3x21nRmlUYz1UJEAYfAFCbyym/zP3RglWj+8b0t7PNxheOaheD/ltRO5ZgckWjOmlqJQ==",
       "dev": true,
       "requires": {
-        "chalk": "<5",
-        "commander": "^10.0.0",
-        "prettier": "^2.8.7",
-        "tiny-invariant": "^1.3.1",
-        "typescript": "^4.9.5"
+        "commander": "^13.0.0",
+        "prettier": "^3.4.2",
+        "tiny-invariant": "^1.3.3"
       },
       "dependencies": {
         "commander": {
-          "version": "10.0.0",
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+          "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
           "dev": true
         },
-        "prettier": {
-          "version": "2.8.8",
-          "dev": true
-        },
-        "typescript": {
-          "version": "4.9.5",
+        "tiny-invariant": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+          "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
           "dev": true
         }
       }
@@ -49741,9 +49727,9 @@
       "version": "1.2.1"
     },
     "prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true
     },
     "prettier-plugin-tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tsd": "^0.31.1",
     "tsup": "^8.3.5",
     "turbo": "^2.3.3",
-    "typescript": "<4.8"
+    "typescript": "^5.7.2"
   },
   "engines": {
     "node": ">=22.x"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
-    "dependency-cruiser": "^16.3.3",
-    "prettier": "^3.3.2",
+    "dependency-cruiser": "^16.9.0",
+    "prettier": "^3.4.2",
     "publint": "^0.2.8",
     "ts-morph": "^22.0.0",
     "tsd": "^0.31.1",
-    "tsup": "^8.1.0",
+    "tsup": "^8.3.5",
     "turbo": "^2.3.3",
     "typescript": "<4.8"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
+    "@types/node": "^18.19.70",
     "dependency-cruiser": "^16.9.0",
     "prettier": "^3.4.2",
     "publint": "^0.2.8",
@@ -31,5 +32,8 @@
   },
   "engines": {
     "node": ">=22.x"
+  },
+  "overrides": {
+    "@types/node": "$@types/node"
   }
 }

--- a/packages/liveblocks-client/package.json
+++ b/packages/liveblocks-client/package.json
@@ -38,11 +38,7 @@
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
-    "@liveblocks/jest-config": "*",
-    "@types/ws": "^8.5.10",
-    "dotenv": "^16.4.5",
-    "msw": "^0.39.1",
-    "ws": "^8.17.1"
+    "@liveblocks/jest-config": "*"
   },
   "sideEffects": false,
   "bugs": {

--- a/packages/liveblocks-client/test-d/room-api.test-d.ts
+++ b/packages/liveblocks-client/test-d/room-api.test-d.ts
@@ -1,4 +1,5 @@
-import { BaseMetadata, createClient } from "@liveblocks/client";
+import type { BaseMetadata } from "@liveblocks/client";
+import { createClient } from "@liveblocks/client";
 import type {
   BaseUserMeta,
   Json,

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -53,7 +53,7 @@
     "@types/ws": "^8.5.10",
     "dotenv": "^16.4.5",
     "eslint-plugin-rulesdir": "^0.2.2",
-    "msw": "^0.47.4",
+    "msw": "^1.3.5",
     "ws": "^8.17.1"
   },
   "repository": {

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -264,6 +264,7 @@ describe("room", () => {
       {},
       undefined,
       SOCKET_SEQUENCE(
+        // @ts-expect-error We're testing unknown codes
         SOCKET_REFUSES(4242 /* Unknown code */, "An unknown error reason"),
         SOCKET_AUTOCONNECT_AND_ROOM_STATE() // Repeated to infinity
       )
@@ -282,6 +283,7 @@ describe("room", () => {
       {},
       undefined,
       SOCKET_SEQUENCE(
+        // @ts-expect-error We're testing unknown codes
         SOCKET_REFUSES(4342 /* Unknown code */, "An unknown error reason"),
         SOCKET_AUTOCONNECT_AND_ROOM_STATE() // Repeated to infinity
       )

--- a/packages/liveblocks-core/src/immutable.ts
+++ b/packages/liveblocks-core/src/immutable.ts
@@ -243,7 +243,7 @@ export function patchLiveObject<O extends LsonObject>(
   const updates: Partial<O> = {};
 
   for (const key in next) {
-    patchLiveObjectKey(root, key, prev[key], next[key]);
+    patchLiveObjectKey(root, key, prev[key] as Json, next[key] as Json);
   }
 
   for (const key in prev) {

--- a/packages/liveblocks-emails/package.json
+++ b/packages/liveblocks-emails/package.json
@@ -45,7 +45,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "csstype": "3.0.2",
-    "msw": "^2.0.2"
+    "msw": "^2.7.0"
   },
   "sideEffects": false,
   "bugs": {

--- a/packages/liveblocks-emails/src/__tests__/_lexical-helpers.ts
+++ b/packages/liveblocks-emails/src/__tests__/_lexical-helpers.ts
@@ -55,7 +55,7 @@ export const docUpdate = new Uint8Array([
   42, 167, 186, 229, 132, 1, 1, 0, 1, 130, 146, 255, 129, 1, 2, 4, 1, 6, 34,
 ]);
 
-export const docUpdateBuffer = docUpdate.buffer as ArrayBuffer;
+export const docUpdateBuffer = docUpdate.buffer;
 
 export const MENTIONED_USER_ID = "user-4";
 export const MENTION_ID = "in_QQ6EOi7jsH-LNw0C8Lpaf";

--- a/packages/liveblocks-emails/src/__tests__/_tiptap-helpers.ts
+++ b/packages/liveblocks-emails/src/__tests__/_tiptap-helpers.ts
@@ -32,7 +32,7 @@ export const docUpdate = new Uint8Array([
   110, 32, 114, 105, 103, 104, 116, 63, 1, 197, 164, 177, 247, 3, 1, 39, 30,
 ]);
 
-export const docUpdateBuffer = docUpdate.buffer as ArrayBuffer;
+export const docUpdateBuffer = docUpdate.buffer;
 
 export const MENTIONED_USER_ID = "user-0";
 export const MENTION_ID = "in_8QpppsmEJhJzWQ8Q3B7BP";

--- a/packages/liveblocks-emails/src/lexical-editor.ts
+++ b/packages/liveblocks-emails/src/lexical-editor.ts
@@ -145,9 +145,11 @@ function createSerializedLexicalElementNode(
       if (content instanceof Y.XmlText) {
         children.push(createSerializedLexicalElementNode(content));
       } else if (content instanceof Y.Map) {
-        children.push(createSerializedLexicalMapNode(content));
+        children.push(createSerializedLexicalMapNode(content as Y.Map<Json>));
       } else if (content instanceof Y.XmlElement) {
-        children.push(createSerializedLexicalDecoratorNode(content));
+        children.push(
+          createSerializedLexicalDecoratorNode(content as Y.XmlElement)
+        );
       }
     }
     // ContentString is used to store text content of a text node in the Y.js doc.
@@ -197,7 +199,9 @@ export function createSerializedLexicalRootNode(
         if (content instanceof Y.XmlText) {
           children.push(createSerializedLexicalElementNode(content));
         } else if (content instanceof Y.XmlElement) {
-          children.push(createSerializedLexicalDecoratorNode(content));
+          children.push(
+            createSerializedLexicalDecoratorNode(content as Y.XmlElement)
+          );
         }
       }
 

--- a/packages/liveblocks-node-lexical/package.json
+++ b/packages/liveblocks-node-lexical/package.json
@@ -40,15 +40,14 @@
   },
   "peerDependencies": {
     "@lexical/headless": "0.16.1",
+    "@lexical/markdown": "0.16.1",
     "@lexical/selection": "0.16.1",
     "@lexical/yjs": "0.16.1",
-    "@lexical/markdown": "0.16.1",
     "lexical": "0.16.1"
   },
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
-    "@liveblocks/jest-config": "*",
-    "@types/node": "^20.14.8"
+    "@liveblocks/jest-config": "*"
   },
   "bugs": {
     "url": "https://github.com/liveblocks/liveblocks/issues"

--- a/packages/liveblocks-node-prosemirror/package.json
+++ b/packages/liveblocks-node-prosemirror/package.json
@@ -50,7 +50,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/node": "^20.14.8",
-    "msw": "^2.6.4"
+    "msw": "^2.7.0"
   },
   "bugs": {
     "url": "https://github.com/liveblocks/liveblocks/issues"

--- a/packages/liveblocks-node-prosemirror/package.json
+++ b/packages/liveblocks-node-prosemirror/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
-    "@types/node": "^20.14.8",
     "msw": "^2.7.0"
   },
   "bugs": {

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
-    "@types/node": "^20.17.12",
     "@types/node-fetch": "^2.6.6",
     "msw": "^2.7.0",
     "svix": "^0.75.0"

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
-    "@types/node": "^20.7.1",
+    "@types/node": "^20.17.12",
     "@types/node-fetch": "^2.6.6",
     "msw": "^2.7.0",
     "svix": "^0.75.0"

--- a/packages/liveblocks-node/package.json
+++ b/packages/liveblocks-node/package.json
@@ -44,7 +44,7 @@
     "@liveblocks/jest-config": "*",
     "@types/node": "^20.7.1",
     "@types/node-fetch": "^2.6.6",
-    "msw": "^2.0.2",
+    "msw": "^2.7.0",
     "svix": "^0.75.0"
   },
   "bugs": {

--- a/packages/liveblocks-react-lexical/package.json
+++ b/packages/liveblocks-react-lexical/package.json
@@ -64,7 +64,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "msw": "^0.27.1",
+    "msw": "^1.3.5",
     "rollup": "3.28.0",
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",

--- a/packages/liveblocks-react-tiptap/package.json
+++ b/packages/liveblocks-react-tiptap/package.json
@@ -69,7 +69,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "msw": "^0.27.1",
+    "msw": "^1.3.5",
     "rollup": "3.28.0",
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",

--- a/packages/liveblocks-react-ui/package.json
+++ b/packages/liveblocks-react-ui/package.json
@@ -101,7 +101,7 @@
     "emojibase": "^15.3.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "msw": "^0.27.1",
+    "msw": "^1.3.5",
     "rollup": "3.28.0",
     "stylelint": "^15.10.2",
     "stylelint-config-standard": "^34.0.0",

--- a/packages/liveblocks-react-ui/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react-ui/test-d/augmentation.test-d.tsx
@@ -1,4 +1,3 @@
-
 import type {
   InboxNotificationData,
   LiveList,
@@ -6,10 +5,8 @@ import type {
   LiveObject,
 } from "@liveblocks/core";
 import { expectError, expectType } from "tsd";
-import {
-  InboxNotification,
-  InboxNotificationCustomKindProps,
-} from "@liveblocks/react-ui";
+import type { InboxNotificationCustomKindProps } from "@liveblocks/react-ui";
+import { InboxNotification } from "@liveblocks/react-ui";
 
 // TODO: Create type tests for all components/props
 

--- a/packages/liveblocks-react-ui/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react-ui/test-d/no-augmentation.test-d.tsx
@@ -1,10 +1,7 @@
-
 import type { ActivityData, InboxNotificationData } from "@liveblocks/core";
 import { expectError, expectType } from "tsd";
-import {
-  InboxNotification,
-  InboxNotificationCustomKindProps,
-} from "@liveblocks/react-ui";
+import type { InboxNotificationCustomKindProps } from "@liveblocks/react-ui";
+import { InboxNotification } from "@liveblocks/react-ui";
 
 // TODO: Create type tests for all components/props
 

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -76,7 +76,7 @@
     "date-fns": "^3.6.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "itertools": "^2.3.2",
-    "msw": "1.3.2",
+    "msw": "^1.3.5",
     "react-error-boundary": "^4.0.13"
   },
   "sideEffects": false,

--- a/packages/liveblocks-react/src/lib/AsyncResult.ts
+++ b/packages/liveblocks-react/src/lib/AsyncResult.ts
@@ -17,8 +17,10 @@ export function ASYNC_OK<T, F extends string>(
   data?: T
 ): AsyncSuccess<T, F> {
   if (arguments.length === 1) {
+    // @ts-expect-error too dynamic to type
     return Object.freeze({ isLoading: false, data: fieldOrData });
   } else {
+    // @ts-expect-error too dynamic to type
     return Object.freeze({ isLoading: false, [fieldOrData as F]: data });
   }
 }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -366,6 +366,7 @@ function makeRoomContextBundle<
     // context consistent internally.
     return (
       <LiveblocksProviderWithClient client={client} allowNesting>
+        {/* @ts-expect-error {...props} is the same type as props */}
         <RoomProvider {...props} />
       </LiveblocksProviderWithClient>
     );
@@ -2551,7 +2552,13 @@ function useRoomPermissions(roomId: string) {
  *
  * This is an internal API, use `createRoomContext` instead.
  */
-export function useRoomContextBundleOrNull() {
+export function useRoomContextBundleOrNull(): RoomContextBundle<
+  JsonObject,
+  LsonObject,
+  BaseUserMeta,
+  Json,
+  BaseMetadata
+> | null {
   const client = useClientOrNull();
   const room = useRoomOrNull<never, never, never, never, never>();
   return client && room ? getOrCreateRoomContextBundle(client) : null;
@@ -2562,7 +2569,13 @@ export function useRoomContextBundleOrNull() {
  *
  * This is an internal API, use `createRoomContext` instead.
  */
-export function useRoomContextBundle() {
+export function useRoomContextBundle(): RoomContextBundle<
+  JsonObject,
+  LsonObject,
+  BaseUserMeta,
+  Json,
+  BaseMetadata
+> {
   const client = useClient();
   return getOrCreateRoomContextBundle(client);
 }

--- a/packages/liveblocks-react/src/use-sync-external-store-with-selector.ts
+++ b/packages/liveblocks-react/src/use-sync-external-store-with-selector.ts
@@ -69,9 +69,9 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
           // Even if the selector has changed, the currently rendered selection
           // may be equal to the new selection. We should attempt to reuse the
           // current value if possible, to preserve downstream memoizations.
-          if (inst!.hasValue) {
-            const currentSelection = inst!.value;
-            if (isEqual(currentSelection!, nextSelection)) {
+          if (inst.hasValue) {
+            const currentSelection = inst.value;
+            if (isEqual(currentSelection, nextSelection)) {
               memoizedSelection = currentSelection!;
               return currentSelection;
             }
@@ -126,10 +126,10 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
   );
 
   useEffect(() => {
-    inst!.hasValue = true;
-    inst!.value = value;
+    inst.hasValue = true;
+    inst.value = value;
   }, [value]);
 
   useDebugValue(value);
-  return value!;
+  return value;
 }

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -1,10 +1,5 @@
-import {
-  BaseMetadata,
-  Json,
-  LiveList,
-  LiveObject,
-  Lson,
-} from "@liveblocks/client";
+import type { BaseMetadata, Json, Lson } from "@liveblocks/client";
+import { LiveObject, LiveList } from "@liveblocks/client";
 import * as classic from "@liveblocks/react";
 import * as suspense from "@liveblocks/react/suspense";
 import { expectAssignable, expectError, expectType } from "tsd";

--- a/packages/liveblocks-react/tsconfig.json
+++ b/packages/liveblocks-react/tsconfig.json
@@ -5,7 +5,6 @@
   "compilerOptions": {
     "module": "es2020",
     "lib": ["dom"],
-    "skipLibCheck": true,
 
     // Transform JSX syntax from input *.tsx files into _jsx() calls in the outputted build
     "jsx": "react-jsx"

--- a/packages/liveblocks-redux/package.json
+++ b/packages/liveblocks-redux/package.json
@@ -44,7 +44,7 @@
     "@liveblocks/jest-config": "*",
     "@reduxjs/toolkit": "^1.7.2",
     "@testing-library/jest-dom": "^6.4.6",
-    "msw": "^0.36.4",
+    "msw": "^1.3.5",
     "redux": "^4.1.2"
   },
   "sideEffects": false,

--- a/packages/liveblocks-yjs/package.json
+++ b/packages/liveblocks-yjs/package.json
@@ -45,7 +45,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@testing-library/jest-dom": "^6.4.6",
-    "msw": "^0.47.4"
+    "msw": "^1.3.5"
   },
   "sideEffects": false,
   "bugs": {

--- a/packages/liveblocks-yjs/src/awareness.ts
+++ b/packages/liveblocks-yjs/src/awareness.ts
@@ -175,7 +175,7 @@ export class Awareness<
         acc.set(otherClientId, otherPresence || {});
       }
       return acc;
-    }, new Map());
+    }, new Map<number, unknown>());
 
     // add this client's yjs presence to states (local client not represented in others)
     const localPresence = this.room.getSelf()?.presence[Y_PRESENCE_KEY];

--- a/packages/liveblocks-zustand/package.json
+++ b/packages/liveblocks-zustand/package.json
@@ -44,7 +44,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@testing-library/jest-dom": "^6.4.6",
-    "msw": "^0.36.4",
+    "msw": "^1.3.5",
     "zustand": "^5.0.1"
   },
   "sideEffects": false,

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -212,7 +212,12 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
             const liveblocksStatePart = root.get(key);
             if (liveblocksStatePart === undefined) {
               updates[key] = get()[key];
-              patchLiveObjectKey(root, key, undefined, get()[key]);
+              patchLiveObjectKey(
+                root,
+                key,
+                undefined,
+                get()[key] as Json | undefined
+              );
             } else {
               updates[key] = lsonToJson(
                 liveblocksStatePart
@@ -278,7 +283,12 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
         if (maybeRoom) {
           const room = maybeRoom;
           isPatching = true;
-          updatePresence(room, oldState, newState, presenceMapping);
+          updatePresence(
+            room,
+            oldState as JsonObject,
+            newState as JsonObject,
+            presenceMapping
+          );
 
           room.batch(() => {
             if (storageRoot) {
@@ -326,11 +336,15 @@ function patchState<T>(
     partialState[key] = state[key];
   }
 
-  const patched = legacy_patchImmutableObject(partialState, updates);
+  const patched = legacy_patchImmutableObject(
+    partialState as JsonObject,
+    updates
+  );
 
   const result: Partial<T> = {};
 
   for (const key in mapping) {
+    // @ts-expect-error key is a key of T
     result[key] = patched[key];
   }
 
@@ -408,8 +422,8 @@ function patchLiveblocksStorage<O extends LsonObject, TState>(
     }
 
     if (oldState[key] !== newState[key]) {
-      const oldVal = oldState[key];
-      const newVal = newState[key];
+      const oldVal = oldState[key] as Json | undefined;
+      const newVal = newState[key] as Json | undefined;
       patchLiveObjectKey(root, key, oldVal, newVal);
     }
   }

--- a/packages/liveblocks-zustand/test-d/basic.test-d.ts
+++ b/packages/liveblocks-zustand/test-d/basic.test-d.ts
@@ -1,8 +1,6 @@
 import { createClient, LiveList } from "@liveblocks/client";
-import {
-  liveblocks as liveblocksMiddleware,
-  WithLiveblocks,
-} from "@liveblocks/zustand";
+import type { WithLiveblocks } from "@liveblocks/zustand";
+import { liveblocks as liveblocksMiddleware } from "@liveblocks/zustand";
 import { devtools, persist } from "zustand/middleware";
 
 import { create } from "zustand";

--- a/schema-lang/liveblocks-schema/package.json
+++ b/schema-lang/liveblocks-schema/package.json
@@ -32,7 +32,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/didyoumean": "^1.2.0",
-    "ast-generator": "^0.1.0",
+    "ast-generator": "^0.2.3",
     "peggy": "^2.0.1",
     "pkg": "^4.4.9",
     "ts-node": "^10.9.1",

--- a/schema-lang/liveblocks-schema/src/__tests__/examples.test.ts
+++ b/schema-lang/liveblocks-schema/src/__tests__/examples.test.ts
@@ -138,12 +138,10 @@ describe("examples", () => {
             name: {
               _kind: "TypeName",
               name: "Storage",
-              range: expect.anything(),
             },
             leadingComment: null,
             isStatic: false,
             fields: expect.anything(),
-            range: expect.anything(),
           });
         })
       );
@@ -158,7 +156,6 @@ describe("examples", () => {
           expect(parseOnly(content)).toEqual({
             _kind: "Document",
             definitions: expect.anything(),
-            range: expect.anything(),
           });
 
           if (!expectedError) {

--- a/schema-lang/liveblocks-schema/src/ast/ast.grammar
+++ b/schema-lang/liveblocks-schema/src/ast/ast.grammar
@@ -5,6 +5,9 @@
 #
 # This is used to generate the AST TypeScript module.
 #
+Document:
+    definitions  @Definition+
+
 
 @ScalarType:
     | StringType
@@ -53,10 +56,6 @@ ArrayType:
 TypeRef:
     ref           TypeName
     asLiveObject  `boolean`
-
-
-Document:
-    definitions  @Definition+
 
 
 FieldDef:

--- a/schema-lang/liveblocks-schema/src/ast/index.ts
+++ b/schema-lang/liveblocks-schema/src/ast/index.ts
@@ -18,10 +18,12 @@ function assertRange(
 ): asserts range is Range {
   assert(
     isRange(range),
-    `Invalid value for range in "${JSON.stringify(
-      currentContext
-    )}".\nExpected: Range\nGot: ${JSON.stringify(range)}`
+    `Invalid value for range in "${JSON.stringify(currentContext)}".\nExpected: Range\nGot: ${JSON.stringify(range)}`
   );
+}
+
+function asNode<N extends Node>(node: N): N {
+  return Object.defineProperty(node, "range", { enumerable: false });
 }
 
 export function isDefinition(node: Node): node is Definition {
@@ -236,17 +238,15 @@ export function arrayType(ofType: Type, range: Range = [0, 0]): ArrayType {
     (() => {
       assert(
         isType(ofType),
-        `Invalid value for "ofType" arg in "ArrayType" call.\nExpected: @Type\nGot:      ${JSON.stringify(
-          ofType
-        )}`
+        `Invalid value for "ofType" arg in "ArrayType" call.\nExpected: @Type\nGot:      ${JSON.stringify(ofType)}`
       );
       assertRange(range, "ArrayType");
     })();
-  return {
+  return asNode({
     _kind: "ArrayType",
     ofType,
     range,
-  };
+  });
 }
 
 export function booleanType(range: Range = [0, 0]): BooleanType {
@@ -254,10 +254,10 @@ export function booleanType(range: Range = [0, 0]): BooleanType {
     (() => {
       assertRange(range, "BooleanType");
     })();
-  return {
+  return asNode({
     _kind: "BooleanType",
     range,
-  };
+  });
 }
 
 export function document(
@@ -270,17 +270,15 @@ export function document(
         Array.isArray(definitions) &&
           definitions.length > 0 &&
           definitions.every((item) => isDefinition(item)),
-        `Invalid value for "definitions" arg in "Document" call.\nExpected: @Definition+\nGot:      ${JSON.stringify(
-          definitions
-        )}`
+        `Invalid value for "definitions" arg in "Document" call.\nExpected: @Definition+\nGot:      ${JSON.stringify(definitions)}`
       );
       assertRange(range, "Document");
     })();
-  return {
+  return asNode({
     _kind: "Document",
     definitions,
     range,
-  };
+  });
 }
 
 export function fieldDef(
@@ -295,37 +293,27 @@ export function fieldDef(
     (() => {
       assert(
         name._kind === "Identifier",
-        `Invalid value for "name" arg in "FieldDef" call.\nExpected: Identifier\nGot:      ${JSON.stringify(
-          name
-        )}`
+        `Invalid value for "name" arg in "FieldDef" call.\nExpected: Identifier\nGot:      ${JSON.stringify(name)}`
       );
       assert(
         typeof optional === "boolean",
-        `Invalid value for "optional" arg in "FieldDef" call.\nExpected: boolean\nGot:      ${JSON.stringify(
-          optional
-        )}`
+        `Invalid value for "optional" arg in "FieldDef" call.\nExpected: boolean\nGot:      ${JSON.stringify(optional)}`
       );
       assert(
         isType(type),
-        `Invalid value for "type" arg in "FieldDef" call.\nExpected: @Type\nGot:      ${JSON.stringify(
-          type
-        )}`
+        `Invalid value for "type" arg in "FieldDef" call.\nExpected: @Type\nGot:      ${JSON.stringify(type)}`
       );
       assert(
         leadingComment === null || typeof leadingComment === "string",
-        `Invalid value for "leadingComment" arg in "FieldDef" call.\nExpected: string?\nGot:      ${JSON.stringify(
-          leadingComment
-        )}`
+        `Invalid value for "leadingComment" arg in "FieldDef" call.\nExpected: string?\nGot:      ${JSON.stringify(leadingComment)}`
       );
       assert(
         trailingComment === null || typeof trailingComment === "string",
-        `Invalid value for "trailingComment" arg in "FieldDef" call.\nExpected: string?\nGot:      ${JSON.stringify(
-          trailingComment
-        )}`
+        `Invalid value for "trailingComment" arg in "FieldDef" call.\nExpected: string?\nGot:      ${JSON.stringify(trailingComment)}`
       );
       assertRange(range, "FieldDef");
     })();
-  return {
+  return asNode({
     _kind: "FieldDef",
     name,
     optional,
@@ -333,7 +321,7 @@ export function fieldDef(
     leadingComment,
     trailingComment,
     range,
-  };
+  });
 }
 
 export function identifier(name: string, range: Range = [0, 0]): Identifier {
@@ -341,17 +329,15 @@ export function identifier(name: string, range: Range = [0, 0]): Identifier {
     (() => {
       assert(
         typeof name === "string",
-        `Invalid value for "name" arg in "Identifier" call.\nExpected: string\nGot:      ${JSON.stringify(
-          name
-        )}`
+        `Invalid value for "name" arg in "Identifier" call.\nExpected: string\nGot:      ${JSON.stringify(name)}`
       );
       assertRange(range, "Identifier");
     })();
-  return {
+  return asNode({
     _kind: "Identifier",
     name,
     range,
-  };
+  });
 }
 
 export function literalType(
@@ -364,17 +350,15 @@ export function literalType(
         typeof value === "string" ||
           typeof value === "number" ||
           typeof value === "boolean",
-        `Invalid value for "value" arg in "LiteralType" call.\nExpected: string | number | boolean\nGot:      ${JSON.stringify(
-          value
-        )}`
+        `Invalid value for "value" arg in "LiteralType" call.\nExpected: string | number | boolean\nGot:      ${JSON.stringify(value)}`
       );
       assertRange(range, "LiteralType");
     })();
-  return {
+  return asNode({
     _kind: "LiteralType",
     value,
     range,
-  };
+  });
 }
 
 export function liveListType(
@@ -385,17 +369,15 @@ export function liveListType(
     (() => {
       assert(
         isType(ofType),
-        `Invalid value for "ofType" arg in "LiveListType" call.\nExpected: @Type\nGot:      ${JSON.stringify(
-          ofType
-        )}`
+        `Invalid value for "ofType" arg in "LiveListType" call.\nExpected: @Type\nGot:      ${JSON.stringify(ofType)}`
       );
       assertRange(range, "LiveListType");
     })();
-  return {
+  return asNode({
     _kind: "LiveListType",
     ofType,
     range,
-  };
+  });
 }
 
 export function liveMapType(
@@ -407,24 +389,20 @@ export function liveMapType(
     (() => {
       assert(
         isType(keyType),
-        `Invalid value for "keyType" arg in "LiveMapType" call.\nExpected: @Type\nGot:      ${JSON.stringify(
-          keyType
-        )}`
+        `Invalid value for "keyType" arg in "LiveMapType" call.\nExpected: @Type\nGot:      ${JSON.stringify(keyType)}`
       );
       assert(
         isType(valueType),
-        `Invalid value for "valueType" arg in "LiveMapType" call.\nExpected: @Type\nGot:      ${JSON.stringify(
-          valueType
-        )}`
+        `Invalid value for "valueType" arg in "LiveMapType" call.\nExpected: @Type\nGot:      ${JSON.stringify(valueType)}`
       );
       assertRange(range, "LiveMapType");
     })();
-  return {
+  return asNode({
     _kind: "LiveMapType",
     keyType,
     valueType,
     range,
-  };
+  });
 }
 
 export function nullType(range: Range = [0, 0]): NullType {
@@ -432,10 +410,10 @@ export function nullType(range: Range = [0, 0]): NullType {
     (() => {
       assertRange(range, "NullType");
     })();
-  return {
+  return asNode({
     _kind: "NullType",
     range,
-  };
+  });
 }
 
 export function numberType(range: Range = [0, 0]): NumberType {
@@ -443,10 +421,10 @@ export function numberType(range: Range = [0, 0]): NumberType {
     (() => {
       assertRange(range, "NumberType");
     })();
-  return {
+  return asNode({
     _kind: "NumberType",
     range,
-  };
+  });
 }
 
 export function objectLiteralType(
@@ -458,17 +436,15 @@ export function objectLiteralType(
       assert(
         Array.isArray(fields) &&
           fields.every((item) => item._kind === "FieldDef"),
-        `Invalid value for "fields" arg in "ObjectLiteralType" call.\nExpected: FieldDef*\nGot:      ${JSON.stringify(
-          fields
-        )}`
+        `Invalid value for "fields" arg in "ObjectLiteralType" call.\nExpected: FieldDef*\nGot:      ${JSON.stringify(fields)}`
       );
       assertRange(range, "ObjectLiteralType");
     })();
-  return {
+  return asNode({
     _kind: "ObjectLiteralType",
     fields,
     range,
-  };
+  });
 }
 
 export function objectTypeDefinition(
@@ -482,39 +458,31 @@ export function objectTypeDefinition(
     (() => {
       assert(
         name._kind === "TypeName",
-        `Invalid value for "name" arg in "ObjectTypeDefinition" call.\nExpected: TypeName\nGot:      ${JSON.stringify(
-          name
-        )}`
+        `Invalid value for "name" arg in "ObjectTypeDefinition" call.\nExpected: TypeName\nGot:      ${JSON.stringify(name)}`
       );
       assert(
         Array.isArray(fields) &&
           fields.every((item) => item._kind === "FieldDef"),
-        `Invalid value for "fields" arg in "ObjectTypeDefinition" call.\nExpected: FieldDef*\nGot:      ${JSON.stringify(
-          fields
-        )}`
+        `Invalid value for "fields" arg in "ObjectTypeDefinition" call.\nExpected: FieldDef*\nGot:      ${JSON.stringify(fields)}`
       );
       assert(
         leadingComment === null || typeof leadingComment === "string",
-        `Invalid value for "leadingComment" arg in "ObjectTypeDefinition" call.\nExpected: string?\nGot:      ${JSON.stringify(
-          leadingComment
-        )}`
+        `Invalid value for "leadingComment" arg in "ObjectTypeDefinition" call.\nExpected: string?\nGot:      ${JSON.stringify(leadingComment)}`
       );
       assert(
         typeof isStatic === "boolean",
-        `Invalid value for "isStatic" arg in "ObjectTypeDefinition" call.\nExpected: boolean\nGot:      ${JSON.stringify(
-          isStatic
-        )}`
+        `Invalid value for "isStatic" arg in "ObjectTypeDefinition" call.\nExpected: boolean\nGot:      ${JSON.stringify(isStatic)}`
       );
       assertRange(range, "ObjectTypeDefinition");
     })();
-  return {
+  return asNode({
     _kind: "ObjectTypeDefinition",
     name,
     fields,
     leadingComment,
     isStatic,
     range,
-  };
+  });
 }
 
 export function stringType(range: Range = [0, 0]): StringType {
@@ -522,10 +490,10 @@ export function stringType(range: Range = [0, 0]): StringType {
     (() => {
       assertRange(range, "StringType");
     })();
-  return {
+  return asNode({
     _kind: "StringType",
     range,
-  };
+  });
 }
 
 export function typeName(name: string, range: Range = [0, 0]): TypeName {
@@ -533,17 +501,15 @@ export function typeName(name: string, range: Range = [0, 0]): TypeName {
     (() => {
       assert(
         typeof name === "string",
-        `Invalid value for "name" arg in "TypeName" call.\nExpected: string\nGot:      ${JSON.stringify(
-          name
-        )}`
+        `Invalid value for "name" arg in "TypeName" call.\nExpected: string\nGot:      ${JSON.stringify(name)}`
       );
       assertRange(range, "TypeName");
     })();
-  return {
+  return asNode({
     _kind: "TypeName",
     name,
     range,
-  };
+  });
 }
 
 export function typeRef(
@@ -555,24 +521,20 @@ export function typeRef(
     (() => {
       assert(
         ref._kind === "TypeName",
-        `Invalid value for "ref" arg in "TypeRef" call.\nExpected: TypeName\nGot:      ${JSON.stringify(
-          ref
-        )}`
+        `Invalid value for "ref" arg in "TypeRef" call.\nExpected: TypeName\nGot:      ${JSON.stringify(ref)}`
       );
       assert(
         typeof asLiveObject === "boolean",
-        `Invalid value for "asLiveObject" arg in "TypeRef" call.\nExpected: boolean\nGot:      ${JSON.stringify(
-          asLiveObject
-        )}`
+        `Invalid value for "asLiveObject" arg in "TypeRef" call.\nExpected: boolean\nGot:      ${JSON.stringify(asLiveObject)}`
       );
       assertRange(range, "TypeRef");
     })();
-  return {
+  return asNode({
     _kind: "TypeRef",
     ref,
     asLiveObject,
     range,
-  };
+  });
 }
 
 export function unionType(
@@ -585,17 +547,15 @@ export function unionType(
         Array.isArray(members) &&
           members.length > 0 &&
           members.every((item) => isNonUnionType(item)),
-        `Invalid value for "members" arg in "UnionType" call.\nExpected: @NonUnionType+\nGot:      ${JSON.stringify(
-          members
-        )}`
+        `Invalid value for "members" arg in "UnionType" call.\nExpected: @NonUnionType+\nGot:      ${JSON.stringify(members)}`
       );
       assertRange(range, "UnionType");
     })();
-  return {
+  return asNode({
     _kind: "UnionType",
     members,
     range,
-  };
+  });
 }
 
 interface Visitor<TContext> {

--- a/schema-lang/liveblocks-schema/src/checker/__tests__/__snapshots__/checker.test.ts.snap
+++ b/schema-lang/liveblocks-schema/src/checker/__tests__/__snapshots__/checker.test.ts.snap
@@ -14,23 +14,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "r",
-              "range": [
-                56,
-                57,
-              ],
             },
             "optional": false,
-            "range": [
-              56,
-              65,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                59,
-                65,
-              ],
             },
           },
           {
@@ -39,23 +27,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "g",
-              "range": [
-                67,
-                68,
-              ],
             },
             "optional": false,
-            "range": [
-              67,
-              76,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                70,
-                76,
-              ],
             },
           },
           {
@@ -64,23 +40,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "b",
-              "range": [
-                78,
-                79,
-              ],
             },
             "optional": false,
-            "range": [
-              78,
-              87,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                81,
-                87,
-              ],
             },
           },
         ],
@@ -89,15 +53,7 @@ exports[`checker large document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "RGB",
-          "range": [
-            50,
-            53,
-          ],
         },
-        "range": [
-          45,
-          89,
-        ],
       },
       {
         "_kind": "ObjectTypeDefinition",
@@ -108,23 +64,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "type",
-              "range": [
-                117,
-                121,
-              ],
             },
             "optional": false,
-            "range": [
-              117,
-              154,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "StringType",
-              "range": [
-                123,
-                154,
-              ],
             },
           },
           {
@@ -133,23 +77,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "x",
-              "range": [
-                163,
-                164,
-              ],
             },
             "optional": false,
-            "range": [
-              163,
-              172,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                166,
-                172,
-              ],
             },
           },
           {
@@ -158,23 +90,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "y",
-              "range": [
-                181,
-                182,
-              ],
             },
             "optional": false,
-            "range": [
-              181,
-              190,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                184,
-                190,
-              ],
             },
           },
           {
@@ -183,23 +103,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "width",
-              "range": [
-                199,
-                204,
-              ],
             },
             "optional": false,
-            "range": [
-              199,
-              212,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                206,
-                212,
-              ],
             },
           },
           {
@@ -208,23 +116,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "height",
-              "range": [
-                221,
-                227,
-              ],
             },
             "optional": false,
-            "range": [
-              221,
-              235,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                229,
-                235,
-              ],
             },
           },
           {
@@ -233,39 +129,19 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "fills",
-              "range": [
-                244,
-                249,
-              ],
             },
             "optional": true,
-            "range": [
-              244,
-              257,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "ArrayType",
               "ofType": {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  252,
-                  255,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "RGB",
-                  "range": [
-                    252,
-                    255,
-                  ],
                 },
               },
-              "range": [
-                252,
-                257,
-              ],
             },
           },
           {
@@ -274,39 +150,19 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "strokes",
-              "range": [
-                266,
-                273,
-              ],
             },
             "optional": true,
-            "range": [
-              266,
-              289,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "LiveListType",
               "ofType": {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  285,
-                  288,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "RGB",
-                  "range": [
-                    285,
-                    288,
-                  ],
                 },
               },
-              "range": [
-                276,
-                289,
-              ],
             },
           },
         ],
@@ -315,15 +171,7 @@ exports[`checker large document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "Rect",
-          "range": [
-            102,
-            106,
-          ],
         },
-        "range": [
-          97,
-          297,
-        ],
       },
       {
         "_kind": "ObjectTypeDefinition",
@@ -334,23 +182,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "type",
-              "range": [
-                327,
-                331,
-              ],
             },
             "optional": false,
-            "range": [
-              327,
-              366,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "StringType",
-              "range": [
-                333,
-                366,
-              ],
             },
           },
           {
@@ -359,23 +195,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "cx",
-              "range": [
-                375,
-                377,
-              ],
             },
             "optional": false,
-            "range": [
-              375,
-              385,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                379,
-                385,
-              ],
             },
           },
           {
@@ -384,23 +208,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "cy",
-              "range": [
-                394,
-                396,
-              ],
             },
             "optional": false,
-            "range": [
-              394,
-              404,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                398,
-                404,
-              ],
             },
           },
           {
@@ -409,23 +221,11 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "radius",
-              "range": [
-                413,
-                419,
-              ],
             },
             "optional": false,
-            "range": [
-              413,
-              427,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                421,
-                427,
-              ],
             },
           },
           {
@@ -434,31 +234,15 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "fill",
-              "range": [
-                436,
-                440,
-              ],
             },
             "optional": true,
-            "range": [
-              436,
-              448,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                445,
-                448,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  445,
-                  448,
-                ],
               },
             },
           },
@@ -468,31 +252,15 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "stroke",
-              "range": [
-                457,
-                463,
-              ],
             },
             "optional": true,
-            "range": [
-              457,
-              469,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                466,
-                469,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  466,
-                  469,
-                ],
               },
             },
           },
@@ -502,15 +270,7 @@ exports[`checker large document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "Circle",
-          "range": [
-            310,
-            316,
-          ],
         },
-        "range": [
-          305,
-          477,
-        ],
       },
       {
         "_kind": "ObjectTypeDefinition",
@@ -521,31 +281,15 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "mycircle",
-              "range": [
-                543,
-                551,
-              ],
             },
             "optional": false,
-            "range": [
-              543,
-              571,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "TypeRef",
               "asLiveObject": true,
-              "range": [
-                553,
-                571,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "Circle",
-                "range": [
-                  564,
-                  570,
-                ],
               },
             },
           },
@@ -555,31 +299,15 @@ exports[`checker large document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "myrect",
-              "range": [
-                580,
-                586,
-              ],
             },
             "optional": false,
-            "range": [
-              580,
-              604,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "TypeRef",
               "asLiveObject": true,
-              "range": [
-                588,
-                604,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "Rect",
-                "range": [
-                  599,
-                  603,
-                ],
               },
             },
           },
@@ -589,20 +317,8 @@ exports[`checker large document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "Storage",
-          "range": [
-            490,
-            497,
-          ],
         },
-        "range": [
-          485,
-          612,
-        ],
       },
-    ],
-    "range": [
-      7,
-      612,
     ],
   },
   "definitions": [
@@ -615,23 +331,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "r",
-            "range": [
-              56,
-              57,
-            ],
           },
           "optional": false,
-          "range": [
-            56,
-            65,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              59,
-              65,
-            ],
           },
         },
         {
@@ -640,23 +344,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "g",
-            "range": [
-              67,
-              68,
-            ],
           },
           "optional": false,
-          "range": [
-            67,
-            76,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              70,
-              76,
-            ],
           },
         },
         {
@@ -665,23 +357,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "b",
-            "range": [
-              78,
-              79,
-            ],
           },
           "optional": false,
-          "range": [
-            78,
-            87,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              81,
-              87,
-            ],
           },
         },
       ],
@@ -690,15 +370,7 @@ exports[`checker large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "RGB",
-        "range": [
-          50,
-          53,
-        ],
       },
-      "range": [
-        45,
-        89,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -709,23 +381,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "type",
-            "range": [
-              117,
-              121,
-            ],
           },
           "optional": false,
-          "range": [
-            117,
-            154,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "StringType",
-            "range": [
-              123,
-              154,
-            ],
           },
         },
         {
@@ -734,23 +394,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "x",
-            "range": [
-              163,
-              164,
-            ],
           },
           "optional": false,
-          "range": [
-            163,
-            172,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              166,
-              172,
-            ],
           },
         },
         {
@@ -759,23 +407,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "y",
-            "range": [
-              181,
-              182,
-            ],
           },
           "optional": false,
-          "range": [
-            181,
-            190,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              184,
-              190,
-            ],
           },
         },
         {
@@ -784,23 +420,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "width",
-            "range": [
-              199,
-              204,
-            ],
           },
           "optional": false,
-          "range": [
-            199,
-            212,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              206,
-              212,
-            ],
           },
         },
         {
@@ -809,23 +433,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "height",
-            "range": [
-              221,
-              227,
-            ],
           },
           "optional": false,
-          "range": [
-            221,
-            235,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              229,
-              235,
-            ],
           },
         },
         {
@@ -834,39 +446,19 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "fills",
-            "range": [
-              244,
-              249,
-            ],
           },
           "optional": true,
-          "range": [
-            244,
-            257,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
             "ofType": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                252,
-                255,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  252,
-                  255,
-                ],
               },
             },
-            "range": [
-              252,
-              257,
-            ],
           },
         },
         {
@@ -875,39 +467,19 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "strokes",
-            "range": [
-              266,
-              273,
-            ],
           },
           "optional": true,
-          "range": [
-            266,
-            289,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "LiveListType",
             "ofType": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                285,
-                288,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  285,
-                  288,
-                ],
               },
             },
-            "range": [
-              276,
-              289,
-            ],
           },
         },
       ],
@@ -916,15 +488,7 @@ exports[`checker large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Rect",
-        "range": [
-          102,
-          106,
-        ],
       },
-      "range": [
-        97,
-        297,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -935,23 +499,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "type",
-            "range": [
-              327,
-              331,
-            ],
           },
           "optional": false,
-          "range": [
-            327,
-            366,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "StringType",
-            "range": [
-              333,
-              366,
-            ],
           },
         },
         {
@@ -960,23 +512,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cx",
-            "range": [
-              375,
-              377,
-            ],
           },
           "optional": false,
-          "range": [
-            375,
-            385,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              379,
-              385,
-            ],
           },
         },
         {
@@ -985,23 +525,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cy",
-            "range": [
-              394,
-              396,
-            ],
           },
           "optional": false,
-          "range": [
-            394,
-            404,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              398,
-              404,
-            ],
           },
         },
         {
@@ -1010,23 +538,11 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "radius",
-            "range": [
-              413,
-              419,
-            ],
           },
           "optional": false,
-          "range": [
-            413,
-            427,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              421,
-              427,
-            ],
           },
         },
         {
@@ -1035,31 +551,15 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "fill",
-            "range": [
-              436,
-              440,
-            ],
           },
           "optional": true,
-          "range": [
-            436,
-            448,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              445,
-              448,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "RGB",
-              "range": [
-                445,
-                448,
-              ],
             },
           },
         },
@@ -1069,31 +569,15 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "stroke",
-            "range": [
-              457,
-              463,
-            ],
           },
           "optional": true,
-          "range": [
-            457,
-            469,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              466,
-              469,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "RGB",
-              "range": [
-                466,
-                469,
-              ],
             },
           },
         },
@@ -1103,15 +587,7 @@ exports[`checker large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Circle",
-        "range": [
-          310,
-          316,
-        ],
       },
-      "range": [
-        305,
-        477,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -1122,31 +598,15 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "mycircle",
-            "range": [
-              543,
-              551,
-            ],
           },
           "optional": false,
-          "range": [
-            543,
-            571,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": true,
-            "range": [
-              553,
-              571,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Circle",
-              "range": [
-                564,
-                570,
-              ],
             },
           },
         },
@@ -1156,31 +616,15 @@ exports[`checker large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "myrect",
-            "range": [
-              580,
-              586,
-            ],
           },
           "optional": false,
-          "range": [
-            580,
-            604,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": true,
-            "range": [
-              588,
-              604,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Rect",
-              "range": [
-                599,
-                603,
-              ],
             },
           },
         },
@@ -1190,15 +634,7 @@ exports[`checker large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Storage",
-        "range": [
-          490,
-          497,
-        ],
       },
-      "range": [
-        485,
-        612,
-      ],
     },
   ],
   "getDefinition": [Function],
@@ -1211,31 +647,15 @@ exports[`checker large document (snapshot test) 1`] = `
         "name": {
           "_kind": "Identifier",
           "name": "mycircle",
-          "range": [
-            543,
-            551,
-          ],
         },
         "optional": false,
-        "range": [
-          543,
-          571,
-        ],
         "trailingComment": null,
         "type": {
           "_kind": "TypeRef",
           "asLiveObject": true,
-          "range": [
-            553,
-            571,
-          ],
           "ref": {
             "_kind": "TypeName",
             "name": "Circle",
-            "range": [
-              564,
-              570,
-            ],
           },
         },
       },
@@ -1245,31 +665,15 @@ exports[`checker large document (snapshot test) 1`] = `
         "name": {
           "_kind": "Identifier",
           "name": "myrect",
-          "range": [
-            580,
-            586,
-          ],
         },
         "optional": false,
-        "range": [
-          580,
-          604,
-        ],
         "trailingComment": null,
         "type": {
           "_kind": "TypeRef",
           "asLiveObject": true,
-          "range": [
-            588,
-            604,
-          ],
           "ref": {
             "_kind": "TypeName",
             "name": "Rect",
-            "range": [
-              599,
-              603,
-            ],
           },
         },
       },
@@ -1279,15 +683,7 @@ exports[`checker large document (snapshot test) 1`] = `
     "name": {
       "_kind": "TypeName",
       "name": "Storage",
-      "range": [
-        490,
-        497,
-      ],
     },
-    "range": [
-      485,
-      612,
-    ],
   },
 }
 `;
@@ -1306,23 +702,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "r",
-              "range": [
-                56,
-                57,
-              ],
             },
             "optional": false,
-            "range": [
-              56,
-              62,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                59,
-                62,
-              ],
             },
           },
           {
@@ -1331,23 +715,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "g",
-              "range": [
-                64,
-                65,
-              ],
             },
             "optional": false,
-            "range": [
-              64,
-              70,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                67,
-                70,
-              ],
             },
           },
           {
@@ -1356,23 +728,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "b",
-              "range": [
-                72,
-                73,
-              ],
             },
             "optional": false,
-            "range": [
-              72,
-              78,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                75,
-                78,
-              ],
             },
           },
         ],
@@ -1381,15 +741,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "RGB",
-          "range": [
-            50,
-            53,
-          ],
         },
-        "range": [
-          45,
-          80,
-        ],
       },
       {
         "_kind": "ObjectTypeDefinition",
@@ -1400,23 +752,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "type",
-              "range": [
-                108,
-                112,
-              ],
             },
             "optional": false,
-            "range": [
-              108,
-              120,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "LiteralType",
-              "range": [
-                114,
-                120,
-              ],
               "value": "rect",
             },
           },
@@ -1426,23 +766,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "x",
-              "range": [
-                129,
-                130,
-              ],
             },
             "optional": false,
-            "range": [
-              129,
-              135,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                132,
-                135,
-              ],
             },
           },
           {
@@ -1451,23 +779,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "y",
-              "range": [
-                144,
-                145,
-              ],
             },
             "optional": false,
-            "range": [
-              144,
-              150,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                147,
-                150,
-              ],
             },
           },
           {
@@ -1476,23 +792,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "width",
-              "range": [
-                159,
-                164,
-              ],
             },
             "optional": false,
-            "range": [
-              159,
-              169,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                166,
-                169,
-              ],
             },
           },
           {
@@ -1501,23 +805,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "height",
-              "range": [
-                178,
-                184,
-              ],
             },
             "optional": false,
-            "range": [
-              178,
-              189,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                186,
-                189,
-              ],
             },
           },
           {
@@ -1526,39 +818,19 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "fills",
-              "range": [
-                198,
-                203,
-              ],
             },
             "optional": true,
-            "range": [
-              198,
-              211,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "ArrayType",
               "ofType": {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  206,
-                  209,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "RGB",
-                  "range": [
-                    206,
-                    209,
-                  ],
                 },
               },
-              "range": [
-                206,
-                211,
-              ],
             },
           },
           {
@@ -1567,39 +839,19 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "strokes",
-              "range": [
-                220,
-                227,
-              ],
             },
             "optional": true,
-            "range": [
-              220,
-              243,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "LiveListType",
               "ofType": {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  239,
-                  242,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "RGB",
-                  "range": [
-                    239,
-                    242,
-                  ],
                 },
               },
-              "range": [
-                230,
-                243,
-              ],
             },
           },
         ],
@@ -1608,15 +860,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "Rect",
-          "range": [
-            93,
-            97,
-          ],
         },
-        "range": [
-          88,
-          251,
-        ],
       },
       {
         "_kind": "ObjectTypeDefinition",
@@ -1627,23 +871,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "type",
-              "range": [
-                281,
-                285,
-              ],
             },
             "optional": false,
-            "range": [
-              281,
-              295,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "LiteralType",
-              "range": [
-                287,
-                295,
-              ],
               "value": "circle",
             },
           },
@@ -1653,23 +885,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "cx",
-              "range": [
-                304,
-                306,
-              ],
             },
             "optional": false,
-            "range": [
-              304,
-              311,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                308,
-                311,
-              ],
             },
           },
           {
@@ -1678,23 +898,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "cy",
-              "range": [
-                320,
-                322,
-              ],
             },
             "optional": false,
-            "range": [
-              320,
-              327,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                324,
-                327,
-              ],
             },
           },
           {
@@ -1703,23 +911,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "radius",
-              "range": [
-                336,
-                342,
-              ],
             },
             "optional": false,
-            "range": [
-              336,
-              347,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "NumberType",
-              "range": [
-                344,
-                347,
-              ],
             },
           },
           {
@@ -1728,31 +924,15 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "fill",
-              "range": [
-                356,
-                360,
-              ],
             },
             "optional": true,
-            "range": [
-              356,
-              368,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                365,
-                368,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  365,
-                  368,
-                ],
               },
             },
           },
@@ -1762,31 +942,15 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "stroke",
-              "range": [
-                377,
-                383,
-              ],
             },
             "optional": true,
-            "range": [
-              377,
-              389,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                386,
-                389,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  386,
-                  389,
-                ],
               },
             },
           },
@@ -1796,15 +960,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "Circle",
-          "range": [
-            264,
-            270,
-          ],
         },
-        "range": [
-          259,
-          397,
-        ],
       },
       {
         "_kind": "ObjectTypeDefinition",
@@ -1815,16 +971,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "mycircle",
-              "range": [
-                463,
-                471,
-              ],
             },
             "optional": false,
-            "range": [
-              463,
-              498,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "UnionType",
@@ -1832,30 +980,14 @@ exports[`checker large legacy document (snapshot test) 1`] = `
                 {
                   "_kind": "TypeRef",
                   "asLiveObject": true,
-                  "range": [
-                    473,
-                    491,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "Circle",
-                    "range": [
-                      484,
-                      490,
-                    ],
                   },
                 },
                 {
                   "_kind": "NullType",
-                  "range": [
-                    494,
-                    498,
-                  ],
                 },
-              ],
-              "range": [
-                473,
-                498,
               ],
             },
           },
@@ -1865,16 +997,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             "name": {
               "_kind": "Identifier",
               "name": "myrect",
-              "range": [
-                507,
-                513,
-              ],
             },
             "optional": false,
-            "range": [
-              507,
-              547,
-            ],
             "trailingComment": null,
             "type": {
               "_kind": "UnionType",
@@ -1882,37 +1006,17 @@ exports[`checker large legacy document (snapshot test) 1`] = `
                 {
                   "_kind": "TypeRef",
                   "asLiveObject": true,
-                  "range": [
-                    515,
-                    531,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "Rect",
-                    "range": [
-                      526,
-                      530,
-                    ],
                   },
                 },
                 {
                   "_kind": "StringType",
-                  "range": [
-                    534,
-                    540,
-                  ],
                 },
                 {
                   "_kind": "NullType",
-                  "range": [
-                    543,
-                    547,
-                  ],
                 },
-              ],
-              "range": [
-                515,
-                547,
               ],
             },
           },
@@ -1922,20 +1026,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
         "name": {
           "_kind": "TypeName",
           "name": "Storage",
-          "range": [
-            410,
-            417,
-          ],
         },
-        "range": [
-          405,
-          555,
-        ],
       },
-    ],
-    "range": [
-      7,
-      555,
     ],
   },
   "definitions": [
@@ -1948,23 +1040,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "r",
-            "range": [
-              56,
-              57,
-            ],
           },
           "optional": false,
-          "range": [
-            56,
-            62,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              59,
-              62,
-            ],
           },
         },
         {
@@ -1973,23 +1053,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "g",
-            "range": [
-              64,
-              65,
-            ],
           },
           "optional": false,
-          "range": [
-            64,
-            70,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              67,
-              70,
-            ],
           },
         },
         {
@@ -1998,23 +1066,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "b",
-            "range": [
-              72,
-              73,
-            ],
           },
           "optional": false,
-          "range": [
-            72,
-            78,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              75,
-              78,
-            ],
           },
         },
       ],
@@ -2023,15 +1079,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "RGB",
-        "range": [
-          50,
-          53,
-        ],
       },
-      "range": [
-        45,
-        80,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -2042,23 +1090,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "type",
-            "range": [
-              108,
-              112,
-            ],
           },
           "optional": false,
-          "range": [
-            108,
-            120,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "LiteralType",
-            "range": [
-              114,
-              120,
-            ],
             "value": "rect",
           },
         },
@@ -2068,23 +1104,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "x",
-            "range": [
-              129,
-              130,
-            ],
           },
           "optional": false,
-          "range": [
-            129,
-            135,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              132,
-              135,
-            ],
           },
         },
         {
@@ -2093,23 +1117,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "y",
-            "range": [
-              144,
-              145,
-            ],
           },
           "optional": false,
-          "range": [
-            144,
-            150,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              147,
-              150,
-            ],
           },
         },
         {
@@ -2118,23 +1130,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "width",
-            "range": [
-              159,
-              164,
-            ],
           },
           "optional": false,
-          "range": [
-            159,
-            169,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              166,
-              169,
-            ],
           },
         },
         {
@@ -2143,23 +1143,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "height",
-            "range": [
-              178,
-              184,
-            ],
           },
           "optional": false,
-          "range": [
-            178,
-            189,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              186,
-              189,
-            ],
           },
         },
         {
@@ -2168,39 +1156,19 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "fills",
-            "range": [
-              198,
-              203,
-            ],
           },
           "optional": true,
-          "range": [
-            198,
-            211,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
             "ofType": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                206,
-                209,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  206,
-                  209,
-                ],
               },
             },
-            "range": [
-              206,
-              211,
-            ],
           },
         },
         {
@@ -2209,39 +1177,19 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "strokes",
-            "range": [
-              220,
-              227,
-            ],
           },
           "optional": true,
-          "range": [
-            220,
-            243,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "LiveListType",
             "ofType": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                239,
-                242,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "RGB",
-                "range": [
-                  239,
-                  242,
-                ],
               },
             },
-            "range": [
-              230,
-              243,
-            ],
           },
         },
       ],
@@ -2250,15 +1198,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Rect",
-        "range": [
-          93,
-          97,
-        ],
       },
-      "range": [
-        88,
-        251,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -2269,23 +1209,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "type",
-            "range": [
-              281,
-              285,
-            ],
           },
           "optional": false,
-          "range": [
-            281,
-            295,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "LiteralType",
-            "range": [
-              287,
-              295,
-            ],
             "value": "circle",
           },
         },
@@ -2295,23 +1223,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cx",
-            "range": [
-              304,
-              306,
-            ],
           },
           "optional": false,
-          "range": [
-            304,
-            311,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              308,
-              311,
-            ],
           },
         },
         {
@@ -2320,23 +1236,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cy",
-            "range": [
-              320,
-              322,
-            ],
           },
           "optional": false,
-          "range": [
-            320,
-            327,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              324,
-              327,
-            ],
           },
         },
         {
@@ -2345,23 +1249,11 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "radius",
-            "range": [
-              336,
-              342,
-            ],
           },
           "optional": false,
-          "range": [
-            336,
-            347,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              344,
-              347,
-            ],
           },
         },
         {
@@ -2370,31 +1262,15 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "fill",
-            "range": [
-              356,
-              360,
-            ],
           },
           "optional": true,
-          "range": [
-            356,
-            368,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              365,
-              368,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "RGB",
-              "range": [
-                365,
-                368,
-              ],
             },
           },
         },
@@ -2404,31 +1280,15 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "stroke",
-            "range": [
-              377,
-              383,
-            ],
           },
           "optional": true,
-          "range": [
-            377,
-            389,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              386,
-              389,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "RGB",
-              "range": [
-                386,
-                389,
-              ],
             },
           },
         },
@@ -2438,15 +1298,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Circle",
-        "range": [
-          264,
-          270,
-        ],
       },
-      "range": [
-        259,
-        397,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -2457,16 +1309,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "mycircle",
-            "range": [
-              463,
-              471,
-            ],
           },
           "optional": false,
-          "range": [
-            463,
-            498,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -2474,30 +1318,14 @@ exports[`checker large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": true,
-                "range": [
-                  473,
-                  491,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Circle",
-                  "range": [
-                    484,
-                    490,
-                  ],
                 },
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  494,
-                  498,
-                ],
               },
-            ],
-            "range": [
-              473,
-              498,
             ],
           },
         },
@@ -2507,16 +1335,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "myrect",
-            "range": [
-              507,
-              513,
-            ],
           },
           "optional": false,
-          "range": [
-            507,
-            547,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -2524,37 +1344,17 @@ exports[`checker large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": true,
-                "range": [
-                  515,
-                  531,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Rect",
-                  "range": [
-                    526,
-                    530,
-                  ],
                 },
               },
               {
                 "_kind": "StringType",
-                "range": [
-                  534,
-                  540,
-                ],
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  543,
-                  547,
-                ],
               },
-            ],
-            "range": [
-              515,
-              547,
             ],
           },
         },
@@ -2564,15 +1364,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Storage",
-        "range": [
-          410,
-          417,
-        ],
       },
-      "range": [
-        405,
-        555,
-      ],
     },
   ],
   "getDefinition": [Function],
@@ -2585,16 +1377,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
         "name": {
           "_kind": "Identifier",
           "name": "mycircle",
-          "range": [
-            463,
-            471,
-          ],
         },
         "optional": false,
-        "range": [
-          463,
-          498,
-        ],
         "trailingComment": null,
         "type": {
           "_kind": "UnionType",
@@ -2602,30 +1386,14 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             {
               "_kind": "TypeRef",
               "asLiveObject": true,
-              "range": [
-                473,
-                491,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "Circle",
-                "range": [
-                  484,
-                  490,
-                ],
               },
             },
             {
               "_kind": "NullType",
-              "range": [
-                494,
-                498,
-              ],
             },
-          ],
-          "range": [
-            473,
-            498,
           ],
         },
       },
@@ -2635,16 +1403,8 @@ exports[`checker large legacy document (snapshot test) 1`] = `
         "name": {
           "_kind": "Identifier",
           "name": "myrect",
-          "range": [
-            507,
-            513,
-          ],
         },
         "optional": false,
-        "range": [
-          507,
-          547,
-        ],
         "trailingComment": null,
         "type": {
           "_kind": "UnionType",
@@ -2652,37 +1412,17 @@ exports[`checker large legacy document (snapshot test) 1`] = `
             {
               "_kind": "TypeRef",
               "asLiveObject": true,
-              "range": [
-                515,
-                531,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "Rect",
-                "range": [
-                  526,
-                  530,
-                ],
               },
             },
             {
               "_kind": "StringType",
-              "range": [
-                534,
-                540,
-              ],
             },
             {
               "_kind": "NullType",
-              "range": [
-                543,
-                547,
-              ],
             },
-          ],
-          "range": [
-            515,
-            547,
           ],
         },
       },
@@ -2692,15 +1432,7 @@ exports[`checker large legacy document (snapshot test) 1`] = `
     "name": {
       "_kind": "TypeName",
       "name": "Storage",
-      "range": [
-        410,
-        417,
-      ],
     },
-    "range": [
-      405,
-      555,
-    ],
   },
 }
 `;

--- a/schema-lang/liveblocks-schema/src/checker/__tests__/checker.test.ts
+++ b/schema-lang/liveblocks-schema/src/checker/__tests__/checker.test.ts
@@ -21,15 +21,12 @@ describe("checker", () => {
     const reporter = ErrorReporter.fromText(schemaText);
     const output = check(parseDocument(reporter), reporter);
 
-    const range = expect.any(Array);
-
     expect(output).toEqual({
       root: {
         _kind: "ObjectTypeDefinition",
         name: {
           _kind: "TypeName",
           name: "Storage",
-          range,
         },
         isStatic: false,
         leadingComment: null,
@@ -41,20 +38,16 @@ describe("checker", () => {
             name: {
               _kind: "Identifier",
               name: "x",
-              range,
             },
             optional: false,
             type: {
               _kind: "TypeRef",
               asLiveObject: false,
-              range,
               ref: {
                 _kind: "TypeName",
                 name: "IamStatic",
-                range,
               },
             },
-            range,
           },
           {
             _kind: "FieldDef",
@@ -63,7 +56,6 @@ describe("checker", () => {
             name: {
               _kind: "Identifier",
               name: "y",
-              range,
             },
             optional: false,
             type: {
@@ -71,15 +63,11 @@ describe("checker", () => {
               ref: {
                 _kind: "TypeName",
                 name: "IamLive",
-                range,
               },
               asLiveObject: true,
-              range,
             },
-            range,
           },
         ],
-        range,
       },
 
       ast: expect.any(Object),
@@ -93,12 +81,10 @@ describe("checker", () => {
       name: {
         _kind: "TypeName",
         name: "IamStatic",
-        range,
       },
       isStatic: true,
       leadingComment: null,
       fields: [],
-      range,
     });
 
     const y = output.root.fields[1].type as AST.TypeRef;
@@ -107,12 +93,10 @@ describe("checker", () => {
       name: {
         _kind: "TypeName",
         name: "IamLive",
-        range,
       },
       isStatic: false,
       leadingComment: null,
       fields: [],
-      range,
     });
   });
 

--- a/schema-lang/liveblocks-schema/src/parser/__tests__/__snapshots__/parser.test.ts.snap
+++ b/schema-lang/liveblocks-schema/src/parser/__tests__/__snapshots__/parser.test.ts.snap
@@ -13,23 +13,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "r",
-            "range": [
-              62,
-              63,
-            ],
           },
           "optional": false,
-          "range": [
-            62,
-            71,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              65,
-              71,
-            ],
           },
         },
         {
@@ -38,23 +26,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "g",
-            "range": [
-              73,
-              74,
-            ],
           },
           "optional": false,
-          "range": [
-            73,
-            82,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              76,
-              82,
-            ],
           },
         },
         {
@@ -63,23 +39,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "b",
-            "range": [
-              84,
-              85,
-            ],
           },
           "optional": false,
-          "range": [
-            84,
-            93,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              87,
-              93,
-            ],
           },
         },
       ],
@@ -88,15 +52,7 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Color",
-        "range": [
-          54,
-          59,
-        ],
       },
-      "range": [
-        49,
-        95,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -107,23 +63,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cx",
-            "range": [
-              125,
-              127,
-            ],
           },
           "optional": false,
-          "range": [
-            125,
-            135,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              129,
-              135,
-            ],
           },
         },
         {
@@ -132,23 +76,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cy",
-            "range": [
-              144,
-              146,
-            ],
           },
           "optional": false,
-          "range": [
-            144,
-            154,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              148,
-              154,
-            ],
           },
         },
         {
@@ -157,23 +89,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "r",
-            "range": [
-              163,
-              164,
-            ],
           },
           "optional": false,
-          "range": [
-            163,
-            172,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              166,
-              172,
-            ],
           },
         },
         {
@@ -182,39 +102,19 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "fill",
-            "range": [
-              181,
-              185,
-            ],
           },
           "optional": true,
-          "range": [
-            181,
-            195,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
             "ofType": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                188,
-                193,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "Color",
-                "range": [
-                  188,
-                  193,
-                ],
               },
             },
-            "range": [
-              188,
-              195,
-            ],
           },
         },
         {
@@ -223,31 +123,15 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "stroke",
-            "range": [
-              204,
-              210,
-            ],
           },
           "optional": true,
-          "range": [
-            204,
-            218,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              213,
-              218,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Color",
-              "range": [
-                213,
-                218,
-              ],
             },
           },
         },
@@ -257,16 +141,8 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "third",
-            "range": [
-              227,
-              232,
-            ],
           },
           "optional": true,
-          "range": [
-            227,
-            272,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
@@ -279,23 +155,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
                   "name": {
                     "_kind": "Identifier",
                     "name": "r",
-                    "range": [
-                      237,
-                      238,
-                    ],
                   },
                   "optional": false,
-                  "range": [
-                    237,
-                    246,
-                  ],
                   "trailingComment": null,
                   "type": {
                     "_kind": "NumberType",
-                    "range": [
-                      240,
-                      246,
-                    ],
                   },
                 },
                 {
@@ -304,23 +168,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
                   "name": {
                     "_kind": "Identifier",
                     "name": "g",
-                    "range": [
-                      248,
-                      249,
-                    ],
                   },
                   "optional": false,
-                  "range": [
-                    248,
-                    257,
-                  ],
                   "trailingComment": null,
                   "type": {
                     "_kind": "NumberType",
-                    "range": [
-                      251,
-                      257,
-                    ],
                   },
                 },
                 {
@@ -329,35 +181,15 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
                   "name": {
                     "_kind": "Identifier",
                     "name": "b",
-                    "range": [
-                      259,
-                      260,
-                    ],
                   },
                   "optional": false,
-                  "range": [
-                    259,
-                    268,
-                  ],
                   "trailingComment": null,
                   "type": {
                     "_kind": "NumberType",
-                    "range": [
-                      262,
-                      268,
-                    ],
                   },
                 },
               ],
-              "range": [
-                235,
-                270,
-              ],
             },
-            "range": [
-              235,
-              272,
-            ],
           },
         },
       ],
@@ -366,15 +198,7 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Circle",
-        "range": [
-          108,
-          114,
-        ],
       },
-      "range": [
-        103,
-        280,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -384,15 +208,7 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Foo",
-        "range": [
-          293,
-          296,
-        ],
       },
-      "range": [
-        288,
-        299,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -403,23 +219,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "version",
-            "range": [
-              378,
-              385,
-            ],
           },
           "optional": false,
-          "range": [
-            378,
-            393,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              387,
-              393,
-            ],
           },
         },
         {
@@ -428,23 +232,11 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "version",
-            "range": [
-              402,
-              409,
-            ],
           },
           "optional": false,
-          "range": [
-            402,
-            467,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "NumberType",
-            "range": [
-              411,
-              467,
-            ],
           },
         },
         {
@@ -453,31 +245,15 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "mycircle",
-            "range": [
-              476,
-              484,
-            ],
           },
           "optional": true,
-          "range": [
-            476,
-            502,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": true,
-            "range": [
-              487,
-              502,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Bar",
-              "range": [
-                498,
-                501,
-              ],
             },
           },
         },
@@ -487,31 +263,15 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "someField",
-            "range": [
-              603,
-              612,
-            ],
           },
           "optional": false,
-          "range": [
-            603,
-            630,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              614,
-              630,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "_undefinedThing_",
-              "range": [
-                614,
-                630,
-              ],
             },
           },
         },
@@ -521,16 +281,8 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "list",
-            "range": [
-              639,
-              643,
-            ],
           },
           "optional": false,
-          "range": [
-            639,
-            691,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "LiveListType",
@@ -540,20 +292,8 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
                 "_kind": "ArrayType",
                 "ofType": {
                   "_kind": "NumberType",
-                  "range": [
-                    662,
-                    668,
-                  ],
                 },
-                "range": [
-                  662,
-                  670,
-                ],
               },
-              "range": [
-                654,
-                690,
-              ],
               "valueType": {
                 "_kind": "LiveListType",
                 "ofType": {
@@ -563,39 +303,15 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
                     "ofType": {
                       "_kind": "TypeRef",
                       "asLiveObject": false,
-                      "range": [
-                        681,
-                        684,
-                      ],
                       "ref": {
                         "_kind": "TypeName",
                         "name": "Bar",
-                        "range": [
-                          681,
-                          684,
-                        ],
                       },
                     },
-                    "range": [
-                      681,
-                      686,
-                    ],
                   },
-                  "range": [
-                    681,
-                    688,
-                  ],
                 },
-                "range": [
-                  672,
-                  689,
-                ],
               },
             },
-            "range": [
-              645,
-              691,
-            ],
           },
         },
       ],
@@ -604,15 +320,7 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Foo",
-        "range": [
-          311,
-          314,
-        ],
       },
-      "range": [
-        306,
-        766,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -622,15 +330,7 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "abc",
-        "range": [
-          779,
-          782,
-        ],
       },
-      "range": [
-        774,
-        842,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -641,52 +341,24 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "a",
-            "range": [
-              872,
-              873,
-            ],
           },
           "optional": false,
-          "range": [
-            872,
-            901,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "StringType",
-                "range": [
-                  875,
-                  881,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  884,
-                  890,
-                ],
               },
               {
                 "_kind": "ArrayType",
                 "ofType": {
                   "_kind": "NumberType",
-                  "range": [
-                    893,
-                    899,
-                  ],
                 },
-                "range": [
-                  893,
-                  901,
-                ],
               },
-            ],
-            "range": [
-              875,
-              901,
             ],
           },
         },
@@ -696,16 +368,8 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "b",
-            "range": [
-              910,
-              911,
-            ],
           },
           "optional": false,
-          "range": [
-            910,
-            941,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
@@ -714,35 +378,15 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
               "members": [
                 {
                   "_kind": "StringType",
-                  "range": [
-                    914,
-                    920,
-                  ],
                 },
                 {
                   "_kind": "NumberType",
-                  "range": [
-                    923,
-                    929,
-                  ],
                 },
                 {
                   "_kind": "NumberType",
-                  "range": [
-                    932,
-                    938,
-                  ],
                 },
-              ],
-              "range": [
-                914,
-                938,
               ],
             },
-            "range": [
-              914,
-              941,
-            ],
           },
         },
         {
@@ -751,52 +395,24 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "c",
-            "range": [
-              988,
-              989,
-            ],
           },
           "optional": false,
-          "range": [
-            988,
-            1024,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "StringType",
-                "range": [
-                  992,
-                  998,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  1001,
-                  1007,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  1010,
-                  1016,
-                ],
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1019,
-                  1023,
-                ],
               },
-            ],
-            "range": [
-              992,
-              1023,
             ],
           },
         },
@@ -806,45 +422,21 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "d",
-            "range": [
-              1033,
-              1034,
-            ],
           },
           "optional": false,
-          "range": [
-            1033,
-            1062,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "StringType",
-                "range": [
-                  1038,
-                  1044,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  1047,
-                  1053,
-                ],
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1057,
-                  1061,
-                ],
               },
-            ],
-            "range": [
-              1037,
-              1061,
             ],
           },
         },
@@ -854,45 +446,21 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "e",
-            "range": [
-              1071,
-              1072,
-            ],
           },
           "optional": false,
-          "range": [
-            1071,
-            1100,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "StringType",
-                "range": [
-                  1075,
-                  1081,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  1085,
-                  1091,
-                ],
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1094,
-                  1098,
-                ],
               },
-            ],
-            "range": [
-              1075,
-              1099,
             ],
           },
         },
@@ -902,45 +470,21 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "f",
-            "range": [
-              1109,
-              1110,
-            ],
           },
           "optional": false,
-          "range": [
-            1109,
-            1140,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "StringType",
-                "range": [
-                  1114,
-                  1120,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  1124,
-                  1130,
-                ],
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1133,
-                  1137,
-                ],
               },
-            ],
-            "range": [
-              1114,
-              1138,
             ],
           },
         },
@@ -950,45 +494,21 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "g",
-            "range": [
-              1149,
-              1150,
-            ],
           },
           "optional": false,
-          "range": [
-            1149,
-            1199,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "NullType",
-                "range": [
-                  1152,
-                  1156,
-                ],
               },
               {
                 "_kind": "NumberType",
-                "range": [
-                  1159,
-                  1165,
-                ],
               },
               {
                 "_kind": "StringType",
-                "range": [
-                  1168,
-                  1199,
-                ],
               },
-            ],
-            "range": [
-              1152,
-              1199,
             ],
           },
         },
@@ -998,20 +518,8 @@ exports[`syntactic parser large document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Unions",
-        "range": [
-          855,
-          861,
-        ],
       },
-      "range": [
-        850,
-        1207,
-      ],
     },
-  ],
-  "range": [
-    7,
-    1207,
   ],
 }
 `;
@@ -1029,31 +537,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "r",
-            "range": [
-              62,
-              63,
-            ],
           },
           "optional": false,
-          "range": [
-            62,
-            68,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              65,
-              68,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Int",
-              "range": [
-                65,
-                68,
-              ],
             },
           },
         },
@@ -1063,31 +555,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "g",
-            "range": [
-              70,
-              71,
-            ],
           },
           "optional": false,
-          "range": [
-            70,
-            76,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              73,
-              76,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Int",
-              "range": [
-                73,
-                76,
-              ],
             },
           },
         },
@@ -1097,31 +573,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "b",
-            "range": [
-              78,
-              79,
-            ],
           },
           "optional": false,
-          "range": [
-            78,
-            84,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              81,
-              84,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Int",
-              "range": [
-                81,
-                84,
-              ],
             },
           },
         },
@@ -1131,15 +591,7 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Color",
-        "range": [
-          54,
-          59,
-        ],
       },
-      "range": [
-        49,
-        86,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -1150,31 +602,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cx",
-            "range": [
-              116,
-              118,
-            ],
           },
           "optional": false,
-          "range": [
-            116,
-            125,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              120,
-              125,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Float",
-              "range": [
-                120,
-                125,
-              ],
             },
           },
         },
@@ -1184,31 +620,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "cy",
-            "range": [
-              134,
-              136,
-            ],
           },
           "optional": false,
-          "range": [
-            134,
-            143,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              138,
-              143,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Float",
-              "range": [
-                138,
-                143,
-              ],
             },
           },
         },
@@ -1218,31 +638,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "r",
-            "range": [
-              152,
-              153,
-            ],
           },
           "optional": false,
-          "range": [
-            152,
-            160,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              155,
-              160,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Float",
-              "range": [
-                155,
-                160,
-              ],
             },
           },
         },
@@ -1252,39 +656,19 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "fill",
-            "range": [
-              169,
-              173,
-            ],
           },
           "optional": true,
-          "range": [
-            169,
-            183,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
             "ofType": {
               "_kind": "TypeRef",
               "asLiveObject": false,
-              "range": [
-                176,
-                181,
-              ],
               "ref": {
                 "_kind": "TypeName",
                 "name": "Color",
-                "range": [
-                  176,
-                  181,
-                ],
               },
             },
-            "range": [
-              176,
-              183,
-            ],
           },
         },
         {
@@ -1293,31 +677,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "stroke",
-            "range": [
-              192,
-              198,
-            ],
           },
           "optional": true,
-          "range": [
-            192,
-            206,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              201,
-              206,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Color",
-              "range": [
-                201,
-                206,
-              ],
             },
           },
         },
@@ -1327,16 +695,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "third",
-            "range": [
-              215,
-              220,
-            ],
           },
           "optional": true,
-          "range": [
-            215,
-            251,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
@@ -1349,31 +709,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                   "name": {
                     "_kind": "Identifier",
                     "name": "r",
-                    "range": [
-                      225,
-                      226,
-                    ],
                   },
                   "optional": false,
-                  "range": [
-                    225,
-                    231,
-                  ],
                   "trailingComment": null,
                   "type": {
                     "_kind": "TypeRef",
                     "asLiveObject": false,
-                    "range": [
-                      228,
-                      231,
-                    ],
                     "ref": {
                       "_kind": "TypeName",
                       "name": "Int",
-                      "range": [
-                        228,
-                        231,
-                      ],
                     },
                   },
                 },
@@ -1383,31 +727,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                   "name": {
                     "_kind": "Identifier",
                     "name": "g",
-                    "range": [
-                      233,
-                      234,
-                    ],
                   },
                   "optional": false,
-                  "range": [
-                    233,
-                    239,
-                  ],
                   "trailingComment": null,
                   "type": {
                     "_kind": "TypeRef",
                     "asLiveObject": false,
-                    "range": [
-                      236,
-                      239,
-                    ],
                     "ref": {
                       "_kind": "TypeName",
                       "name": "Int",
-                      "range": [
-                        236,
-                        239,
-                      ],
                     },
                   },
                 },
@@ -1417,44 +745,20 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                   "name": {
                     "_kind": "Identifier",
                     "name": "b",
-                    "range": [
-                      241,
-                      242,
-                    ],
                   },
                   "optional": false,
-                  "range": [
-                    241,
-                    247,
-                  ],
                   "trailingComment": null,
                   "type": {
                     "_kind": "TypeRef",
                     "asLiveObject": false,
-                    "range": [
-                      244,
-                      247,
-                    ],
                     "ref": {
                       "_kind": "TypeName",
                       "name": "Int",
-                      "range": [
-                        244,
-                        247,
-                      ],
                     },
                   },
                 },
               ],
-              "range": [
-                223,
-                249,
-              ],
             },
-            "range": [
-              223,
-              251,
-            ],
           },
         },
       ],
@@ -1463,15 +767,7 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Circle",
-        "range": [
-          99,
-          105,
-        ],
       },
-      "range": [
-        94,
-        259,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -1481,15 +777,7 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Foo",
-        "range": [
-          272,
-          275,
-        ],
       },
-      "range": [
-        267,
-        278,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -1500,31 +788,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "version",
-            "range": [
-              357,
-              364,
-            ],
           },
           "optional": false,
-          "range": [
-            357,
-            369,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              366,
-              369,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Int",
-              "range": [
-                366,
-                369,
-              ],
             },
           },
         },
@@ -1534,31 +806,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "version",
-            "range": [
-              378,
-              385,
-            ],
           },
           "optional": false,
-          "range": [
-            378,
-            440,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              387,
-              440,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Int",
-              "range": [
-                387,
-                440,
-              ],
             },
           },
         },
@@ -1568,31 +824,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "mycircle",
-            "range": [
-              449,
-              457,
-            ],
           },
           "optional": true,
-          "range": [
-            449,
-            475,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": true,
-            "range": [
-              460,
-              475,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "Bar",
-              "range": [
-                471,
-                474,
-              ],
             },
           },
         },
@@ -1602,31 +842,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "someField",
-            "range": [
-              576,
-              585,
-            ],
           },
           "optional": false,
-          "range": [
-            576,
-            603,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "TypeRef",
             "asLiveObject": false,
-            "range": [
-              587,
-              603,
-            ],
             "ref": {
               "_kind": "TypeName",
               "name": "_undefinedThing_",
-              "range": [
-                587,
-                603,
-              ],
             },
           },
         },
@@ -1636,16 +860,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "list",
-            "range": [
-              612,
-              616,
-            ],
           },
           "optional": false,
-          "range": [
-            612,
-            661,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "LiveListType",
@@ -1656,28 +872,12 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                 "ofType": {
                   "_kind": "TypeRef",
                   "asLiveObject": false,
-                  "range": [
-                    635,
-                    638,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "Int",
-                    "range": [
-                      635,
-                      638,
-                    ],
                   },
                 },
-                "range": [
-                  635,
-                  640,
-                ],
               },
-              "range": [
-                627,
-                660,
-              ],
               "valueType": {
                 "_kind": "LiveListType",
                 "ofType": {
@@ -1687,39 +887,15 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                     "ofType": {
                       "_kind": "TypeRef",
                       "asLiveObject": false,
-                      "range": [
-                        651,
-                        654,
-                      ],
                       "ref": {
                         "_kind": "TypeName",
                         "name": "Bar",
-                        "range": [
-                          651,
-                          654,
-                        ],
                       },
                     },
-                    "range": [
-                      651,
-                      656,
-                    ],
                   },
-                  "range": [
-                    651,
-                    658,
-                  ],
                 },
-                "range": [
-                  642,
-                  659,
-                ],
               },
             },
-            "range": [
-              618,
-              661,
-            ],
           },
         },
       ],
@@ -1728,15 +904,7 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Foo",
-        "range": [
-          290,
-          293,
-        ],
       },
-      "range": [
-        285,
-        733,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -1746,15 +914,7 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "abc",
-        "range": [
-          746,
-          749,
-        ],
       },
-      "range": [
-        741,
-        809,
-      ],
     },
     {
       "_kind": "ObjectTypeDefinition",
@@ -1765,16 +925,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "a",
-            "range": [
-              839,
-              840,
-            ],
           },
           "optional": false,
-          "range": [
-            839,
-            862,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -1782,33 +934,17 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  842,
-                  848,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "String",
-                  "range": [
-                    842,
-                    848,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  851,
-                  854,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    851,
-                    854,
-                  ],
                 },
               },
               {
@@ -1816,28 +952,12 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                 "ofType": {
                   "_kind": "TypeRef",
                   "asLiveObject": false,
-                  "range": [
-                    857,
-                    860,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "Int",
-                    "range": [
-                      857,
-                      860,
-                    ],
                   },
                 },
-                "range": [
-                  857,
-                  862,
-                ],
               },
-            ],
-            "range": [
-              842,
-              862,
             ],
           },
         },
@@ -1847,16 +967,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "b",
-            "range": [
-              871,
-              872,
-            ],
           },
           "optional": false,
-          "range": [
-            871,
-            896,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "ArrayType",
@@ -1866,61 +978,29 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
                 {
                   "_kind": "TypeRef",
                   "asLiveObject": false,
-                  "range": [
-                    875,
-                    881,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "String",
-                    "range": [
-                      875,
-                      881,
-                    ],
                   },
                 },
                 {
                   "_kind": "TypeRef",
                   "asLiveObject": false,
-                  "range": [
-                    884,
-                    887,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "Int",
-                    "range": [
-                      884,
-                      887,
-                    ],
                   },
                 },
                 {
                   "_kind": "TypeRef",
                   "asLiveObject": false,
-                  "range": [
-                    890,
-                    893,
-                  ],
                   "ref": {
                     "_kind": "TypeName",
                     "name": "Int",
-                    "range": [
-                      890,
-                      893,
-                    ],
                   },
                 },
-              ],
-              "range": [
-                875,
-                893,
               ],
             },
-            "range": [
-              875,
-              896,
-            ],
           },
         },
         {
@@ -1929,16 +1009,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "c",
-            "range": [
-              943,
-              944,
-            ],
           },
           "optional": false,
-          "range": [
-            943,
-            973,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -1946,62 +1018,30 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  947,
-                  953,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "String",
-                  "range": [
-                    947,
-                    953,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  956,
-                  959,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    956,
-                    959,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  962,
-                  965,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    962,
-                    965,
-                  ],
                 },
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  968,
-                  972,
-                ],
               },
-            ],
-            "range": [
-              947,
-              972,
             ],
           },
         },
@@ -2011,16 +1051,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "d",
-            "range": [
-              982,
-              983,
-            ],
           },
           "optional": false,
-          "range": [
-            982,
-            1008,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -2028,46 +1060,22 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  987,
-                  993,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "String",
-                  "range": [
-                    987,
-                    993,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  996,
-                  999,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    996,
-                    999,
-                  ],
                 },
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1003,
-                  1007,
-                ],
               },
-            ],
-            "range": [
-              986,
-              1007,
             ],
           },
         },
@@ -2077,16 +1085,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "e",
-            "range": [
-              1017,
-              1018,
-            ],
           },
           "optional": false,
-          "range": [
-            1017,
-            1043,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -2094,46 +1094,22 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  1021,
-                  1027,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "String",
-                  "range": [
-                    1021,
-                    1027,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  1031,
-                  1034,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    1031,
-                    1034,
-                  ],
                 },
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1037,
-                  1041,
-                ],
               },
-            ],
-            "range": [
-              1021,
-              1042,
             ],
           },
         },
@@ -2143,16 +1119,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "f",
-            "range": [
-              1052,
-              1053,
-            ],
           },
           "optional": false,
-          "range": [
-            1052,
-            1080,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
@@ -2160,46 +1128,22 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  1057,
-                  1063,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "String",
-                  "range": [
-                    1057,
-                    1063,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  1067,
-                  1070,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    1067,
-                    1070,
-                  ],
                 },
               },
               {
                 "_kind": "NullType",
-                "range": [
-                  1073,
-                  1077,
-                ],
               },
-            ],
-            "range": [
-              1057,
-              1078,
             ],
           },
         },
@@ -2209,63 +1153,31 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
           "name": {
             "_kind": "Identifier",
             "name": "g",
-            "range": [
-              1089,
-              1090,
-            ],
           },
           "optional": false,
-          "range": [
-            1089,
-            1136,
-          ],
           "trailingComment": null,
           "type": {
             "_kind": "UnionType",
             "members": [
               {
                 "_kind": "NullType",
-                "range": [
-                  1092,
-                  1096,
-                ],
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  1099,
-                  1102,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "Int",
-                  "range": [
-                    1099,
-                    1102,
-                  ],
                 },
               },
               {
                 "_kind": "TypeRef",
                 "asLiveObject": false,
-                "range": [
-                  1105,
-                  1136,
-                ],
                 "ref": {
                   "_kind": "TypeName",
                   "name": "String",
-                  "range": [
-                    1105,
-                    1136,
-                  ],
                 },
               },
-            ],
-            "range": [
-              1092,
-              1136,
             ],
           },
         },
@@ -2275,20 +1187,8 @@ exports[`syntactic parser large legacy document (snapshot test) 1`] = `
       "name": {
         "_kind": "TypeName",
         "name": "Unions",
-        "range": [
-          822,
-          828,
-        ],
       },
-      "range": [
-        817,
-        1144,
-      ],
     },
-  ],
-  "range": [
-    7,
-    1144,
   ],
 }
 `;

--- a/shared/jest-config/index.js
+++ b/shared/jest-config/index.js
@@ -9,6 +9,21 @@ module.exports = {
   testEnvironment: "jsdom",
 
   preset: "ts-jest",
+
+  // NOTE: See https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1503684089
+  transform: {
+    ".tsx?": [
+      "ts-jest",
+      {
+        // Note: We shouldn't need to include `isolatedModules` here because it's a deprecated config option in TS 5,
+        // but setting it to `true` fixes the `ESM syntax is not allowed in a CommonJS module when
+        // 'verbatimModuleSyntax' is enabled` error that we're seeing when running our Jest tests.
+        isolatedModules: true,
+        useESM: true,
+      },
+    ],
+  },
+
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
   testPathIgnorePatterns: ["__tests__/_.*", "__tests__/(.+/)*_.*"],
   roots: ["<rootDir>/src"],

--- a/shared/jest-config/package.json
+++ b/shared/jest-config/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@types/jest": "^29.5.12",
+    "@types/jest": "^29.5.14",
     "fast-check": "^3.19.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "ts-jest": "^29.1.5",
+    "ts-jest": "^29.2.5",
     "whatwg-fetch": "^3.6.20"
   }
 }

--- a/shared/tsconfig.common.json
+++ b/shared/tsconfig.common.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     // Default compilation target for any code that runs in the browser
     "target": "es2022",
+    "skipLibCheck": true,
 
     // For all packages, let TypeScript use the following standardized way to
     // resolve modules
@@ -21,7 +22,7 @@
     "allowUnreachableCode": false, // False makes this stricter: errors instead of warns
     "allowUnusedLabels": false, // False makes this stricter: errors instead of warns
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,

--- a/shared/tsconfig.common.json
+++ b/shared/tsconfig.common.json
@@ -19,11 +19,10 @@
 
     // Use better type checking
     "strict": true,
+    "verbatimModuleSyntax": true,
     "allowUnreachableCode": false, // False makes this stricter: errors instead of warns
     "allowUnusedLabels": false, // False makes this stricter: errors instead of warns
     "forceConsistentCasingInFileNames": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,

--- a/tools/create-liveblocks-app/package.json
+++ b/tools/create-liveblocks-app/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@types/command-line-args": "^5.2.0",
     "@types/degit": "^2.8.3",
-    "@types/node": "^17.0.39",
     "@types/prompts": "^2.4.1",
     "cross-env": "^7.0.3",
     "esbuild": "^0.15.12"

--- a/tools/liveblocks-codemod/package.json
+++ b/tools/liveblocks-codemod/package.json
@@ -20,7 +20,8 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/is-git-clean": "1.1.2",
-    "@types/jscodeshift": "0.11.11"
+    "@types/jscodeshift": "0.11.11",
+    "@types/node": "^22.10.5"
   },
   "dependencies": {
     "execa": "4.0.3",

--- a/tools/liveblocks-codemod/package.json
+++ b/tools/liveblocks-codemod/package.json
@@ -20,8 +20,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/is-git-clean": "1.1.2",
-    "@types/jscodeshift": "0.11.11",
-    "@types/node": "^22.10.5"
+    "@types/jscodeshift": "0.11.11"
   },
   "dependencies": {
     "execa": "4.0.3",

--- a/tools/liveblocks-devtools/package.json
+++ b/tools/liveblocks-devtools/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^1.0.4",
     "@liveblocks/core": "*",
-    "@plasmohq/storage": "^1.8.0",
+    "@plasmohq/storage": "^1.13.0",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-popover": "^1.0.3",
     "@radix-ui/react-select": "^1.2.0",
@@ -25,7 +25,7 @@
     "classnames": "^2.3.2",
     "fast-equals": "^5.0.1",
     "js-base64": "^3.7.5",
-    "plasmo": "^0.83.0",
+    "plasmo": "^0.89.4",
     "prism-react-renderer": "^2.0.6",
     "react": "18.2.0",
     "react-arborist": "^3.4.0",


### PR DESCRIPTION
This PR upgrades TypeScript to 5.7 (the latest TS version) everywhere.

I had to upgrade a few dependencies to make this possible.
Across this monorepo, the variety of dependencies is now reduced:

| Library | Before this PR | After this PR |
|--------|--------|--------|
| `msw` | `0.27.2`, `0.36.4`, `0.36.8`, `0.39.2`, `0.47.4`, `1.3.2`, `2.0.2`, `2.4.9`, `2.6.4` | `1.3.5`[^1], `2.7.0` |
| `typescript` | `4.7.4`, `4.9.5`, `5.2.2`, `5.3.3`, `5.5.2`, `5.6.2`, `5.6.3` | `5.2.2`[^2], `5.3.3`[^2], `5.7.2` |
| `@types/node` | `17.0.45`, `18.19.34`, `20.14.8`, `20.17.6`, `20.7.1`, `22.5.5` | `18.19.70` |

[^1]: To get rid of this, we should follow [this upgrade guide](https://mswjs.io/docs/migrations/1.x-to-2.x/). Out of scope for this PR.
[^2]: These versions are pinned by dev dependencies. All of our projects now use `5.7.2`. If you run `tsc --version` in any of our packages, you should see `5.7.2`.

Also, I updated some no-longer-supported TS config settings. Most notably `importsNotUsedAsValues + isolatedModules` → `verbatimModuleSyntax`, and I had to make a few (all minor) type annotations to support 5.x.