### PR TITLE
Upgrade ast-generator to 0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12643,40 +12643,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ast-generator": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ast-generator/-/ast-generator-0.2.3.tgz",
-      "integrity": "sha512-a8Hobx1hzary7eIiSW3x21nRmlUYz1UJEAYfAFCbyym/zP3RglWj+8b0t7PNxheOaheD/ltRO5ZgckWjOmlqJQ==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^13.0.0",
-        "prettier": "^3.4.2",
-        "tiny-invariant": "^1.3.3"
-      },
-      "bin": {
-        "generate-ast": "dist/index.js"
-      },
-      "peerDependencies": {
-        "typescript": "^4 || ^5"
-      }
-    },
-    "node_modules/ast-generator/node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ast-generator/node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ast-types": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
@@ -22083,6 +22049,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ohm-js": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.1.0.tgz",
+      "integrity": "sha512-xc3B5dgAjTBQGHaH7B58M2Pmv6WvzrJ/3/7LeUzXNg0/sY3jQPdSd/S2SstppaleO77rifR1tyhdfFGNIwxf2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.1"
       }
     },
     "node_modules/once": {
@@ -32704,7 +32681,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/didyoumean": "^1.2.0",
-        "ast-generator": "^0.2.3",
+        "ast-generator": "^0.3.0",
         "peggy": "^2.0.1",
         "pkg": "^4.4.9",
         "ts-node": "^10.9.1",
@@ -32716,6 +32693,33 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "schema-lang/liveblocks-schema/node_modules/ast-generator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ast-generator/-/ast-generator-0.3.0.tgz",
+      "integrity": "sha512-+XuHT6tNsMjeJjgHdPTH0qcHXnNbBgFiu3rzKfjk/DvczIDZb+jxt8PdBR3x6Zld6AJDk1fxCoMZX3W7NdvGcw==",
+      "dev": true,
+      "bin": {
+        "generate-ast": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "commander": "^13",
+        "ohm-js": "^17",
+        "prettier": "^3",
+        "tiny-invariant": "^1",
+        "typescript": "^4 || ^5"
+      }
+    },
+    "schema-lang/liveblocks-schema/node_modules/commander": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "schema-lang/liveblocks-schema/node_modules/ts-node": {
       "version": "10.9.1",
@@ -38961,7 +38965,7 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@types/didyoumean": "^1.2.0",
-        "ast-generator": "^0.2.3",
+        "ast-generator": "^0.3.0",
         "didyoumean": "^1.2.2",
         "peggy": "^2.0.1",
         "pkg": "^4.4.9",
@@ -38973,6 +38977,20 @@
         "arg": {
           "version": "4.1.3",
           "dev": true
+        },
+        "ast-generator": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/ast-generator/-/ast-generator-0.3.0.tgz",
+          "integrity": "sha512-+XuHT6tNsMjeJjgHdPTH0qcHXnNbBgFiu3rzKfjk/DvczIDZb+jxt8PdBR3x6Zld6AJDk1fxCoMZX3W7NdvGcw==",
+          "dev": true,
+          "requires": {}
+        },
+        "commander": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+          "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+          "dev": true,
+          "peer": true
         },
         "ts-node": {
           "version": "10.9.1",
@@ -44237,31 +44255,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
-    },
-    "ast-generator": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ast-generator/-/ast-generator-0.2.3.tgz",
-      "integrity": "sha512-a8Hobx1hzary7eIiSW3x21nRmlUYz1UJEAYfAFCbyym/zP3RglWj+8b0t7PNxheOaheD/ltRO5ZgckWjOmlqJQ==",
-      "dev": true,
-      "requires": {
-        "commander": "^13.0.0",
-        "prettier": "^3.4.2",
-        "tiny-invariant": "^1.3.3"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-          "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
-          "dev": true
-        },
-        "tiny-invariant": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-          "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-          "dev": true
-        }
-      }
     },
     "ast-types": {
       "version": "0.14.2",
@@ -50591,6 +50584,13 @@
         "define-properties": "^1.2.0",
         "es-abstract": "^1.22.1"
       }
