### PR TITLE
Support filtering thread metadata by absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## vNEXT (Not yet published)
 
+### `@liveblocks/react`
+
+Filtering threads by metadata using `useThreads({ query })` (or
+`useUserThreads_experimental({ query })`) now supports explicit filtering for
+metadata absence using `null`.
+
+For example, you can now use `{ query: { metadata: { color: null } } }` to
+filter threads that do not have a `color` attribute in their metadata.
+
+> [!NOTE]  
+> Although officially never supported before, due to a bug in previous
+> implementations, filtering for metadata absence was sort of possible by using
+> explicit-`undefined`. This is no longer supported. If you relied on this
+> behavior, please ensure you change `undefined` to `null` (which will actually
+> also filter the threads in the backend properly).
+
+```tsx
+// Filter pinned threads that don't have a `color` set
+useThreads({ query: { metadata: { pinned: true, color: null } } });
+
+// These two queries are now equivalent
+useThreads({ query: { metadata: { pinned: true } } });
+useThreads({ query: { metadata: { pinned: true, color: undefined } } });
+```
+
 ## 2.15.2
 
 ### All packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ filter threads that do not have a `color` attribute in their metadata.
 > [!NOTE]  
 > Although officially never supported before, due to a bug in previous
 > implementations, filtering for metadata absence was sort of possible by using
