### PR TITLE
Comments canvas example: Active threads and list

### DIFF
--- a/examples/nextjs-comments-canvas/src/app/Providers.tsx
+++ b/examples/nextjs-comments-canvas/src/app/Providers.tsx
@@ -2,40 +2,43 @@
 
 import { LiveblocksProvider } from "@liveblocks/react";
 import { PropsWithChildren } from "react";
+import { ActiveThreadProvider } from "../components/ActiveThreadProvider";
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <LiveblocksProvider
-      authEndpoint="/api/liveblocks-auth"
-      // Get users' info from their ID
-      resolveUsers={async ({ userIds }) => {
-        const searchParams = new URLSearchParams(
-          userIds.map((userId) => ["userIds", userId])
-        );
-        const response = await fetch(`/api/users?${searchParams}`);
+    <ActiveThreadProvider>
+      <LiveblocksProvider
+        authEndpoint="/api/liveblocks-auth"
+        // Get users' info from their ID
+        resolveUsers={async ({ userIds }) => {
+          const searchParams = new URLSearchParams(
+            userIds.map((userId) => ["userIds", userId])
+          );
+          const response = await fetch(`/api/users?${searchParams}`);
 
-        if (!response.ok) {
-          throw new Error("Problem resolving users");
-        }
+          if (!response.ok) {
+            throw new Error("Problem resolving users");
+          }
 
-        const users = await response.json();
-        return users;
-      }}
-      // Find a list of users that match the current search term
-      resolveMentionSuggestions={async ({ text }) => {
-        const response = await fetch(
-          `/api/users/search?text=${encodeURIComponent(text)}`
-        );
+          const users = await response.json();
+          return users;
+        }}
+        // Find a list of users that match the current search term
+        resolveMentionSuggestions={async ({ text }) => {
+          const response = await fetch(
+            `/api/users/search?text=${encodeURIComponent(text)}`
+          );
 
-        if (!response.ok) {
-          throw new Error("Problem resolving mention suggestions");
-        }
+          if (!response.ok) {
+            throw new Error("Problem resolving mention suggestions");
+          }
 
-        const userIds = await response.json();
-        return userIds;
-      }}
-    >
-      {children}
-    </LiveblocksProvider>
+          const userIds = await response.json();
+          return userIds;
+        }}
+      >
+        {children}
+      </LiveblocksProvider>
+    </ActiveThreadProvider>
   );
 }

--- a/examples/nextjs-comments-canvas/src/app/page.tsx
+++ b/examples/nextjs-comments-canvas/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Loading } from "../components/Loading";
 import { ClientSideSuspense } from "@liveblocks/react";
 import { ErrorBoundary } from "react-error-boundary";
 import { CommentsCanvas } from "../components/CommentsCanvas";
+import { ThreadList } from "../components/ThreadList";
 
 export default function Page() {
   const roomId = useExampleRoomId("liveblocks:examples:nextjs-comments-canvas");
@@ -19,7 +20,29 @@ export default function Page() {
         }
       >
         <ClientSideSuspense fallback={<Loading />}>
-          <CommentsCanvas />
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              right: 300,
+              top: 0,
+              bottom: 0,
+            }}
+          >
+            <CommentsCanvas />
+          </div>
+          <div
+            style={{
+              width: 300,
+              position: "absolute",
+              right: 0,
+              top: 0,
+              bottom: 0,
+              background: "white",
+            }}
+          >
+            <ThreadList />
+          </div>
         </ClientSideSuspense>
       </ErrorBoundary>
     </RoomProvider>

--- a/examples/nextjs-comments-canvas/src/app/page.tsx
+++ b/examples/nextjs-comments-canvas/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
               style={{
                 position: "absolute",
                 left: 0,
-                right: 300,
+                right: 260,
                 top: 0,
                 bottom: 0,
               }}