+    },
+    "ohm-js": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.1.0.tgz",
+      "integrity": "sha512-xc3B5dgAjTBQGHaH7B58M2Pmv6WvzrJ/3/7LeUzXNg0/sY3jQPdSd/S2SstppaleO77rifR1tyhdfFGNIwxf2Q==",
+      "dev": true,
+      "peer": true
     },
     "once": {
       "version": "1.4.0",

--- a/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/comment-plugin-provider.tsx
@@ -5,7 +5,7 @@ import {
   removeClassNamesFromElement,
 } from "@lexical/utils";
 import { shallow } from "@liveblocks/client";
-import { useClient, useRoom, useErrorListener } from "@liveblocks/react";
+import { useClient, useErrorListener, useRoom } from "@liveblocks/react";
 import {
   getUmbrellaStoreForClient,
   useSignal,

--- a/schema-lang/liveblocks-schema/package.json
+++ b/schema-lang/liveblocks-schema/package.json
@@ -32,7 +32,7 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@types/didyoumean": "^1.2.0",
-    "ast-generator": "^0.2.3",
+    "ast-generator": "^0.3.0",
     "peggy": "^2.0.1",
     "pkg": "^4.4.9",
     "ts-node": "^10.9.1",

--- a/schema-lang/liveblocks-schema/src/ast/ast.grammar
+++ b/schema-lang/liveblocks-schema/src/ast/ast.grammar
@@ -5,121 +5,106 @@
 #
 # This is used to generate the AST TypeScript module.
 #
-Document:
-    definitions  @Definition+
+Document {
+  definitions: @Definition+
+}
 
-
-@ScalarType:
-    | StringType
-    | NumberType
-    | BooleanType
-    | NullType
-    | LiteralType
-
+@ScalarType =
+  | StringType
+  | NumberType
+  | BooleanType
+  | NullType
+  | LiteralType
 
 # A custom user-defined type definition
-@Definition:
-    | ObjectTypeDefinition
+@Definition =
+  | ObjectTypeDefinition
 
+@NonUnionType =
+  | @ScalarType
+  | ArrayType
+  | ObjectLiteralType
+  | @LiveType
+  | TypeRef
 
-@NonUnionType:
-    | @ScalarType
-    | ArrayType
-    | ObjectLiteralType
-    | @LiveType
-    | TypeRef
+@Type =
+  | @NonUnionType
+  | UnionType
 
-
-@Type:
-    | @NonUnionType
-    | UnionType
-
-
-@LiveType:
-    # NOTE: LiveObject is *NOT* a LiveType, but a special modifier on TypeRef
-    | LiveMapType
-    | LiveListType
-
+@LiveType =
+  # NOTE: LiveObject is *NOT* a LiveType, but a special modifier on TypeRef
+  | LiveMapType
+  | LiveListType
 
 # e.g. "A | B", "A | (B | C)", etc
-UnionType:
-    members  @NonUnionType+
-
+UnionType {
+  members: @NonUnionType+
+}
 
 # e.g. "string[]", or "number[][]", etc.
-ArrayType:
-    ofType  @Type
-
+ArrayType {
+  ofType: @Type
+}
 
 # Reference to a custom, user-defined, type. Not a built-in. Things like
 # "Circle", "BlogPost", "LiveObject<Circle>", "LiveObject<BlogPost>", etc.
-TypeRef:
-    ref           TypeName
-    asLiveObject  `boolean`
+TypeRef {
+  ref: TypeName
+  asLiveObject: boolean
+}
 
-
-FieldDef:
-    name             Identifier
-    optional         `boolean`
-    type             @Type
-    leadingComment   `string`?
-    trailingComment  `string`?
-
+FieldDef {
+  name: Identifier
+  optional: boolean
+  type: @Type
+  leadingComment?: string
+  trailingComment?: string
+}
 
 # e.g. "Circle" or "Person" -- used in type positions
-TypeName:
-    name  `string`
-
+TypeName {
+  name: string
+}
 
 # e.g. "x" or "y" -- used in field positions
-Identifier:
-    name  `string`
-
+Identifier {
+  name: string
+}
 
 # e.g. LiveList<number>
-LiveListType:
-    ofType  @Type
-
+LiveListType {
+  ofType: @Type
+}
 
 # e.g. LiveMap<string, number>
-LiveMapType:
-    keyType    @Type
-    valueType  @Type
-
+LiveMapType {
+  keyType: @Type
+  valueType: @Type
+}
 
 # e.g. { cx: Number; cy: Number; r: Float }
-ObjectLiteralType:
-    fields  FieldDef*
-
+ObjectLiteralType {
+  fields: FieldDef*
+}
 
 # e.g. type Circle { cx: Number; cy: Number; r: Float }
-ObjectTypeDefinition:
-    name            TypeName
-    fields          FieldDef*
-    leadingComment  `string`?
+ObjectTypeDefinition {
+  name: TypeName
+  fields: FieldDef*
+  leadingComment?: string
 
-    # True whether this type is only referenced in JSON contexts only. False
-    # when this type definition is only ever referenced by a "LiveObject<>"
-    # modifier. Not set in the parsing phase, and will receive its definitive
-    # value in the checking phase.
-    isStatic  `boolean`
+  # True whether this type is only referenced in JSON contexts only. False
+  # when this type definition is only ever referenced by a "LiveObject<>"
+  # modifier. Not set in the parsing phase, and will receive its definitive
+  # value in the checking phase.
+  isStatic: boolean
+}
 
+StringType { }
+NumberType { }
+BooleanType { }
+NullType { }
 
-StringType:
-    # no fields
-
-
-NumberType:
-    # no fields
-
-
-BooleanType:
-    # no fields
-
-
-NullType:
-    # no fields
-
-
-LiteralType:
-    value  `string | number | boolean`
+LiteralType {
+  value: string | number | boolean
+}


### PR DESCRIPTION
Upgrades `ast-generator` to 0.3, and adopts to the new AST grammar syntax. There are no changes to the generated output.