### PR TITLE
Ensure not server side for every suspense hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### `@liveblocks/react`
 
-- Fix bug in internal store to avoid to fetch on the server on first render.
+- Improve error message if hooks are accidentally called server side
 
 ### `@liveblocks/zustand`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react`
+
+- Fix bug in internal store to avoid to fetch on the server on first render.
+
+### `@liveblocks/zustand`
+
 - Fix bug in Zustand typing in case the multi-argument form of `set()` is used
   (thanks [@hans-lizihan](https://github.com/hans-lizihan))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT (not yet published)
 
+## v2.16.2
+
 ### `@liveblocks/react`
 
 - Improve error message if hooks are accidentally called server side

--- a/packages/liveblocks-react/src/lib/ssr.ts
+++ b/packages/liveblocks-react/src/lib/ssr.ts
@@ -1,0 +1,8 @@
+export function ensureNotServerSide(): void {
+  // Error early if suspense is used in a server-side context
+  if (typeof window === "undefined") {
+    throw new Error(
+      "You cannot use the Suspense version of Liveblocks hooks server side. Make sure to only call them client side by using a ClientSideSuspense wrapper.\nFor tips, see https://liveblocks.io/docs/api-reference/liveblocks-react#ClientSideSuspense"
+    );
+  }
+}

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -37,6 +37,7 @@ import { config } from "./config";
 import { useIsInsideRoom } from "./contexts";
 import { ASYNC_OK } from "./lib/AsyncResult";
 import { count } from "./lib/itertools";
+import { ensureNotServerSide } from "./lib/ssr";
 import { useInitial, useInitialUnlessFunction } from "./lib/use-initial";
 import { useLatest } from "./lib/use-latest";
 import { use } from "./lib/use-polyfill";
@@ -412,6 +413,7 @@ function useInboxNotificationsSuspense_withClient(client: OpaqueClient) {
   const store = getLiveblocksExtrasForClient(client).store;
 
   // Suspend until there are at least some inbox notifications
+  ensureNotOnServer();
   use(store.outputs.loadingNotifications.waitUntilLoaded());
 
   // We're in a Suspense world here, and as such, the useInboxNotifications()
@@ -433,6 +435,9 @@ function useUnreadInboxNotificationsCount_withClient(client: OpaqueClient) {
 function useUnreadInboxNotificationsCountSuspense_withClient(
   client: OpaqueClient
 ) {
+  // Throw error if we're calling this hook server side
+  ensureNotServerSide();
+
   const store = getLiveblocksExtrasForClient(client).store;
 
   // Suspend until there are at least some inbox notifications
@@ -979,6 +984,9 @@ function useUserThreads_experimental<M extends BaseMetadata>(
 function useUserThreadsSuspense_experimental<M extends BaseMetadata>(
   options: UseUserThreadsOptions<M> = {}
 ): ThreadsAsyncSuccess<M> {
+  // Throw error if we're calling this hook server side
+  ensureNotServerSide();
+
   const client = useClient();
   const { store } = getLiveblocksExtrasForClient<M>(client);
   const queryKey = makeUserThreadsQueryKey(options.query);

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -410,10 +410,12 @@ function useInboxNotifications_withClient<T>(
 }
 
 function useInboxNotificationsSuspense_withClient(client: OpaqueClient) {
+  // Throw error if we're calling this hook server side
+  ensureNotServerSide();
+
   const store = getLiveblocksExtrasForClient(client).store;
 
   // Suspend until there are at least some inbox notifications
-  ensureNotOnServer();
   use(store.outputs.loadingNotifications.waitUntilLoaded());
 
   // We're in a Suspense world here, and as such, the useInboxNotifications()

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -62,6 +62,7 @@ import {
 
 import { config } from "./config";
 import { RoomContext, useIsInsideRoom, useRoomOrNull } from "./contexts";
+import { ensureNotServerSide } from "./lib/ssr";
 import { useInitial } from "./lib/use-initial";
 import { useLatest } from "./lib/use-latest";
 import { use } from "./lib/use-polyfill";
@@ -2047,6 +2048,9 @@ function useRoomNotificationSettingsSuspense(): [
   RoomNotificationSettingsAsyncSuccess,
   (settings: Partial<RoomNotificationSettings>) => void,
 ] {
+  // Throw error if we're calling this hook server side
+  ensureNotServerSide();
+
   const client = useClient();
   const store = getRoomExtrasForClient(client).store;
   const room = useRoom();
@@ -2152,6 +2156,9 @@ function useHistoryVersions(): HistoryVersionsAsyncResult {
  * const { versions } = useHistoryVersions();
  */
 function useHistoryVersionsSuspense(): HistoryVersionsAsyncSuccess {
+  // Throw error if we're calling this hook server side
+  ensureNotServerSide();
+
   const client = useClient();
   const room = useRoom();
   const store = getRoomExtrasForClient(client).store;
@@ -2201,17 +2208,8 @@ function useUpdateRoomNotificationSettings() {
   );
 }
 
-function ensureNotServerSide(): void {
-  // Error early if suspense is used in a server-side context
-  if (typeof window === "undefined") {
-    throw new Error(
-      "You cannot use the Suspense version of this hook on the server side. Make sure to only call them on the client side.\nFor tips, see https://liveblocks.io/docs/api-reference/liveblocks-react#suspense-avoid-ssr"
-    );
-  }
-}
-
 function useSuspendUntilPresenceReady(): void {
-  // Throw an error if we're calling this on the server side
+  // Throw error if we're calling this hook server side
   ensureNotServerSide();
 
   const room = useRoom();
@@ -2297,7 +2295,7 @@ function useOtherSuspense<P extends JsonObject, U extends BaseUserMeta, T>(
 }
 
 function useSuspendUntilStorageReady(): void {
-  // Throw an error if we're calling this on the server side
+  // Throw error if we're calling this hook server side
   ensureNotServerSide();
 
   const room = useRoom();
@@ -2332,6 +2330,9 @@ function useStorageStatusSuspense(
 function useThreadsSuspense<M extends BaseMetadata>(
   options: UseThreadsOptions<M> = {}
 ): ThreadsAsyncSuccess<M> {
+  // Throw error if we're calling this hook server side
+  ensureNotServerSide();
+
   const client = useClient();
   const room = useRoom();
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -399,17 +399,12 @@ export class PaginatedResource {
     }
 
     // Wrap the request to load room threads (and notifications) in an auto-retry function so that if the request fails,
-    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error.
-    //
-    // We do not want to run this code on the server so if `window` is not defined, we return a resolved promise.
-    const initialPageFetch$ =
-      typeof window !== "undefined"
-        ? autoRetry(
-            () => this.#fetchPage(/* cursor */ undefined),
-            5,
-            [5000, 5000, 10000, 15000]
-          )
-        : Promise.resolve(null);
+    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error
+    const initialPageFetch$ = autoRetry(
+      () => this.#fetchPage(/* cursor */ undefined),
+      5,
+      [5000, 5000, 10000, 15000]
+    );
 
     const promise = usify(initialPageFetch$);
 
@@ -478,13 +473,12 @@ class SinglePageResource {
     }
 
     // Wrap the request to load room threads (and notifications) in an auto-retry function so that if the request fails,
-    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error.
-    //
-    // We do not want to run this code on the server so if `window` is not defined, we return a resolved promise.
-    const initialFetcher$ =
-      typeof window !== "undefined"
-        ? autoRetry(() => this.#fetchPage(), 5, [5000, 5000, 10000, 15000])
-        : Promise.resolve();
+    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error
+    const initialFetcher$ = autoRetry(
+      () => this.#fetchPage(),
+      5,
+      [5000, 5000, 10000, 15000]
+    );
 
     const promise = usify(initialFetcher$);
 

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -399,12 +399,17 @@ export class PaginatedResource {
     }
 
     // Wrap the request to load room threads (and notifications) in an auto-retry function so that if the request fails,
-    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error
-    const initialPageFetch$ = autoRetry(
-      () => this.#fetchPage(/* cursor */ undefined),
-      5,
-      [5000, 5000, 10000, 15000]
-    );
+    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error.
+    //
+    // We do not want to run this code on the server so if `window` is not defined, we return a resolved promise.
+    const initialPageFetch$ =
+      typeof window !== "undefined"
+        ? autoRetry(
+            () => this.#fetchPage(/* cursor */ undefined),
+            5,
+            [5000, 5000, 10000, 15000]
+          )
+        : Promise.resolve(null);
 
     const promise = usify(initialPageFetch$);
 
@@ -473,12 +478,13 @@ class SinglePageResource {
     }
 
     // Wrap the request to load room threads (and notifications) in an auto-retry function so that if the request fails,
-    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error
-    const initialFetcher$ = autoRetry(
-      () => this.#fetchPage(),
-      5,
-      [5000, 5000, 10000, 15000]
-    );
+    // we retry for at most 5 times with incremental backoff delays. If all retries fail, the auto-retry function throws an error.
+    //
+    // We do not want to run this code on the server so if `window` is not defined, we return a resolved promise.
+    const initialFetcher$ =
+      typeof window !== "undefined"
+        ? autoRetry(() => this.#fetchPage(), 5, [5000, 5000, 10000, 15000])
+        : Promise.resolve();
 
     const promise = usify(initialFetcher$);
 


### PR DESCRIPTION
~~This PR fixes an issue in the umbrella store to avoid to fetch on the server on first render.~~

~~This bug has been discovered during an example implementation when using suspense hooks where the error `To use Liveblocks client in a non-DOM environment with a url as auth endpoint, you need to provide a fetch polyfill.` was hit.~~

~~The fix is to return a resolved promise in `waitUntilLoaded` method of `PaginatedResource` and `SinglePageResource` where the `window` object is undefined. It will avoid to make any fetch on the server on first render when use with suspense hooks.~~


After re-thinking and finding a deep more the root cause. It was appearing it's in fact a matter of DX where some suspense hooks wasn't clearly explaining that they cannot be used without being wrapped in a `<ClientSideSuspense />`. 

The fix now ensures that every suspense hook aren't run on the server and update the error message.

Thanks 🙏🏻 