### PR TITLE
Optimize `.getOrCreateRoom()` and `.upsertRoom()` Node methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/node`
+
+- Optimize `.getOrCreateRoom()` to only make a single round-trip to the server.
+- Optimize `.upsertRoom()` to only make a single round-trip to the server.
+
 ## v2.22.1
 
 ### `@liveblocks/react-blocknote`

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -593,35 +593,44 @@ response as the
 
 ```ts
 const room = await liveblocks.upsertRoom("my-room-id", {
-  defaultAccesses: ["room:write"],
+  // These fields will get updated when the room exists, or will be created
+  update: {
+    metadata: { color: "red" },
+  },
+  // These fields will only be set when the room will get created
+  create: {
+    defaultAccesses: ["room:write"],
+  },
 });
 
 // { type: "room", id: "my-room-id", metadata: {...}, ... }
 console.log(room);
 ```
 
-A number of room creation options are available, allowing you to set permissions
-and attach custom metadata.
+A number of room update or creation options are available, allowing you to set
+permissions and attach custom metadata.
 
 ```ts
 const room = await liveblocks.upsertRoom("my-room-id", {
-  // The default room permissions. `[]` for private, `["room:write"]` for public.
-  defaultAccesses: [],
+  update: {
+    // The default room permissions. `[]` for private, `["room:write"]` for public.
+    defaultAccesses: [],
 
-  // Optional, the room's group ID permissions
-  groupsAccesses: {
-    design: ["room:write"],
-    engineering: ["room:presence:write", "room:read"],
-  },
+    // Optional, the room's group ID permissions
+    groupsAccesses: {
+      design: ["room:write"],
+      engineering: ["room:presence:write", "room:read"],
+    },
 
-  // Optional, the room's user ID permissions
-  usersAccesses: {
-    "my-user-id": ["room:write"],
-  },
+    // Optional, the room's user ID permissions
+    usersAccesses: {
+      "my-user-id": ["room:write"],
+    },
 
-  // Optional, custom metadata to attach to the room
-  metadata: {
-    myRoomType: "whiteboard",
+    // Optional, custom metadata to attach to the room
+    metadata: {
+      myRoomType: "whiteboard",
+    },
   },
 });
 ```

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -3399,15 +3399,15 @@
               },
               "usersAccesses": {
                 "type": ["object"],
-                "description": "A map of user identifiers to permissions list. Setting the value as `null` will clear all users’ accesses. Setting one user identifier as `null` will clear this user’s accesses."
+                "description": "A map of user identifiers to permissions list."
               },
               "groupsAccesses": {
                 "type": ["object"],
-                "description": "A map of group identifiers to permissions list. Setting the value as `null` will clear all groups’ accesses. Setting one group identifier as `null` will clear this group’s accesses."
+                "description": "A map of group identifiers to permissions list."
               },
               "metadata": {
                 "type": ["object"],
-                "description": "A map of metadata keys to their values (`string` or `string[]`). Setting the value as `null` will clear all metadata. Setting a key as `null` will clear the key."
+                "description": "A map of metadata keys to their values (`string` or `string[]`)."
               }
             },
             "required": ["defaultAccesses"]

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -114,7 +114,7 @@
       },
       "post": {
         "summary": "Create room",
-        "description": "This endpoint creates a new room. `id` and `defaultAccesses` are required. Corresponds to [`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms). \n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 40 characters. `usersAccesses` is optional field.\n- `groupsAccesses` are optional fields.\n",
+        "description": "This endpoint creates a new room. `id` and `defaultAccesses` are required. When provided with a `?idempotent` query argument, will not return a 409 when the room already exists, but instead return the existing room as-is. Corresponds to [`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms), or to [`liveblocks.getOrCreateRoom`](docs/api-reference/liveblocks-node#get-or-create-rooms-roomId) when `?idempotent` is provided. \n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 40 characters. `usersAccesses` is optional field.\n- `groupsAccesses` are optional fields.\n",
         "tags": ["Room"],
         "parameters": [],
         "responses": {
@@ -384,6 +384,111 @@
         ],
         "operationId": "delete-rooms-roomId",
         "description": "This endpoint deletes a room. A deleted room is no longer accessible from the API or the dashboard and it cannot be restored. Corresponds to [`liveblocks.deleteRoom`](/docs/api-reference/liveblocks-node#delete-rooms-roomid)."
