### PR TITLE
Rename `OptionalPromise<T>` → `Awaitable<T>`

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -5,6 +5,7 @@ import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
 detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export type {
+  Awaitable,
   BaseActivitiesData,
   BaseMetadata,
   BaseUserMeta,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -44,9 +44,9 @@ import {
   makeAuthDelegateForRoom,
   makeCreateSocketDelegateForRoom,
 } from "./room";
+import type { Awaitable } from "./types/Awaitable";
 import type { LiveblocksErrorContext } from "./types/LiveblocksError";
 import { LiveblocksError } from "./types/LiveblocksError";
-import type { OptionalPromise } from "./types/OptionalPromise";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1_000;
@@ -413,7 +413,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
    */
   resolveMentionSuggestions?: (
     args: ResolveMentionSuggestionsArgs
-  ) => OptionalPromise<string[]>;
+  ) => Awaitable<string[]>;
 
   /**
    * A function that returns user info from user IDs.
@@ -421,7 +421,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 
   /**
    * A function that returns room info from room IDs.
@@ -429,7 +429,7 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
    */
   resolveRoomsInfo?: (
     args: ResolveRoomsInfoArgs
-  ) => OptionalPromise<(DRI | undefined)[] | undefined>;
+  ) => Awaitable<(DRI | undefined)[] | undefined>;
 
   /**
    * Prevent the current browser tab from being closed if there are any locally

--- a/packages/liveblocks-core/src/comments/comment-body.ts
+++ b/packages/liveblocks-core/src/comments/comment-body.ts
@@ -12,7 +12,7 @@ import type {
   CommentBodyParagraph,
   CommentBodyText,
 } from "../protocol/Comments";
-import type { OptionalPromise } from "../types/OptionalPromise";
+import type { Awaitable } from "../types/Awaitable";
 
 type CommentBodyBlockElementName = Exclude<
   CommentBodyBlockElement,
@@ -131,7 +131,7 @@ export type StringifyCommentBodyOptions<U extends BaseUserMeta = DU> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 };
 
 export function isCommentBodyParagraph(
@@ -238,7 +238,7 @@ export async function resolveUsersInCommentBody<U extends BaseUserMeta>(
   body: CommentBody,
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>
 ): Promise<Map<string, U["info"]>> {
   const resolvedUsers = new Map<string, U["info"]>();
 

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -267,6 +267,7 @@ export type {
   SyncSource,
 } from "./room";
 export type { GetThreadsOptions, UploadAttachmentOptions } from "./room";
+export type { Awaitable } from "./types/Awaitable";
 export type { Immutable } from "./types/Immutable";
 export type {
   IWebSocket,
@@ -279,7 +280,6 @@ export { WebsocketCloseCodes } from "./types/IWebSocket";
 export type { LiveblocksErrorContext } from "./types/LiveblocksError";
 export { LiveblocksError } from "./types/LiveblocksError";
 export type { NodeMap, ParentToChildNodeMap } from "./types/NodeMap";
-export type { OptionalPromise } from "./types/OptionalPromise";
 export type { OthersEvent } from "./types/Others";
 export { TextEditorType } from "./types/Others";
 export type { Patchable } from "./types/Patchable";

--- a/packages/liveblocks-core/src/types/Awaitable.ts
+++ b/packages/liveblocks-core/src/types/Awaitable.ts
@@ -1,0 +1,2 @@
+// See https://stackoverflow.com/a/56129545/148872
+export type Awaitable<T> = T | PromiseLike<T>;

--- a/packages/liveblocks-core/src/types/OptionalPromise.ts
+++ b/packages/liveblocks-core/src/types/OptionalPromise.ts
@@ -1,1 +1,0 @@
-export type OptionalPromise<T> = T | Promise<T>;

--- a/packages/liveblocks-emails/src/__tests__/_helpers.ts
+++ b/packages/liveblocks-emails/src/__tests__/_helpers.ts
@@ -1,4 +1,5 @@
 import type {
+  Awaitable,
   BaseUserMeta,
   CommentBody,
   CommentData,
@@ -8,7 +9,6 @@ import type {
   InboxNotificationTextMentionData,
   InboxNotificationThreadData,
   IUserInfo,
-  OptionalPromise,
   ResolveUsersArgs,
   ThreadData,
 } from "@liveblocks/core";
@@ -275,9 +275,7 @@ export const makeThreadNotificationEvent = ({
 
 export const resolveUsers = <U extends BaseUserMeta = DU>({
   userIds,
-}: ResolveUsersArgs): OptionalPromise<
-  (U["info"] | undefined)[] | undefined
-> => {
+}: ResolveUsersArgs): Awaitable<(U["info"] | undefined)[] | undefined> => {
   const users: (U["info"] | undefined)[] = [];
 
   for (const userId of userIds) {
@@ -296,7 +294,7 @@ export const RESOLVED_ROOM_INFO_TEST: DRI = {
 };
 export const getResolvedCommentUrl = (commentId: string): string =>
   `https://resend.com/#${commentId}`;
-export const resolveRoomInfo = (): OptionalPromise<DRI | undefined> => {
+export const resolveRoomInfo = (): Awaitable<DRI | undefined> => {
   return RESOLVED_ROOM_INFO_TEST;
 };
 

--- a/packages/liveblocks-emails/src/comment-body.tsx
+++ b/packages/liveblocks-emails/src/comment-body.tsx
@@ -1,11 +1,11 @@
 import type {
+  Awaitable,
   BaseUserMeta,
   CommentBody,
   CommentBodyLink,
   CommentBodyMention,
   CommentBodyText,
   DU,
-  OptionalPromise,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 import {
@@ -147,7 +147,7 @@ export type ConvertCommentBodyAsReactOptions<U extends BaseUserMeta = DU> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 };
 
 /**
@@ -281,7 +281,7 @@ export type ConvertCommentBodyAsHtmlOptions<U extends BaseUserMeta = DU> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 };
 
 /**

--- a/packages/liveblocks-emails/src/lib/__tests__/batch-users-resolver.test.ts
+++ b/packages/liveblocks-emails/src/lib/__tests__/batch-users-resolver.test.ts
@@ -1,8 +1,8 @@
 import type {
+  Awaitable,
   BaseUserMeta,
   DU,
   IUserInfo,
-  OptionalPromise,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 
@@ -33,7 +33,7 @@ describe("batch users resolve", () => {
     resolveUsersMock = jest.fn(
       <U extends BaseUserMeta = DU>({
         userIds,
-      }: ResolveUsersArgs): OptionalPromise<
+      }: ResolveUsersArgs): Awaitable<
         (U["info"] | undefined)[] | undefined
       > => {
         const users: (U["info"] | undefined)[] = [];

--- a/packages/liveblocks-emails/src/lib/authors.ts
+++ b/packages/liveblocks-emails/src/lib/authors.ts
@@ -1,6 +1,6 @@
 import type {
+  Awaitable,
   BaseUserMeta,
-  OptionalPromise,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 
@@ -12,7 +12,7 @@ export const resolveAuthorsInfo = async <U extends BaseUserMeta>({
   userIds: string[];
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 }): Promise<Map<string, U["info"]>> => {
   const resolvedUsers = new Map<string, U["info"]>();
   if (!resolveUsers) {

--- a/packages/liveblocks-emails/src/lib/batch-users-resolver.ts
+++ b/packages/liveblocks-emails/src/lib/batch-users-resolver.ts
@@ -1,7 +1,7 @@
 import type {
+  Awaitable,
   BaseUserMeta,
   DU,
-  OptionalPromise,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 import { Promise_withResolvers } from "@liveblocks/core";
@@ -10,7 +10,7 @@ import { createDevelopmentWarning } from "./warning";
 
 type ResolveUserOptionalPromise<U extends BaseUserMeta> = (
   args: ResolveUsersArgs
-) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+) => Awaitable<(U["info"] | undefined)[] | undefined>;
 
 /**
  * Batch calls to `resolveUsers` to one and only call.
@@ -99,7 +99,7 @@ export function createBatchUsersResolver<U extends BaseUserMeta = DU>({
 }: {
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
   callerName: string;
 }): CreateBatchUsersResolverReturnType<U> {
   const warnIfNoResolveUsers = createDevelopmentWarning(

--- a/packages/liveblocks-emails/src/liveblocks-text-editor.tsx
+++ b/packages/liveblocks-emails/src/liveblocks-text-editor.tsx
@@ -5,14 +5,13 @@
  * and then convert them more easily as React or as html.
  */
 
