### PR TITLE
Add new Relax<T> to help define discriminated union types

### DIFF
--- a/packages/liveblocks-core/src/auth-manager.ts
+++ b/packages/liveblocks-core/src/auth-manager.ts
@@ -1,6 +1,7 @@
 import { StopRetrying } from "./connection";
 import { isPlainObject } from "./lib/guards";
 import type { Json } from "./lib/Json";
+import type { Relax } from "./lib/Relax";
 import type {
   Authentication,
   CustomAuthenticationResult,
@@ -29,10 +30,7 @@ type AuthEndpoint =
 
 export type AuthenticationOptions = {
   polyfills?: Polyfills;
-} & (
-  | { publicApiKey: string; authEndpoint?: never }
-  | { publicApiKey?: never; authEndpoint: AuthEndpoint }
-);
+} & Relax<{ publicApiKey: string } | { authEndpoint: AuthEndpoint }>;
 
 export function createAuthManager(
   authOptions: AuthenticationOptions,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -13,6 +13,7 @@ import type { Observable } from "./lib/EventSource";
 import * as console from "./lib/fancy-console";
 import type { Json, JsonObject } from "./lib/Json";
 import type { NoInfr } from "./lib/NoInfer";
+import type { Relax } from "./lib/Relax";
 import type { Resolve } from "./lib/Resolve";
 import { Signal } from "./lib/signals";
 import type { CustomAuthenticationResult } from "./protocol/Authentication";
@@ -444,23 +445,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
 
   /** @internal */
   enableDebugLogging?: boolean;
-} & (
-  | { publicApiKey: string; authEndpoint?: never }
-  | { publicApiKey?: never; authEndpoint: AuthEndpoint }
-);
-// ^^^^^^^^^^^^^^^
-// NOTE: Potential upgrade path by introducing a new property:
-//
-//   | { publicApiKey: string; authEndpoint?: never; authUrl?: never }
-//   | { publicApiKey?: never; authEndpoint: AuthEndpoint; authUrl?: never }
-//   | { publicApiKey?: never; authEndpoint?: never; authUrl?: AuthUrl }
-//
-// Where:
-//
-//   export type AuthUrl =
-//     | string
-//     | ((room: string) => Promise<{ token: string }>);
-//
+} & Relax<{ publicApiKey: string } | { authEndpoint: AuthEndpoint }>;
 
 function getBaseUrl(baseUrl?: string | undefined): string {
   if (

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -131,6 +131,7 @@ export { objectToQuery } from "./lib/objectToQuery";
 export type { Poller } from "./lib/Poller";
 export { makePoller } from "./lib/Poller";
 export { asPos, makePosition } from "./lib/position";
+export type { Relax } from "./lib/Relax";
 export type { Resolve } from "./lib/Resolve";
 export { shallow } from "./lib/shallow";
 export type { ISignal, SignalType } from "./lib/signals";

--- a/packages/liveblocks-core/src/lib/Relax.ts
+++ b/packages/liveblocks-core/src/lib/Relax.ts
@@ -1,0 +1,30 @@
+import type { Resolve } from "./Resolve";
+
+/**
+ * Relaxes a discriminated union type definition, by explicitly adding
+ * properties defined in any other member as 'never'.
+ *
+ * This makes accessing the members much more relaxed in TypeScript.
+ *
+ * For example:
+ *   type MyUnion = Relax<
+ *     | { foo: string }
+ *     | { foo: number; bar: string; }
+ *     | { qux: boolean }
+ *   >;
+ *
+ *   // With Relax, accessing is much easier:
+ *   union.foo;       // string | number | undefined
+ *   union.bar;       // string | undefined
+ *   union.qux;       // boolean
+ *   union.whatever;  // Error: Property 'whatever' does not exist on type 'MyUnion'
+ *
+ *   // Without Relax, these would all be type errors:
+ *   union.foo; // Error: Property 'foo' does not exist on type 'MyUnion'
+ *   union.bar; // Error: Property 'bar' does not exist on type 'MyUnion'
+ *   union.qux; // Error: Property 'qux' does not exist on type 'MyUnion'
+ */
+export type Relax<T> = DistributiveRelax<T, T extends any ? keyof T : never>;
+type DistributiveRelax<T, Ks extends string | number | symbol> = T extends any
+  ? Resolve<{ [K in keyof T]: T[K] } & { [K in Exclude<Ks, keyof T>]?: never }>
+  : never;

--- a/packages/liveblocks-core/src/protocol/Authentication.ts
+++ b/packages/liveblocks-core/src/protocol/Authentication.ts
@@ -1,7 +1,10 @@
-export type CustomAuthenticationResult =
-  | { token: string; error?: never }
-  | { token?: never; error: "forbidden"; reason: string } // Will stop retrying and disconnect
-  | { token?: never; error: string; reason: string }; // Will log the error and keep retrying
+import type { Relax } from "../lib/Relax";
+
+export type CustomAuthenticationResult = Relax<
+  | { token: string }
+  | { error: "forbidden"; reason: string } // Will stop retrying and disconnect
+  | { error: string; reason: string } // Will log the error and keep retrying
+>;
 
 export type Authentication =
   | {

--- a/packages/liveblocks-core/src/protocol/Comments.ts
+++ b/packages/liveblocks-core/src/protocol/Comments.ts
@@ -1,5 +1,6 @@
 import type { DM } from "../globals/augmentation";
 import type { DateToString } from "../lib/DateToString";
+import type { Relax } from "../lib/Relax";
 
 export type BaseMetadata = Record<
   string,
@@ -84,20 +85,14 @@ export type CommentData = {
   editedAt?: Date;
   reactions: CommentReaction[];
   attachments: CommentAttachment[];
-} & (
-  | { body: CommentBody; deletedAt?: never }
-  | { body?: never; deletedAt: Date }
-);
+} & Relax<{ body: CommentBody } | { deletedAt: Date }>;
 
 export type CommentDataPlain = Omit<
   DateToString<CommentData>,
   "reactions" | "body"
 > & {
   reactions: DateToString<CommentReaction>[];
-} & (
-    | { body: CommentBody; deletedAt?: never }
-    | { body?: never; deletedAt: string }
-  );
+} & Relax<{ body: CommentBody } | { deletedAt: string }>;
 
 export type CommentBodyBlockElement = CommentBodyParagraph;
 

--- a/packages/liveblocks-core/src/types/Others.ts
+++ b/packages/liveblocks-core/src/types/Others.ts
@@ -1,10 +1,14 @@
 import type { DP, DU } from "../globals/augmentation";
 import type { JsonObject } from "../lib/Json";
+import type { Relax } from "../lib/Relax";
 import type { Resolve } from "../lib/Resolve";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import type { User } from "./User";
 
-export type InternalOthersEvent<P extends JsonObject, U extends BaseUserMeta> =
+export type InternalOthersEvent<
+  P extends JsonObject,
+  U extends BaseUserMeta,
+> = Relax<
   | { type: "leave"; user: User<P, U> }
   | { type: "enter"; user: User<P, U> }
   | {
@@ -12,7 +16,8 @@ export type InternalOthersEvent<P extends JsonObject, U extends BaseUserMeta> =
       user: User<P, U>;
       updates: Partial<P>;
     }
-  | { type: "reset"; user?: never };
+  | { type: "reset" }
+>;
 
 export type OthersEvent<
   P extends JsonObject = DP,

--- a/packages/liveblocks-core/test-d/Relax.test-d.ts
+++ b/packages/liveblocks-core/test-d/Relax.test-d.ts
@@ -1,0 +1,69 @@
+import type { Relax } from "@liveblocks/core";
+import { expectType } from "tsd";
+
+{
+  type Actual = Relax<{ foo: string | number }>;
+  type Expected = { foo: string | number };
+
+  let ru!: Actual;
+  expectType<Expected>(ru);
+}
+
+{
+  type Actual = Relax<{ foo: string } | { foo: number }>;
+  type Expected = { foo: string } | { foo: number };
+
+  let ru!: Actual;
+  expectType<Expected>(ru);
+}
+
+{
+  type Actual = Relax<{ foo: string } | { bar: number }>;
+  type Expected = { foo: string; bar?: never } | { bar: number; foo?: never };
+
+  let ru!: Actual;
+  expectType<Expected>(ru);
+}
+
+{
+  type Actual = Relax<
+    | { a: "hey"; b: string }
+    | { c: number; d: boolean }
+    | { e: Error; f: Date }
+    | { a: "hi"; d: boolean }
+  >;
+  type Expected =
+    | { a: "hey"; b: string; c?: never; d?: never; e?: never; f?: never }
+    | { c: number; d: boolean; a?: never; b?: never; e?: never; f?: never }
+    | { e: Error; f: Date; a?: never; b?: never; c?: never; d?: never }
+    | { a: "hi"; d: boolean; b?: never; c?: never; e?: never; f?: never };
+
+  let ru!: Actual;
+  expectType<Expected>(ru);
+}
+
+{
+  type Actual = Relax<
+    | { type: "thing1"; payload: string }
+    | { type: "thing2"; payload: boolean }
+    | { type: "thing3"; payload: number }
+    | { type: "thing4" }
+  >;
+
+  let ru!: Actual;
+  expectType<string | number | boolean | undefined>(ru.payload);
+  if (ru.type === "thing3") {
+    expectType<number>(ru.payload);
+  }
+  if (ru.payload === "string") {
+    expectType<"thing1">(ru.type);
+  }
+}
+
+{
+  type Actual = Relax<{ a: string } | {}>;
+  type Expected = { a: string } | { a?: never };
+
+  let ru!: Actual;
+  expectType<Expected>(ru);
+}

--- a/packages/liveblocks-react-ui/src/primitives/EmojiPicker/contexts.ts
+++ b/packages/liveblocks-react-ui/src/primitives/EmojiPicker/contexts.ts
@@ -3,28 +3,28 @@ import { nn } from "@liveblocks/core";
 import type { Dispatch, KeyboardEvent, SetStateAction } from "react";
 import { createContext, useContext } from "react";
 
+type Relax<T> = DistributiveRelax<T, T extends any ? keyof T : never>;
+type DistributiveRelax<T, Ks extends string | number | symbol> = T extends any
+  ? Resolve<{ [K in keyof T]: T[K] } & { [K in Exclude<Ks, keyof T>]?: never }>
+  : never;
+
 import type {
   EmojiPickerData,
   EmojiPickerInteraction,
   EmojiPickerSelectionDirection,
 } from "./types";
 
-type EmojiPickerContextData =
-  | {
-      data?: never;
-      error?: never;
-      isLoading: true;
-    }
+type EmojiPickerContextData = Relax<
+  | { isLoading: true }
   | {
       data: EmojiPickerData;
-      error?: never;
       isLoading: false;
     }
   | {
-      data?: never;
       error: Error;
       isLoading: false;
-    };
+    }
+>;
 
 export type EmojiPickerContext = Resolve<
   EmojiPickerContextData & {

--- a/packages/liveblocks-react-ui/src/primitives/EmojiPicker/contexts.ts
+++ b/packages/liveblocks-react-ui/src/primitives/EmojiPicker/contexts.ts
@@ -1,12 +1,7 @@
-import type { Resolve } from "@liveblocks/core";
+import type { Relax, Resolve } from "@liveblocks/core";
 import { nn } from "@liveblocks/core";
 import type { Dispatch, KeyboardEvent, SetStateAction } from "react";
 import { createContext, useContext } from "react";
-
-type Relax<T> = DistributiveRelax<T, T extends any ? keyof T : never>;
-type DistributiveRelax<T, Ks extends string | number | symbol> = T extends any
-  ? Resolve<{ [K in keyof T]: T[K] } & { [K in Exclude<Ks, keyof T>]?: never }>
-  : never;
 
 import type {
   EmojiPickerData,

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -30,6 +30,7 @@ import type {
   PartialUnless,
   Patchable,
   QueryMetadata,
+  Relax,
   Resolve,
   RoomEventMessage,
   StorageStatus,
@@ -143,13 +144,6 @@ export type CommentReactionOptions = {
 
 // -----------------------------------------------------------------------
 
-type NoPaginationFields = {
-  hasFetchedAll?: never;
-  isFetchingMore?: never;
-  fetchMore?: never;
-  fetchMoreError?: never;
-};
-
 type PaginationFields = {
   hasFetchedAll: boolean;
   isFetchingMore: boolean;
@@ -161,10 +155,9 @@ export type PagedAsyncSuccess<T, F extends string> = Resolve<
   AsyncSuccess<T, F> & PaginationFields
 >;
 
-export type PagedAsyncResult<T, F extends string> =
-  | Resolve<AsyncLoading<F> & NoPaginationFields>
-  | Resolve<AsyncError<F> & NoPaginationFields>
-  | PagedAsyncSuccess<T, F>;
+export type PagedAsyncResult<T, F extends string> = Relax<
+  AsyncLoading<F> | AsyncError<F> | PagedAsyncSuccess<T, F>
+>;
 
 // -----------------------------------------------------------------------
 
@@ -255,22 +248,14 @@ export type MutationContext<
   ) => void;
 };
 
-export type ThreadSubscription =
+export type ThreadSubscription = Relax<
   // The user is not subscribed to the thread
-  | {
-      status: "not-subscribed";
-      unreadSince?: never;
-    }
+  | { status: "not-subscribed" }
   // The user is subscribed to the thread but has never read it
-  | {
-      status: "subscribed";
-      unreadSince: null;
-    }
+  | { status: "subscribed"; unreadSince: null }
   // The user is subscribed to the thread and has read it
-  | {
-      status: "subscribed";
-      unreadSince: Date;
-    };
+  | { status: "subscribed"; unreadSince: Date }
+>;
 
 export type SharedContextBundle<U extends BaseUserMeta> = {
   classic: {


### PR DESCRIPTION
Relaxes a discriminated union type definition, by explicitly adding properties defined in any other member as `never`. We used to do this manually, but with this helper, TypeScript will automatically do it.

This makes accessing the members much more relaxed in TypeScript.

For example:

```ts
type MyUnion = Relax<
  | { foo: string }
  | { foo: number; bar: string }
  | { qux: boolean }
>;
```

Normally, these will all be type errors: 🤔

```ts
const union: MyUnion = ...;
union.foo; // Error: Property 'foo' does not exist on type 'MyUnion'
union.bar; // Error: Property 'bar' does not exist on type 'MyUnion'
union.qux; // Error: Property 'qux' does not exist on type 'MyUnion'
```

With `Relax<T>`, accessing fields is much easier: 😇

```ts
const union: MyUnion = ...;
union.foo; // string | number | undefined
union.bar; // string | undefined
union.qux; // boolean
union.whatever; // Error: Property 'whatever' does not exist on type 'MyUnion'
```