@@ -34,7 +34,7 @@ export default function Page() {
             </div>
             <div
               style={{
-                width: 300,
+                width: 260,
                 position: "absolute",
                 right: 0,
                 top: 0,

--- a/examples/nextjs-comments-canvas/src/app/page.tsx
+++ b/examples/nextjs-comments-canvas/src/app/page.tsx
@@ -20,28 +20,30 @@ export default function Page() {
         }
       >
         <ClientSideSuspense fallback={<Loading />}>
-          <div
-            style={{
-              position: "absolute",
-              left: 0,
-              right: 300,
-              top: 0,
-              bottom: 0,
-            }}
-          >
-            <CommentsCanvas />
-          </div>
-          <div
-            style={{
-              width: 300,
-              position: "absolute",
-              right: 0,
-              top: 0,
-              bottom: 0,
-              background: "white",
-            }}
-          >
-            <ThreadList />
+          <div style={{ width: "100vw", height: "100vh" }}>
+            <div
+              style={{
+                position: "absolute",
+                left: 0,
+                right: 300,
+                top: 0,
+                bottom: 0,
+              }}
+            >
+              <CommentsCanvas />
+            </div>
+            <div
+              style={{
+                width: 300,
+                position: "absolute",
+                right: 0,
+                top: 0,
+                bottom: 0,
+                background: "white",
+              }}
+            >
+              <ThreadList />
+            </div>
           </div>
         </ClientSideSuspense>
       </ErrorBoundary>

--- a/examples/nextjs-comments-canvas/src/components/ActiveThreadProvider.tsx
+++ b/examples/nextjs-comments-canvas/src/components/ActiveThreadProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { ReactNode, createContext, useContext, useState } from "react";
+import { useEditThreadMetadata } from "@liveblocks/react/suspense";
+import { useMaxZIndex } from "../hooks";
+
+type ActiveThreadProviderProps = {
+  activeThreadId: string | null;
+  setActiveThreadId: (activeThreadId: string | null) => void;
+};
+
+const ActiveThread = createContext<ActiveThreadProviderProps | undefined>(
+  undefined
+);
+
+export function ActiveThreadProvider({ children }: { children: ReactNode }) {
+  const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
+
+  return (
+    <ActiveThread.Provider value={{ activeThreadId, setActiveThreadId }}>
+      {children}
+    </ActiveThread.Provider>
+  );
+}
+
+export function useActiveThread(threadId: string) {
+  const context = useContext(ActiveThread);
+  const editThreadMetadata = useEditThreadMetadata();
+  const maxZIndex = useMaxZIndex();
+
+  if (!context) {
+    throw new Error(
+      "useActiveThread must be used within an ActiveThreadProvider"
+    );
+  }
+
+  // Is current threadId open
+  const open = context.activeThreadId === threadId;
+
+  // Allow opening and closing current threadId
+  const setOpen = (open: boolean) => {
+    context.setActiveThreadId(open ? threadId : null);
+
+    // Set this thread's z-index higher than others when it opens
+    editThreadMetadata({
+      threadId,
+      metadata: { zIndex: maxZIndex + 1 },
+    });
+  };
+
+  return { open, setOpen };
+}

--- a/examples/nextjs-comments-canvas/src/components/CommentsCanvas.module.css
+++ b/examples/nextjs-comments-canvas/src/components/CommentsCanvas.module.css
@@ -1,7 +1,7 @@
 .wrapper {
   position: relative;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 }
 

--- a/examples/nextjs-comments-canvas/src/components/CommentsCanvas.tsx
+++ b/examples/nextjs-comments-canvas/src/components/CommentsCanvas.tsx
@@ -132,14 +132,13 @@ function DraggableThread({ thread }: { thread: ThreadData }) {
           )}
         </div>
       </div>
-      {open ? (
-        <Thread
-          thread={thread}
-          className="thread"
-          data-flip-vertical={nearBottomEdge || undefined}
-          data-flip-horizontal={nearRightEdge || undefined}
-        />
-      ) : null}
+      <Thread
+        style={open ? undefined : { display: "none" }}
+        thread={thread}
+        className="thread"
+        data-flip-vertical={nearBottomEdge || undefined}
+        data-flip-horizontal={nearRightEdge || undefined}
+      />
     </div>
   );
 }

