### PR TITLE
Split messages behind a flag before pushing through the websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 ### `@liveblocks/client`
 
-- Add unstable_splitMessagesIfNeeded option to split up messages if the max
-  message size is exceeded.
+- Add `unstable_largeMessageStrategy` flag (experimental) to allow specifying
+  the preferred strategy for dealing with messages that are too large to send
+  over WebSockets. There now is a choice between:
+
+  - `default` Just send anyway (although it will fail)
+  - `error` Error early in the client, don't attempt to send
+  - `fallback-to-http` Send the message over HTTP instead of WebSocket
+  - `split` Split the large message up into smaller chunks (this sacrifices
+    atomicity)
+
+- Deprecated the `unstable_fallbackToHTTP` experimental flag (please set
+  `unstable_largeMessageStrategy="fallback-to-http"` instead).
 
 ## v2.16.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/client`
+
+- Add unstable_splitMessagesIfNeeded option to split up messages if the max
+  message size is exceeded.
+
 ## v2.16.2
 
 ### `@liveblocks/react`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,27 @@
 
 ### `@liveblocks/client`
 
-- Add `unstable_largeMessageStrategy` flag (experimental) to allow specifying
+- Report a console error when a client attempts to send a WebSocket message that
+  is >1 MB (which is not supported). Previously the client would silently fail
+  in this scenario.
+
+- Added a new client config option `largeMessageStrategy` to allow specifying
   the preferred strategy for dealing with messages that are too large to send
   over WebSockets. There now is a choice between:
 
