### PR TITLE
Mention node

### DIFF
--- a/packages/liveblocks-react-tiptap/src/index.ts
+++ b/packages/liveblocks-react-tiptap/src/index.ts
@@ -15,6 +15,8 @@ export type { FloatingThreadsProps } from "./comments/FloatingThreads";
 export { FloatingThreads } from "./comments/FloatingThreads";
 export { useLiveblocksExtension } from "./LiveblocksExtension";
 export { useIsEditorReady } from "./LiveblocksExtension";
+export { MentionExtension } from "./mentions/MentionExtension";
+export { MentionNode } from "./mentions/MentionNode";
 export type { FloatingToolbarProps } from "./toolbar/FloatingToolbar";
 export { FloatingToolbar } from "./toolbar/FloatingToolbar";
 export type {

--- a/packages/liveblocks-react-tiptap/src/mentions/MentionExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/mentions/MentionExtension.ts
@@ -19,6 +19,7 @@ import {
   LIVEBLOCKS_MENTION_TYPE,
 } from "../types";
 import { getMentionsFromNode, mapFragment } from "../utils";
+import { MentionNode } from "./MentionNode";
 import type { MentionsListHandle, MentionsListProps } from "./MentionsList";
 import { MentionsList } from "./MentionsList";
 
@@ -118,6 +119,10 @@ export const MentionExtension = Extension.create<MentionExtensionOptions>({
       onCreateMention: () => {},
       onDeleteMention: () => {},
     };
+  },
+
+  addExtensions() {
+    return [MentionNode];
   },
 
   addProseMirrorPlugins() {

--- a/packages/liveblocks-react-tiptap/src/mentions/MentionExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/mentions/MentionExtension.ts
@@ -1,25 +1,24 @@
 import { createInboxNotificationId } from "@liveblocks/core";
 import {
   combineTransactionSteps,
+  Extension,
   getChangedRanges,
-  mergeAttributes,
-  Node,
 } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Slice } from "@tiptap/pm/model";
 import { Plugin } from "@tiptap/pm/state";
-import { ReactNodeViewRenderer, ReactRenderer } from "@tiptap/react";
+import { ReactRenderer } from "@tiptap/react";
 import Suggestion from "@tiptap/suggestion";
 import { ySyncPluginKey } from "y-prosemirror";
 
 import {
+  LIVEBLOCKS_MENTION_EXTENSION,
   LIVEBLOCKS_MENTION_KEY,
   LIVEBLOCKS_MENTION_NOTIFIER_KEY,
   LIVEBLOCKS_MENTION_PASTE_KEY,
   LIVEBLOCKS_MENTION_TYPE,
 } from "../types";
 import { getMentionsFromNode, mapFragment } from "../utils";
-import { Mention } from "./Mention";
 import type { MentionsListHandle, MentionsListProps } from "./MentionsList";
 import { MentionsList } from "./MentionsList";
 
@@ -110,86 +109,10 @@ const notifier = ({
   });
 };
 
