### PR TITLE
Add missing package entry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ components that can easily be dropped into your product to boost growth:
 [Text Editor](https://liveblocks.io/docs/ready-made-features/text-editor),
 [AI Copilots](https://liveblocks.io/docs/ready-made-features/ai-copilots),
 [Presence](https://liveblocks.io/docs/ready-made-features/presence), and
-[Notifications](https://liveblocks.io/docs/ready-made-features/notifications). You can decide
-features which you want to use based on your requirements and the collaborative
-experiences you’re looking to add.
+[Notifications](https://liveblocks.io/docs/ready-made-features/notifications).
+You can decide features which you want to use based on your requirements and the
+collaborative experiences you’re looking to add.
 
 If you have more advanced needs, you can also leverage Liveblocks to
-[host and scale local-first sync engines](https://liveblocks.io/docs/platform/sync-datastore) such as
-Liveblocks Storage and Yjs.
+[host and scale local-first sync engines](https://liveblocks.io/docs/platform/sync-datastore)
+such as Liveblocks Storage and Yjs.
 
 ### Packages and SDKs
 
@@ -56,6 +56,7 @@ notifications, and more.
 - [`@liveblocks/react`](https://liveblocks.io/docs/api-reference/liveblocks-react)
 - [`@liveblocks/react-ui`](https://liveblocks.io/docs/api-reference/liveblocks-react-ui)
 - [`@liveblocks/react-tiptap`](https://liveblocks.io/docs/api-reference/liveblocks-react-tiptap)
+- [`@liveblocks/node-prosemirror`](https://liveblocks.io/docs/api-reference/liveblocks-node-prosemirror)
 - [`@liveblocks/react-lexical`](https://liveblocks.io/docs/api-reference/liveblocks-react-lexical)
 - [`@liveblocks/node-lexical`](https://liveblocks.io/docs/api-reference/liveblocks-node-lexical)
 - [`@liveblocks/redux`](https://liveblocks.io/docs/api-reference/liveblocks-redux)


### PR DESCRIPTION
Add missing package entry for `@liveblocks/node-prosemirror` in main README.md