-> explicit-`undefined`. This is no longer supported. If you relied on this
-> behavior, please ensure you change `undefined` to `null` (which will actually
-> also filter the threads in the backend properly).
+> explicit-`undefined`. This is no longer supported, because it would not
+> properly filter the threads in the backend. If you relied on this behavior,
+> please ensure you change `undefined` to `null`.
 
 ```tsx
 // Filter pinned threads that don't have a `color` set

--- a/guides/pages/how-to-filter-threads-using-query-language.mdx
+++ b/guides/pages/how-to-filter-threads-using-query-language.mdx
@@ -37,6 +37,9 @@ metadata['priority']:3
 // Threads with { pinned: false } boolean metadata
 metadata['pinned']:false
 
+// Threads without a `color` property
+metadata['color']:null
+
 // Combine queries with AND
 resolved:true AND metadata['priority']:3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4083,9 +4083,9 @@
       "link": true
     },
     "node_modules/@liveblocks/query-parser": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@liveblocks/query-parser/-/query-parser-0.0.4.tgz",
-      "integrity": "sha512-z8phxAT+GBErZ0Qz6Cy6Qqlyjs7bRwoqKtCf+EkmxIBBjpdnCqmXuMTEp+clPfimomOo3IYMNYiDvB3y0YiKEQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@liveblocks/query-parser/-/query-parser-0.0.5.tgz",
+      "integrity": "sha512-mjpUpx2XetFHZt5bkKI0vN9WmMlKOyaIVeWNIhn5Dnn+rr2qOICKyHh+/ReuAYqSj5WJ6EdxoynHRfd7usmoKA==",
       "dev": true
     },
     "node_modules/@liveblocks/react": {
@@ -29157,7 +29157,7 @@
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/query-parser": "^0.0.4",
+        "@liveblocks/query-parser": "^0.0.5",
         "@types/ws": "^8.5.10",
         "dotenv": "^16.4.5",
         "eslint-plugin-rulesdir": "^0.2.2",
@@ -29634,7 +29634,7 @@
       "devDependencies": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/query-parser": "^0.0.4",
+        "@liveblocks/query-parser": "^0.0.5",
         "@testing-library/jest-dom": "6.4.6",
         "@testing-library/react": "14.1.2",
         "date-fns": "^3.6.0",
@@ -35756,7 +35756,7 @@
       "requires": {
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/query-parser": "^0.0.4",
+        "@liveblocks/query-parser": "^0.0.5",
         "@types/ws": "^8.5.10",
         "dotenv": "^16.4.5",
         "eslint-plugin-rulesdir": "^0.2.2",
@@ -36165,9 +36165,9 @@
       }
     },
     "@liveblocks/query-parser": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@liveblocks/query-parser/-/query-parser-0.0.4.tgz",
-      "integrity": "sha512-z8phxAT+GBErZ0Qz6Cy6Qqlyjs7bRwoqKtCf+EkmxIBBjpdnCqmXuMTEp+clPfimomOo3IYMNYiDvB3y0YiKEQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@liveblocks/query-parser/-/query-parser-0.0.5.tgz",
+      "integrity": "sha512-mjpUpx2XetFHZt5bkKI0vN9WmMlKOyaIVeWNIhn5Dnn+rr2qOICKyHh+/ReuAYqSj5WJ6EdxoynHRfd7usmoKA==",
       "dev": true
     },
     "@liveblocks/react": {
@@ -36177,7 +36177,7 @@
         "@liveblocks/core": "2.15.2",
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
-        "@liveblocks/query-parser": "^0.0.4",
+        "@liveblocks/query-parser": "^0.0.5",
         "@testing-library/jest-dom": "6.4.6",
         "@testing-library/react": "14.1.2",
         "date-fns": "^3.6.0",

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
-    "@liveblocks/query-parser": "^0.0.4",
+    "@liveblocks/query-parser": "^0.0.5",
     "@types/ws": "^8.5.10",
     "dotenv": "^16.4.5",
     "eslint-plugin-rulesdir": "^0.2.2",

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -136,7 +136,7 @@ export { shallow } from "./lib/shallow";
 export type { ISignal, SignalType } from "./lib/signals";
 export { batch, DerivedSignal, MutableSignal, Signal } from "./lib/signals";
 export { SortedList } from "./lib/SortedList";
-export { stringify, unstringify } from "./lib/stringify";
+export { stringify } from "./lib/stringify";
 export type { QueryParams, URLSafeString } from "./lib/url";
 export { url, urljoin } from "./lib/url";
 export type { Brand, DistributiveOmit } from "./lib/utils";

--- a/packages/liveblocks-core/src/lib/__tests__/objectToQuery.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/objectToQuery.test.ts
@@ -1,7 +1,7 @@
 import { QueryParser } from "@liveblocks/query-parser";
 import * as fc from "fast-check";
 
-import { objectToQuery } from "../objectToQuery";
+import { objectToQuery, quote } from "../objectToQuery";
 
 describe("objectToQuery", () => {
   it("should convert a simple key/value pair to a query", () => {
@@ -9,7 +9,7 @@ describe("objectToQuery", () => {
       org: "liveblocks:engineering",
     });
 
-    expect(query).toEqual('org:"liveblocks:engineering"');
+    expect(query).toEqual("org:'liveblocks:engineering'");
   });
 
   it("should convert a nested object with operator to a query", () => {
@@ -19,7 +19,7 @@ describe("objectToQuery", () => {
       },
     });
 
-    expect(query).toEqual('org^"liveblocks:"');
+    expect(query).toEqual("org^'liveblocks:'");
   });
 
   it("should convert an indexed field object to a query", () => {
@@ -35,7 +35,7 @@ describe("objectToQuery", () => {
     });
 
     expect(query).toEqual(
-      'metadata["status"]:"open" metadata["priority"]:3 metadata["color"]:null metadata["org"]^"liveblocks:"'
+      "metadata['status']:'open' metadata['priority']:3 metadata['color']:null metadata['org']^'liveblocks:'"
     );
   });
 
@@ -56,7 +56,7 @@ describe("objectToQuery", () => {
     });
 
     expect(query).toEqual(
-      'resolved:true roomId^"engineering:" metadata["status"]:"open" metadata["priority"]:3 metadata["color"]:null metadata["org"]^"liveblocks:"'
+      "resolved:true roomId^'engineering:' metadata['status']:'open' metadata['priority']:3 metadata['color']:null metadata['org']^'liveblocks:'"
     );
   });
 
@@ -64,8 +64,9 @@ describe("objectToQuery", () => {
     "string",
     "string with spaces",
     "string with special characters: !@#$%^&*()",
-    "'string with single quotes'",
     '"string with double quotes"',
+    "'string with single quotes'",
+    "string with 'single' and \"double\" quotes",
   ])("should work with funky string value: %s", (value) => {
     const query = objectToQuery({
       org: value,
@@ -74,10 +75,10 @@ describe("objectToQuery", () => {
       },
     });
 
-    const expectedValue = JSON.stringify(value);
+    const expectedValue = quote(value);
 
     expect(query).toEqual(
-      `org:${expectedValue} metadata["org"]:${expectedValue}`
+      `org:${expectedValue} metadata['org']:${expectedValue}`
     );
   });
 
@@ -126,27 +127,29 @@ describe("objectToQuery", () => {
       )
     ));
 
-  it.each(["'string with single quotes'", '"string with double quotes"'])(
-    "should work with funky key: %s",
-    (key) => {
-      const query = objectToQuery({
-        metadata: {
-          [key]: "value",
-        },
-      });
+  it.each([
+    "'string with single quotes'",
+    '"string with double quotes"',
+    '"string with both \'single\' and "double" quotes"',
+    "`strings with \\`tick\\` quotes`",
+  ])("should work with funky key: %s", (key) => {
+    const query = objectToQuery({
+      metadata: {
+        [key]: "value",
+      },
+    });
 
-      expect(query).toEqual(`metadata[${JSON.stringify(key)}]:"value"`);
-    }
-  );
+    expect(query).toEqual(`metadata[${quote(key)}]:'value'`);
+  });
 
   it("should avoid injections", () => {
-    const query = objectToQuery({ foo: '" OR evil:"' });
+    const query1 = objectToQuery({ foo: '" OR evil:"' });
     //                                 ^^^^^^^^^^^^^ Injection attack with double-quoted strings
 
     const query2 = objectToQuery({ foo: "' OR evil:'" });
     //                                  ^^^^^^^^^^^^^ Injection attack with single-quoted strings
 
-    expect(query).toEqual('foo:"\\" OR evil:\\""');
+    expect(query1).toEqual("foo:'\" OR evil:\"'");
     expect(query2).toEqual("foo:\"' OR evil:'\"");
   });
 });

--- a/packages/liveblocks-core/src/lib/__tests__/objectToQuery.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/objectToQuery.test.ts
@@ -30,11 +30,12 @@ describe("objectToQuery", () => {
         org: {
           startsWith: "liveblocks:",
         },
+        color: null,
       },
     });
 
     expect(query).toEqual(
-      'metadata["status"]:"open" AND metadata["priority"]:3 AND metadata["org"]^"liveblocks:"'
+      'metadata["status"]:"open" metadata["priority"]:3 metadata["color"]:null metadata["org"]^"liveblocks:"'
     );
   });
 
@@ -46,6 +47,7 @@ describe("objectToQuery", () => {
         org: {
           startsWith: "liveblocks:",
         },
+        color: null,
       },
       resolved: true,
       roomId: {
@@ -54,7 +56,7 @@ describe("objectToQuery", () => {
     });
 
     expect(query).toEqual(
-      'resolved:true AND roomId^"engineering:" AND metadata["status"]:"open" AND metadata["priority"]:3 AND metadata["org"]^"liveblocks:"'
+      'resolved:true roomId^"engineering:" metadata["status"]:"open" metadata["priority"]:3 metadata["color"]:null metadata["org"]^"liveblocks:"'
     );
   });
 
@@ -75,7 +77,7 @@ describe("objectToQuery", () => {
     const expectedValue = JSON.stringify(value);
 
     expect(query).toEqual(
-      `org:${expectedValue} AND metadata["org"]:${expectedValue}`
+      `org:${expectedValue} metadata["org"]:${expectedValue}`
     );
   });
 

--- a/packages/liveblocks-core/src/lib/__tests__/stringify.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/stringify.test.ts
@@ -1,4 +1,4 @@
-import { stringify, unstringify } from "../stringify";
+import { stringify } from "../stringify";
 
 describe("stringify", () => {
   it("returns the same result as JSON.stringify", () => {
@@ -41,27 +41,12 @@ describe("stringify", () => {
     );
   });
 
-  it("maintains explicitly-undefined keys", () => {
-    expect(stringify(undefined)).toEqual(JSON.stringify("_explicit_undefined"));
+  it("explicitly-undefined keys become implicit-undefined", () => {
     expect(stringify([{ b: true, c: undefined, a: 2 }])).toEqual(
-      '[{"a":2,"b":true,"c":"_explicit_undefined"}]'
+      '[{"a":2,"b":true}]'
     );
-    expect(stringify([{ a: 2, b: true }])).not.toEqual(
+    expect(stringify([{ a: 2, b: true }])).toEqual(
       stringify([{ b: true, c: undefined, a: 2 }])
     );
-  });
-
-  it("parse back explicit-undefined keys correctly", () => {
-    expect(unstringify(stringify(undefined))).toEqual(undefined);
-    expect(
-      unstringify(stringify([{ b: true, c: undefined, a: 2 }, 3]))
-    ).toEqual([{ b: true, a: 2 }, 3]);
-
-    // @ts-expect-error this is fine
-    const [parsed] = unstringify(stringify([{ a: 1, b: undefined }]));
-    expect(parsed).toEqual({ a: 1 });
-    expect(parsed.b).toEqual(undefined);
-    expect("b" in parsed).toEqual(true); // Retain explicit-undefined!
-    expect("non-existing" in parsed).toEqual(false);
   });
 });

--- a/packages/liveblocks-core/src/lib/objectToQuery.ts
+++ b/packages/liveblocks-core/src/lib/objectToQuery.ts
@@ -91,7 +91,7 @@ export function objectToQuery(obj: {
   let filterList: Filter[] = [];
   const entries = Object.entries(obj);
 
-  const keyValuePairs: [string, string | number | boolean][] = [];
+  const keyValuePairs: [string, string | number | boolean | null][] = [];
   const keyValuePairsWithOperator: [string, Record<"startsWith", string>][] =
     [];
   const indexedKeys: [string, Record<string, FilterValue | undefined>][] = [];
@@ -185,7 +185,8 @@ const isSimpleValue = (value: unknown) => {
   return (
     typeof value === "string" ||
     typeof value === "number" ||
-    typeof value === "boolean"
+    typeof value === "boolean" ||
+    value === null
   );
 };
 

--- a/packages/liveblocks-core/src/lib/objectToQuery.ts
+++ b/packages/liveblocks-core/src/lib/objectToQuery.ts
@@ -19,12 +19,12 @@ import { isPlainObject, isStartsWithOperator } from "./guards";
  * // resolved:true AND metadata["status"]:open AND metadata["priority"]:3 AND metadata["org"]^"liveblocks:"
  * ```
  */
