### PR TITLE
Add optional `useRoom({ allowOutsideRoom: true })` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react`
+
+- Add optional `useRoom({ allowOutsideRoom: true })` option. When this option is
+  set, the hook might return `null` when used outside of a room, whereas the
+  default behavior of the hook is be to throw.
+
 ## v2.19.0
 
 ### `@liveblocks/*`

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1380,6 +1380,17 @@ import { useRoom } from "@liveblocks/react/suspense";
 const room = useRoom();
 ```
 
+Will throw when used outside of a [`RoomProvider`][]. If you don’t want this
+hook to throw when used outside of a Room context (for example to write
+components in a way that they can be used both inside and outside of a
+Liveblocks room), you can use the `{ allowOutsideRoom }` option:
+
+```ts
+import { useRoom } from "@liveblocks/react/suspense";
+
+const room = useRoom({ allowOutsideRoom: true }); // Possibly `null`
+```
+
 ### useIsInsideRoom [@badge=Both]
 
 Returns a boolean, `true` if the hook was called inside a

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -13,9 +13,9 @@ import {
   useEditRoomComment,
   useLayoutEffect,
   useResolveMentionSuggestions,
-  useRoomOrNull,
   useRoomPermissions,
 } from "@liveblocks/react/_private";
+import { useRoom } from "@liveblocks/react";
 import type {
   ComponentPropsWithoutRef,
   ComponentType,
@@ -650,7 +650,7 @@ export const Composer = forwardRef(
     }: ComposerProps<M>,
     forwardedRef: ForwardedRef<HTMLFormElement>
   ) => {
-    const room = useRoomOrNull();
+    const room = useRoom({ allowOutsideRoom: true });
 
     const roomId = _roomId !== undefined ? _roomId : room?.id;
     if (roomId === undefined) {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -13,9 +13,9 @@ import {
   useLayoutEffect,
   useMentionSuggestions,
   useResolveMentionSuggestions,
-  useRoomOrNull,
   useSyncSource,
 } from "@liveblocks/react/_private";
+import { useRoom } from "@liveblocks/react";
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import type {
@@ -1208,7 +1208,7 @@ const ComposerForm = forwardRef<HTMLFormElement, ComposerFormProps>(
     const [isEmpty, setEmpty] = useState(true);
     const [isSubmitting, setSubmitting] = useState(false);
     const [isFocused, setFocused] = useState(false);
-    const room = useRoomOrNull();
+    const room = useRoom({ allowOutsideRoom: true });
 
     const roomId = _roomId !== undefined ? _roomId : room?.id;
     if (roomId === undefined) {

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -102,6 +102,22 @@ describe("useRoom", () => {
   });
 });
 
+describe("useRoom({ allowOutsideRoom })", () => {
+  test("useRoom({ allowOutsideRoom }) should not return null when inside room", () => {
+    const { result } = renderHook(() => useRoom({ allowOutsideRoom: true }));
+    const room = result.current;
+    expect(room).not.toBe(null);
+  });
+
+  test("useRoom({ allowOutsideRoom }) should return null when outside room", () => {
+    const { result } = renderHook(() => useRoom({ allowOutsideRoom: true }), {
+      wrapper: undefined, // Skip using RoomProvider wrapper
+    });
+    const room = result.current;
+    expect(room).toBe(null);
+  });
+});
+
 describe("useIsInsideRoom", () => {
   test("useIsInsideRoom should return true inside a room", () => {
     const { result } = renderHook(() => useIsInsideRoom());

--- a/packages/liveblocks-react/src/_private.ts
+++ b/packages/liveblocks-react/src/_private.ts
@@ -1,6 +1,5 @@
 // Private APIs
 
-export { useRoomOrNull } from "./contexts";
 export { useLayoutEffect } from "./lib/use-layout-effect";
 export { getUmbrellaStoreForClient } from "./liveblocks";
 export { useClientOrNull } from "./liveblocks";

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -689,9 +689,23 @@ function useRoom<
   U extends BaseUserMeta = DU,
   E extends Json = DE,
   M extends BaseMetadata = DM,
->(): Room<P, S, U, E, M> {
+>(options?: { allowOutsideRoom: false }): Room<P, S, U, E, M>;
+function useRoom<
+  P extends JsonObject = DP,
+  S extends LsonObject = DS,
+  U extends BaseUserMeta = DU,
+  E extends Json = DE,
+  M extends BaseMetadata = DM,
+>(options: { allowOutsideRoom: boolean }): Room<P, S, U, E, M> | null;
+function useRoom<
+  P extends JsonObject = DP,
+  S extends LsonObject = DS,
+  U extends BaseUserMeta = DU,
+  E extends Json = DE,
+  M extends BaseMetadata = DM,
+>(options?: { allowOutsideRoom: boolean }): Room<P, S, U, E, M> | null {
   const room = useRoomOrNull<P, S, U, E, M>();
-  if (room === null) {
+  if (room === null && !options?.allowOutsideRoom) {
     throw new Error("RoomProvider is missing from the React tree.");
   }
   return room;

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -400,7 +400,8 @@ type RoomContextBundleCommon<
    * Returns the Room of the nearest RoomProvider above in the React component
    * tree.
    */
