### PR TITLE
Improve and fix pasting HTML in composer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 /packages/liveblocks-core/	@nvie @sugardarius @marcbouchenoire
 /packages/liveblocks-client/	@nvie @sugardarius @marcbouchenoire
 /packages/liveblocks-react/	@nvie @sugardarius @marcbouchenoire
-/packages/liveblocks-react-ui/	@marcbouchenoire @jrowny
+/packages/liveblocks-react-ui/	@marcbouchenoire
 /packages/liveblocks-react-lexical/	@jrowny @nimeshnayaju
 /packages/liveblocks-react-tiptap/	@jrowny @nimeshnayaju
 /packages/liveblocks-emails/	@sugardarius

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react-ui`
+
+- Improve and fix pasting HTML into the composer.
+
 ## v2.20.0
 
 ### `@liveblocks/client`

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -669,6 +669,24 @@ test.describe("Composer", () => {
 
       await setClipboard(
         page,
+        "<body><b><p>paragraph</p></b></body>",
+        "text/html"
+      );
+      await editor.focus();
+      await page.keyboard.press("ControlOrMeta+V");
+
+      await editor.press("Enter");
+
+      // ➡️ The submitted comment contains the formatted text based on the pasted HTML
+      const outputWithB = await getOutputJson(page);
+      expect(outputWithB?.body.content[0].children).toEqual([
+        { text: "paragraph" },
+      ]);
+
+      await resetPage(page);
+
+      await setClipboard(
+        page,
         "<p>paragraph</p><br class='Apple-interchange-newline' >",
         "text/html"
       );

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -653,6 +653,38 @@ test.describe("Composer", () => {
 
       await resetPage(page);
 
+      await setClipboard(page, "<body><p>paragraph</p></body>", "text/html");
+      await editor.focus();
+      await page.keyboard.press("ControlOrMeta+V");
+
+      await editor.press("Enter");
+
+      // ➡️ The submitted comment contains the formatted text based on the pasted HTML
+      const outputWithBody = await getOutputJson(page);
+      expect(outputWithBody?.body.content[0].children).toEqual([
+        { text: "paragraph" },
+      ]);
+
+      await resetPage(page);
+
+      await setClipboard(
+        page,
+        "<p>paragraph</p><br class='Apple-interchange-newline' >",
+        "text/html"
+      );
+      await editor.focus();
+      await page.keyboard.press("ControlOrMeta+V");
+
+      await editor.press("Enter");
+
+      // ➡️ The submitted comment contains the formatted text based on the pasted HTML
+      const outputWithTrailingBr = await getOutputJson(page);
+      expect(outputWithTrailingBr?.body.content[0].children).toEqual([
+        { text: "paragraph" },
+      ]);
+
+      await resetPage(page);
+
       await setClipboard(
         page,
         "<p>Hello, <a href='https://liveblocks.io/'>world!</a></p>",

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -39,7 +39,7 @@ async function getEditorText(editor: Locator) {
   return text?.replace(/[\u200B-\u200F\uFEFF]/g, "");
 }
 
-async function pasteData(page: Page, data: string, format = "text/plain") {
+async function setClipboard(page: Page, data: string, format = "text/plain") {
   await page.evaluate(
     async ({ data, format }) => {
       const item = new ClipboardItem({
@@ -53,8 +53,6 @@ async function pasteData(page: Page, data: string, format = "text/plain") {
       format,
     }
   );
-
-  await page.keyboard.press("ControlOrMeta+V");
 }
 
 function resetPage(page: Page) {
@@ -399,7 +397,8 @@ test.describe("Composer", () => {
 
       // Select "Hello" and paste a URL
       await selectText(editor.getByText("Hello"), "Hello");
-      await pasteData(page, "https://liveblocks.io");
+      await setClipboard(page, "https://liveblocks.io");
+      await page.keyboard.press("ControlOrMeta+V");
 
       // ➡️ The editor contains the link
       expect(
@@ -418,7 +417,8 @@ test.describe("Composer", () => {
 
       // Select "Hello" and paste an invalid URL (or any non-URL text)
       await selectText(editor.getByText("Hello"), "Hello");
-      await pasteData(page, "liveblocks");
+      await setClipboard(page, "liveblocks");
+      await page.keyboard.press("ControlOrMeta+V");
 
       // ➡️ The editor doesn't contain any link
       expect(await editor.locator("span > a").count()).toEqual(0);
@@ -435,7 +435,8 @@ test.describe("Composer", () => {
 
       // Select everything and paste a URL
       await editor.selectText();
-      await pasteData(page, "https://liveblocks.io");
+      await setClipboard(page, "https://liveblocks.io");
+      await page.keyboard.press("ControlOrMeta+V");
 
       // ➡️ The editor doesn't contain the pasted link
       expect(
@@ -611,7 +612,45 @@ test.describe("Composer", () => {
       expect(outputCopied).toEqual(outputPasted);
     });
 
-    // TODO: Pasting HTML tests
+    test("should support pasting HTML", async () => {
+      const { editor } = getComposer(page);
+
+      await setClipboard(
+        page,
+        "   <p>paragraph</p> <p>plain, <strong>bold</strong> </p>  \n   <p><code  data-test=''>code </code><em> /italic</em>  <s>strikethrough</s> ,. <b><i><s><code> all</code></i></s></b> </p>  ",
+        "text/html"
+      );
+      await editor.focus();
+      await page.keyboard.press("ControlOrMeta+V");
+
+      await editor.press("Enter");
+
+      // ➡️ The submitted comment contains the formatted text based on the pasted HTML
+      const output = await getOutputJson(page);
+      expect(output?.body.content[0].children).toEqual([{ text: "paragraph" }]);
+      expect(output?.body.content[1].children).toEqual([
+        { text: "plain, " },
+        { text: "bold", bold: true },
+        { text: " " },
+      ]);
+      expect(output?.body.content[2].children).toEqual([
+        { text: "code ", code: true },
+        { text: " /italic", italic: true },
+        { text: "  " },
+        { text: "strikethrough", strikethrough: true },
+        { text: " ,. " },
+        {
+          text: " all",
+          bold: true,
+          code: true,
+          italic: true,
+          strikethrough: true,
+        },
+        { text: " " },
+      ]);
+
+      // TODO: Pasting links
+    });
   });
 
   test.describe("autoFocus", () => {

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -102,7 +102,9 @@ function jsxTextChildren(
 
 function deserialize(node: Node): DeserializedNode {
   if (node.nodeType === 3) {
-    return node.textContent;
+    const text = node.textContent;
+
+    return text ? { text } : null;
   } else if (node.nodeType !== 1) {
     return null;
   } else if (node.nodeName === "BR") {

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -14,7 +14,7 @@ import { getFiles } from "../../utils/data-transfer";
 
 // Based on: https://github.com/ianstormtaylor/slate/blob/main/site/examples/paste-html.tsx
 
-const NEWLINE_REGEX = /\r\n|\r|\n/g;
+const NEWLINE_REGEX = /[\r\n]/g;
 const WHITESPACE_REGEX = /\s+/g;
 
 type OmitTextChildren<T> = Omit<T, "text" | "children">;
@@ -106,7 +106,7 @@ function jsxTextChildren(
 function deserialize(node: Node): DeserializedNode {
   if (node.nodeType === 3) {
     let text = node.textContent;
-    const isMultiLine = text?.match(NEWLINE_REGEX);
+    const isMultiLine = text && NEWLINE_REGEX.test(text);
 
     if (text && isMultiLine) {
       text = text.replace(WHITESPACE_REGEX, " ").trim();

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -14,6 +14,7 @@ import { getFiles } from "../../utils/data-transfer";
 
 // Based on: https://github.com/ianstormtaylor/slate/blob/main/site/examples/paste-html.tsx
 
+const NEWLINE_REGEX = /\r\n|\r|\n/g;
 const WHITESPACE_REGEX = /\s+/g;
 
 type OmitTextChildren<T> = Omit<T, "text" | "children">;
@@ -105,7 +106,7 @@ function jsxTextChildren(
 function deserialize(node: Node): DeserializedNode {
   if (node.nodeType === 3) {
     let text = node.textContent;
-    const isMultiLine = text?.includes("\n");
+    const isMultiLine = text?.match(NEWLINE_REGEX);
 
     if (text && isMultiLine) {
       text = text.replace(WHITESPACE_REGEX, " ").trim();

--- a/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/paste.ts
@@ -14,6 +14,8 @@ import { getFiles } from "../../utils/data-transfer";
 
 // Based on: https://github.com/ianstormtaylor/slate/blob/main/site/examples/paste-html.tsx
 
+const WHITESPACE_REGEX = /\s+/g;
+
 type OmitTextChildren<T> = Omit<T, "text" | "children">;
 
 type ComposerBodyElementTag = OmitTextChildren<
@@ -102,7 +104,12 @@ function jsxTextChildren(
 
 function deserialize(node: Node): DeserializedNode {
   if (node.nodeType === 3) {
-    const text = node.textContent;
+    let text = node.textContent;
+    const isMultiLine = text?.includes("\n");
+
+    if (text && isMultiLine) {
+      text = text.replace(WHITESPACE_REGEX, " ").trim();
+    }
 
     return text ? { text } : null;
   } else if (node.nodeType !== 1) {


### PR DESCRIPTION
Fixes https://discord.com/channels/913109211746009108/1347692586533519370/1347692586533519370.

This PR fixes how inline HTML text nodes are treated when pasting HTML and improves how whitespace is preserved (or not) within those nodes.

### Example

Pasting the following `text/html`:

```html
<div>
  <div class="tw-flex tw-flex-col tw-gap-3">Hello, world<a
      class="tw-text-blue-600 hover:tw-cursor-pointer hover:tw-underline tw-contents" data-testid="page-link"
      href="http://google.com"><span
        class="tw-contents"> (Page 1)</span></a><a
      class="tw-text-blue-600 hover:tw-cursor-pointer hover:tw-underline tw-contents" data-testid="page-link"
      href="http://google.com"><span
        class="tw-contents"> (Page 2)</span></a></div>
</div>
```

#### Before

[ (Page 1)](http://google.com/)[ (Page 2)](http://google.com/)

#### After

Hello, world[ (Page 1)](http://google.com/)[ (Page 2)](http://google.com/)

---

@jrowny I feel bad for adding you to all `@liveblocks/react-ui` PRs so I'm updating `CODEOWNERS`