-type SimpleFilterValue = string | number | boolean;
+type SimpleFilterValue = string | number | boolean | null;
 type OperatorFilterValue = { startsWith: string };
 
 type FilterValue = SimpleFilterValue | OperatorFilterValue;
 
-type Filter = NumberFilter | StringFilter | BooleanFilter;
+type Filter = NumberFilter | StringFilter | BooleanFilter | NullFilter;
 
 type NumberFilter = {
   key: string;
@@ -42,6 +42,12 @@ type BooleanFilter = {
   key: string;
   operator: ":";
   value: boolean;
+};
+
+type NullFilter = {
+  key: string;
+  operator: ":";
+  value: null;
 };
 
 /**
@@ -137,14 +143,14 @@ export function objectToQuery(obj: {
   });
 
   return filterList
-    .map(({ key, operator, value }) =>
-      formatFilter(key, operator, formatFilterValue(value))
+    .map(
+      ({ key, operator, value }) => `${key}${operator}${JSON.stringify(value)}`
     )
-    .join(" AND ");
+    .join(" ");
 }
 
 const getFiltersFromKeyValuePairs = (
-  keyValuePairs: [string, string | number | boolean][]
+  keyValuePairs: [string, string | number | boolean | null][]
 ): Filter[] => {
   const filters: Filter[] = [];
   keyValuePairs.forEach(([key, value]) => {
@@ -183,25 +189,11 @@ const isSimpleValue = (value: unknown) => {
   );
 };
 
-const formatFilter = (key: string, operator: ":" | "^", value: string) => {
-  return `${key}${operator}${value}`;
-};
-
 const formatFilterKey = (key: string, nestedKey?: string) => {
   if (nestedKey) {
     return `${key}[${JSON.stringify(nestedKey)}]`;
   }
   return key;
-};
-
-const formatFilterValue = (value: string | number | boolean) => {
-  if (typeof value === "string") {
-    if (isStringEmpty(value)) {
-      throw new Error("Value cannot be empty");
-    }
-    return JSON.stringify(value);
-  }
-  return value.toString();
 };
 
 const isStringEmpty = (value: string) => {

--- a/packages/liveblocks-core/src/lib/objectToQuery.ts
+++ b/packages/liveblocks-core/src/lib/objectToQuery.ts
@@ -143,9 +143,7 @@ export function objectToQuery(obj: {
   });
 
   return filterList
-    .map(
-      ({ key, operator, value }) => `${key}${operator}${JSON.stringify(value)}`
-    )
+    .map(({ key, operator, value }) => `${key}${operator}${quote(value)}`)
     .join(" ");
 }
 
@@ -192,7 +190,7 @@ const isSimpleValue = (value: unknown) => {
 
 const formatFilterKey = (key: string, nestedKey?: string) => {
   if (nestedKey) {
-    return `${key}[${JSON.stringify(nestedKey)}]`;
+    return `${key}[${quote(nestedKey)}]`;
   }
   return key;
 };
@@ -200,3 +198,13 @@ const formatFilterKey = (key: string, nestedKey?: string) => {
 const isStringEmpty = (value: string) => {
   return !value || value.toString().trim() === "";
 };
+
+/**
+ * Quotes a string using single quotes when possible, or double-quotes when
+ * needed.
+ */
+export function quote(value: unknown): string {
+  return typeof value !== "string" || value.includes("'")
+    ? JSON.stringify(value)
+    : `'${value}'`;
+}

--- a/packages/liveblocks-core/src/lib/stringify.ts
+++ b/packages/liveblocks-core/src/lib/stringify.ts
@@ -2,15 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 
-//
-// NOTE! Storing and parsing back explicit-undefined is a temporary hack,
-// necessary until we fix this bug:
-// https://linear.app/liveblocks/issue/LB-1333/officially-support-querying-for-absence-of-metadata
-//
-// After fixing that bug, we can also remove this hack.
-//
-const EXPLICIT_UNDEFINED_PLACEHOLDER = "_explicit_undefined";
-
 function replacer(_key: string, value: unknown) {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? Object.keys(value)
@@ -20,26 +11,7 @@ function replacer(_key: string, value: unknown) {
           sorted[key] = value[key];
           return sorted;
         }, {})
-    : value === undefined
-      ? EXPLICIT_UNDEFINED_PLACEHOLDER
-      : value;
-}
-
-function reviver(key: string, value: unknown) {
-  if (!key && value === EXPLICIT_UNDEFINED_PLACEHOLDER) {
-    return undefined;
-  }
-
-  // For objects, preserve "_explicit_undefined" values as undefined properties
-  if (value && typeof value === "object") {
-    for (const k in value) {
-      // @ts-expect-error this is fine
-      if (value[k] === EXPLICIT_UNDEFINED_PLACEHOLDER) {
-        Object.defineProperty(value, k, { value: undefined });
-      }
-    }
-  }
-  return value;
+    : value;
 }
 
 /**
@@ -48,13 +20,4 @@ function reviver(key: string, value: unknown) {
  */
 export function stringify(value: unknown): string {
   return JSON.stringify(value, replacer);
-}
-
-/**
- * Like JSON.stringify(), but returns the same value no matter how keys in any
- * nested objects are ordered.
- */
-export function unstringify(value: string): unknown {
-  // eslint-disable-next-line no-restricted-syntax
-  return JSON.parse(value, reviver) as unknown;
 }

