### PR TITLE
CHANGELOG — WEEK 03

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -36,7 +36,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ## Dashboard
 
-– Allow rate limit configuration for webhook endpoints.
+- Allow rate limit configuration for webhook endpoints.
 
 ## Contributors
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -17,7 +17,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ## v2.16.0
 
-We've created new toolbar elements that allow you import a default floating toolbar
+We've created new toolbar elements that allow you to import a default floating toolbar
 in Tiptap and Lexical. It's also possible to use these APIs to build custom or
 static toolbars. We've updated a number of our examples to show how to do this.
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,10 +15,91 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 3 (2025-01-17)
 
-## Dashboard
+## v2.16.0
 
-- Allow rate limit configuration for webhook endpoints.
-- Fix download comments attachments action in text editor view from room detail page.
+We've created new toolbar elements that allow you import a default floating toolbar
+in Tiptap and Lexical. It's also possible to use these APIs to build custom or
+static toolbars. We've updated a number of our examples to show how to do this.
+
+Our error listener APIs will now receive more errors in general, including
+errors from using Comments & Notifications. Previously, these would only receive
+room connection errors from Presence, Storage, or Yjs. For example, now when 
+creation of a thread fails, deletion of a comment fails, marking a notification 
+as read fails, etc.
+
+### `@liveblocks/react`
+
+#### **Breaking**: More errors can appear in `useErrorListener()`
+
+```ts
+// ❌ Before: required a RoomProvider and would only notify about errors for that room
+// ✅ Now: requires a LiveblocksProvider and will notify about errors for any room
+useErrorListener((err: LiveblocksError) => {
+  /* show toast, or notify Sentry, Datadog, etc */
+});
+```
+
+See the
+[Upgrade Guide for 2.16](https://liveblocks.io/docs/platform/upgrading/2.16) to
+learn how to adapt your code.
+
+#### Filtering by absence of metadata
+
+We now support filtering threads by _absence_ of metadata as well in
+`useThreads({ query })` (or `useUserThreads_experimental({ query })`). For example,
+you can now filter threads that do not have a `color` attribute set in their 
+metadata:
+
+```ts
+useThreads({
+  query: {
+    // Filter any "pinned" threads that don't have a color set
+    metadata: {
+      pinned: true,
+      color: null, // ✨
+    },
+  },
+});
+```
+
+See the
+[Upgrade Guide for 2.16](https://liveblocks.io/docs/platform/upgrading/2.16) to
+learn how to adapt your code.
+
+#### Bug fixes
+
+- Automatically refresh Comments and Notifications when the browser window
+  regains focus.
+
+### `@liveblocks/client`
+
+The error listener APIs will now receive more errors in general, including
+errors from using Comments & Notifications. Previously, these would only receive
+room connection errors from Presence, Storage, or Yjs.
+
+```ts
+// 👌 Same as before, but might now also receive errors related to Comments & Notifications
+room.subscribe("error", (err) => { ... });
+```
+
+### `@liveblocks/react-ui`
+
+- Most of the icons used in the default components are now usable as
+  `<Icon.* />` via `import { Icon } from "@liveblocks/react-ui"`.
+
+### `@liveblocks/react-lexical` and `@liveblocks/react-tiptap`
+
+- Add `<Toolbar />` and `<FloatingToolbar />` components to simplify building
+  editor toolbars. They come with default controls out-of-the-box based on what
+  the editor they’re attached to supports, but they’re also heavily extendable
+  and customizable. Use inner components like `<Toolbar.Toggle />` and
+  `<Toolbar.Separator />` to extend the defaults with your own actions, or start
+  from scratch while customizing some of the defaults via
+  `<Toolbar.SectionInline />` or `<Toolbar.BlockSelector />` for example.
+
+### `@liveblocks/react-lexical`
+
+- Add `isTextFormatActive` and `isBlockNodeActive` utilities.
 
 ## Examples
 
@@ -30,6 +111,11 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
   - [Text editor comments (Tiptap)](https://liveblocks.io/examples/text-editor-comments/nextjs-comments-tiptap).
   - [Next.js Tiptap editor](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced).
   - [Next.js Tiptap editor](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced).
+ 
+## Dashboard
+
+- Allow rate limit configuration for webhook endpoints.
+- Fix download comments attachments action in text editor view from room detail page.
 
 ## Contributors
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -22,7 +22,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ## Examples
 
-- Update [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit) to use the nbew `FloatingToolbar.
+- Updated [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit) to use the new `FloatingToolbar.
 - Updated many text editor examples to use the new `FloatingToolbar`:
   - [Advanced collaborative text editor (Tiptap)](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced)`.
   - [Collaborative text editor (Tiptap)](https://liveblocks.io/examples/collaborative-text-editor/nextjs-tiptap).

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -34,9 +34,13 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 - New blog post: [What’s new in Liveblocks: December 2024](https://liveblocks.io/blog/whats-new-in-liveblocks-december-edition-2024).
 
+## Dashboard
+
+– Allow rate limit configuration for webhook endpoints.
+
 ## Contributors
 
-ctnicholas, nvie, marcbouchenoire
+ctnicholas, nvie, marcbouchenoire, jrowny
 
 # Week 52 (2024-12-27)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -22,7 +22,7 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 ## Examples
 
-- Updated [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit) to use the new `FloatingToolbar.
+- Updated [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit) to use the new `FloatingToolbar`.
 - Updated many text editor examples to use the new `FloatingToolbar`:
   - [Advanced collaborative text editor (Tiptap)](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced)`.
   - [Collaborative text editor (Tiptap)](https://liveblocks.io/examples/collaborative-text-editor/nextjs-tiptap).

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -13,6 +13,10 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 -->
 
+# Week 3 (2025-01-17)
+
+## Contributors
+
 # Week 2 (2025-01-10)
 
 ## 2.15.2

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -15,7 +15,14 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 # Week 3 (2025-01-17)
 
+## Dashboard
+
+- Allow rate limit configuration for webhook endpoints.
+- Fix download comments attachments action in text editor view from room detail page.
+
 ## Contributors
+
+jrowny, sugardarius
 
 # Week 2 (2025-01-10)
 
@@ -34,13 +41,9 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 
 - New blog post: [What’s new in Liveblocks: December 2024](https://liveblocks.io/blog/whats-new-in-liveblocks-december-edition-2024).
 
-## Dashboard
-
-- Allow rate limit configuration for webhook endpoints.
-
 ## Contributors
 
-ctnicholas, nvie, marcbouchenoire, jrowny
+ctnicholas, nvie, marcbouchenoire
 
 # Week 52 (2024-12-27)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,9 +20,20 @@ nimeshnayaju, nvie, ofoucherot, pierrelevaillant, stevenfabre, sugardarius
 - Allow rate limit configuration for webhook endpoints.
 - Fix download comments attachments action in text editor view from room detail page.
 
+## Examples
+
+- Update [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit) to use the nbew `FloatingToolbar.
+- Updated many text editor examples to use the new `FloatingToolbar`:
+  - [Advanced collaborative text editor (Tiptap)](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced)`.
+  - [Collaborative text editor (Tiptap)](https://liveblocks.io/examples/collaborative-text-editor/nextjs-tiptap).
+  - [Collaborative text editor (Lexical)](https://liveblocks.io/examples/collaborative-text-editor/nextjs-lexical).
+  - [Text editor comments (Tiptap)](https://liveblocks.io/examples/text-editor-comments/nextjs-comments-tiptap).
+  - [Next.js Tiptap editor](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced).
+  - [Next.js Tiptap editor](https://liveblocks.io/examples/collaborative-text-editor-advanced/nextjs-tiptap-advanced).
+
 ## Contributors
 
-jrowny, sugardarius
+jrowny, sugardarius, ctnicholas, nvie, marcbouchenoire
 
 # Week 2 (2025-01-10)
 
@@ -88,7 +99,7 @@ rollup, esbuild, etc) to also down-compile code from dependencies inside
 ## Examples
 
 - Adjusted email templates to allow switching the logo more easily.
-- Next.js Starter Kit improvements:
+- [Next.js Starter Kit](https://liveblocks.io/nextjs-starter-kit) improvements:
   - Renaming a document updates it immediately for everyone else.
   - Clicking outside of the rename input saves the new name.
   - Added tldraw's dark mode.


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-03-2025/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 17th of January.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.