### PR TITLE
remove pending selection, as its not needed

### DIFF
--- a/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
@@ -1,7 +1,7 @@
 import { Extension, Mark, mergeAttributes } from "@tiptap/core";
 import type { Node } from "@tiptap/pm/model";
 import type { Transaction } from "@tiptap/pm/state";
-import { Plugin, TextSelection } from "@tiptap/pm/state";
+import { Plugin } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { ySyncPluginKey } from "y-prosemirror";
 
@@ -203,7 +203,7 @@ export const CommentsExtension = Extension.create<
 
   addStorage() {
     return {
-      pendingCommentSelection: null,
+      pendingComment: false,
     };
   },
 
@@ -220,10 +220,7 @@ export const CommentsExtension = Extension.create<
             data: null,
           })
         );
-        this.storage.pendingCommentSelection = new TextSelection(
-          this.editor.state.selection.$anchor,
-          this.editor.state.selection.$head
-        );
+        this.storage.pendingComment = true;
         return true;
       },
       selectThread: (id: string | null) => () => {
@@ -238,13 +235,14 @@ export const CommentsExtension = Extension.create<
       addComment:
         (id: string) =>
         ({ commands }) => {
-          if (!this.storage.pendingCommentSelection) {
+          if (
+            !this.storage.pendingComment ||
+            this.editor.state.selection.empty
+          ) {
             return false;
           }
-          this.editor.state.selection = this.storage.pendingCommentSelection;
           commands.setMark(LIVEBLOCKS_COMMENT_MARK_TYPE, { threadId: id });
-          this.storage.pendingCommentSelection = null;
-
+          this.storage.pendingComment = false;
           return true;
         },
     };
@@ -258,28 +256,22 @@ export const CommentsExtension = Extension.create<
     { transaction }: { transaction: Transaction } // TODO: remove this after submitting PR to tiptap
   ) {
     // ignore changes made by yjs
-    if (
-      !this.storage.pendingCommentSelection ||
-      transaction.getMeta(ySyncPluginKey)
-    ) {
+    if (!this.storage.pendingComment || transaction.getMeta(ySyncPluginKey)) {
       return;
     }
-    this.storage.pendingCommentSelection = null;
+    // if selection changes, hide the composer. We could keep the composer open and move it to the new selection?
+    this.storage.pendingComment = false;
   },
-  // TODO: this.storage.pendingCommentSelection needs to be a Yjs Relative Position that gets translated back to absolute position.
-  // Commit: eba949d32d6010a3d8b3f7967d73d4deb015b02a has code that can help with this.
   addProseMirrorPlugins() {
     return [
       new Plugin({
         key: ACTIVE_SELECTION_PLUGIN,
         props: {
-          decorations: ({ doc }) => {
-            const active = this.storage.pendingCommentSelection !== null;
-            if (!active) {
+          decorations: ({ doc, selection }) => {
+            if (!this.storage.pendingComment) {
               return DecorationSet.create(doc, []);
             }
-            const { from, to } = this.storage
-              .pendingCommentSelection as TextSelection;
+            const { from, to } = selection;
             const decorations: Decoration[] = [
               Decoration.inline(from, to, {
                 class: "lb-root lb-tiptap-active-selection",

--- a/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
@@ -46,9 +46,9 @@ export const FloatingComposer = forwardRef<
     selector: (ctx) => ({
       showComposer: !!(
         ctx.editor?.storage.liveblocksComments as
-          | CommentsExtensionStorage
-          | undefined
-      )?.pendingCommentSelection,
+        | CommentsExtensionStorage
+        | undefined
+      )?.pendingComment,
     }),
     equalityFn: (prev, next) => {
       if (!next) return false;

--- a/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
@@ -48,7 +48,7 @@ export const FloatingComposer = forwardRef<
         ctx.editor?.storage.liveblocksComments as
         | CommentsExtensionStorage
         | undefined
-      )?.pendingComment,
+      )?.pendingComment && !editor?.state.selection.empty,
     }),
     equalityFn: (prev, next) => {
       if (!next) return false;

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -21,7 +21,7 @@ export const THREADS_PLUGIN_KEY = new PluginKey<ThreadPluginState>(
 export const LIVEBLOCKS_COMMENT_MARK_TYPE = "liveblocksCommentMark";
 
 export type CommentsExtensionStorage = {
-  pendingCommentSelection: TextSelection | null;
+  pendingComment: boolean;
 };
 
 export const enum ThreadPluginActions {


### PR DESCRIPTION
I incorrectly assumed that bluring (unfocusing) the editor removed its selection state and stored that in pendingCommentSelection. That is unnecessary complication because the selection state is properly stored.

this PR simplifies the approach by only storing a boolean, rather than a selection. editor.state.selection is used where pendingCommentSelection was used previously.

this also fixes (most) of the issues with commenting while a collaborator is editing. Thanks @yousefED for the tip!