-export const MentionExtension = Node.create<MentionExtensionOptions>({
-  name: LIVEBLOCKS_MENTION_TYPE,
-  group: "inline",
-  inline: true,
-  selectable: true,
-  atom: true,
+export const MentionExtension = Extension.create<MentionExtensionOptions>({
+  name: LIVEBLOCKS_MENTION_EXTENSION,
 
   priority: 101,
-  parseHTML() {
-    return [
-      {
-        tag: "liveblocks-mention",
-      },
-    ];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return ["liveblocks-mention", mergeAttributes(HTMLAttributes)];
-  },
-
-  addNodeView() {
-    return ReactNodeViewRenderer(Mention, {
-      contentDOMElementTag: "span",
-    });
-  },
-
-  addAttributes() {
-    return {
-      id: {
-        default: null,
-        parseHTML: (element) => element.getAttribute("data-id"),
-        renderHTML: (attributes) => {
-          if (!attributes.id) {
-            return {};
-          }
-
-          return {
-            "data-id": attributes.id as string, // "as" typing because TipTap doesn't have a way to type attributes
-          };
-        },
-      },
-      notificationId: {
-        default: null,
-        parseHTML: (element) => element.getAttribute("data-notification-id"),
-        renderHTML: (attributes) => {
-          if (!attributes.notificationId) {
-            return {};
-          }
-
-          return {
-            "data-notification-id": attributes.notificationId as string, // "as" typing because TipTap doesn't have a way to type attributes
-          };
-        },
-      },
-    };
-  },
-  addKeyboardShortcuts() {
-    return {
-      Backspace: () =>
-        this.editor.commands.command(({ tr, state }) => {
-          let isMention = false;
-          const { selection } = state;
-          const { empty, anchor } = selection;
-
-          if (!empty) {
-            return false;
-          }
-
-          state.doc.nodesBetween(anchor - 1, anchor, (node, pos) => {
-            if (node.type.name === this.name) {
-              isMention = true;
-              tr.insertText("", pos, pos + node.nodeSize);
-            }
-          });
-
-          return isMention;
-        }),
-    };
-  },
-
   addOptions() {
     return {
       onCreateMention: () => {},
@@ -218,7 +141,7 @@ export const MentionExtension = Node.create<MentionExtensionOptions>({
             .focus()
             .insertContentAt(range, [
               {
-                type: this.name,
+                type: LIVEBLOCKS_MENTION_TYPE,
                 attrs: props as Record<string, string>,
               },
               {
@@ -235,7 +158,7 @@ export const MentionExtension = Node.create<MentionExtensionOptions>({
         },
         allow: ({ state, range }) => {
           const $from = state.doc.resolve(range.from);
-          const type = state.schema.nodes[this.name];
+          const type = state.schema.nodes[LIVEBLOCKS_MENTION_TYPE];
           const allow = !!$from.parent.type.contentMatch.matchType(type);
 
           return allow;

--- a/packages/liveblocks-react-tiptap/src/mentions/MentionNode.ts
+++ b/packages/liveblocks-react-tiptap/src/mentions/MentionNode.ts
@@ -1,0 +1,86 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { LIVEBLOCKS_MENTION_TYPE } from "../types";
+import { Mention } from "./Mention";
+
+export const MentionNode = Node.create<never, never>({
+  name: LIVEBLOCKS_MENTION_TYPE,
+  group: "inline",
+  inline: true,
+  selectable: true,
+  atom: true,
+
+  priority: 101,
+  parseHTML() {
+    return [
+      {
+        tag: "liveblocks-mention",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["liveblocks-mention", mergeAttributes(HTMLAttributes)];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(Mention, {
+      contentDOMElementTag: "span",
+    });
+  },
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-id"),
+        renderHTML: (attributes) => {
+          if (!attributes.id) {
+            return {};
+          }
+
+          return {
+            "data-id": attributes.id as string, // "as" typing because TipTap doesn't have a way to type attributes
+          };
+        },
+      },
+      notificationId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-notification-id"),
+        renderHTML: (attributes) => {
+          if (!attributes.notificationId) {
+            return {};
+          }
+
+          return {
+            "data-notification-id": attributes.notificationId as string, // "as" typing because TipTap doesn't have a way to type attributes
+          };
+        },
+      },
+    };
+  },
+  addKeyboardShortcuts() {
+    return {
+      Backspace: () =>
+        this.editor.commands.command(({ tr, state }) => {
+          let isMention = false;
+          const { selection } = state;
+          const { empty, anchor } = selection;
+
+          if (!empty) {
+            return false;
+          }
+
+          state.doc.nodesBetween(anchor - 1, anchor, (node, pos) => {
+            if (node.type.name === this.name) {
+              isMention = true;
+              tr.insertText("", pos, pos + node.nodeSize);
+            }
+          });
+
+          return isMention;
+        }),
+    };
+  },
+});

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -18,6 +18,8 @@ export const LIVEBLOCKS_MENTION_PASTE_KEY = new PluginKey(
 export const LIVEBLOCKS_MENTION_NOTIFIER_KEY = new PluginKey(
   "lb-plugin-mention-notify"
 );
+
+export const LIVEBLOCKS_MENTION_EXTENSION = "liveblocksMentionExt";
 export const LIVEBLOCKS_MENTION_TYPE = "liveblocksMention";
 
 export const THREADS_ACTIVE_SELECTION_PLUGIN = new PluginKey(


### PR DESCRIPTION
In preparation for blocknote support, we're separating the mention node so it can be used outside of the tiptap extension.