### PR TITLE
Add better error handling to `@liveblocks/node` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### `@liveblocks/node`
 
 - Allow passing optional AbortSignal to all client methods
+- Fix bug in encoding of error information in the LiveblocksError when an API
+  call fails
 
 ## v2.18.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT (not yet published)
 
+## v2.19.0
+
 ### `@liveblocks/*`
 
 - Output ES modules by default (but CJS builds are still included)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - Allow passing optional AbortSignal to all client methods
 - Fix bug in encoding of error information in the LiveblocksError when an API
-  call fails
+  call fails (thanks for reporting, @robcresswell!)
 
 ## v2.18.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Output ES modules by default (but CJS builds are still included)
 - Modernize internal build tool settings
 
+### `@liveblocks/node`
+
+- Allow passing optional AbortSignal to all client methods
+
 ## v2.18.3
 
 ### `@liveblocks/node`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Allow passing optional AbortSignal to all client methods
 - Fix bug in encoding of error information in the LiveblocksError when an API
   call fails (thanks for reporting, @robcresswell!)
+- Fix `getStorageDocument("my-room", "json")` typing in its output `LiveMap`
+  instances as `ReadonlyMap` instead of serialized plain objects.
 
 ## v2.18.3
 

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -248,7 +248,7 @@ describe("client", () => {
 
   test("should throw a LiveblocksError when getRooms receives an error response", async () => {
     const error = {
-      error: "InvalidSecretKey",
+      error: "INVALID_SECRET_KEY",
       message: "Invalid secret key",
     };
 
@@ -275,7 +275,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Invalid secret key");
+        expect(err.errorId).toBe("INVALID_SECRET_KEY");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -364,7 +365,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Comment not found");
+        expect(err.errorId).toBe("RESOURCE_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -425,7 +427,7 @@ describe("client", () => {
     };
 
     const error = {
-      error: "RESOURCE_ALREADY_EXISTES",
+      error: "RESOURCE_ALREADY_EXISTS",
       message: "Thread already exists",
     };
 
@@ -458,7 +460,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(409);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Thread already exists");
+        expect(err.errorId).toBe("RESOURCE_ALREADY_EXISTS");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -514,7 +517,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Thread not found");
+        expect(err.errorId).toBe("THREAD_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -547,7 +551,11 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Room not found");
+        expect(err.errorId).toBe("ROOM_NOT_FOUND");
+        expect(err.suggestion).toBe(
+          "Please use a valid room ID, room IDs are available in the dashboard: https://liveblocks.io/dashboard/rooms"
+        );
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -880,7 +888,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Inbox notification not found");
+        expect(err.errorId).toBe("INBOX_NOTIFICATION_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1006,7 +1015,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("User not found");
+        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1072,7 +1082,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Room not found");
+        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1154,7 +1165,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Room not found");
+        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1216,7 +1228,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Room not found");
+        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1265,7 +1278,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Room not found");
+        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1321,7 +1335,7 @@ describe("client", () => {
 
     const error = {
       error: "RESOURCE_NOT_FOUND",
-      message: "Inbox notification",
+      message: "Inbox notification frobbed",
     };
 
     server.use(
@@ -1348,7 +1362,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("Inbox notification frobbed");
+        expect(err.errorId).toBe("RESOURCE_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1442,7 +1457,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("User not found");
+        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1577,7 +1593,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("User not found");
+        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1633,7 +1650,8 @@ describe("client", () => {
       expect(err instanceof LiveblocksError).toBe(true);
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
-        expect(err.message).toBe(JSON.stringify(error));
+        expect(err.message).toBe("User not found");
+        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -134,9 +134,6 @@ describe("client", () => {
           expect(err.message).toBe(
             "An error happened without an error message"
           );
-          expect(err.errorId).toBe(undefined);
-          expect(err.reason).toBe(undefined);
-          expect(err.suggestion).toBe(undefined);
         }
       }
     });
@@ -162,9 +159,6 @@ describe("client", () => {
           expect(err.message).toBe(
             "An error happened without an error message"
           );
-          expect(err.errorId).toBe(undefined);
-          expect(err.reason).toBe(undefined);
-          expect(err.suggestion).toBe(undefined);
         }
       }
     });
@@ -188,9 +182,12 @@ describe("client", () => {
           expect(err.name).toBe("LiveblocksError");
           expect(err.status).toBe(499);
           expect(err.message).toBe("I'm not a JSON response");
-          expect(err.errorId).toBe(undefined);
-          expect(err.reason).toBe(undefined);
-          expect(err.suggestion).toBe(undefined);
+          expect(String(err)).toBe(
+            "LiveblocksError: I'm not a JSON response (status 499)"
+          );
+          expect(err.toString()).toBe(
+            "LiveblocksError: I'm not a JSON response (status 499)"
+          );
         }
       }
     });
@@ -219,9 +216,6 @@ describe("client", () => {
           expect(err.message).toBe(
             "An error happened without an error message"
           );
-          expect(err.errorId).toBe(undefined);
-          expect(err.reason).toBe(undefined);
-          expect(err.suggestion).toBe(undefined);
         }
       }
     });
@@ -392,7 +386,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Invalid secret key");
-        expect(err.errorId).toBe("INVALID_SECRET_KEY");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -482,7 +475,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Comment not found");
-        expect(err.errorId).toBe("RESOURCE_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -577,7 +569,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(409);
         expect(err.message).toBe("Thread already exists");
-        expect(err.errorId).toBe("RESOURCE_ALREADY_EXISTS");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -634,7 +625,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Thread not found");
-        expect(err.errorId).toBe("THREAD_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -668,9 +658,8 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Room not found");
-        expect(err.errorId).toBe("ROOM_NOT_FOUND");
-        expect(err.suggestion).toBe(
-          "Please use a valid room ID, room IDs are available in the dashboard: https://liveblocks.io/dashboard/rooms"
+        expect(String(err)).toBe(
+          "LiveblocksError: Room not found (status 404)\nSuggestion: Please use a valid room ID, room IDs are available in the dashboard: https://liveblocks.io/dashboard/rooms\nSee also: https://liveblocks.io/docs/api-reference/rest-api-endpoints"
         );
         expect(err.name).toBe("LiveblocksError");
       }
@@ -1005,7 +994,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Inbox notification not found");
-        expect(err.errorId).toBe("INBOX_NOTIFICATION_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1132,7 +1120,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("User not found");
-        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1199,7 +1186,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Room not found");
-        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1282,7 +1268,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Room not found");
-        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1345,7 +1330,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Room not found");
-        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1395,7 +1379,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Room not found");
-        expect(err.errorId).toBe("ROOM_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1479,7 +1462,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("Inbox notification frobbed");
-        expect(err.errorId).toBe("RESOURCE_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1574,7 +1556,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("User not found");
-        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1710,7 +1691,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("User not found");
-        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }
@@ -1767,7 +1747,6 @@ describe("client", () => {
       if (err instanceof LiveblocksError) {
         expect(err.status).toBe(404);
         expect(err.message).toBe("User not found");
-        expect(err.errorId).toBe("USER_NOT_FOUND");
         expect(err.name).toBe("LiveblocksError");
       }
     }

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -111,6 +111,122 @@ describe("client", () => {
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
+  describe("LiveblocksError message formatting", () => {
+    test("should throw a LiveblocksError when response is missing a body", async () => {
+      server.use(
+        http.get(`${DEFAULT_BASE_URL}/v2/rooms`, () => {
+          return new HttpResponse(null, { status: 499 });
+        })
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      // This should throw a LiveblocksError
+      try {
+        await client.getRooms();
+        // If it doesn't throw, fail the test.
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(LiveblocksError);
+        if (err instanceof LiveblocksError) {
+          expect(err.name).toBe("LiveblocksError");
+          expect(err.status).toBe(499);
+          expect(err.message).toBe(
+            "An error happened without an error message"
+          );
+          expect(err.errorId).toBe(undefined);
+          expect(err.reason).toBe(undefined);
+          expect(err.suggestion).toBe(undefined);
+        }
+      }
+    });
+    test("should throw a LiveblocksError when response has empty body", async () => {
+      server.use(
+        http.get(`${DEFAULT_BASE_URL}/v2/rooms`, () => {
+          return HttpResponse.text("", { status: 499 });
+        })
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      // This should throw a LiveblocksError
+      try {
+        await client.getRooms();
+        // If it doesn't throw, fail the test.
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(LiveblocksError);
+        if (err instanceof LiveblocksError) {
+          expect(err.name).toBe("LiveblocksError");
+          expect(err.status).toBe(499);
+          expect(err.message).toBe(
+            "An error happened without an error message"
+          );
+          expect(err.errorId).toBe(undefined);
+          expect(err.reason).toBe(undefined);
+          expect(err.suggestion).toBe(undefined);
+        }
+      }
+    });
+    test("should throw a LiveblocksError when response has non-JSON body", async () => {
+      server.use(
+        http.get(`${DEFAULT_BASE_URL}/v2/rooms`, () => {
+          return HttpResponse.text("I'm not a JSON response", { status: 499 });
+        })
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      // This should throw a LiveblocksError
+      try {
+        await client.getRooms();
+        // If it doesn't throw, fail the test.
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(LiveblocksError);
+        if (err instanceof LiveblocksError) {
+          expect(err.name).toBe("LiveblocksError");
+          expect(err.status).toBe(499);
+          expect(err.message).toBe("I'm not a JSON response");
+          expect(err.errorId).toBe(undefined);
+          expect(err.reason).toBe(undefined);
+          expect(err.suggestion).toBe(undefined);
+        }
+      }
+    });
+    test("should throw a LiveblocksError when response has JSON body without a message field", async () => {
+      server.use(
+        http.get(`${DEFAULT_BASE_URL}/v2/rooms`, () => {
+          return HttpResponse.json(
+            { messsag: 'Misspelled "message" field' },
+            { status: 499 }
+          );
+        })
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      // This should throw a LiveblocksError
+      try {
+        await client.getRooms();
+        // If it doesn't throw, fail the test.
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err).toBeInstanceOf(LiveblocksError);
+        if (err instanceof LiveblocksError) {
+          expect(err.name).toBe("LiveblocksError");
+          expect(err.status).toBe(499);
+          expect(err.message).toBe(
+            "An error happened without an error message"
+          );
+          expect(err.errorId).toBe(undefined);
+          expect(err.reason).toBe(undefined);
+          expect(err.suggestion).toBe(undefined);
+        }
+      }
+    });
+  });
+
   test("should return a list of room when getRooms receives a successful response", async () => {
     const client = new Liveblocks({ secret: "sk_xxx" });
     await expect(client.getRooms()).resolves.toEqual({

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -1397,7 +1397,7 @@ export class Liveblocks {
 
     const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-resolved`,
-      undefined,
+      {},
       options
     );
 
@@ -1424,7 +1424,7 @@ export class Liveblocks {
 
     const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-unresolved`,
-      undefined,
+      {},
       options
     );
 

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -1870,8 +1870,8 @@ export class LiveblocksError extends Error {
   readonly errorId?: string;
 
   private constructor(
-    status: number,
     message: string,
+    status: number,
     reason?: string,
     suggestion?: string,
     errorId?: string
@@ -1885,15 +1885,25 @@ export class LiveblocksError extends Error {
   }
 
   static async from(res: Response): Promise<LiveblocksError> {
-    const text = await res.text();
-    const obj = JSON.parse(text) as JsonObject;
-    const err = new LiveblocksError(
+    const FALLBACK = "An error happened without an error message";
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      text = FALLBACK;
+    }
+    let obj: JsonObject;
+    try {
+      obj = JSON.parse(text) as JsonObject;
+    } catch {
+      obj = { message: text };
+    }
+    return new LiveblocksError(
+      (obj.message || FALLBACK) as string,
       res.status,
-      obj.message as string,
       obj.reason as string | undefined,
       obj.suggestion as string | undefined,
       obj.error as string | undefined
     );
-    return err;
   }
 }

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -475,8 +475,7 @@ export class Liveblocks {
     const res = await this.#get(path, queryParams, options);
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const data = (await res.json()) as {
@@ -540,8 +539,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const data = (await res.json()) as RoomDataPlain;
@@ -572,8 +570,7 @@ export class Liveblocks {
     const res = await this.#get(url`/v2/rooms/${roomId}`, {}, options);
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const data = (await res.json()) as RoomDataPlain;
@@ -632,8 +629,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const data = (await res.json()) as RoomDataPlain;
@@ -663,8 +659,7 @@ export class Liveblocks {
     const res = await this.#delete(url`/v2/rooms/${roomId}`, options);
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -685,8 +680,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as Promise<{ data: RoomUser<U>[] }>;
@@ -709,8 +703,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -762,8 +755,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return (await res.json()) as Promise<PlainLsonObject | ToSimplifiedJson<S>>;
   }
@@ -788,8 +780,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return (await res.json()) as Promise<PlainLsonObject>;
   }
@@ -805,8 +796,7 @@ export class Liveblocks {
   ): Promise<void> {
     const res = await this.#delete(url`/v2/rooms/${roomId}/storage`, options);
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -839,8 +829,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as Promise<JsonObject>;
@@ -866,8 +855,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -890,8 +878,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return res.arrayBuffer();
   }
@@ -914,8 +901,7 @@ export class Liveblocks {
   ): Promise<Schema> {
     const res = await this.#post(url`/v2/schemas`, { name, body }, options);
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     const data = (await res.json()) as SchemaPlain;
 
@@ -941,8 +927,7 @@ export class Liveblocks {
   ): Promise<Schema> {
     const res = await this.#get(url`/v2/schemas/${schemaId}`, {}, options);
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     const data = (await res.json()) as SchemaPlain;
 
@@ -975,8 +960,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const data = (await res.json()) as SchemaPlain;
@@ -1003,8 +987,7 @@ export class Liveblocks {
   ): Promise<void> {
     const res = await this.#delete(url`/v2/schemas/${schemaId}`, options);
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1020,8 +1003,7 @@ export class Liveblocks {
   ): Promise<Schema> {
     const res = await this.#get(url`/v2/rooms/${roomId}/schema`, {}, options);
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const data = (await res.json()) as SchemaPlain;
@@ -1056,8 +1038,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return (await res.json()) as Promise<{ schema: string }>;
   }
@@ -1073,8 +1054,7 @@ export class Liveblocks {
   ): Promise<void> {
     const res = await this.#delete(url`/v2/rooms/${roomId}/schema`, options);
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1144,8 +1124,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     const { data } = (await res.json()) as { data: ThreadDataPlain<M>[] };
     return {
@@ -1173,8 +1152,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
   }
@@ -1202,8 +1180,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return (await res.json()) as Promise<ThreadParticipants>;
   }
@@ -1229,8 +1206,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return convertToCommentData((await res.json()) as CommentDataPlain);
   }
@@ -1265,8 +1241,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     return convertToCommentData((await res.json()) as CommentDataPlain);
   }
@@ -1298,8 +1273,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return convertToCommentData((await res.json()) as CommentDataPlain);
@@ -1323,8 +1297,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1358,8 +1331,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
@@ -1383,8 +1355,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1409,8 +1380,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
@@ -1437,8 +1407,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
@@ -1474,8 +1443,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as M;
@@ -1512,8 +1480,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const reaction = (await res.json()) as CommentUserReactionPlain;
@@ -1555,8 +1522,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1581,8 +1547,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return convertToInboxNotificationData(
@@ -1639,8 +1604,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     const { data } = (await res.json()) as {
@@ -1673,8 +1637,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as RoomNotificationSettings;
@@ -1703,8 +1666,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as RoomNotificationSettings;
@@ -1730,8 +1692,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1757,8 +1718,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
     const data = (await res.json()) as RoomDataPlain;
     return {
@@ -1787,8 +1747,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1812,8 +1771,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1833,8 +1791,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 
@@ -1855,8 +1812,7 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as UserNotificationSettings;
@@ -1881,8 +1837,7 @@ export class Liveblocks {
     );
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
 
     return (await res.json()) as UserNotificationSettings;
@@ -1903,18 +1858,42 @@ export class Liveblocks {
       options
     );
     if (!res.ok) {
-      const text = await res.text();
-      throw new LiveblocksError(res.status, text);
+      throw await LiveblocksError.from(res);
     }
   }
 }
 
 export class LiveblocksError extends Error {
-  status: number;
+  readonly status: number;
+  readonly reason?: string;
+  readonly suggestion?: string;
+  readonly errorId?: string;
 
-  constructor(status: number, message = "") {
+  private constructor(
+    status: number,
+    message: string,
+    reason?: string,
+    suggestion?: string,
+    errorId?: string
+  ) {
     super(message);
     this.name = "LiveblocksError";
     this.status = status;
+    this.reason = reason;
+    this.suggestion = suggestion;
+    this.errorId = errorId;
+  }
+
+  static async from(res: Response): Promise<LiveblocksError> {
+    const text = await res.text();
+    const obj = JSON.parse(text) as JsonObject;
+    const err = new LiveblocksError(
+      res.status,
+      obj.message as string,
+      obj.reason as string | undefined,
+      obj.suggestion as string | undefined,
+      obj.error as string | undefined
+    );
+    return err;
   }
 }

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -274,7 +274,7 @@ export class Liveblocks {
 
   async #get(
     path: URLSafeString,
-    params: QueryParams,
+    params?: QueryParams,
     options?: RequestOptions
   ): Promise<Response> {
     const url = urljoin(this.#baseUrl, path, params);
@@ -581,7 +581,7 @@ export class Liveblocks {
     roomId: string,
     options?: RequestOptions
   ): Promise<RoomData> {
-    const res = await this.#get(url`/v2/rooms/${roomId}`, {}, options);
+    const res = await this.#get(url`/v2/rooms/${roomId}`, undefined, options);
 
     if (!res.ok) {
       throw await LiveblocksError.from(res);
@@ -689,7 +689,7 @@ export class Liveblocks {
   ): Promise<{ data: RoomUser<U>[] }> {
     const res = await this.#get(
       url`/v2/rooms/${roomId}/active_users`,
-      {},
+      undefined,
       options
     );
 
@@ -939,7 +939,11 @@ export class Liveblocks {
     schemaId: string,
     options?: RequestOptions
   ): Promise<Schema> {
-    const res = await this.#get(url`/v2/schemas/${schemaId}`, {}, options);
+    const res = await this.#get(
+      url`/v2/schemas/${schemaId}`,
+      undefined,
+      options
+    );
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }
@@ -1015,7 +1019,11 @@ export class Liveblocks {
     roomId: string,
     options?: RequestOptions
   ): Promise<Schema> {
-    const res = await this.#get(url`/v2/rooms/${roomId}/schema`, {}, options);
+    const res = await this.#get(
+      url`/v2/rooms/${roomId}/schema`,
+      undefined,
+      options
+    );
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }
@@ -1162,7 +1170,7 @@ export class Liveblocks {
 
     const res = await this.#get(
       url`/v2/rooms/${roomId}/threads/${threadId}`,
-      {},
+      undefined,
       options
     );
     if (!res.ok) {
@@ -1190,7 +1198,7 @@ export class Liveblocks {
 
     const res = await this.#get(
       url`/v2/rooms/${roomId}/threads/${threadId}/participants`,
-      {},
+      undefined,
       options
     );
     if (!res.ok) {
@@ -1216,7 +1224,7 @@ export class Liveblocks {
 
     const res = await this.#get(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${commentId}`,
-      {},
+      undefined,
       options
     );
     if (!res.ok) {
@@ -1389,7 +1397,7 @@ export class Liveblocks {
 
     const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-resolved`,
-      {},
+      undefined,
       options
     );
 
@@ -1416,7 +1424,7 @@ export class Liveblocks {
 
     const res = await this.#post(
       url`/v2/rooms/${roomId}/threads/${threadId}/mark-as-unresolved`,
-      {},
+      undefined,
       options
     );
 
@@ -1557,7 +1565,7 @@ export class Liveblocks {
 
     const res = await this.#get(
       url`/v2/users/${userId}/inbox-notifications/${inboxNotificationId}`,
-      {},
+      undefined,
       options
     );
     if (!res.ok) {
@@ -1647,7 +1655,7 @@ export class Liveblocks {
 
     const res = await this.#get(
       url`/v2/rooms/${roomId}/users/${userId}/notification-settings`,
-      {},
+      undefined,
       options
     );
     if (!res.ok) {
@@ -1822,7 +1830,7 @@ export class Liveblocks {
 
     const res = await this.#get(
       url`/v2/users/${userId}/notification-settings`,
-      {},
+      undefined,
       options
     );
     if (!res.ok) {

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -42,6 +42,7 @@ import {
   convertToInboxNotificationData,
   convertToThreadData,
   objectToQuery,
+  tryParseJson,
   url,
   urljoin,
 } from "@liveblocks/core";
@@ -1905,12 +1906,7 @@ export class LiveblocksError extends Error {
     } catch {
       text = FALLBACK;
     }
-    let obj: JsonObject;
-    try {
-      obj = JSON.parse(text) as JsonObject;
-    } catch {
-      obj = { message: text };
-    }
+    const obj = (tryParseJson(text) ?? { message: text }) as JsonObject;
     return new LiveblocksError(
       (obj.message || FALLBACK) as string,
       res.status,

--- a/packages/liveblocks-node/test-d/augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/augmentation.test-d.ts
@@ -176,7 +176,7 @@ async () => {
     expectType<readonly string[]>(root.animals);
     expectType<string>(root.person.name);
     expectType<number>(root.person.age);
-    expectType<number | undefined>(root.scores.get("foo"));
+    expectType<number | undefined>(root.scores["foo"]);
   }
 
   // .getComment()


### PR DESCRIPTION
This PR adds two quality-of-life improvements to `@liveblocks/node`:

1. Fixes weirdly-encoded error messages in `LiveblocksError` where the message string seems to be the whole response's JSON body. This was making it harder than necessary to programmatically handle specific errors.
2. Adds support for passing an `AbortSignal` to every method (optional).

Fixes #1978 
