### PR TITLE
Only loosen dupe detection of exactly-same versions when inside a testing context

### DIFF
--- a/packages/liveblocks-core/src/dupe-detection.ts
+++ b/packages/liveblocks-core/src/dupe-detection.ts
@@ -39,7 +39,7 @@ export function detectDupes(
 
   if (!g[pkgId]) {
     g[pkgId] = pkgBuildInfo;
-  } else if (g[pkgId] === pkgBuildInfo) {
+  } else if (process.env.NODE_ENV === "test" && g[pkgId] === pkgBuildInfo) {
     // Allow it, see https://github.com/liveblocks/liveblocks/pull/1004
   } else {
     const msg = [


### PR DESCRIPTION
In prod/dev contexts, we definitely still want to error when this situation occurs.