-  useRoom(): Room<P, S, U, E, M>;
+  useRoom(options?: { allowOutsideRoom: false }): Room<P, S, U, E, M>;
+  useRoom(options: { allowOutsideRoom: boolean }): Room<P, S, U, E, M> | null;
 
   /**
    * Returns the current connection status for the Room, and triggers

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -259,6 +259,14 @@ declare global {
   expectType<number>(room.getPresence().cursor.x);
   expectType<number>(room.getPresence().cursor.y);
   expectError(room.getPresence().nonexisting);
+
+  expectType<string>(classic.useRoom({ allowOutsideRoom: false }).id);
+  expectType<string | undefined>(
+    classic.useRoom({ allowOutsideRoom: true })?.id
+  );
+  expectType<string | undefined>(
+    classic.useRoom({ allowOutsideRoom: !Math.random() })?.id
+  );
 }
 
 // useRoom() (suspense)
@@ -267,6 +275,14 @@ declare global {
   expectType<number>(room.getPresence().cursor.x);
   expectType<number>(room.getPresence().cursor.y);
   expectError(room.getPresence().nonexisting);
+
+  expectType<string>(suspense.useRoom({ allowOutsideRoom: false }).id);
+  expectType<string | undefined>(
+    suspense.useRoom({ allowOutsideRoom: true })?.id
+  );
+  expectType<string | undefined>(
+    suspense.useRoom({ allowOutsideRoom: !Math.random() })?.id
+  );
 }
 
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -252,6 +252,11 @@ const ctx = createRoomContext<P, S, U, E, M>(client);
 
 // The useRoom() hook
 expectType<Room<P, S, U, E, M>>(ctx.useRoom());
+expectType<Room<P, S, U, E, M>>(ctx.useRoom({ allowOutsideRoom: false }));
+expectType<Room<P, S, U, E, M> | null>(
+  ctx.useRoom({ allowOutsideRoom: !Math.random() })
+);
+expectType<Room<P, S, U, E, M> | null>(ctx.useRoom({ allowOutsideRoom: true }));
 
 // useIsInsideRoom()
 expectType<boolean>(ctx.useIsInsideRoom());

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -162,6 +162,14 @@ import { expectAssignable, expectError, expectType } from "tsd";
   const room = classic.useRoom();
   expectType<Json | undefined>(room.getPresence().cursor);
   expectType<Json | undefined>(room.getPresence().nonexisting);
+
+  expectType<string>(classic.useRoom({ allowOutsideRoom: false }).id);
+  expectType<string | undefined>(
+    classic.useRoom({ allowOutsideRoom: true })?.id
+  );
+  expectType<string | undefined>(
+    classic.useRoom({ allowOutsideRoom: !Math.random() })?.id
+  );
 }
 
 // useRoom() (suspense)
@@ -169,6 +177,14 @@ import { expectAssignable, expectError, expectType } from "tsd";
   const room = suspense.useRoom();
   expectType<Json | undefined>(room.getPresence().cursor);
   expectType<Json | undefined>(room.getPresence().nonexisting);
+
+  expectType<string>(suspense.useRoom({ allowOutsideRoom: false }).id);
+  expectType<string | undefined>(
+    suspense.useRoom({ allowOutsideRoom: true })?.id
+  );
+  expectType<string | undefined>(
+    suspense.useRoom({ allowOutsideRoom: !Math.random() })?.id
+  );
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
This adds an optional `useRoom({ allowOutsideRoom: true })` API to replace the `useRoomOrNull` private/internal hook that some users have started relying on. This new API should be more easily discovered, reduce the number of public APIs we expose at the top-level, yet still provide correct typing.

```ts
// Inferred TypeScript types
useRoom()                            // returns Room
useRoom({ allowOutsideRoom: true })  // returns Room | null
```

When used outside of a RoomProvider context:

```ts
// Runtime behavior
useRoom()                            // throws
useRoom({ allowOutsideRoom: true })  // returns null
```

See also, [this Slack message](https://liveblocks.slack.com/archives/C083U8FAUF8/p1740491333528449?thread_ts=1740396195.278319&cid=C083U8FAUF8) for context.
