### PR TITLE
Update Liveblocks emails documentation for BlockNote

### DIFF
--- a/docs/pages/api-reference/liveblocks-emails.mdx
+++ b/docs/pages/api-reference/liveblocks-emails.mdx
@@ -971,6 +971,14 @@ Tiptap optionally allows you to
 instead of just one. For now, these functions only support one editor per room,
 but we’ll be looking to add support for more later.
 
+#### BlockNote
+
+This package does not yet support our
+[collaborative BlockNote text editor](/docs/api-reference/liveblocks-react-blocknote)
+integration. Support of BlockNote is planned for a future release and is
+currently on our development roadmap. Users requiring BlockNote compatibility
+should monitor package updates for this upcoming feature.
+
 ### prepareTextMentionNotificationEmailAsReact [#prepare-text-mention-notification-email-as-react]
 
 Takes a


### PR DESCRIPTION
Add limitation paragraph to indicate we don't support BlockNote yet in `@liveblocks/emails`.
Thanks 🙏🏻 