### PR TITLE
Display toolbar buttons names by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## vNEXT (not yet published)
 
+## v2.16.1
+
+### `@liveblocks/react-lexical` and `@liveblocks/react-tiptap`
+
+- `<Toolbar.Button />` and `<Toolbar.Toggle />` now display their `name`
+  visually if `children` and `icon` aren’t set.
+
 ## v2.16.0
 
 Our error listener APIs will now receive more errors in general, including

--- a/packages/liveblocks-react-lexical/src/toolbar/toolbar.tsx
+++ b/packages/liveblocks-react-lexical/src/toolbar/toolbar.tsx
@@ -233,6 +233,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           variant="toolbar"
           ref={forwardedRef}
           icon={icon}
+          aria-label={!children ? name : undefined}
           {...props}
           onKeyDown={handleKeyDown}
         >

--- a/packages/liveblocks-react-lexical/src/toolbar/toolbar.tsx
+++ b/packages/liveblocks-react-lexical/src/toolbar/toolbar.tsx
@@ -236,7 +236,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           {...props}
           onKeyDown={handleKeyDown}
         >
-          {children}
+          {!children && !icon ? name : children}
         </Button>
       </ShortcutTooltip>
     );
@@ -670,7 +670,7 @@ export const Toolbar = Object.assign(
      * A button for triggering actions.
      *
      * @example
-     * <Toolbar.Button name="Comment" shortcut="Mod-Shift-E" onClick={() => { ... }}>Comment</Toolbar.Button>
+     * <Toolbar.Button name="Comment" shortcut="Mod-Shift-E" onClick={() => { ... }} />
      *
      * @example
      * <Toolbar.Button name="Mention someone" icon={<Icon.Mention />} onClick={() => { ... }} />
@@ -681,7 +681,7 @@ export const Toolbar = Object.assign(
      * A toggle button for values that can be active or inactive.
      *
      * @example
-     * <Toolbar.Toggle name="Bold" active={isBold}>Bold</Toolbar.Toggle>
+     * <Toolbar.Toggle name="Bold" active={isBold} />
      *
      * @example
      * <Toolbar.Toggle name="Italic" icon={<Icon.Italic />} shortcut="Mod-I" active={isItalic} onClick={() => { ... }} />

--- a/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
+++ b/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
@@ -213,7 +213,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           {...props}
           onKeyDown={handleKeyDown}
         >
-          {children}
+          {!children && !icon ? name : children}
         </Button>
       </ShortcutTooltip>
     );
@@ -743,7 +743,7 @@ export const Toolbar = Object.assign(
      * A button for triggering actions.
      *
      * @example
-     * <Toolbar.Button name="Comment" shortcut="Mod-Shift-E" onClick={() => { ... }}>Comment</Toolbar.Button>
+     * <Toolbar.Button name="Comment" shortcut="Mod-Shift-E" onClick={() => { ... }} />
      *
      * @example
      * <Toolbar.Button name="Mention someone" icon={<Icon.Mention />} onClick={() => { ... }} />
@@ -754,7 +754,7 @@ export const Toolbar = Object.assign(
      * A toggle button for values that can be active or inactive.
      *
      * @example
-     * <Toolbar.Toggle name="Bold" active={isBold}>Bold</Toolbar.Toggle>
+     * <Toolbar.Toggle name="Bold" active={isBold} />
      *
      * @example
      * <Toolbar.Toggle name="Italic" icon={<Icon.Italic />} shortcut="Mod-I" active={isItalic} onClick={() => { ... }} />

--- a/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
+++ b/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
@@ -210,6 +210,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           variant="toolbar"
           ref={forwardedRef}
           icon={icon}
+          aria-label={!children ? name : undefined}
           {...props}
           onKeyDown={handleKeyDown}
         >


### PR DESCRIPTION
Tiny improvement to make the case of `<Toolbar.Button name="foo" />` behave more like expectations:

```
// 2.16.0 
<Toolbar.Button name="Bold" /> // An empty (broken) button

// With this PR
<Toolbar.Button name="Bold" /> // A text-only button with a "Bold" label
```

For additional context, `name` is required (used in the button’s mandatory tooltip and its `aria-label` value), `icon` and `children` aren’t.

Other cases (with/without an `icon`, with custom `children`, etc) aren't affected by this PR.