+      }
+    },
+    "/rooms/{roomId}/upsert": {
+      "post": {
+        "summary": "Upsert (update or create) room",
+        "tags": ["Room"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the room"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. Returns the updated or created room.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Room"
+                },
+                "examples": {
+                  "example": {
+                    "value": {
+                      "type": "room",
+                      "id": "react-todo-list",
+                      "lastConnectionAt": "2022-08-04T21:07:09.380Z",
+                      "createdAt": "2022-07-13T14:32:50.697Z",
+                      "metadata": {
+                        "color": "blue",
+                        "size": "10",
+                        "target": ["abc", "def"]
+                      },
+                      "defaultAccesses": ["room:write"],
+                      "groupsAccesses": {
+                        "marketing": ["room:write"]
+                      },
+                      "usersAccesses": {
+                        "alice": ["room:write"],
+                        "vinod": ["room:write"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "operationId": "post-rooms-roomId",
+        "description": "This endpoint updates specific properties of a room. Corresponds to [`liveblocks.upsertRoom`](docs/api-reference/liveblocks-node#upsert-rooms-roomId). \n\nIt’s not necessary to provide the entire room’s information. \nSetting a property to `null` means to delete this property. For example, if you want to remove access to a specific user without losing other users: \n``{\n    \"usersAccesses\": {\n        \"john\": null\n    }\n}``\n`defaultAccessess`, `metadata`, `usersAccesses`, `groupsAccesses` can be updated.\n\n- `defaultAccessess` could be `[]` or `[\"room:write\"]` (private or public). \n- `metadata` could be key/value as `string` or `string[]`. `metadata` supports maximum 50 entries. Key length has a limit of 40 characters maximum. Value length has a limit of 256 characters maximum. `metadata` is optional field.\n- `usersAccesses` could be `[]` or `[\"room:write\"]` for every records. `usersAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `usersAccesses` is optional field.\n- `groupsAccesses` could be `[]` or `[\"room:write\"]` for every records. `groupsAccesses` can contain 100 ids maximum. Id length has a limit of 256 characters. `groupsAccesses` is optional field.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertRoom"
+              },
+              "examples": {
+                "example": {
+                  "value": {
+                    "update": {
+                      "usersAccesses": {
+                        "vinod": ["room:write"],
+                        "alice": ["room:write"]
+                      },
+                      "groupsAccesses": {
+                        "marketing": ["room:write"]
+                      },
+                      "metadata": {
+                        "color": "blue"
+                      }
+                    },
+                    "create": {
+                      "defaultAccesses": ["room:write"]
+                    }
+                  }
+                }
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        }
       }
     },
     "/rooms/{roomId}/update-room-id": {
@@ -3254,6 +3359,61 @@
             "description": "A map of metadata keys to their values (`string` or `string[]`). Setting the value as `null` will clear all metadata. Setting a key as `null` will clear the key."
           }
         }
+      },
+      "UpsertRoom": {
+        "type": "object",
+        "title": "UpsertRoom",
+        "additionalProperties": false,
+        "properties": {
+          "update": {
+            "type": "object",
+            "properties": {
+              "defaultAccesses": {
+                "type": ["array", "null"],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "usersAccesses": {
+                "type": ["object", "null"],
+                "description": "A map of user identifiers to permissions list. Setting the value as `null` will clear all users’ accesses. Setting one user identifier as `null` will clear this user’s accesses."
+              },
+              "groupsAccesses": {
+                "type": ["object", "null"],
+                "description": "A map of group identifiers to permissions list. Setting the value as `null` will clear all groups’ accesses. Setting one group identifier as `null` will clear this group’s accesses."
+              },
+              "metadata": {
+                "type": ["object", "null"],
+                "description": "A map of metadata keys to their values (`string` or `string[]`). Setting the value as `null` will clear all metadata. Setting a key as `null` will clear the key."
+              }
+            }
+          },
+          "create": {
+            "type": "object",
+            "properties": {
+              "defaultAccesses": {
+                "type": ["array"],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "usersAccesses": {
+                "type": ["object"],
+                "description": "A map of user identifiers to permissions list. Setting the value as `null` will clear all users’ accesses. Setting one user identifier as `null` will clear this user’s accesses."
+              },
+              "groupsAccesses": {
+                "type": ["object"],
+                "description": "A map of group identifiers to permissions list. Setting the value as `null` will clear all groups’ accesses. Setting one group identifier as `null` will clear this group’s accesses."
+              },
+              "metadata": {
+                "type": ["object"],
+                "description": "A map of metadata keys to their values (`string` or `string[]`). Setting the value as `null` will clear all metadata. Setting a key as `null` will clear the key."
+              }
+            },
+            "required": ["defaultAccesses"]
+          }
+        },
+        "required": ["update"]
       },
       "CreateRoom": {
         "title": "CreateRoom",

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -329,6 +329,23 @@ export type RequestOptions = {
 };
 
 /**
+ * Converts ISO-formatted date strings to Date instances on RoomDataPlain
+ * values.
+ */
+function inflateRoomData(room: RoomDataPlain): RoomData {
+  const createdAt = new Date(room.createdAt);
+  const lastConnectionAt = room.lastConnectionAt
+    ? new Date(room.lastConnectionAt)
+    : undefined;
+
+  return {
+    ...room,
+    createdAt,
+    lastConnectionAt,
+  };
+}
+
+/**
  * Interact with the Liveblocks API from your Node.js backend.
  */
 export class Liveblocks {
@@ -598,20 +615,7 @@ export class Liveblocks {
     }
 
     const page = (await res.json()) as Page<RoomDataPlain>;
-    const rooms: RoomData[] = page.data.map((room) => {
-      // Convert lastConnectionAt and createdAt from ISO date strings to Date objects
-      const lastConnectionAt = room.lastConnectionAt
-        ? new Date(room.lastConnectionAt)
-        : undefined;
-
-      const createdAt = new Date(room.createdAt);
-      return {
-        ...room,
-        createdAt,
-        lastConnectionAt,
-      };
-    });
-
+    const rooms: RoomData[] = page.data.map(inflateRoomData);
     return {
       ...page,
       data: rooms,
@@ -690,18 +694,7 @@ export class Liveblocks {
     }
 
     const data = (await res.json()) as RoomDataPlain;
-
-    // Convert lastConnectionAt and createdAt from ISO date strings to Date objects
-    const lastConnectionAt = data.lastConnectionAt
-      ? new Date(data.lastConnectionAt)
-      : undefined;
-
-    const createdAt = new Date(data.createdAt);
-    return {
-      ...data,
-      lastConnectionAt,
-      createdAt,
-    };
+    return inflateRoomData(data);
   }
 
   /**
@@ -751,18 +744,7 @@ export class Liveblocks {
     }
 
     const data = (await res.json()) as RoomDataPlain;
-
-    // Convert lastConnectionAt and createdAt from ISO date strings to Date objects
-    const lastConnectionAt = data.lastConnectionAt
-      ? new Date(data.lastConnectionAt)
-      : undefined;
-
-    const createdAt = new Date(data.createdAt);
-    return {
-      ...data,
-      lastConnectionAt,
-      createdAt,
-    };
+    return inflateRoomData(data);
   }
 
   /**
@@ -782,18 +764,7 @@ export class Liveblocks {
     }
 
     const data = (await res.json()) as RoomDataPlain;
-
-    // Convert lastConnectionAt and createdAt from ISO date strings to Date objects
-    const lastConnectionAt = data.lastConnectionAt
-      ? new Date(data.lastConnectionAt)
-      : undefined;
-
-    const createdAt = new Date(data.createdAt);
-    return {
-      ...data,
-      createdAt,
-      lastConnectionAt,
-    };
+    return inflateRoomData(data);
   }
 
   /**
@@ -830,18 +801,7 @@ export class Liveblocks {
     }
 
     const data = (await res.json()) as RoomDataPlain;
-
-    // Convert lastConnectionAt and createdAt from ISO date strings to Date objects
-    const lastConnectionAt = data.lastConnectionAt
-      ? new Date(data.lastConnectionAt)
-      : undefined;
-
-    const createdAt = new Date(data.createdAt);
-    return {
-      ...data,
-      lastConnectionAt,
-      createdAt,
-    };
+    return inflateRoomData(data);
   }
 
   /**
@@ -1973,14 +1933,9 @@ export class Liveblocks {
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }
+
     const data = (await res.json()) as RoomDataPlain;
-    return {
-      ...data,
-      createdAt: new Date(data.createdAt),
-      lastConnectionAt: data.lastConnectionAt
-        ? new Date(data.lastConnectionAt)
-        : undefined,
-    };
+    return inflateRoomData(data);
   }
 
   public async triggerInboxNotification<K extends KDAD>(

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -319,6 +319,11 @@ export type UpdateRoomOptions = {
   metadata?: Record<string, string | string[] | null>;
 };
 
+export type UpsertRoomOptions = {
+  update: UpdateRoomOptions;
+  create?: CreateRoomOptions;
+};
+
 export type RequestOptions = {
   signal?: AbortSignal;
 };
@@ -733,13 +738,12 @@ export class Liveblocks {
    */
   public async upsertRoom(
     roomId: string,
-    update: UpdateRoomOptions,
-    create?: CreateRoomOptions,
+    params: UpsertRoomOptions,
     options?: RequestOptions
   ): Promise<RoomData> {
     const res = await this.#post(
       url`/v2/rooms/${roomId}/upsert`,
-      { update, create },
+      params,
       options
     );
     if (!res.ok) {

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -380,6 +380,25 @@ export class Liveblocks {
     });
   }
 
+  async #patch(
+    path: URLSafeString,
+    json: Json,
+    options?: RequestOptions
+  ): Promise<Response> {
+    const url = urljoin(this.#baseUrl, path);
+    const headers = {
+      Authorization: `Bearer ${this.#secret}`,
+      "Content-Type": "application/json",
+    };
+    const fetch = await fetchPolyfill();
+    return await fetch(url, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify(json),
+      signal: options?.signal,
+    });
+  }
+
   async #putBinary(
     path: URLSafeString,
     body: Uint8Array,

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -25,6 +25,7 @@ export type {
   Schema,
   ThreadParticipants,
   UpdateRoomOptions,
+  UpsertRoomOptions,
 } from "./client";
 export { Liveblocks, LiveblocksError } from "./client";
 export type {


### PR DESCRIPTION
This PR updates the Node client to make the `.getOrCreateRoom()` and `.upsertRoom()` methods make a single round-trip to the Liveblocks server, instead of two.