### PR TITLE
Update BlockNote types

### DIFF
--- a/packages/liveblocks-react-blocknote/src/initialization/liveblocksEditorOptions.ts
+++ b/packages/liveblocks-react-blocknote/src/initialization/liveblocksEditorOptions.ts
@@ -10,18 +10,25 @@ import type {
 import type { Extension } from "@tiptap/core";
 
 import { withLiveblocksSchema } from "./schema";
-/**
- * Helper funcction to add Liveblocks support to BlockNoteEditorOptions
- */
-export const withLiveblocksEditorOptions = <
+
+type WithLiveblocksEditorOptions<
   B extends BlockSchema = DefaultBlockSchema,
   I extends InlineContentSchema = DefaultInlineContentSchema,
   S extends StyleSchema = DefaultStyleSchema,
->(
+> = (
   liveblocksExtension: Extension,
-  blocknoteOptions: Partial<BlockNoteEditorOptions<B, I, S>> = {},
-  liveblocksOptions: Partial<{ mentions: boolean }> = {}
-): Partial<BlockNoteEditorOptions<B, I, S>> => ({
+  blocknoteOptions?: Partial<BlockNoteEditorOptions<B, I, S>>,
+  liveblocksOptions?: Partial<{ mentions: boolean }>
+) => Partial<BlockNoteEditorOptions<B, I, S>>;
+
+/**
+ * Helper function to add Liveblocks support to BlockNoteEditorOptions
+ */
+export const withLiveblocksEditorOptions: WithLiveblocksEditorOptions = (
+  liveblocksExtension,
+  blocknoteOptions = {},
+  liveblocksOptions = {}
+) => ({
   // add the liveblocks schema (i.e.: add the mention node to the schema)
   schema: withLiveblocksSchema(blocknoteOptions.schema, liveblocksOptions),
 

--- a/packages/liveblocks-react-blocknote/src/initialization/useCreateBlockNoteWithLiveblocks.ts
+++ b/packages/liveblocks-react-blocknote/src/initialization/useCreateBlockNoteWithLiveblocks.ts
@@ -14,25 +14,28 @@ import type { LiveblocksExtensionOptions } from "../BlockNoteLiveblocksExtension
 import { useLiveblocksExtension } from "../BlockNoteLiveblocksExtension";
 import { withLiveblocksEditorOptions } from "./liveblocksEditorOptions";
 
-/**
- * Function that can be used instead of standard useCreateBlockNote to add Liveblocks support
- */
-export const useCreateBlockNoteWithLiveblocks = <
+type UseCreateBlockNoteWithLiveblocks<
   B extends BlockSchema = DefaultBlockSchema,
   I extends InlineContentSchema = DefaultInlineContentSchema,
   S extends StyleSchema = DefaultStyleSchema,
->(
-  blocknoteOptions: Partial<BlockNoteEditorOptions<B, I, S>> = {},
-  liveblocksOptions: LiveblocksExtensionOptions = undefined,
-  deps: DependencyList = []
-) => {
-  const liveblocksExtension = useLiveblocksExtension(liveblocksOptions);
-  return useCreateBlockNote(
-    withLiveblocksEditorOptions(
-      liveblocksExtension,
-      blocknoteOptions,
-      liveblocksOptions
-    ),
-    [liveblocksExtension, ...deps]
-  );
-};
+> = (
+  blocknoteOptions: Partial<BlockNoteEditorOptions<B, I, S>>,
+  liveblocksOptions: LiveblocksExtensionOptions,
+  deps: DependencyList
+) => Partial<BlockNoteEditorOptions<B, I, S>>;
+
+/**
+ * Function that can be used instead of standard useCreateBlockNote to add Liveblocks support
+ */
+export const useCreateBlockNoteWithLiveblocks: UseCreateBlockNoteWithLiveblocks =
+  (blocknoteOptions = {}, liveblocksOptions = undefined, deps = []) => {
+    const liveblocksExtension = useLiveblocksExtension(liveblocksOptions);
+    return useCreateBlockNote(
+      withLiveblocksEditorOptions(
+        liveblocksExtension,
+        blocknoteOptions,
+        liveblocksOptions
+      ),
+      [liveblocksExtension, ...deps]
+    );
+  };


### PR DESCRIPTION
Hi LiveBlocks team!

When integrating with our BlockNote examples, we found an issue with the types being outputted by your package. It seems for some reason to be including more types than it should be.

Before the change:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/a28dd98b-7b27-4fab-be9b-c92cbe7b1fe8" />

> **Notice:** this is incorrectly including the `defaultSchema` object in the generated `.d.ts` file

After the change:

```ts
type WithLiveblocksEditorOptions<B extends BlockSchema = DefaultBlockSchema, I extends InlineContentSchema = DefaultInlineContentSchema, S extends StyleSchema = DefaultStyleSchema> = (liveblocksExtension: Extension, blocknoteOptions?: Partial<BlockNoteEditorOptions<B, I, S>>, liveblocksOptions?: Partial<{
    mentions: boolean;
}>) => Partial<BlockNoteEditorOptions<B, I, S>>;
/**
 * Helper function to add Liveblocks support to BlockNoteEditorOptions
 */
declare const withLiveblocksEditorOptions: WithLiveblocksEditorOptions;
```


In the interest of not meddling with your build system, this change purposefully is not resolving the root cause of the issue (the way that `rollup-plugin-dts` incorrectly resolves the default type arguments. Luckily there was easy enough of a workaround for this by adding types to the functions separately (bit strange that it works, but it does).
