### PR TITLE
Fix typo in custom notification example

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -1883,7 +1883,7 @@ Displays a custom notification kind.
           {...props}
         >
           {activityData.errorDescription}
-        </InboxNotification>
+        </InboxNotification.Custom>
       )
     },
   }}


### PR DESCRIPTION
I noticed this small typo when checking out custom notifications. Nothing too wild!