### PR TITLE
Fix notification settings docs/example usage

### DIFF
--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -3318,17 +3318,17 @@ console.log(settings);
     </div>
 
   </PropertiesListItem>
-  <PropertiesListItem name="settings.email" type="ChannelNotificationSetting">
+  <PropertiesListItem name="settings.email" type="NotificationChannelSettings">
     The email notification settings.
   </PropertiesListItem>
-  <PropertiesListItem name="settings.slack" type="ChannelNotificationSetting">
-    The slack notification settings.
+  <PropertiesListItem name="settings.slack" type="NotificationChannelSettings">
+    The Slack notification settings.
   </PropertiesListItem>
-  <PropertiesListItem name="settings.teams" type="ChannelNotificationSetting">
-    The microsoft teams notification settings.
+  <PropertiesListItem name="settings.teams" type="NotificationChannelSettings">
+    The Microsoft Teams notification settings.
   </PropertiesListItem>
-  <PropertiesListItem name="settings.webPush" type="ChannelNotificationSetting">
-    The web push notification settings.
+  <PropertiesListItem name="settings.webPush" type="NotificationChannelSettings">
+    The Web Push notification settings.
   </PropertiesListItem>
 </PropertiesList>
 

--- a/docs/pages/ready-made-features/notifications/email-notifications.mdx
+++ b/docs/pages/ready-made-features/notifications/email-notifications.mdx
@@ -252,7 +252,7 @@ function NotificationSettings() {
         Receive thread notifications by email:
         <input
           type="checkbox"
-          checked={settings.email.thread}
+          checked={settings.email?.thread}
           onChange={(e) =>
             updateSettings({ email: { thread: e.target.checked } })
           }

--- a/guides/pages/how-to-create-a-notification-settings-panel.mdx
+++ b/guides/pages/how-to-create-a-notification-settings-panel.mdx
@@ -260,7 +260,7 @@ function NotificationSettings() {
         </>
       ) : null}
 
