### PR TITLE
Use non-deprecated Jest APIs

### DIFF
--- a/packages/liveblocks-core/src/__tests__/connection.test.ts
+++ b/packages/liveblocks-core/src/__tests__/connection.test.ts
@@ -23,7 +23,7 @@ describe("ManagedSocket", () => {
     await jest.advanceTimersByTimeAsync(4000);
     mgr.disconnect();
 
-    expect(didConnect).not.toBeCalled();
+    expect(didConnect).not.toHaveBeenCalled();
   });
 
   test("authenticate + websocket connection are successes but no ROOM_STATE still means not connected", async () => {
@@ -43,7 +43,7 @@ describe("ManagedSocket", () => {
     await jest.advanceTimersByTimeAsync(4000);
     mgr.disconnect();
 
-    expect(didConnect).not.toBeCalled();
+    expect(didConnect).not.toHaveBeenCalled();
   });
 
   test("authenticate + websocket connection + ROOM_STATE = connected", async () => {
@@ -63,6 +63,6 @@ describe("ManagedSocket", () => {
     await jest.advanceTimersByTimeAsync(4000);
     mgr.disconnect();
 
-    expect(didConnect).toBeCalledTimes(1);
+    expect(didConnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1959,7 +1959,7 @@ describe("room", () => {
 
       storage.root.set("x", 1);
 
-      expect(storageStatusCallback).toBeCalledWith("synchronizing");
+      expect(storageStatusCallback).toHaveBeenCalledWith("synchronizing");
       expect(room.getStorageStatus()).toBe("synchronizing");
 
       const storageJson = lsonToJson(storage.root);
@@ -1976,7 +1976,7 @@ describe("room", () => {
       await waitUntilStorageUpdate(room);
       expectStorage({ x: 1 });
       expect(room.getStorageStatus()).toBe("synchronized");
-      expect(storageStatusCallback).toBeCalledWith("synchronized");
+      expect(storageStatusCallback).toHaveBeenCalledWith("synchronized");
 
       expect(storageStatusCallback).toHaveBeenCalledTimes(2);
     });

--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -196,15 +196,15 @@ describe("finite state machine", () => {
         .onEnter("yellow", onEnterYellow)
         .onEnter("green", onEnterGreen);
 
-      expect(onEnterRed).not.toBeCalled();
-      expect(onEnterYellow).not.toBeCalled();
-      expect(onEnterGreen).not.toBeCalled();
+      expect(onEnterRed).not.toHaveBeenCalled();
+      expect(onEnterYellow).not.toHaveBeenCalled();
+      expect(onEnterGreen).not.toHaveBeenCalled();
 
       fsm.start();
 
-      expect(onEnterRed).toBeCalledTimes(1);
-      expect(onEnterYellow).not.toBeCalled();
-      expect(onEnterGreen).not.toBeCalled();
+      expect(onEnterRed).toHaveBeenCalledTimes(1);
+      expect(onEnterYellow).not.toHaveBeenCalled();
+      expect(onEnterGreen).not.toHaveBeenCalled();
     });
 
     test("does not execute onExit/onEnter events when explicitly staying in the same state", () => {
@@ -516,25 +516,25 @@ describe("finite state machine", () => {
       .start();
 
     expect(fsm.currentState).toEqual("one");
-    expect(reset).not.toBeCalled();
-    expect(inced).not.toBeCalled();
+    expect(reset).not.toHaveBeenCalled();
+    expect(inced).not.toHaveBeenCalled();
     fsm.send({ type: "GO" });
-    expect(reset).toBeCalledTimes(1);
-    expect(inced).not.toBeCalled();
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(inced).not.toHaveBeenCalled();
     fsm.send({ type: "GO" });
-    expect(reset).toBeCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
     expect(inced).toHaveBeenLastCalledWith(
       { x: 1, y: 13, patch: expect.any(Function) },
       { type: "GO" }
     );
     fsm.send({ type: "GO" });
-    expect(reset).toBeCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
     expect(inced).toHaveBeenLastCalledWith(
       { x: 2, y: 13, patch: expect.any(Function) },
       { type: "GO" }
     );
     fsm.send({ type: "GO" });
-    expect(reset).toBeCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
     expect(inced).toHaveBeenLastCalledWith(
       { x: 3, y: 13, patch: expect.any(Function) },
       { type: "GO" }


### PR DESCRIPTION
Noticed we were still using these deprecated Jest APIs. This gets rid of those TypeScript nags.