-import {
-  type BaseUserMeta,
-  type DU,
-  html,
-  htmlSafe,
-  type OptionalPromise,
-  type ResolveUsersArgs,
+import type {
+  Awaitable,
+  BaseUserMeta,
+  DU,
+  ResolveUsersArgs,
 } from "@liveblocks/core";
+import { html, htmlSafe } from "@liveblocks/core";
 import type { ComponentType, ReactNode } from "react";
 
 import type {
@@ -278,7 +277,7 @@ const resolveUsersInLiveblocksTextEditorNodes = async <U extends BaseUserMeta>(
   nodes: LiveblocksTextEditorNode[],
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>
 ): Promise<Map<string, U["info"]>> => {
   const resolvedUsers = new Map<string, U["info"]>();
   if (!resolveUsers) {
@@ -396,7 +395,7 @@ export type ConvertTextEditorNodesAsReactOptions<U extends BaseUserMeta = DU> =
      */
     resolveUsers?: (
       args: ResolveUsersArgs
-    ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+    ) => Awaitable<(U["info"] | undefined)[] | undefined>;
   };
 
 /**
@@ -493,7 +492,7 @@ export type ConvertTextEditorNodesAsHtmlOptions<U extends BaseUserMeta = DU> = {
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 };
 
 /**

--- a/packages/liveblocks-emails/src/text-mention-notification.tsx
+++ b/packages/liveblocks-emails/src/text-mention-notification.tsx
@@ -1,8 +1,8 @@
 import type {
+  Awaitable,
   BaseUserMeta,
   DRI,
   DU,
-  OptionalPromise,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 import type {
@@ -163,9 +163,7 @@ type PrepareTextMentionNotificationEmailBaseDataOptions = {
   /**
    * A function that returns room info from room IDs.
    */
-  resolveRoomInfo?: (
-    args: ResolveRoomInfoArgs
-  ) => OptionalPromise<DRI | undefined>;
+  resolveRoomInfo?: (args: ResolveRoomInfoArgs) => Awaitable<DRI | undefined>;
 };
 
 export type TextMentionNotificationEmailBaseData = {
@@ -253,7 +251,7 @@ export type PrepareTextMentionNotificationEmailAsReactOptions<
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 
   /**
    * The components used to customize the resulting React nodes. Each components has
@@ -364,7 +362,7 @@ export type PrepareTextMentionNotificationEmailAsHtmlOptions<
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
 
   /**
    * The styles used to customize the html elements in the resulting html safe string.

--- a/packages/liveblocks-emails/src/thread-notification.tsx
+++ b/packages/liveblocks-emails/src/thread-notification.tsx
@@ -1,4 +1,5 @@
 import type {
+  Awaitable,
   BaseRoomInfo,
   BaseUserMeta,
   CommentBody,
@@ -6,7 +7,6 @@ import type {
   DRI,
   DU,
   InboxNotificationData,
-  OptionalPromise,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 import {
@@ -127,9 +127,7 @@ type PrepareThreadNotificationEmailBaseDataOptions = {
   /**
    * A function that returns room info from room IDs.
    */
-  resolveRoomInfo?: (
-    args: ResolveRoomInfoArgs
-  ) => OptionalPromise<DRI | undefined>;
+  resolveRoomInfo?: (args: ResolveRoomInfoArgs) => Awaitable<DRI | undefined>;
 };
 
 export type ThreadNotificationEmailBaseData = (
@@ -259,7 +257,7 @@ export type PrepareThreadNotificationEmailAsHtmlOptions<
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
   /**
    * The styles used to customize the html elements in the resulting html safe string inside a comment body.
    * Each styles has priority over the base styles inherited.
@@ -410,7 +408,7 @@ export type PrepareThreadNotificationEmailAsReactOptions<
    */
   resolveUsers?: (
     args: ResolveUsersArgs
-  ) => OptionalPromise<(U["info"] | undefined)[] | undefined>;
+  ) => Awaitable<(U["info"] | undefined)[] | undefined>;
   /**
    * The components used to customize the resulting React nodes inside a comment body.
    * Each components has priority over the base components inherited internally defined.


### PR DESCRIPTION
Renames our internal helper type `OptionalPromise<T>` to `Awaitable<T>`. I wanted to add this type only to realize we already had this. I've seen the name `Awaitable` used in many other libraries too, it seems to be the more common name in the community for this type — also, see [this SO answer](https://stackoverflow.com/a/56129545/148872).

Also avoids reading `OptionalPromise<T>` as meaning `Promise<T> | undefined`.