-      {settings.thread ? (
+      {settings.slack ? (
         <>
           <label>
             Receive document invites notifications on Slack

--- a/guides/pages/what-to-check-before-enabling-a-new-notification-kind.mdx
+++ b/guides/pages/what-to-check-before-enabling-a-new-notification-kind.mdx
@@ -201,7 +201,7 @@ function NotificationSettings() {
       <input
         type="checkbox"
         // +++
-        checked={settings.email.thread}
+        checked={settings.email?.thread}
         onChange={(e) =>
           updateSettings({ email: { thread: e.target.checked } })
         }

--- a/starter-kits/nextjs-starter-kit/components/Inbox/Inbox.module.css
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/Inbox.module.css
@@ -12,7 +12,7 @@
 
 .inboxHeaderButtons {
   display: flex;
-  gap: var(--space-6);
+  gap: var(--space-3);
 }
 
 .inboxHeader h2 {

--- a/starter-kits/nextjs-starter-kit/components/Inbox/Inbox.tsx
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/Inbox.tsx
@@ -1,4 +1,4 @@
-import { ClientSideSuspense, useIsInsideRoom } from "@liveblocks/react";
+import { ClientSideSuspense } from "@liveblocks/react";
 import {
   useInboxNotifications,
   useMarkAllInboxNotificationsAsRead,
@@ -19,7 +19,6 @@ export function Inbox({ className, ...props }: ComponentProps<"div">) {
   // Count unread notifications to tell if "mark all" button should be disabled
   const markAllInboxNotificationsAsRead = useMarkAllInboxNotificationsAsRead();
   const { count } = useUnreadInboxNotificationsCount();
-  const isInsideRoom = useIsInsideRoom();
 
   return (
     <div className={clsx(className, styles.inbox)} {...props}>
@@ -33,14 +32,12 @@ export function Inbox({ className, ...props }: ComponentProps<"div">) {
           >
             Mark all as read
           </Button>
-          {isInsideRoom ? (
-            <InboxSettingsDialog>
-              <Button variant="secondary" iconButton>
-                <span className="sr-only">Notification channels</span>
-                <SettingsIcon />
-              </Button>
-            </InboxSettingsDialog>
-          ) : null}
+          <InboxSettingsDialog>
+            <Button variant="secondary" iconButton>
+              <span className="sr-only">Notification channels</span>
+              <SettingsIcon />
+            </Button>
+          </InboxSettingsDialog>
         </div>
       </div>
       <ClientSideSuspense

--- a/starter-kits/nextjs-starter-kit/components/Inbox/Inbox.tsx
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/Inbox.tsx
@@ -1,4 +1,4 @@
-import { ClientSideSuspense } from "@liveblocks/react";
+import { ClientSideSuspense, useIsInsideRoom } from "@liveblocks/react";
 import {
   useInboxNotifications,
   useMarkAllInboxNotificationsAsRead,
@@ -19,6 +19,7 @@ export function Inbox({ className, ...props }: ComponentProps<"div">) {
   // Count unread notifications to tell if "mark all" button should be disabled
   const markAllInboxNotificationsAsRead = useMarkAllInboxNotificationsAsRead();
   const { count } = useUnreadInboxNotificationsCount();
+  const isInsideRoom = useIsInsideRoom();
 
   return (
     <div className={clsx(className, styles.inbox)} {...props}>
@@ -32,12 +33,14 @@ export function Inbox({ className, ...props }: ComponentProps<"div">) {
           >
             Mark all as read
           </Button>
-          <InboxSettingsDialog>
-            <Button variant="secondary" iconButton>
-              <span className="sr-only">Notification channels</span>
-              <SettingsIcon />
-            </Button>
-          </InboxSettingsDialog>
+          {isInsideRoom ? (
+            <InboxSettingsDialog>
+              <Button variant="secondary" iconButton>
+                <span className="sr-only">Notification channels</span>
+                <SettingsIcon />
+              </Button>
+            </InboxSettingsDialog>
+          ) : null}
         </div>
       </div>
       <ClientSideSuspense

--- a/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.module.css
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.module.css
@@ -37,6 +37,13 @@
   gap: var(--space-7);
 }
 
+.loading {
+  display: flex;
+  place-items: center;
+  place-content: center;
+  min-height: 100px;
+}
+
 .selectBox {
   margin: 0 var(--space-8);
   display: flex;

--- a/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
@@ -1,122 +1,145 @@
 import {
+  useIsInsideRoom,
   useNotificationSettings,
   useRoomNotificationSettings,
 } from "@liveblocks/react/suspense";
-import { ReactNode } from "react";
+import clsx from "clsx";
+import { ReactNode, Suspense } from "react";
 import { Dialog } from "@/primitives/Dialog";
 import { Select } from "@/primitives/Select";
 import { Spinner } from "@/primitives/Spinner";
 import { Switch } from "@/primitives/Switch";
 import styles from "./InboxSettingsDialog.module.css";
 
-export function InboxSettingsDialog({ children }: { children: ReactNode }) {
+function RoomNotificationSettings() {
+  // Render which thread notifications should be received (for both the inbox, and also in webhooks)
+  const [roomSettings, updateRoomSettings] = useRoomNotificationSettings();
+
+  return (
+    <div className={styles.selectBox}>
+      <Select
+        aboveOverlay
+        initialValue="replies_and_mentions"
+        items={[
+          {
+            title: "All threads",
+            value: "all",
+            description: "All comment and thread activity",
+          },
+          {
+            title: "Participating threads",
+            value: "replies_and_mentions",
+            description:
+              "All mentions and replies in threads you're participating in",
+          },
+          {
+            title: "No threads",
+            value: "none",
+            description: "No thread notifications are received",
+          },
+        ]}
+        onChange={(value) => {
+          updateRoomSettings({
+            threads: value as any,
+          });
+        }}
+        value={roomSettings.settings.threads}
+      />
+    </div>
+  );
+}
+
+function EmailNotificationSettings() {
   // Render settings that change how notifications webhooks are sent
   // These webhooks can be sent on different channels, with different settings for each
   // Below we're just using the email channel, but you could also add slack or teams, for instance
-  const [{ isLoading, settings, error }, updateSettings] =
-    useNotificationSettings();
+  const [{ settings }, updateSettings] = useNotificationSettings();
 
-  // Render which thread notifications should be received (for both the inbox, and also in webhooks)
-  const [roomSettings, updateRoomSettings] = useRoomNotificationSettings();
+  return (
+    <div className={styles.switchBox}>
+      <Switch
+        label="Document invites"
+        id="email-invited-to-document"
+        disabled={!settings.email}
+        checked={settings.email?.$addedToDocument}
+        onCheckedChange={() =>
+          updateSettings({
+            email: {
+              $addedToDocument: settings.email
+                ? !settings.email.$addedToDocument
+                : false,
+            },
+          })
+        }
+        justifyBetween
+      />
+      <Switch
+        label="New comments in threads"
+        id="email-thread"
+        disabled={!settings.email}
+        checked={settings.email?.thread}
+        onCheckedChange={() =>
+          updateSettings({
+            email: {
+              thread: settings.email ? !settings.email.thread : false,
+            },
+          })
+        }
+        justifyBetween
+      />
+      <Switch
+        label="New mentions in text documents"
+        id="email-text-mention"
+        disabled={!settings.email}
+        checked={settings.email?.textMention}
+        onCheckedChange={() =>
+          updateSettings({
+            email: {
+              textMention: settings.email ? !settings.email.textMention : false,
+            },
+          })
+        }
+        justifyBetween
+      />
+    </div>
+  );
+}
+
+export function InboxSettingsDialog({ children }: { children: ReactNode }) {
+  const isInsideRoom = useIsInsideRoom();
 
   return (
     <Dialog
       title="Notification channels"
       content={
-        error ? (
-          <div className={styles.dialog}>
-            Error fetching notifications settings.
-          </div>
-        ) : isLoading ? (
-          <div className={styles.dialog}>
-            <Spinner />
-          </div>
-        ) : (
-          <div className={styles.dialog}>
-            <div className={styles.switches}>
-              <h3>In this document, receive thread notifications for… </h3>
-              <div className={styles.selectBox}>
-                <Select
-                  aboveOverlay
-                  initialValue="replies_and_mentions"
-                  items={[
-                    {
-                      title: "All threads",
-                      value: "all",
-                      description: "All comment and thread activity",
-                    },
-                    {
-                      title: "Participating threads",
-                      value: "replies_and_mentions",
-                      description:
-                        "All mentions and replies in threads you're participating in",
-                    },
-                    {
-                      title: "No threads",
-                      value: "none",
-                      description: "No thread notifications are received",
-                    },
-                  ]}
-                  onChange={(value) => {
-                    updateRoomSettings({
-                      threads: value as any,
-                    });
-                  }}
-                  value={roomSettings.settings.threads}
-                />
-              </div>
-              <h3>In all documents, receive emails for…</h3>
-              <div className={styles.switchBox}>
-                <Switch
-                  label="Document invites"
-                  id="email-invited-to-document"
-                  disabled={!settings.email}
-                  checked={settings.email?.$addedToDocument}
-                  onCheckedChange={() =>
-                    updateSettings({
-                      email: {
-                        $addedToDocument: settings.email
-                          ? !settings.email.$addedToDocument
-                          : false,
-                      },
-                    })
+        <div className={styles.dialog}>
+          <div className={styles.switches}>
+            {isInsideRoom ? (
+              <>
+                <h3>In this document, receive thread notifications for… </h3>
+                <Suspense
+                  fallback={
+                    <div className={clsx(styles.switchBox, styles.loading)}>
+                      <Spinner />
+                    </div>
                   }
-                  justifyBetween
-                />
-                <Switch
-                  label="New comments in threads"
-                  id="email-thread"
-                  disabled={!settings.email}
-                  checked={settings.email?.thread}
-                  onCheckedChange={() =>
-                    updateSettings({
-                      email: {
-                        thread: settings.email ? !settings.email.thread : false,
-                      },
-                    })
-                  }
-                  justifyBetween
-                />
-                <Switch
-                  label="New mentions in text documents"
-                  id="email-text-mention"
-                  disabled={!settings.email}
-                  checked={settings.email?.textMention}
-                  onCheckedChange={() =>
-                    updateSettings({
-                      email: {
-                        textMention: settings.email
-                          ? !settings.email.textMention
-                          : false,
-                      },
-                    })
-                  }
-                  justifyBetween
-                />
-              </div>
-            </div>
+                >
+                  <RoomNotificationSettings />
+                </Suspense>
+              </>
+            ) : null}
+            <h3>In all documents, receive emails for…</h3>
+            <Suspense
+              fallback={
+                <div className={clsx(styles.switchBox, styles.loading)}>
+                  <Spinner />
+                </div>
+              }
+            >
+              <EmailNotificationSettings />
+            </Suspense>
           </div>
-        )
+        </div>
       }
     >
       {children}

--- a/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
@@ -70,11 +70,14 @@ export function InboxSettingsDialog({ children }: { children: ReactNode }) {
                 <Switch
                   label="Document invites"
                   id="email-invited-to-document"
-                  checked={settings.email.$addedToDocument}
+                  disabled={!settings.email}
+                  checked={settings.email?.$addedToDocument}
                   onCheckedChange={() =>
                     updateSettings({
                       email: {
-                        $addedToDocument: !settings.email.$addedToDocument,
+                        $addedToDocument: settings.email
+                          ? !settings.email.$addedToDocument
+                          : false,
                       },
                     })
                   }
@@ -83,10 +86,13 @@ export function InboxSettingsDialog({ children }: { children: ReactNode }) {
                 <Switch
                   label="New comments in threads"
                   id="email-thread"
-                  checked={settings.email.thread}
+                  disabled={!settings.email}
+                  checked={settings.email?.thread}
                   onCheckedChange={() =>
                     updateSettings({
-                      email: { thread: !settings.email.thread },
+                      email: {
+                        thread: settings.email ? !settings.email.thread : false,
+                      },
                     })
                   }
                   justifyBetween
@@ -94,10 +100,15 @@ export function InboxSettingsDialog({ children }: { children: ReactNode }) {
                 <Switch
                   label="New mentions in text documents"
                   id="email-text-mention"
-                  checked={settings.email.textMention}
+                  disabled={!settings.email}
+                  checked={settings.email?.textMention}
                   onCheckedChange={() =>
                     updateSettings({
-                      email: { textMention: !settings.email.textMention },
+                      email: {
+                        textMention: settings.email
+                          ? !settings.email.textMention
+                          : false,
+                      },
                     })
                   }
                   justifyBetween


### PR DESCRIPTION
I found a few issues around notification settings in the docs and the Starter Kit, the changes are best read commit-by-commit.