### PR TITLE
spread set to support devtools

### DIFF
--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -275,9 +275,9 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
     }
 
     const store = config(
-      (args) => {
+      (...args) => {
         const { liveblocks: _, ...oldState } = get();
-        set(args);
+        set(...args);
         const { liveblocks: __, ...newState } = get();
 
         if (maybeRoom) {


### PR DESCRIPTION
### Fixing a bug

- Liveblock zustand assumes `set` in zustand to only have 1 argument. but actually it takes 3. This is breaking integration with other middlewares like devtools.

#### How to test it
may need to update example with liveblock zustand to include devtools