### PR TITLE
Log input data when `JSON.stringify()` calls fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/client`
+
+- Log more details in specific error cases to help debugging
+
 ### `@liveblocks/react`
 
 - Increases the allowed stale time for polled user threads data. Only affects

--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -16,6 +16,7 @@ import type { DateToString } from "./lib/DateToString";
 import { DefaultMap } from "./lib/DefaultMap";
 import type { Json, JsonObject } from "./lib/Json";
 import { objectToQuery } from "./lib/objectToQuery";
+import { stringifyOrLog as stringify } from "./lib/stringify";
 import type { QueryParams, URLSafeString } from "./lib/url";
 import { url, urljoin } from "./lib/url";
 import { raise } from "./lib/utils";
@@ -1688,7 +1689,7 @@ class HttpClient {
   ): Promise<Response> {
     return await this.#rawFetch(endpoint, authValue, {
       method: "POST",
-      body: JSON.stringify(body),
+      body: stringify(body),
     });
   }
 
@@ -1734,7 +1735,7 @@ class HttpClient {
       {
         ...options,
         method: "POST",
-        body: JSON.stringify(body),
+        body: stringify(body),
       },
       params
     );

--- a/packages/liveblocks-core/src/auth-manager.ts
+++ b/packages/liveblocks-core/src/auth-manager.ts
@@ -2,6 +2,7 @@ import { StopRetrying } from "./connection";
 import { isPlainObject } from "./lib/guards";
 import type { Json } from "./lib/Json";
 import type { Relax } from "./lib/Relax";
+import { stringifyOrLog as stringify } from "./lib/stringify";
 import type {
   Authentication,
   CustomAuthenticationResult,
@@ -314,7 +315,7 @@ async function fetchAuthEndpoint(
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(body),
+    body: stringify(body),
   });
   if (!res.ok) {
     const reason = `${
@@ -343,7 +344,7 @@ async function fetchAuthEndpoint(
 
   if (!isPlainObject(data) || typeof data.token !== "string") {
     throw new Error(
-      `Expected a JSON response of the form \`{ token: "..." }\` when doing a POST request on "${endpoint}", but got ${JSON.stringify(
+      `Expected a JSON response of the form \`{ token: "..." }\` when doing a POST request on "${endpoint}", but got ${stringify(
         data
       )}`
     );

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -1,6 +1,7 @@
 import { assertNever, nn } from "../lib/assert";
 import { isPlainObject } from "../lib/guards";
 import type { Json } from "../lib/Json";
+import { stringifyOrLog as stringify } from "../lib/stringify";
 import { deepClone, entries } from "../lib/utils";
 import type { CreateOp, Op } from "../protocol/Op";
 import { OpCode } from "../protocol/Op";
@@ -172,7 +173,7 @@ export function getTreesDiffOperations(
       if (crdt.type === CrdtType.OBJECT) {
         if (
           currentCrdt.type !== CrdtType.OBJECT ||
-          JSON.stringify(crdt.data) !== JSON.stringify(currentCrdt.data)
+          stringify(crdt.data) !== stringify(currentCrdt.data)
         ) {
           ops.push({
             type: OpCode.UPDATE_OBJECT,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -137,7 +137,7 @@ export { shallow } from "./lib/shallow";
 export type { ISignal, SignalType } from "./lib/signals";
 export { batch, DerivedSignal, MutableSignal, Signal } from "./lib/signals";
 export { SortedList } from "./lib/SortedList";
-export { stringify } from "./lib/stringify";
+export { stableStringify } from "./lib/stringify";
 export type { QueryParams, URLSafeString } from "./lib/url";
 export { url, urljoin } from "./lib/url";
 export type { Brand, DistributiveOmit } from "./lib/utils";

--- a/packages/liveblocks-core/src/lib/__tests__/stringify.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/stringify.test.ts
@@ -1,9 +1,9 @@
-import { stringify } from "../stringify";
+import { stableStringify } from "../stringify";
 
-describe("stringify", () => {
+describe("stable stringify", () => {
   it("returns the same result as JSON.stringify", () => {
     expect(
-      stringify({
+      stableStringify({
         a: 2,
       })
     ).toEqual(
@@ -11,21 +11,21 @@ describe("stringify", () => {
         a: 2,
       })
     );
-    expect(stringify([1, 2, 3])).toEqual(JSON.stringify([1, 2, 3]));
-    expect(stringify("string")).toEqual(JSON.stringify("string"));
-    expect(stringify(2)).toEqual(JSON.stringify(2));
-    expect(stringify(true)).toEqual(JSON.stringify(true));
-    expect(stringify(null)).toEqual(JSON.stringify(null));
+    expect(stableStringify([1, 2, 3])).toEqual(JSON.stringify([1, 2, 3]));
+    expect(stableStringify("string")).toEqual(JSON.stringify("string"));
+    expect(stableStringify(2)).toEqual(JSON.stringify(2));
+    expect(stableStringify(true)).toEqual(JSON.stringify(true));
+    expect(stableStringify(null)).toEqual(JSON.stringify(null));
   });
 
   it("supports objects in a stable way", () => {
     expect(
-      stringify({
+      stableStringify({
         a: 2,
         b: true,
       })
     ).toEqual(
-      stringify({
+      stableStringify({
         b: true,
         a: 2,
       })
@@ -33,20 +33,20 @@ describe("stringify", () => {
   });
 
   it("supports nested objects", () => {
-    expect(stringify([{ a: 2, b: true }])).toEqual(
-      stringify([{ b: true, a: 2 }])
+    expect(stableStringify([{ a: 2, b: true }])).toEqual(
+      stableStringify([{ b: true, a: 2 }])
     );
-    expect(stringify([{ a: 2, b: true, c: [[{ e: -0, d: 0 }]] }])).toEqual(
-      stringify([{ b: true, a: 2, c: [[{ d: 0, e: 0 }]] }])
-    );
+    expect(
+      stableStringify([{ a: 2, b: true, c: [[{ e: -0, d: 0 }]] }])
+    ).toEqual(stableStringify([{ b: true, a: 2, c: [[{ d: 0, e: 0 }]] }]));
   });
 
   it("explicitly-undefined keys become implicit-undefined", () => {
-    expect(stringify([{ b: true, c: undefined, a: 2 }])).toEqual(
+    expect(stableStringify([{ b: true, c: undefined, a: 2 }])).toEqual(
       '[{"a":2,"b":true}]'
     );
-    expect(stringify([{ a: 2, b: true }])).toEqual(
-      stringify([{ b: true, c: undefined, a: 2 }])
+    expect(stableStringify([{ a: 2, b: true }])).toEqual(
+      stableStringify([{ b: true, c: undefined, a: 2 }])
     );
   });
 });

--- a/packages/liveblocks-core/src/lib/batch.ts
+++ b/packages/liveblocks-core/src/lib/batch.ts
@@ -2,7 +2,7 @@ import type { AsyncResult } from "./AsyncResult";
 import { Promise_withResolvers } from "./controlledPromise";
 import type { Callback, UnsubscribeCallback } from "./EventSource";
 import { MutableSignal } from "./signals";
-import { stringify } from "./stringify";
+import { stableStringify } from "./stringify";
 
 const DEFAULT_SIZE = 50;
 
@@ -141,7 +141,7 @@ export class Batch<O, I> {
   get(input: I): Promise<O> {
     // Check if there's already an identical call in the queue.
     const existingCall = this.#queue.find(
-      (call) => stringify(call.input) === stringify(input)
+      (call) => stableStringify(call.input) === stableStringify(input)
     );
 
     // If an existing call exists, return its promise.
@@ -172,7 +172,7 @@ export function createBatchStore<O, I>(batch: Batch<O, I>): BatchStore<O, I> {
   const signal = new MutableSignal(new Map<string, AsyncResult<O>>());
 
   function getCacheKey(args: I): string {
-    return stringify(args);
+    return stableStringify(args);
   }
 
   function update(cacheKey: string, state: AsyncResult<O>) {

--- a/packages/liveblocks-core/src/lib/stringify.ts
+++ b/packages/liveblocks-core/src/lib/stringify.ts
@@ -15,9 +15,9 @@ function replacer(_key: string, value: unknown) {
 }
 
 /**
- * Like JSON.stringify(), but returns the same value no matter how keys in any
- * nested objects are ordered.
+ * Like JSON.stringify(), but using stable (sorted) object key order, so that
+ * it returns the same value for the same keys, no matter their order.
  */
-export function stringify(value: unknown): string {
+export function stableStringify(value: unknown): string {
   return JSON.stringify(value, replacer);
 }

--- a/packages/liveblocks-core/src/lib/stringify.ts
+++ b/packages/liveblocks-core/src/lib/stringify.ts
@@ -21,3 +21,19 @@ function replacer(_key: string, value: unknown) {
 export function stableStringify(value: unknown): string {
   return JSON.stringify(value, replacer);
 }
+
+/**
+ * Drop-in replacement for JSON.stringify(), which will log any payload to the
+ * console if it could not be stringified somehow.
+ */
+export function stringifyOrLog(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    /* eslint-disable rulesdir/console-must-be-fancy */
+    console.error(`Could not stringify: ${(err as Error).message}`);
+    console.error(value);
+    /* eslint-enable rulesdir/console-must-be-fancy */
+    throw err;
+  }
+}

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -31,6 +31,7 @@ import type { Json, JsonObject } from "./lib/Json";
 import { isJsonArray, isJsonObject } from "./lib/Json";
 import { asPos } from "./lib/position";
 import { DerivedSignal, PatchableSignal, Signal } from "./lib/signals";
+import { stringifyOrLog as stringify } from "./lib/stringify";
 import {
   compact,
   deepClone,
@@ -1665,7 +1666,7 @@ export function createRoom<
 
     for (const halfOps of [firstHalf, secondHalf]) {
       const half: UpdateStorageClientMsg = { ops: halfOps, ...rest };
-      const text = JSON.stringify([half]);
+      const text = stringify([half]);
       if (!isTooBigForWebSocket(text)) {
         yield text;
       } else {
@@ -1698,7 +1699,7 @@ export function createRoom<
     const secondHalf = messages.slice(mid);
 
     for (const half of [firstHalf, secondHalf]) {
-      const text = JSON.stringify(half);
+      const text = stringify(half);
       if (!isTooBigForWebSocket(text)) {
         yield text;
       } else {
@@ -1723,7 +1724,7 @@ export function createRoom<
   function sendMessages(messages: ClientMsg<P, E>[]) {
     const strategy = config.largeMessageStrategy ?? "default";
 
-    const text = JSON.stringify(messages);
+    const text = stringify(messages);
     if (!isTooBigForWebSocket(text)) {
       return managedSocket.send(text); // Happy path
     }

--- a/packages/liveblocks-react-ui/src/utils/memoize.ts
+++ b/packages/liveblocks-react-ui/src/utils/memoize.ts
@@ -1,4 +1,4 @@
-import { stringify } from "@liveblocks/core";
+import { stableStringify } from "@liveblocks/core";
 
 export function memoize<TArgs extends unknown[], TReturn>(
   fn: (...args: TArgs) => TReturn
@@ -6,7 +6,7 @@ export function memoize<TArgs extends unknown[], TReturn>(
   const cache = new Map<string, TReturn>();
 
   return (...args: TArgs): TReturn => {
-    const key = JSON.stringify(args.map((arg) => stringify(arg)));
+    const key = JSON.stringify(args.map((arg) => stableStringify(arg)));
     const cached = cache.get(key);
 
     if (cached !== undefined) {

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -37,7 +37,7 @@ import {
   nn,
   shallow,
   Signal,
-  stringify,
+  stableStringify,
 } from "@liveblocks/core";
 
 import { ASYNC_ERR, ASYNC_LOADING, ASYNC_OK } from "./lib/AsyncResult";
@@ -219,13 +219,13 @@ export function makeRoomThreadsQueryKey(
   roomId: string,
   query: ThreadsQuery<BaseMetadata> | undefined
 ) {
-  return stringify([roomId, query ?? {}]);
+  return stableStringify([roomId, query ?? {}]);
 }
 
 export function makeUserThreadsQueryKey(
   query: ThreadsQuery<BaseMetadata> | undefined
 ) {
-  return stringify(query ?? {});
+  return stableStringify(query ?? {});
 }
 
 /**

--- a/packages/liveblocks-react/src/use-mention-suggestions.ts
+++ b/packages/liveblocks-react/src/use-mention-suggestions.ts
@@ -1,4 +1,4 @@
-import { stringify } from "@liveblocks/core";
+import { stableStringify } from "@liveblocks/core";
 import { useEffect, useRef, useState } from "react";
 
 import {
@@ -27,7 +27,9 @@ export function useMentionSuggestions(roomId: string, search?: string) {
     }
 
     const resolveMentionSuggestionsArgs = { text: search, roomId };
-    const mentionSuggestionsCacheKey = stringify(resolveMentionSuggestionsArgs);
+    const mentionSuggestionsCacheKey = stableStringify(
+      resolveMentionSuggestionsArgs
+    );
     let debounceTimeout: number | undefined;
     let isCanceled = false;
 


### PR DESCRIPTION
This PR:

- Renames the existing `stringify` → `stableStringify`
- Adds a new `stringifyOrLog` which is a drop-in replacement for `JSON.stringify()`, but which will report the input data to the console in case that stringify call fails. This should help us debug certain complex use cases.
