### PR TITLE
Update READ for e2e tests

### DIFF
--- a/e2e/next-sandbox/README.md
+++ b/e2e/next-sandbox/README.md
@@ -22,3 +22,23 @@ NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=https://api.liveblocks.io/v7
 - run `npm install`
 - run `npm run dev`
 - In another terminal, run `npm run test`
+
+# User Notification Settings Configuration
+
+To make the user notification settings e2e tests running locally you need to
+ensure you have setup your project notification settings first. It can be done
+by doing either:
+
+- 👉🏻 Go to the project notification page on the dashboard locally (e.g
+  `http://localhost:3001/dashboard/<account_id>/projects/<project_id>/notifications`)
+  → It will automatically do the job just by visiting this page.
+- 👉🏻 Run the following CURL request:
+  ```sh
+  curl -X POST \
+    'https://<dev_worker_url>/dashboard/projects/<project_id>/notification-settings/setup' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: <authorization_token>' \
+    -d '{}'
+  ```
+  → It will setup your project notification settings.
+  > Those user notification settings e2e tests are skipped on CI for now.


### PR DESCRIPTION
Adding a section in the `README.md` file to explain to configure notification settings to make the e2e tests run locally. 
I will check next week to make run on CI if it's really relevant based on the setup we should make, 