### PR TITLE
Use declaration maps for improved local development

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build all packages
         run: |
-          npm run build -- --filter='./packages/*'
+          NODE_ENV="production" npm run build -- --filter='./packages/*'
 
       - name: Publish packages
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         uses: oven-sh/setup-bun@v1
 
       - name: Build
-        run: npm run build -- --filter ${{ matrix.pkg }}
+        run: NODE_ENV="production" npm run build -- --filter ${{ matrix.pkg }}
 
       - name: Ensure no files are changed
         run: |

--- a/packages/liveblocks-client/settings.json
+++ b/packages/liveblocks-client/settings.json
@@ -1,6 +1,0 @@
-{
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "editor.detectIndentation": false
-}

--- a/packages/liveblocks-client/tsconfig.dts.json
+++ b/packages/liveblocks-client/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-client/tsup.config.ts
+++ b/packages/liveblocks-client/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-core/settings.json
+++ b/packages/liveblocks-core/settings.json
@@ -1,6 +1,0 @@
-{
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.tabSize": 2,
-    "editor.detectIndentation": false
-}

--- a/packages/liveblocks-core/tsconfig.dts.json
+++ b/packages/liveblocks-core/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/e2e/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-core/tsup.config.ts
+++ b/packages/liveblocks-core/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-core/tsup.config.ts
+++ b/packages/liveblocks-core/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-core/tsup.config.ts
+++ b/packages/liveblocks-core/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-emails/tsconfig.dts.json
+++ b/packages/liveblocks-emails/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/liveblocks-emails/tsup.config.ts
+++ b/packages/liveblocks-emails/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-emails/tsup.config.ts
+++ b/packages/liveblocks-emails/tsup.config.ts
@@ -1,8 +1,9 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
+  dts: false,
   splitting: true,
   clean: true,
   format: ["esm", "cjs"],
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-emails/tsup.config.ts
+++ b/packages/liveblocks-emails/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: true,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-node-lexical/tsconfig.dts.json
+++ b/packages/liveblocks-node-lexical/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-node-lexical/tsup.config.ts
+++ b/packages/liveblocks-node-lexical/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-node-lexical/tsup.config.ts
+++ b/packages/liveblocks-node-lexical/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-node-lexical/tsup.config.ts
+++ b/packages/liveblocks-node-lexical/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-node-prosemirror/tsconfig.dts.json
+++ b/packages/liveblocks-node-prosemirror/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-node-prosemirror/tsup.config.ts
+++ b/packages/liveblocks-node-prosemirror/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-node-prosemirror/tsup.config.ts
+++ b/packages/liveblocks-node-prosemirror/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-node-prosemirror/tsup.config.ts
+++ b/packages/liveblocks-node-prosemirror/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-node/tsconfig.dts.json
+++ b/packages/liveblocks-node/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-node/tsup.config.ts
+++ b/packages/liveblocks-node/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-node/tsup.config.ts
+++ b/packages/liveblocks-node/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-node/tsup.config.ts
+++ b/packages/liveblocks-node/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-react/tsconfig.dts.json
+++ b/packages/liveblocks-react/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/liveblocks-react/tsup.config.ts
+++ b/packages/liveblocks-react/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts", "src/suspense.ts", "src/_private.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-react/tsup.config.ts
+++ b/packages/liveblocks-react/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-react/tsup.config.ts
+++ b/packages/liveblocks-react/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts", "src/suspense.ts", "src/_private.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-redux/tsconfig.dts.json
+++ b/packages/liveblocks-redux/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-redux/tsup.config.ts
+++ b/packages/liveblocks-redux/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-redux/tsup.config.ts
+++ b/packages/liveblocks-redux/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-yjs/tsconfig.dts.json
+++ b/packages/liveblocks-yjs/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-yjs/tsup.config.ts
+++ b/packages/liveblocks-yjs/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-yjs/tsup.config.ts
+++ b/packages/liveblocks-yjs/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-yjs/tsup.config.ts
+++ b/packages/liveblocks-yjs/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });

--- a/packages/liveblocks-zustand/tsconfig.dts.json
+++ b/packages/liveblocks-zustand/tsconfig.dts.json
@@ -1,0 +1,14 @@
+{
+  // This config is used to generate declarations with their declaration maps
+  // which tsup's `dts` option doesn't support. https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+}

--- a/packages/liveblocks-zustand/tsup.config.ts
+++ b/packages/liveblocks-zustand/tsup.config.ts
@@ -16,8 +16,10 @@ export default defineConfig({
   },
 
   async onSuccess() {
+    console.log("TSC Build start");
     execSync("tsc --project tsconfig.dts.json", {
       stdio: "inherit",
     });
+    console.log("TSC ⚡️ Build success");
   },
 });

--- a/packages/liveblocks-zustand/tsup.config.ts
+++ b/packages/liveblocks-zustand/tsup.config.ts
@@ -1,10 +1,12 @@
 import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
+const isProductionBuild = process.env.NODE_ENV === "production";
+
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: false,
-  splitting: false,
+  dts: isProductionBuild,
+  splitting: isProductionBuild,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -15,11 +17,13 @@ export default defineConfig({
     options.define.__VERSION__ = JSON.stringify(pkg.version);
   },
 
-  async onSuccess() {
-    console.log("TSC Build start");
-    execSync("tsc --project tsconfig.dts.json", {
-      stdio: "inherit",
-    });
-    console.log("TSC ⚡️ Build success");
-  },
+  onSuccess: isProductionBuild
+    ? undefined
+    : async () => {
+        console.log("TSC Build start");
+        execSync("tsc --project tsconfig.dts.json", {
+          stdio: "inherit",
+        });
+        console.log("TSC ⚡️ Build success");
+      },
 });

--- a/packages/liveblocks-zustand/tsup.config.ts
+++ b/packages/liveblocks-zustand/tsup.config.ts
@@ -1,9 +1,10 @@
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  dts: true,
-  splitting: true,
+  dts: false,
+  splitting: false,
   clean: true,
   format: ["esm", "cjs"],
   sourcemap: true,
@@ -12,5 +13,11 @@ export default defineConfig({
     // Replace __VERSION__ globals with concrete version
     const pkg = require("./package.json");
     options.define.__VERSION__ = JSON.stringify(pkg.version);
+  },
+
+  async onSuccess() {
+    execSync("tsc --project tsconfig.dts.json", {
+      stdio: "inherit",
+    });
   },
 });


### PR DESCRIPTION
This PR aims to allow navigating between the various `packages` monorepo projects by using TS' [declaration maps](https://www.typescriptlang.org/tsconfig/#declarationMap).

1. [tsup doesn't support them](https://tsup.egoist.dev/#generate-typescript-declaration-maps--d-ts-map) 😢
2. The declaration maps shouldn't be shipped in the production builds since we don't ship the `src` folders anyway

### tsup

When generating **production** builds: no changes, the built-in `dts` option is used.

When generating **local** builds: the `dts` option and code-splitting are disabled, and we manually run `tsc` to output declarations and their declaration maps. The `dts` option outputs **bundled** `.d.ts` **and** `.d.cts` files, while `tsc` keeps the same file structure and only outputs `.d.ts` → it shouldn't change anything in local development except for running ["are the types wrong"](https://arethetypeswrong.github.io/) in the `lint:package` scripts locally.

### Rollup

Not done yet.

### Questions

- Is piggy-backing on `NODE_ENV` really a good idea?