### PR TITLE
Composer improvements related to mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Improve mentions behavior around whitespace, fixing a regression introduced in
   `v2.18.3` when we added support for whitespace within mentions.
+- Prevent mention suggestions from scrolling instead of flipping when there’s
+  enough space on the other side (e.g. moving from top to bottom).
 
 ## v2.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react-ui`
+
+- Improve mentions behavior around whitespace, fixing a regression introduced in
+  `v2.18.3` when we added support for whitespace within mentions.
+
 ## v2.19.0
 
 ### `@liveblocks/*`

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -536,12 +536,18 @@ test.describe("Composer", () => {
         page.locator(".lb-composer-suggestions-list-item").first()
       ).toContainText("#!?_1234$%&*()");
 
-      // Mentions cannot start with whitespace
+      // Mentions cannot start with whitespace…
       await editor.pressSequentially(" and @ ");
       await sleep(100);
       await expect(
         page.locator(".lb-composer-mention-suggestions-list")
       ).not.toBeVisible();
+
+      // …but mention suggestions should still open when the cursor is just after the @
+      await editor.press("ArrowLeft");
+      await expect(
+        page.locator(".lb-composer-mention-suggestions-list")
+      ).toBeVisible();
 
       // Mentions cannot contain consecutive whitespace
       await editor.pressSequentially(" and @li      ");

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -302,11 +302,15 @@ function ComposerEditorMentionSuggestionsWrapper({
     update();
 
     // Reset the mention suggestions after the placement update
-    requestAnimationFrame(() => {
+    const animationFrame = requestAnimationFrame(() => {
       mentionSuggestions.style.overflowY = "auto";
       mentionSuggestions.style.maxHeight =
         "var(--lb-composer-floating-available-height)";
     });
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+    };
   }, [userIds?.length, isOpen, elements.floating, update]);
 
   return (

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -257,6 +257,8 @@ function ComposerEditorMentionSuggestionsWrapper({
     placement,
     x,
     y,
+    update,
+    elements,
   } = useFloatingWithOptions({
     position,
     dir,
@@ -278,6 +280,34 @@ function ComposerEditorMentionSuggestionsWrapper({
     const domRange = getDOMRange(editor, mentionDraft.range);
     setReference(domRange ?? null);
   }, [setReference, editor, mentionDraft]);
+
+  // Manually update the placement when the number of suggestions changes
+  // This can prevent the list of suggestions from scrolling instead of moving to the other placement
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    const mentionSuggestions = elements.floating?.firstChild as
+      | HTMLElement
+      | undefined;
+
+    if (!mentionSuggestions) {
+      return;
+    }
+
+    // Force the mention suggestions to grow instead of scrolling
+    mentionSuggestions.style.overflowY = "visible";
+    mentionSuggestions.style.maxHeight = "none";
+
+    // Trigger a placement update
+    update();
+
+    // Reset the mention suggestions after the placement update
+    requestAnimationFrame(() => {
+      mentionSuggestions.style.overflowY = "auto";
+      mentionSuggestions.style.maxHeight =
+        "var(--lb-composer-floating-available-height)";
+    });
+  }, [userIds?.length, isOpen, elements.floating, update]);
 
   return (
     <Persist>

--- a/packages/liveblocks-react-ui/src/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/mentions.ts
@@ -41,17 +41,6 @@ export function getMentionDraftAtSelection(
         return true;
       }
 
-      const after = SlateEditor.after(editor, point, { unit: "character" });
-
-      if (after) {
-        const characterAfter = getCharacterAfter(editor, after);
-
-        // Ignore "@" if it's followed by a whitespace character
-        if (isWhitespaceCharacter(characterAfter?.text)) {
-          return true;
-        }
-      }
-
       return false;
     },
   });
@@ -65,7 +54,7 @@ export function getMentionDraftAtSelection(
   // Check if the match starts with the mention character (not followed by a whitespace character)
   if (
     !matchText.startsWith(MENTION_CHARACTER) ||
-    isWhitespaceCharacter(matchText[1])
+    (matchText.length > 1 && isWhitespaceCharacter(matchText[1]))
   ) {
     return;
   }

--- a/packages/liveblocks-react-ui/src/slate/utils/get-match-range.ts
+++ b/packages/liveblocks-react-ui/src/slate/utils/get-match-range.ts
@@ -102,8 +102,14 @@ export function getMatchRange(
 
   if (include) {
     return {
-      anchor: SlateEditor.before(editor, start, { unit: "offset" }) ?? start,
-      focus: SlateEditor.after(editor, end, { unit: "offset" }) ?? end,
+      anchor:
+        direction === "before" || direction === "both"
+          ? (SlateEditor.before(editor, start, { unit: "offset" }) ?? start)
+          : start,
+      focus:
+        direction === "after" || direction === "both"
+          ? (SlateEditor.after(editor, end, { unit: "offset" }) ?? end)
+          : end,
     };
   }
 


### PR DESCRIPTION
### Fix mention suggestions not opening around whitespace

Fixes https://liveblocks.slack.com/archives/C04TFCME5MF/p1740731569791229

We allowed whitespace in mentions in `2.18.3` but prevented it after `@`, and it led to cases like `hello @| world` not working. This PR fixes that, `hello @| world` works, `hello @ |world` doesn't.

### Improve mention suggestions floating placement

Fixes https://discord.com/channels/913109211746009108/1341426138425327626/1341427760425472162

Scrolling now only happens as a last resort, when both sides don't have enough space.

#### Before

https://github.com/user-attachments/assets/863d35f5-9251-4373-990e-a46964444399

#### After

https://github.com/user-attachments/assets/6b9105f6-abf9-4d99-b177-a6a413070e2a