### PR TITLE
Improve stack traces of REST API errors to include the original error location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/node`
+
+- Fix: improve stack traces of REST API errors to include the original error
+  location.
+
 ## v2.22.0
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -2329,6 +2329,10 @@ export class LiveblocksError extends Error {
   }
 
   static async from(res: Response): Promise<LiveblocksError> {
+    // Retain the stack trace of the original error location, not the async return point
+    const origErrLocation = new Error();
+    Error.captureStackTrace(origErrLocation, LiveblocksError.from); // eslint-disable-line
+
     const FALLBACK = "An error happened without an error message";
     let text: string;
     try {
@@ -2347,6 +2351,8 @@ export class LiveblocksError extends Error {
         .filter(Boolean)
         .join("\n") || undefined;
 
-    return new LiveblocksError(message, res.status, details);
+    const err = new LiveblocksError(message, res.status, details);
+    err.stack = origErrLocation.stack;
+    return err;
   }
 }


### PR DESCRIPTION
### Before

![Screen Shot 2025-03-24 at 17 11 52@2x](https://github.com/user-attachments/assets/b5284300-e072-471f-bf3c-92c1a71f0f05)

As you can see, there is no information in the stack trace about which API request is failing here. This was because the Error instance gets generated after the `await` call, losing all stack information from the original call stack.

### After

You can now see again which API request is throwing this issue:

![Screen Shot 2025-03-24 at 17 15 06@2x](https://github.com/user-attachments/assets/ecf231a1-8660-469c-9a5f-9b05858f7e84)