--- a/examples/nextjs-comments-canvas/src/components/CommentsCanvas.tsx
+++ b/examples/nextjs-comments-canvas/src/components/CommentsCanvas.tsx
@@ -12,10 +12,11 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect } from "react";
 import styles from "./CommentsCanvas.module.css";
 import { Toolbar } from "./Toolbar";
 import { useMaxZIndex, useNearEdge } from "../hooks";
+import { useActiveThread } from "./ActiveThreadProvider";
 
 export function CommentsCanvas() {
   const { threads } = useThreads();
@@ -69,11 +70,17 @@ export function CommentsCanvas() {
 
 // A draggable thread
 function DraggableThread({ thread }: { thread: ThreadData }) {
+  const { open, setOpen } = useActiveThread(thread.id);
+
   // Open threads that have just been created
-  const startOpen = useMemo(() => {
-    return Number(new Date()) - Number(new Date(thread.createdAt)) <= 100;
-  }, [thread]);
-  const [open, setOpen] = useState(startOpen);
+  useEffect(() => {
+    const justCreated =
+      Number(new Date()) - Number(new Date(thread.createdAt)) <= 100;
+
+    if (justCreated) {
+      setOpen(true);
+    }
+  }, [thread, setOpen]);
 
   // Enable drag
   const { attributes, listeners, setNodeRef, transform, node } = useDraggable({

--- a/examples/nextjs-comments-canvas/src/components/ThreadList.tsx
+++ b/examples/nextjs-comments-canvas/src/components/ThreadList.tsx
@@ -1,0 +1,37 @@
+import { Comment } from "@liveblocks/react-ui";
+import { ThreadData } from "@liveblocks/client";
+import { useThreads } from "@liveblocks/react/suspense";
+import { useActiveThread } from "./ActiveThreadProvider";
+
+export function ThreadList() {
+  const { threads } = useThreads();
+
+  return (
+    <>
+      {threads.map((thread) => (
+        <FirstComment key={thread.id} thread={thread} />
+      ))}
+    </>
+  );
+}
+
+function FirstComment({ thread }: { thread: ThreadData }) {
+  const firstComment = thread.comments[0];
+  const { open, setOpen } = useActiveThread(thread.id);
+
+  return (
+    <Comment
+      key={firstComment.id}
+      comment={firstComment}
+      showReactions={false}
+      showActions={false}
+      showAttachments={false}
+      onClick={() => setOpen(!open)}
+      style={{
+        background: open ? "#fafafa" : undefined,
+        cursor: "pointer",
+        borderBottom: "1px solid #eee",
+      }}
+    />
+  );
+}

--- a/examples/nextjs-comments-canvas/src/hooks.ts
+++ b/examples/nextjs-comments-canvas/src/hooks.ts
@@ -26,7 +26,8 @@ export function useNearEdge(ref: React.RefObject<HTMLElement>) {
       const rect = ref.current.getBoundingClientRect();
 
       // Within 400px of right side of screen (i.e. too little space for a thread)
-      const nearRight = rect.left >= window.innerWidth - 320;
+      // 260px is sidebar width
+      const nearRight = rect.left >= window.innerWidth - 320 - 260;
 
       // In bottom half of screen
       const nearBottom = rect.top >= window.innerHeight / 2;


### PR DESCRIPTION
How to modify the comments canvas example to add a sidebar with clickable threads. I've modified the logic so only one thread can be open at a time, and the first comment in each thread is shown in the sidebar.

https://github.com/user-attachments/assets/1f4b5f0f-d997-4e1a-b925-a8effb8350d9

