### PR TITLE
disable PUD by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT (not yet published)
 
+## v2.18.2
+
 ### `@liveblocks/client`
 
 - Improve performance of undo/redo operations on large documents (thanks for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Improve performance of undo/redo operations on large documents (thanks for the
   contribution @rudi-c!)
 
+### `@liveblocks/react-tiptap`
+
+- Fix a performance regression introduced in 2.18.1
+
 ## v2.18.1
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -239,11 +239,19 @@ export const useLiveblocksExtension = (
           this.storage.provider.awareness.getLocalState() as {
             user: IUserInfo;
           };
-        this.storage.permanentUserData?.setUserMapping(
-          this.storage.doc,
-          this.storage.doc.clientID,
-          userId ?? "Unknown" // TODO: change this to the user's ID so we can map it to the user's name
-        );
+        if (this.storage.permanentUserData) {
+          const pud = this.storage.permanentUserData.clients.get(
+            this.storage.doc.clientID
+          );
+          // Only update if there is no entry or if the entry is different
+          if (!pud || pud !== userId) {
+            this.storage.permanentUserData.setUserMapping(
+              this.storage.doc,
+              this.storage.doc.clientID,
+              userId ?? "Unknown" // TODO: change this to the user's ID so we can map it to the user's name
+            );
+          }
+        }
         if (
           info.name !== storedUser?.name ||
           info.color !== storedUser?.color

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -40,6 +40,7 @@ const DEFAULT_OPTIONS: WithRequired<LiveblocksExtensionOptions, "field"> = {
   comments: true,
   mentions: true,
   offlineSupport_experimental: false,
+  enablePermanentUserData: false,
 };
 
 const LiveblocksCollab = Collaboration.extend({
@@ -324,13 +325,14 @@ export const useLiveblocksExtension = (
     },
     addStorage() {
       const provider = getYjsProviderForRoom(room, {
-        enablePermanentUserData: true,
+        enablePermanentUserData:
+          !!options.ai || options.enablePermanentUserData,
         offlineSupport_experimental: options.offlineSupport_experimental,
       });
       return {
         doc: provider.getYDoc(),
         provider,
-        permanentUserData: provider.permanentUserData!, // TODO: we know this is true because we enabeld the option, is there a way to do that without this override?
+        permanentUserData: provider.permanentUserData,
         unsubs: [],
       };
     },

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -88,13 +88,14 @@ export type LiveblocksExtensionOptions = {
   ai?: boolean | AiConfiguration;
   offlineSupport_experimental?: boolean;
   initialContent?: Content;
+  enablePermanentUserData?: boolean;
 };
 
 export type LiveblocksExtensionStorage = {
   unsubs: (() => void)[];
   doc: Doc;
   provider: LiveblocksYjsProvider;
-  permanentUserData: PermanentUserData;
+  permanentUserData?: PermanentUserData;
 };
 
 export type CommentsExtensionStorage = {


### PR DESCRIPTION
Permanent user data is an undocumented feature of Yjs that allows you to track which clientId is mapped to a user, and therefore, to a change. 

Our implementation had a bug where the PUD was set on every persistence update, because PUD is backed by a yjs type, this caused a set, even though it was setting the exact same data over again. This means changing the selection, typing, etc, caused extra writes.

This PR does two things:

1. disables PUD by default, as it's not used except by AI extension
2. fixes the bug where the PUD was updated too often by simply checking if it needs to be set.