--- a/packages/liveblocks-core/src/protocol/Comments.ts
+++ b/packages/liveblocks-core/src/protocol/Comments.ts
@@ -198,5 +198,5 @@ type StringOperators<T> =
  *  - `startsWith` (`^` in query string)
  */
 export type QueryMetadata<M extends BaseMetadata> = {
-  [K in keyof M]: string extends M[K] ? StringOperators<M[K]> : M[K];
+  [K in keyof M]: (string extends M[K] ? StringOperators<M[K]> : M[K]) | null;
 };

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2176,7 +2176,8 @@ export function createRoom<
             user:
               message.actor < 0
                 ? null
-                : others.find((u) => u.connectionId === message.actor) ?? null,
+                : (others.find((u) => u.connectionId === message.actor) ??
+                  null),
             event: message.event,
           });
           break;

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -161,7 +161,7 @@ describe("client", () => {
 
   test("should return a list of room when getRooms with query params receives a successful response", async () => {
     const query =
-      'roomId^"liveblocks:" AND metadata["color"]:"blue" AND metadata["size"]:"10"';
+      'roomId^"liveblocks:" metadata["color"]:"blue" metadata["size"]:"10"';
 
     server.use(
       http.get(`${DEFAULT_BASE_URL}/v2/rooms`, (res) => {
@@ -607,18 +607,13 @@ describe("client", () => {
 
   test("should return a filtered list of threads when a query parameter is used for getThreads with a metadata object", async () => {
     const query =
-      'metadata["status"]:"open" AND metadata["priority"]:3 AND metadata["organization"]^"liveblocks:"';
+      'metadata["status"]:"open" metadata["priority"]:3 metadata["organization"]^"liveblocks:"';
     server.use(
       http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads`, (res) => {
         const url = new URL(res.request.url);
 
         expect(url.searchParams.get("query")).toEqual(query);
-        return HttpResponse.json(
-          {
-            data: [thread],
-          },
-          { status: 200 }
-        );
+        return HttpResponse.json({ data: [thread] }, { status: 200 });
       })
     );
 

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -160,15 +160,15 @@ describe("client", () => {
   });
 
   test("should return a list of room when getRooms with query params receives a successful response", async () => {
-    const query =
-      'roomId^"liveblocks:" metadata["color"]:"blue" metadata["size"]:"10"';
+    const expectedQuery =
+      "roomId^'liveblocks:' metadata['color']:'blue' metadata['size']:'10'";
 
     server.use(
       http.get(`${DEFAULT_BASE_URL}/v2/rooms`, (res) => {
         const url = new URL(res.request.url);
 
         expect(url.searchParams.size).toEqual(1);
-        expect(url.searchParams.get("query")).toEqual(query);
+        expect(url.searchParams.get("query")).toEqual(expectedQuery);
         return HttpResponse.json(
           {
             nextPage: "/v2/rooms?startingAfter=1",
@@ -183,7 +183,7 @@ describe("client", () => {
 
     await expect(
       client.getRooms({
-        query,
+        query: expectedQuery,
       })
     ).resolves.toEqual({
       nextPage: "/v2/rooms?startingAfter=1",
@@ -606,15 +606,18 @@ describe("client", () => {
   });
 
   test("should return a filtered list of threads when a query parameter is used for getThreads with a metadata object", async () => {
-    const query =
-      'metadata["status"]:"open" metadata["priority"]:3 metadata["organization"]^"liveblocks:"';
-    server.use(
-      http.get(`${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads`, (res) => {
-        const url = new URL(res.request.url);
+    const expectedQuery =
+      "metadata['status']:'open' metadata['priority']:3 metadata['organization']^'liveblocks:'";
 
-        expect(url.searchParams.get("query")).toEqual(query);
-        return HttpResponse.json({ data: [thread] }, { status: 200 });
-      })
+    server.use(
+      http.get(
+        `${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads`,
+        ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("query")).toEqual(expectedQuery);
+          return HttpResponse.json({ data: [thread] }, { status: 200 });
+        }
+      )
     );
 
     const client = new Liveblocks({ secret: "sk_xxx" });

--- a/packages/liveblocks-react/package.json
+++ b/packages/liveblocks-react/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
-    "@liveblocks/query-parser": "^0.0.4",
+    "@liveblocks/query-parser": "^0.0.5",
     "@testing-library/jest-dom": "6.4.6",
     "@testing-library/react": "14.1.2",
     "date-fns": "^3.6.0",

--- a/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useThreads.test.tsx
@@ -622,7 +622,7 @@ describe("useThreads", () => {
     }
 
     {
-      // Test 8
+      // Test 8: explicit-undefined keys should be ignored
       const { result, unmount } = renderHook(
         () =>
           useThreads({
@@ -631,6 +631,39 @@ describe("useThreads", () => {
                 pinned: true,
                 // NOTE: Explicitly-undefined means color must be absent!
                 color: undefined, // = color must be absent
+              },
+            },
+          }),
+        {
+          wrapper: ({ children }) => (
+            <RoomProvider id={roomId}>{children}</RoomProvider>
+          ),
+        }
+      );
+
+      await waitFor(() =>
+        expect(result.current).toEqual({
+          isLoading: false,
+          threads: [bluePinnedThread, redPinnedThread, uncoloredPinnedThread],
+          fetchMore: expect.any(Function),
+          isFetchingMore: false,
+          hasFetchedAll: true,
+          fetchMoreError: undefined,
+        })
+      );
+
+      unmount();
+    }
+
+    {
+      // Test 9: explicitly filtering by absence using `null` value
+      const { result, unmount } = renderHook(
+        () =>
+          useThreads({
+            query: {
+              metadata: {
+                pinned: true,
+                color: null, // Explicitly filtered for absence of color
               },
             },
           }),
@@ -656,15 +689,13 @@ describe("useThreads", () => {
     }
 
     {
-      // Test 8
+      // Test 10: explicitly filtering by absence using `null` value
       const { result, unmount } = renderHook(
         () =>
           useThreads({
             query: {
-              metadata: {
-                // @ts-expect-error - `null` is not a legal value, try to use it anyway
-                color: null,
-              },
+              // Explicitly filtered for absence of color
+              metadata: { color: null },
             },
           }),
         {
@@ -677,10 +708,7 @@ describe("useThreads", () => {
       await waitFor(() =>
         expect(result.current).toEqual({
           isLoading: false,
-          threads: [
-            // Metadata can never legally be `null` (like specified in the
-            // query above), so no thread will ever match
-          ],
+          threads: [uncoloredPinnedThread],
           fetchMore: expect.any(Function),
           isFetchingMore: false,
           hasFetchedAll: true,

--- a/packages/liveblocks-react/src/lib/querying.ts
+++ b/packages/liveblocks-react/src/lib/querying.ts
@@ -30,23 +30,23 @@ function matchesMetadata(
   const metadata = thread.metadata;
   return (
     q.metadata === undefined ||
-    Object.entries(q.metadata).every(([key, op]) =>
-      // NOTE: `op` can be explicitly-`undefined` here, which ideally would not
-      // mean "filter for absence" like it does now, as this does not match the
-      // backend behavior at the moment. For an in-depth discussion, see
-      // https://liveblocks.slack.com/archives/C02PZL7QAAW/p1728546988505989
-      matchesOperator(metadata[key], op)
+    Object.entries(q.metadata).every(
+      ([key, op]) =>
+        // Ignore explicit-undefined filters
+        // Boolean logic: op? => value matches the operator
+        op === undefined || matchesOperator(metadata[key], op)
     )
   );
 }
 
 function matchesOperator(
   value: BaseMetadata[string],
-  // NOTE: Ideally, this should not take `undefined` as a possible `op` value
-  // here, see comment above.
-  op: BaseMetadata[string] | { startsWith: string } | undefined
+  op: Exclude<BaseMetadata[string], undefined> | { startsWith: string } | null
 ) {
-  if (isStartsWithOperator(op)) {
+  if (op === null) {
+    // If the operator is `null`, we're doing an explicit query for absence
+    return value === undefined;
+  } else if (isStartsWithOperator(op)) {
     return typeof value === "string" && value.startsWith(op.startsWith);
   } else {
     return value === op;

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -35,7 +35,6 @@ import {
   shallow,
   Signal,
   stringify,
-  unstringify,
 } from "@liveblocks/core";
 
 import { ASYNC_ERR, ASYNC_LOADING, ASYNC_OK } from "./lib/AsyncResult";
@@ -914,7 +913,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
     const loadingUserThreads = new DefaultMap(
       (queryKey: UserQueryKey): LoadableResource<ThreadsAsyncResult<M>> => {
-        const query = unstringify(queryKey) as ThreadsQuery<M>;
+        const query = JSON.parse(queryKey) as ThreadsQuery<M>;
 
         const resource = new PaginatedResource(async (cursor?: string) => {
           const result = await this.#client[
@@ -967,7 +966,7 @@ export class UmbrellaStore<M extends BaseMetadata> {
 
     const loadingRoomThreads = new DefaultMap(
       (queryKey: RoomQueryKey): LoadableResource<ThreadsAsyncResult<M>> => {
-        const [roomId, query] = unstringify(queryKey) as [
+        const [roomId, query] = JSON.parse(queryKey) as [
           roomId: RoomId,
           query: ThreadsQuery<M>,
         ];


### PR DESCRIPTION
Filtering threads by metadata using `useThreads({ query })` (or `useUserThreads_experimental({ query })`) now supports explicit filtering for metadata absence using `null`.

For example, you can now use `{ query: { metadata: { color: null } } }` to filter threads that do not have a `color` attribute in their metadata.

> [!NOTE]  
> Although officially never supported before, due to a bug in previous implementations, filtering for metadata absence was sort of possible by using explicit-`undefined`. This is no longer supported. If you relied on this behavior, please ensure you change `undefined` to `null` (which will actually also filter the threads in the backend properly).

```tsx
// Filter pinned threads that don't have a `color` set
useThreads({ query: { metadata: { pinned: true, color: null } } });

// These two queries are now equivalent
useThreads({ query: { metadata: { pinned: true } } });
useThreads({ query: { metadata: { pinned: true, color: undefined } } });
```

### Checklist

- [x] Deploy [this backend change](https://github.com/liveblocks/liveblocks-backend/pull/693) first
- [x] Write upgrade guide (included in #2167)

Fixes LB-1333
