### PR TITLE
Improve event propagation in `Composer` formatting toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 ### `@liveblocks/react-ui`
 
 - Improve mentions behavior around whitespace, fixing a regression introduced in
-  `v2.18.3` when we added support for whitespace within mentions.
+  `v2.18.3` when we added support for whitespace _within_ mentions.
 - Prevent mention suggestions from scrolling instead of flipping when there’s
   enough space on the other side (e.g. moving from top to bottom).
+- Improve event propagation in the formatting toolbar of `Composer`.
 
 ## v2.19.0
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -1708,17 +1708,38 @@ const ComposerMarkToggle = forwardRef<
   ComposerMarkToggleProps
 >(
   (
-    { children, mark, onValueChange, onClick, asChild, ...props },
+    {
+      children,
+      mark,
+      onValueChange,
+      onClick,
+      onPointerDown,
+      asChild,
+      ...props
+    },
     forwardedRef
   ) => {
     const Component = asChild ? Slot : "button";
     const { marks, toggleMark } = useComposer();
+
+    const handlePointerDown = useCallback(
+      (event: PointerEvent<HTMLButtonElement>) => {
+        onPointerDown?.(event);
+
+        event.preventDefault();
+        event.stopPropagation();
+      },
+      [onPointerDown]
+    );
 
     const handleClick = useCallback(
       (event: MouseEvent<HTMLButtonElement>) => {
         onClick?.(event);
 
         if (!event.isDefaultPrevented()) {
+          event.preventDefault();
+          event.stopPropagation();
+
           toggleMark(mark);
           onValueChange?.(mark);
         }
@@ -1731,6 +1752,7 @@ const ComposerMarkToggle = forwardRef<
         asChild
         pressed={marks[mark]}
         onClick={handleClick}
+        onPointerDown={handlePointerDown}
         {...props}
       >
         <Component {...props} ref={forwardedRef}>


### PR DESCRIPTION
Unlike other parts of `Composer` (and `Comment`, `Thread`, etc), the formatting toolbar's buttons are bubbling their pointer events when they shouldn't.