### PR TITLE
Better type safety on `memoize` util in `@liveblocks/react-ui`

### DIFF
--- a/packages/liveblocks-react-ui/src/utils/memoize.ts
+++ b/packages/liveblocks-react-ui/src/utils/memoize.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-
 import { stringify } from "@liveblocks/core";
 
 export function memoize<TArgs extends unknown[], TReturn>(

--- a/packages/liveblocks-react-ui/src/utils/memoize.ts
+++ b/packages/liveblocks-react-ui/src/utils/memoize.ts
@@ -2,20 +2,22 @@
 
 import { stringify } from "@liveblocks/core";
 
-export function memoize<T extends (...args: any[]) => any>(fn: T): T {
-  const cache = new Map<string, ReturnType<T>>();
+export function memoize<TArgs extends unknown[], TReturn>(
+  fn: (...args: TArgs) => TReturn
+): (...args: TArgs) => TReturn {
+  const cache = new Map<string, TReturn>();
 
-  return ((...args: Parameters<T>): ReturnType<T> => {
+  return (...args: TArgs): TReturn => {
     const key = JSON.stringify(args.map((arg) => stringify(arg)));
+    const cached = cache.get(key);
 
-    if (cache.has(key)) {
-      return cache.get(key)!;
+    if (cached !== undefined) {
+      return cached;
     }
 
-    const result = fn(...args) as ReturnType<T>;
-
+    const result = fn(...args);
     cache.set(key, result);
 
     return result;
-  }) as T;
+  };
 }


### PR DESCRIPTION
It's a small improvement here just for type-safety.

During a code exploration I found that the `memoize` util in the `@liveblocks/react-ui` package was using `any` and type assertions. 

We can do a better type-safety in this case using `unknown`. The benefits are:
- Better type inference.
- No need anymore for type assertion.
- No need anymore to disable an eslint rule.
- We do not loose anymore the type-safety for args.
- With unknown we will prevent accidental type errors if we re-use this memoize function.
- Better error prevention

Visually:
```ts
// With unknown
const memoizedFn = memoize((x: number, y: string) => x + y.length);
// TypeScript knows exactly the types of arguments and the return type

// With any
const memoizedFn = memoize((x: number, y: string) => x + y.length);
// TypeScript loses some type information and relies on type assertions
```

And:
```ts
// TypeScript will gives an error with unknown whereas will compile with any
const memoizedFn = memoize((x: number) => x.invalidMethod());
```

Feel free to ignore or close this PR if you don't think it's useful 😅 As stated it just something I caught during a code exploration on my own.

Thanks 🙏🏻 