### PR TITLE
Various `@liveblocks/react-ui` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react-ui`
+
+- The `InboxNotification` component now uses `resolveRoomsInfo` for
+  `textMention` notifications to make them link to the mentions’ room
+  automatically if `href` isn’t set.
+- Fix names capitalization in lists. (e.g. the list of who reacted in reactions’
+  tooltips)
+
 ## v2.22.2
 
 ### `@liveblocks/node`

--- a/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
+++ b/packages/liveblocks-react-ui/src/components/InboxNotification.tsx
@@ -425,10 +425,6 @@ const InboxNotificationThread = forwardRef<
     const $ = useOverrides(overrides);
     const thread = useInboxNotificationThread(inboxNotification.id);
     const currentUserId = useCurrentUserId();
-    // TODO: If you provide `href` (or plan to), we shouldn't run this hook. We should find a way to conditionally run it.
-    //       Because of batching and the fact that the same hook will be called within <Room /> in the notification's title,
-    //       it's not a big deal, the only scenario where it would be superfluous would be if the user provides their own
-    //       `href` AND disables room names in the title via `showRoomName={false}`.
     const { info } = useRoomInfo(inboxNotification.roomId);
     const contents = useMemo(() => {
       const contents = generateInboxNotificationThreadContents(
@@ -582,12 +578,20 @@ const InboxNotificationTextMention = forwardRef<
       inboxNotification,
       showActions = "hover",
       showRoomName = true,
+      href,
       overrides,
       ...props
     },
     ref
   ) => {
     const $ = useOverrides(overrides);
+    const { info } = useRoomInfo(inboxNotification.roomId);
+    // Use URL from `resolveRoomsInfo` if `href` isn't set.
+    const resolvedHref = useMemo(() => {
+      const resolvedHref = href ?? info?.url;
+
+      return resolvedHref ? generateURL(resolvedHref) : undefined;
+    }, [href, info?.url]);
 
     const unread = useMemo(() => {
       return (
@@ -611,6 +615,7 @@ const InboxNotificationTextMention = forwardRef<
         unread={unread}
         overrides={overrides}
         showActions={showActions}
+        href={resolvedHref}
         {...props}
         ref={ref}
       />

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -779,17 +779,21 @@
  *               Name                *
  *************************************/
 
-.lb-name:where([data-loading]) {
-  &::before {
-    content: "\FEFF";
-    display: inline-block;
-    vertical-align: middle;
-    inline-size: 8ch;
-    block-size: 1.75ex;
-    border-radius: calc(0.5 * var(--lb-radius));
-    background: currentcolor;
-    opacity: $lb-loading-opacity;
-    user-select: none;
+.lb-name {
+  display: inline-block;
+
+  &:where([data-loading]) {
+    &::before {
+      content: "\FEFF";
+      display: inline-block;
+      vertical-align: middle;
+      inline-size: 8ch;
+      block-size: 1.75ex;
+      border-radius: calc(0.5 * var(--lb-radius));
+      background: currentcolor;
+      opacity: $lb-loading-opacity;
+      user-select: none;
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes two issues in `@liveblocks/react-ui`.

### Missing `href` on `textMention` inbox notifications

Reported by @CTNicholas, `textMention` inbox notifications were not using `resolveRoomsInfo` like the `thread` ones.

### Broken capitalization in names lists

The capitalization styles (applied on the first name/word in a list) were not working.

![capitalize](https://github.com/user-attachments/assets/c1dc372f-ac88-4419-a0b3-60931231e1f3)