### PR TITLE
Improve event propagation in `Composer` and `Comment`/`Thread`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react-ui`
+
+- Improve event propagation from `Composer` and the emoji pickers in
+  `Comment`/`Thread`.
+
 ## v2.22.3
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-react-ui/src/components/Comment.tsx
+++ b/packages/liveblocks-react-ui/src/components/Comment.tsx
@@ -572,7 +572,13 @@ export const Comment = forwardRef<HTMLDivElement, CommentProps>(
         // TODO: Add a way to preventDefault from within this callback, to override the default behavior (e.g. showing a confirmation dialog)
         onCommentEdit?.(comment);
 
+        if (event.isDefaultPrevented()) {
+          return;
+        }
+
+        event.stopPropagation();
         event.preventDefault();
+
         setEditing(false);
         editComment({
           commentId: comment.id,

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -751,13 +751,15 @@ export const Composer = forwardRef(
       [onCollapsedChange, canComment]
     );
 
-    const handleCommentSubmit = useCallback(
+    const handleComposerSubmit = useCallback(
       (comment: ComposerSubmitComment, event: FormEvent<HTMLFormElement>) => {
         onComposerSubmit?.(comment, event);
 
         if (event.isDefaultPrevented()) {
           return;
         }
+
+        event.stopPropagation();
 
         if (commentId && threadId) {
           editComment({
@@ -794,7 +796,7 @@ export const Composer = forwardRef(
     return (
       <TooltipProvider>
         <ComposerPrimitive.Form
-          onComposerSubmit={handleCommentSubmit}
+          onComposerSubmit={handleComposerSubmit}
           className={classNames(
             "lb-root lb-composer lb-composer-form",
             className

--- a/packages/liveblocks-react-ui/src/components/internal/EmojiPicker.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/EmojiPicker.tsx
@@ -7,7 +7,7 @@ import {
   type EmojiPickerListRowProps,
   type Locale,
 } from "frimousse";
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, SyntheticEvent } from "react";
 import { forwardRef, useCallback, useState } from "react";
 
 import { useLiveblocksUIConfig } from "../../config";
@@ -96,6 +96,10 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
       [onEmojiSelect]
     );
 
+    const stopPropagation = useCallback((event: SyntheticEvent) => {
+      event.stopPropagation();
+    }, []);
+
     return (
       <PopoverPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
         {children}
@@ -119,6 +123,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
               columns={10}
               emojiVersion={15.1}
               emojibaseUrl={emojibaseUrl}
+              onClick={stopPropagation}
             >
               <div className="lb-emoji-picker-header">
                 <div className="lb-emoji-picker-search-container">


### PR DESCRIPTION
This PR improves event propagation from `Composer` and the emoji pickers in `Comment`/`Thread`, to avoid triggering `onSubmit` from a parent `form` or `onClick` on `Comment`/`Thread` when clicking inside the emoji picker popover.