### PR TITLE
Add advanced `emojibaseUrl` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   automatically if `href` isn’t set.
 - Fix names capitalization in lists. (e.g. the list of who reacted in reactions’
   tooltips)
+- Add `emojibaseUrl` **advanced** option on `LiveblocksUIConfig` to allow
+  choosing where Emojibase’s data used by the Liveblocks emoji picker is fetched
+  from: another CDN, self-hosted files, etc.
 
 ## v2.22.2
 

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -2177,6 +2177,21 @@ Set configuration options for all `@liveblocks/react-ui` components, such as
     not submitted yet. If you want to prevent unsaved changes with Liveblocks,
     but not for composers, you can opt-out by setting this option to `false`.
   </PropertiesListItem>
+  <PropertiesListItem
+    name="emojibaseUrl"
+    type="string"
+    defaultValue={`"https://cdn.jsdelivr.net/npm/emojibase-data"`}
+  >
+    The Liveblocks emoji picker (visible when adding reactions in `Comment`) is built with
+    [Frimousse](https://github.com/liveblocks/frimousse), which fetches its data
+    from [Emojibase](https://emojibase.dev/docs/datasets/).
+
+    This option allows you to change the base URL of where the
+    [`emojibase-data`](https://www.npmjs.com/package/emojibase-data) files
+    should be fetched from, used as follows: `${emojibaseUrl}/${locale}/${file}.json`.
+    (e.g. `${emojibaseUrl}/en/data.json`).
+
+  </PropertiesListItem>
 </PropertiesList>
 
 ### Hooks [#Version-History-hooks]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15315,19 +15315,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/frimousse": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/frimousse/-/frimousse-0.1.0.tgz",
-      "integrity": "sha512-0K6cSb8BVmzn2brlhuw5nlFZuYUO+eWwgVwfFsHaYnKffJYO/WItnfFWfFQ6Zo1NKLq/9EdSVna+eZ07OVffLg==",
-      "license": "MIT",
-      "workspaces": [
-        ".",
-        "site"
-      ],
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
     "node_modules/from2": {
       "version": "2.3.0",
       "dev": true,
@@ -31005,7 +30992,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.3",
-        "frimousse": "^0.1.0",
+        "frimousse": "^0.2.0",
         "slate": "^0.110.2",
         "slate-history": "^0.110.3",
         "slate-hyperscript": "^0.100.0",
@@ -31980,6 +31967,18 @@
     "packages/liveblocks-react-ui/node_modules/@radix-ui/rect": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "packages/liveblocks-react-ui/node_modules/frimousse": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/frimousse/-/frimousse-0.2.0.tgz",
+      "integrity": "sha512-viSrsVQWKR4Q7xzC0lkx3Wu9i1+IHrth0QXn0nlIIJXpltwUnjkGXSTuoW7WHI5aJ4z49WR8E/pyQizFjlNtTA==",
+      "workspaces": [
+        ".",
+        "site"
+      ],
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "packages/liveblocks-react-ui/node_modules/react-remove-scroll": {
       "version": "2.6.0",

--- a/packages/liveblocks-react-ui/package.json
+++ b/packages/liveblocks-react-ui/package.json
@@ -84,7 +84,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
-    "frimousse": "^0.1.0",
+    "frimousse": "^0.2.0",
     "slate": "^0.110.2",
     "slate-history": "^0.110.3",
     "slate-hyperscript": "^0.100.0",

--- a/packages/liveblocks-react-ui/src/components/internal/EmojiPicker.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/EmojiPicker.tsx
@@ -77,7 +77,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
     forwardedRef
   ) => {
     const [isOpen, setOpen] = useState(false);
-    const { portalContainer } = useLiveblocksUIConfig();
+    const { portalContainer, emojibaseUrl } = useLiveblocksUIConfig();
     const $ = useOverrides();
 
     const handleOpenChange = useCallback(
@@ -116,8 +116,9 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
             <EmojiPickerPrimitive.Root
               onEmojiSelect={handleEmojiSelect}
               locale={$.locale as Locale}
-              emojiVersion={15.1}
               columns={10}
+              emojiVersion={15.1}
+              emojibaseUrl={emojibaseUrl}
             >
               <div className="lb-emoji-picker-header">
                 <div className="lb-emoji-picker-search-container">

--- a/packages/liveblocks-react-ui/src/config.tsx
+++ b/packages/liveblocks-react-ui/src/config.tsx
@@ -35,11 +35,27 @@ type LiveblocksUIConfigProps = PropsWithChildren<{
    * composers, you can opt-out by setting this option to `false`.
    */
   preventUnsavedComposerChanges?: boolean;
+
+  /**
+   * The Liveblocks emoji picker (visible when adding reactions in `Comment`) is built with
+   * {@link https://github.com/liveblocks/frimousse | Frimousse}, which fetches its data from
+   * {@link https://emojibase.dev/docs/datasets/ | Emojibase}.
+   *
+   * This option allows you to change the base URL of where the {@link https://www.npmjs.com/package/emojibase-data | `emojibase-data`}
+   * files should be fetched from, used as follows: `${emojibaseUrl}/${locale}/${file}.json`.
+   * (e.g. `${emojibaseUrl}/en/data.json`).
+   *
+   * @example "https://unpkg.com/emojibase-data"
+   *
+   * @example "https://example.com/self-hosted-emojibase-data"
+   */
+  emojibaseUrl?: string;
 }>;
 
 interface LiveblocksUIConfigContext {
   portalContainer?: HTMLElement;
   preventUnsavedComposerChanges?: boolean;
+  emojibaseUrl?: string;
 }
 
 const LiveblocksUIConfigContext = createContext<LiveblocksUIConfigContext>({});
@@ -61,11 +77,16 @@ export function LiveblocksUIConfig({
   components,
   portalContainer,
   preventUnsavedComposerChanges = true,
+  emojibaseUrl,
   children,
 }: LiveblocksUIConfigProps) {
   const liveblocksUIConfig = useMemo(
-    () => ({ portalContainer, preventUnsavedComposerChanges }),
-    [portalContainer, preventUnsavedComposerChanges]
+    () => ({
+      portalContainer,
+      preventUnsavedComposerChanges,
+      emojibaseUrl,
+    }),
+    [portalContainer, preventUnsavedComposerChanges, emojibaseUrl]
   );
 
   return (


### PR DESCRIPTION
This PR exposes Frimousse's [new `emojibaseUrl` option](https://github.com/liveblocks/frimousse/pull/12) on `LiveblocksUIConfig` to allow users for whom fetching [the Emojibase data](https://emojibase.dev/docs/datasets/) from a CDN is problematic (CSP restrictions, security concerns, etc) to use a different source (most likely to self-host the Emojibase files).