### PR TITLE
Poll for Comments & Notifications when window regains focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ See the
 [Upgrade Guide for 2.16](https://liveblocks.io/docs/platform/upgrading/2.16) to
 learn how to adapt your code.
 
+#### Bug fixes
+
+- Automatically refresh Comments and Notifications when the browser window
+  regains focus.
+
 ### `@liveblocks/client`
 
 The error listener APIs will now receive more errors in general, including

--- a/packages/liveblocks-core/src/lib/Poller.ts
+++ b/packages/liveblocks-core/src/lib/Poller.ts
@@ -204,7 +204,7 @@ export function makePoller(
   // unregister these event handlers.
   doc?.addEventListener("visibilitychange", onVisibilityChange);
   win?.addEventListener("online", onVisibilityChange);
-  win?.addEventListener("focus", () => pollNowIfStale());
+  win?.addEventListener("focus", pollNowIfStale);
 
   fsm.start();
   return {

--- a/packages/liveblocks-core/src/lib/Poller.ts
+++ b/packages/liveblocks-core/src/lib/Poller.ts
@@ -204,6 +204,7 @@ export function makePoller(
   // unregister these event handlers.
   doc?.addEventListener("visibilitychange", onVisibilityChange);
   win?.addEventListener("online", onVisibilityChange);
+  win?.addEventListener("focus", () => pollNowIfStale());
 
   fsm.start();
   return {


### PR DESCRIPTION
This PR makes the poller trigger a poll whenever a `focus` event happens on the browser window (and the data is stale). We already triggered a poll when the window became _visible_, but this is slightly different. It also refreshes data if, for example, two windows are open side by side, and you change focus to one of those windows.