-  - `default` Just send anyway (although it will fail)
-  - `error` Error early in the client, don't attempt to send
-  - `fallback-to-http` Send the message over HTTP instead of WebSocket
-  - `split` Split the large message up into smaller chunks (this sacrifices
-    atomicity)
+  - `default` Don’t send anything, but log the error to the console
+  - `split` Split the large message up into smaller chunks (at the cost of
+    sacrificing atomicity)
+  - `experimental-fallback-to-http` Send the message over HTTP instead of
+    WebSocket
 
 - Deprecated the `unstable_fallbackToHTTP` experimental flag (please set
-  `unstable_largeMessageStrategy="fallback-to-http"` instead).
+  `largeMessageStrategy="experimental-fallback-to-http"` instead).
+
+### `@liveblocks/react`
+
+- Added `<LiveblocksProvider largeMessageStrategy="..." />` prop to
+  LiveblocksProvider. See above for possible options.
 
 ## v2.16.2
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -188,19 +188,17 @@ const client = createClient({
   </PropertiesListItem>
   <PropertiesListItem
     name="largeMessageStrategy"
-    detailedType='"default" | "error" | "experimental-fallback-to-http" | "split"'
+    detailedType='"default" | "split" | "experimental-fallback-to-http"'
     defaultValue={`"default"`}
   >
     <div className="-mb-3">
       How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of these values:
     </div>
 
-    - `"default"` Just try to send anyway.
-    - `"error"` Throw an error locally in the client and don't send.
-    - `"experimental-fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
-    - `"split"` Break the message up into chunks each of which is smaller than the maximum message
-    size. Note that this strategy will break atomic handling of client messages on the server, which
-    may or may not be a problem for your use case.
+    - `"default"` Don’t send anything, but log the error to the console.
+    - `"split"` Break the message up into chunks each of which is smaller than the maximum message size.
+      Beware that using `"split"` will sacrifice atomicity of changes! Depending on your use case, this may or may not be problematic.
+    - `"experimental-fallback-to-http"` Try sending the update over HTTP instead of WebSockets (experimental).
 
   </PropertiesListItem>
   <PropertiesListItem

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -189,13 +189,16 @@ const client = createClient({
   <PropertiesListItem
     name="unstable_largeMessageStrategy"
     detailedType='"default" | "error" | "fallback-to-http" | "split"'
+    defaultValue={`"default"`}
   >
-    Experimental. How to handle WebSocket messages that are larger than the maximum message size.
+    <div className="-mb-3">
+      Experimental. How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of four values:
+    </div>
 
-    **Default**: Just try to send anyway.<br />
-    **Error**: Throw an error locally in the client and don't send.<br />
-    **Fallback to HTTP**: Try sending the update over HTTP instead of WebSockets.<br />
-    **Split**: Break the message up into chunks each of which is smaller than the maximum message
+    - `"default"` Just try to send anyway.
+    - `"error"` Throw an error locally in the client and don't send.
+    - `"fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
+    - `"split"` Break the message up into chunks each of which is smaller than the maximum message
     size. Note that this strategy will break atomic handling of client messages on the server, which
     may or may not be a problem for your use case.
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -187,12 +187,18 @@ const client = createClient({
     or [React Native](#createClientReactNative).
   </PropertiesListItem>
   <PropertiesListItem
-    name="unstable_fallbackToHTTP"
-    type="boolean"
-    defaultValue="false"
+    name="unstable_largeMessageStrategy"
+    detailedType='"default" | "error" | "fallback-to-http" | "split"'
   >
-    Experimental. Automatically fall back to HTTP when a message is too large
-    for WebSockets.
+    Experimental. How to handle WebSocket messages that are larger than the maximum message size.
+
+    **Default**: Just try to send anyway.<br />
+    **Error**: Throw an error locally in the client and don't send.<br />
+    **Fallback to HTTP**: Try sending the update over HTTP instead of WebSockets.<br />
+    **Split**: Break the message up into chunks each of which is smaller than the maximum message
+    size. Note that this strategy will break atomic handling of client messages on the server, which
+    may or may not be a problem for your use case.
+
   </PropertiesListItem>
   <PropertiesListItem
     name="unstable_streamData"
@@ -201,13 +207,6 @@ const client = createClient({
   >
     Experimental. Stream the initial Storage content over HTTP, instead of
     waiting for a large initial WebSocket message to be sent from the server.
-  </PropertiesListItem>
-  <PropertiesListItem
-    name="unstable_splitMessagesIfNeeded"
-    type="boolean"
-    defaultValue="false"
-  >
-    Experimental. Split up messages if the max message size is exceeded.
   </PropertiesListItem>
 </PropertiesList>
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -187,17 +187,17 @@ const client = createClient({
     or [React Native](#createClientReactNative).
   </PropertiesListItem>
   <PropertiesListItem
-    name="unstable_largeMessageStrategy"
-    detailedType='"default" | "error" | "fallback-to-http" | "split"'
+    name="largeMessageStrategy"
+    detailedType='"default" | "error" | "experimental-fallback-to-http" | "split"'
     defaultValue={`"default"`}
   >
     <div className="-mb-3">
-      Experimental. How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of four values:
+      How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of these values:
     </div>
 
     - `"default"` Just try to send anyway.
     - `"error"` Throw an error locally in the client and don't send.
-    - `"fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
+    - `"experimental-fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
     - `"split"` Break the message up into chunks each of which is smaller than the maximum message
     size. Note that this strategy will break atomic handling of client messages on the server, which
     may or may not be a problem for your use case.

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -202,6 +202,13 @@ const client = createClient({
     Experimental. Stream the initial Storage content over HTTP, instead of
     waiting for a large initial WebSocket message to be sent from the server.
   </PropertiesListItem>
+  <PropertiesListItem
+    name="unstable_splitMessagesIfNeeded"
+    type="boolean"
+    defaultValue="false"
+  >
+    Experimental. Split up messages if the max message size is exceeded.
+  </PropertiesListItem>
 </PropertiesList>
 
 ### createClient with public key [#createClientPublicKey]

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -390,13 +390,16 @@ function App() {
   <PropertiesListItem
     name="unstable_largeMessageStrategy"
     detailedType='"default" | "error" | "fallback-to-http" | "split"'
+    defaultValue={`"default"`}
   >
-    Experimental. How to handle WebSocket messages that are larger than the maximum message size.
+    <div className="-mb-3">
+      Experimental. How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of four values:
+    </div>
 
-    **Default**: Just try to send anyway.<br />
-    **Error**: Throw an error locally in the client and don't send.<br />
-    **Fallback to HTTP**: Try sending the update over HTTP instead of WebSockets.<br />
-    **Split**: Break the message up into chunks each of which is smaller than the maximum message
+    - `"default"` Just try to send anyway.
+    - `"error"` Throw an error locally in the client and don't send.
+    - `"fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
+    - `"split"` Break the message up into chunks each of which is smaller than the maximum message
     size. Note that this strategy will break atomic handling of client messages on the server, which
     may or may not be a problem for your use case.
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -389,19 +389,17 @@ function App() {
   </PropertiesListItem>
   <PropertiesListItem
     name="largeMessageStrategy"
-    detailedType='"default" | "error" | "experimental-fallback-to-http" | "split"'
+    detailedType='"default" | "split" | "experimental-fallback-to-http"'
     defaultValue={`"default"`}
   >
     <div className="-mb-3">
       How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of these values:
     </div>
 
-    - `"default"` Just try to send anyway.
-    - `"error"` Throw an error locally in the client and don't send.
-    - `"experimental-fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
-    - `"split"` Break the message up into chunks each of which is smaller than the maximum message
-    size. Note that this strategy will break atomic handling of client messages on the server, which
-    may or may not be a problem for your use case.
+    - `"default"` Don’t send anything, but log the error to the console.
+    - `"split"` Break the message up into chunks each of which is smaller than the maximum message size.
+      Beware that using `"split"` will sacrifice atomicity of changes! Depending on your use case, this may or may not be problematic.
+    - `"experimental-fallback-to-http"` Try sending the update over HTTP instead of WebSockets (experimental).
 
   </PropertiesListItem>
   <PropertiesListItem

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -388,12 +388,18 @@ function App() {
     Native](#LiveblocksProviderReactNative).
   </PropertiesListItem>
   <PropertiesListItem
-    name="unstable_fallbackToHTTP"
-    type="boolean"
-    defaultValue="false"
+    name="unstable_largeMessageStrategy"
+    detailedType='"default" | "error" | "fallback-to-http" | "split"'
   >
-    Experimental. Automatically fall back to HTTP when a message is too large
-    for WebSockets.
+    Experimental. How to handle WebSocket messages that are larger than the maximum message size.
+
+    **Default**: Just try to send anyway.<br />
+    **Error**: Throw an error locally in the client and don't send.<br />
+    **Fallback to HTTP**: Try sending the update over HTTP instead of WebSockets.<br />
+    **Split**: Break the message up into chunks each of which is smaller than the maximum message
+    size. Note that this strategy will break atomic handling of client messages on the server, which
+    may or may not be a problem for your use case.
+
   </PropertiesListItem>
   <PropertiesListItem
     name="unstable_streamData"
@@ -402,13 +408,6 @@ function App() {
   >
     Experimental. Stream the initial Storage content over HTTP, instead of
     waiting for a large initial WebSocket message to be sent from the server.
-  </PropertiesListItem>
-  <PropertiesListItem
-    name="unstable_splitMessagesIfNeeded"
-    type="boolean"
-    defaultValue="false"
-  >
-    Experimental. Split up messages if the max message size is exceeded.
   </PropertiesListItem>
 </PropertiesList>
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -403,6 +403,13 @@ function App() {
     Experimental. Stream the initial Storage content over HTTP, instead of
     waiting for a large initial WebSocket message to be sent from the server.
   </PropertiesListItem>
+  <PropertiesListItem
+    name="unstable_splitMessagesIfNeeded"
+    type="boolean"
+    defaultValue="false"
+  >
+    Experimental. Split up messages if the max message size is exceeded.
+  </PropertiesListItem>
 </PropertiesList>
 
 #### LiveblocksProvider with public key [#LiveblocksProviderPublicKey]

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -388,17 +388,17 @@ function App() {
     Native](#LiveblocksProviderReactNative).
   </PropertiesListItem>
   <PropertiesListItem
-    name="unstable_largeMessageStrategy"
-    detailedType='"default" | "error" | "fallback-to-http" | "split"'
+    name="largeMessageStrategy"
+    detailedType='"default" | "error" | "experimental-fallback-to-http" | "split"'
     defaultValue={`"default"`}
   >
     <div className="-mb-3">
-      Experimental. How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of four values:
+      How to handle WebSocket messages that are larger than the maximum message size. Can be set to one of these values:
     </div>
 
     - `"default"` Just try to send anyway.
     - `"error"` Throw an error locally in the client and don't send.
-    - `"fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
+    - `"experimental-fallback-to-http"` Try sending the update over HTTP instead of WebSockets.
     - `"split"` Break the message up into chunks each of which is smaller than the maximum message
     size. Note that this strategy will break atomic handling of client messages on the server, which
     may or may not be a problem for your use case.

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -38,6 +38,7 @@ export type {
   JsonArray,
   JsonObject,
   JsonScalar,
+  LargeMessageStrategy,
   LiveblocksErrorContext,
   LiveListUpdate,
   LiveMapUpdate,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -30,6 +30,7 @@ import type {
   InboxNotificationDeleteInfo,
 } from "./protocol/InboxNotifications";
 import type {
+  LargeMessageStrategy,
   OpaqueRoom,
   OptionalTupleUnless,
   PartialUnless,
@@ -403,9 +404,10 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
   lostConnectionTimeout?: number; // in milliseconds
   backgroundKeepAliveTimeout?: number; // in milliseconds
   polyfills?: Polyfills;
+  unstable_largeMessageStrategy?: LargeMessageStrategy;
+  /** @deprecated Use `unstable_largeMessageStrategy="fallback-to-http"` instead. */
   unstable_fallbackToHTTP?: boolean;
   unstable_streamData?: boolean;
-  unstable_splitMessagesIfNeeded?: boolean;
   /**
    * A function that returns a list of user IDs matching a string.
    */
@@ -614,10 +616,12 @@ export function createClient<U extends BaseUserMeta = DU>(
         enableDebugLogging: clientOptions.enableDebugLogging,
         baseUrl,
         errorEventSource: liveblocksErrorSource,
-        unstable_fallbackToHTTP: !!clientOptions.unstable_fallbackToHTTP,
+        unstable_largeMessageStrategy:
+          clientOptions.unstable_largeMessageStrategy ??
+          (clientOptions.unstable_fallbackToHTTP
+            ? "fallback-to-http"
+            : undefined),
         unstable_streamData: !!clientOptions.unstable_streamData,
-        unstable_splitMessagesIfNeeded:
-          !!clientOptions.unstable_splitMessagesIfNeeded,
         roomHttpClient: httpClient as LiveblocksHttpApi<M>,
         createSyncSource,
       }

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -404,8 +404,8 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
   lostConnectionTimeout?: number; // in milliseconds
   backgroundKeepAliveTimeout?: number; // in milliseconds
   polyfills?: Polyfills;
-  unstable_largeMessageStrategy?: LargeMessageStrategy;
-  /** @deprecated Use `unstable_largeMessageStrategy="fallback-to-http"` instead. */
+  largeMessageStrategy?: LargeMessageStrategy;
+  /** @deprecated Use `largeMessageStrategy="experimental-fallback-to-http"` instead. */
   unstable_fallbackToHTTP?: boolean;
   unstable_streamData?: boolean;
   /**
@@ -616,10 +616,10 @@ export function createClient<U extends BaseUserMeta = DU>(
         enableDebugLogging: clientOptions.enableDebugLogging,
         baseUrl,
         errorEventSource: liveblocksErrorSource,
-        unstable_largeMessageStrategy:
-          clientOptions.unstable_largeMessageStrategy ??
+        largeMessageStrategy:
+          clientOptions.largeMessageStrategy ??
           (clientOptions.unstable_fallbackToHTTP
-            ? "fallback-to-http"
+            ? "experimental-fallback-to-http"
             : undefined),
         unstable_streamData: !!clientOptions.unstable_streamData,
         roomHttpClient: httpClient as LiveblocksHttpApi<M>,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -405,7 +405,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
   polyfills?: Polyfills;
   unstable_fallbackToHTTP?: boolean;
   unstable_streamData?: boolean;
-
+  unstable_splitMessagesIfNeeded?: boolean;
   /**
    * A function that returns a list of user IDs matching a string.
    */
@@ -616,6 +616,8 @@ export function createClient<U extends BaseUserMeta = DU>(
         errorEventSource: liveblocksErrorSource,
         unstable_fallbackToHTTP: !!clientOptions.unstable_fallbackToHTTP,
         unstable_streamData: !!clientOptions.unstable_streamData,
+        unstable_splitMessagesIfNeeded:
+          !!clientOptions.unstable_splitMessagesIfNeeded,
         roomHttpClient: httpClient as LiveblocksHttpApi<M>,
         createSyncSource,
       }

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -249,7 +249,12 @@ export type {
 } from "./protocol/ServerMsg";
 export { ServerMsgCode } from "./protocol/ServerMsg";
 export type { HistoryVersion } from "./protocol/VersionHistory";
-export type { IYjsProvider, PrivateRoomApi, YjsSyncStatus } from "./room";
+export type {
+  IYjsProvider,
+  LargeMessageStrategy,
+  PrivateRoomApi,
+  YjsSyncStatus,
+} from "./room";
 export type {
   BroadcastOptions,
   History,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1070,7 +1070,7 @@ export type PrivateRoomApi = {
 //                         still larger than 1 MB, falls back to "error" strategy.
 //
 // In practice, we'll set threshold to slightly less than 1 MB.
-const MAX_SOCKET_MESSAGE_SIZE = 1024 * 1024 - 1024;
+const MAX_SOCKET_MESSAGE_SIZE = 1024 * 1024 - 512;
 
 function makeIdFactory(connectionId: number): IdFactory {
   let count = 0;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1638,7 +1638,7 @@ export function createRoom<
 
     for (const halfOps of [firstHalf, secondHalf]) {
       const half: UpdateStorageClientMsg = { ops: halfOps, ...rest };
-      const text = JSON.stringify(half);
+      const text = JSON.stringify([half]);
       if (!isTooBigForWebSocket(text)) {
         yield text;
       } else {
@@ -1658,6 +1658,7 @@ export function createRoom<
     if (messages.length < 2) {
       if (messages[0].type === ClientMsgCode.UPDATE_STORAGE) {
         yield* chunkOps(messages[0]);
+        return;
       } else {
         throw new Error(
           "Cannot split into chunks smaller than the allowed message size"
@@ -1689,7 +1690,7 @@ export function createRoom<
     }
 
     // Otherwise we need to measure to be sure
-    return new TextEncoder().encode(text).length < MAX_SOCKET_MESSAGE_SIZE;
+    return new TextEncoder().encode(text).length >= MAX_SOCKET_MESSAGE_SIZE;
   }
 
   function sendMessages(messages: ClientMsg<P, E>[]) {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1221,7 +1221,7 @@ export type RoomDelegates = Omit<Delegates<AuthValue>, "canZombie">;
 export type LargeMessageStrategy =
   | "default"
   | "error"
-  | "fallback-to-http"
+  | "experimental-fallback-to-http"
   | "split";
 
 /** @internal */
@@ -1232,8 +1232,8 @@ export type RoomConfig<M extends BaseMetadata> = {
   throttleDelay: number;
   lostConnectionTimeout: number;
   backgroundKeepAliveTimeout?: number;
+  largeMessageStrategy?: LargeMessageStrategy;
 
-  unstable_largeMessageStrategy?: LargeMessageStrategy;
   unstable_streamData?: boolean;
 
   polyfills?: Polyfills;
@@ -1694,7 +1694,7 @@ export function createRoom<
   }
 
   function sendMessages(messages: ClientMsg<P, E>[]) {
-    const strategy = config.unstable_largeMessageStrategy ?? "default";
+    const strategy = config.largeMessageStrategy ?? "default";
 
     const text = JSON.stringify(messages);
     const isTooBig = strategy !== "default" && isTooBigForWebSocket(text);
@@ -1708,7 +1708,7 @@ export function createRoom<
       case "error":
         throw new Error("Message is too large for websockets");
 
-      case "fallback-to-http": {
+      case "experimental-fallback-to-http": {
         console.warn(
           "Message is too large for websockets, so sending over HTTP instead"
         );

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -871,7 +871,7 @@ export function LiveblocksProvider<U extends BaseUserMeta = DU>(
     lostConnectionTimeout: useInitial(o.lostConnectionTimeout),
     backgroundKeepAliveTimeout: useInitial(o.backgroundKeepAliveTimeout),
     polyfills: useInitial(o.polyfills),
-    unstable_largeMessageStrategy: useInitial(o.unstable_largeMessageStrategy),
+    largeMessageStrategy: useInitial(o.largeMessageStrategy),
     unstable_fallbackToHTTP: useInitial(o.unstable_fallbackToHTTP),
     unstable_streamData: useInitial(o.unstable_streamData),
     preventUnsavedChanges: useInitial(o.preventUnsavedChanges),

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -871,11 +871,9 @@ export function LiveblocksProvider<U extends BaseUserMeta = DU>(
     lostConnectionTimeout: useInitial(o.lostConnectionTimeout),
     backgroundKeepAliveTimeout: useInitial(o.backgroundKeepAliveTimeout),
     polyfills: useInitial(o.polyfills),
+    unstable_largeMessageStrategy: useInitial(o.unstable_largeMessageStrategy),
     unstable_fallbackToHTTP: useInitial(o.unstable_fallbackToHTTP),
     unstable_streamData: useInitial(o.unstable_streamData),
-    unstable_splitMessagesIfNeeded: useInitial(
-      o.unstable_splitMessagesIfNeeded
-    ),
     preventUnsavedChanges: useInitial(o.preventUnsavedChanges),
 
     authEndpoint: useInitialUnlessFunction(o.authEndpoint),

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -873,6 +873,9 @@ export function LiveblocksProvider<U extends BaseUserMeta = DU>(
     polyfills: useInitial(o.polyfills),
     unstable_fallbackToHTTP: useInitial(o.unstable_fallbackToHTTP),
     unstable_streamData: useInitial(o.unstable_streamData),
+    unstable_splitMessagesIfNeeded: useInitial(
+      o.unstable_splitMessagesIfNeeded
+    ),
     preventUnsavedChanges: useInitial(o.preventUnsavedChanges),
 
     authEndpoint: useInitialUnlessFunction(o.authEndpoint),


### PR DESCRIPTION
### Adding a feature

Discussion here: https://discord.com/channels/913109211746009108/1334247484998025389/1334247484998025389

- [ ] e2e tests added
- [ ]  Documentation added

#### How to test it

Add the unstable_splitMessagesIfNeeded: true option to the config and send several messages synchronously which have a combined size > 1MB