### PR TITLE
Fix duplicate h4 IDs by updating section headings on Platform Plans docs page

### DIFF
--- a/docs/pages/platform/plans.mdx
+++ b/docs/pages/platform/plans.mdx
@@ -22,7 +22,7 @@ Liveblocks. Key features include:
 
 {/* This file is ignoring prettier at some points because it's splitting paragraphs in two */}
 
-#### Comments
+#### Comments [Starter plan]
 
 {/* prettier-ignore */}
 Comments is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterMaxComments /> comments per month.
@@ -34,7 +34,7 @@ Comments is free up to <Limits.StarterMauMax /> monthly active users and <Limits
 | MAU overage rate              | —                             |
 | Monthly comments cap          | <Limits.StarterMaxComments /> |
 
-#### Notifications
+#### Notifications [Starter plan]
 
 {/* prettier-ignore */}
 Notifications is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterMaxNotifications /> comments per month.
@@ -46,7 +46,7 @@ Notifications is free up to <Limits.StarterMauMax /> monthly active users and <L
 | MAU overage rate              | —                                  |
 | Monthly notifications cap     | <Limits.StarterMaxNotifications /> |
 
-#### Text Editor
+#### Text Editor [Starter plan]
 
 {/* prettier-ignore */}
 Text Editor is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterTotalTextEditorStored /> data stored.
@@ -58,7 +58,7 @@ Text Editor is free up to <Limits.StarterMauMax /> monthly active users and <Lim
 | MAU overage rate              | —                                       |
 | Total GB stored               | <Limits.StarterTotalTextEditorStored /> |
 
-#### Sync Datastore
+#### Sync Datastore [Starter plan]
 
 {/* prettier-ignore */}
 Sync Datastore is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterTotalCustomAppStored /> data stored.
@@ -82,7 +82,7 @@ companies adding collaboration in production. Key features include:
 - <Limits.ProTeamMembersPerAccount /> team members per account
 - Email support
 
-#### Comments
+#### Comments [Pro plan]
 
 {/* prettier-ignore */}
 Comments is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterMaxComments /> comments per month. You can get higher limits for an additional <Limits.ProStartingPriceComments />.
@@ -94,7 +94,7 @@ Comments is free up to <Limits.StarterMauMax /> monthly active users and <Limits
 | MAU overage rate              | —                             | <Limits.ProPAYGPriceComments /> per each additional user |
 | Monthly comments cap          | <Limits.StarterMaxComments /> | <Limits.ProMaxComments />                                |
 
-#### Notifications
+#### Notifications [Pro plan]
 
 {/* prettier-ignore */}
 Notifications is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterMaxNotifications /> notifications per month. You can get higher limits for an additional <Limits.ProStartingPriceNotifications />.
@@ -106,7 +106,7 @@ Notifications is free up to <Limits.StarterMauMax /> monthly active users and <L
 | MAU overage rate              | —                                  | <Limits.ProPAYGPriceNotifications /> per each additional user |
 | Monthly notifications cap     | <Limits.StarterMaxNotifications /> | <Limits.ProMaxNotifications />                                |
 
-#### Text Editor
+#### Text Editor [Pro plan]
 
 {/* prettier-ignore */}
 Text Editor is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterTotalTextEditorStored /> data stored. You can get higher limits for an additional <Limits.ProStartingPriceTextEditor />.
@@ -118,7 +118,7 @@ Text Editor is free up to <Limits.StarterMauMax /> monthly active users and <Lim
 | MAU overage rate              | —                                       | <Limits.ProPAYGPriceTextEditor /> per each additional user |
 | Total GB stored               | <Limits.StarterTotalTextEditorStored /> | <Limits.ProTotalTextEditorStored />                        |
 
-#### Sync Datastore
+#### Sync Datastore [Pro plan]
 
 {/* prettier-ignore */}
 Sync Datastore is free up to <Limits.StarterMauMax /> monthly active users and <Limits.StarterTotalCustomAppStored /> data stored. You can get higher limits for an additional <Limits.ProStartingPriceCustomApp />.
@@ -144,7 +144,7 @@ security. Key features include:
 - SOC 2 Report
 - 99.9% Uptime SLA
 
-#### Comments
+#### Comments [Enterprise plan]
 
 Comments can be included in the enterprise plan.
 
@@ -155,7 +155,7 @@ Comments can be included in the enterprise plan.
 | MAU overage rate              | Custom    |
 | Monthly comments cap          | Unlimited |
 
-#### Notifications
+#### Notifications [Enterprise plan]
 
 Notifications can be included in the enterprise plan.
 
@@ -166,7 +166,7 @@ Notifications can be included in the enterprise plan.
 | MAU overage rate              | Custom    |
 | Monthly notifications cap     | Unlimited |
 
-#### Text Editor
+#### Text Editor [Enterprise plan]
 
 Text Editor can be included in the enterprise plan.
 
@@ -177,7 +177,7 @@ Text Editor can be included in the enterprise plan.
 | MAU overage rate              | Custom |
 | Total GB stored               | Custom |
 
-#### Sync Datastore
+#### Sync Datastore [Enterprise plan]
 
 Sync Datastore can be included in the enterprise plan.
 


### PR DESCRIPTION
**Description:**  

This PR resolves the issue of duplicate h4 IDs on the Platform Plans docs page. The problem was occurring because headings for sections (e.g., "Comments", "Notifications", etc.) were being rendered with identical text, which—when slugified—resulted in duplicate IDs. 

This change updates the headings to include plan-specific details (such as "[Starter plan]", "[Pro plan]", and "[Enterprise plan]") to ensure uniqueness and navigation.

---

**Changes Made:**  

- **Updated Headings:**  
  For each feature (Comments, Notifications, Text Editor, Sync Datastore), the headings are now explicitly labeled with the plan they belong to. For example:
  ```diff
  - #### Comments
  + #### Comments [Starter plan]
  ```
  This pattern is repeated for the Pro and Enterprise plans to ensure each h4 element is unique.

- **Prettier Ignore Comments:**  
  The inline `prettier-ignore` comments are kept in place where needed to avoid unintended reformatting, ensuring that the content layout remains as intended.

- **Consistency Check:**  
  Verified that every heading now generates a unique slug/ID, preventing conflicts when navigating via anchor links.

---

**Related Issue:**  
Fixes #2248 