### PR TITLE
Add missing typed params for `getUserNotificationSettings` in api client

### DIFF
--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -386,7 +386,9 @@ export interface NotificationHttpApi<M extends BaseMetadata> {
   // Note: Using term `user` on those two following methods
   // to avoid confusion with the same methods used in the `RoomHttpApi`.
   // Let's wait the room subscription renaming to be here.
-  getUserNotificationSettings(): Promise<UserNotificationSettings>;
+  getUserNotificationSettings(options?: {
+    signal?: AbortSignal;
+  }): Promise<UserNotificationSettings>;
 
   updateUserNotificationSettings(
     settings: PartialUserNotificationSettings


### PR DESCRIPTION
Small PR to add some missing typed params in `getUserNotificationSettings` for the api client in `@liveblocks/core`.
It's internal only no impact on the client for end develoeprs.