### PR TITLE
Subscribe/unsubscribe: `@liveblocks/node` methods

### DIFF
--- a/packages/liveblocks-core/src/convert-plain-data.ts
+++ b/packages/liveblocks-core/src/convert-plain-data.ts
@@ -20,6 +20,8 @@ import type {
   SubscriptionDataPlain,
   SubscriptionDeleteInfo,
   SubscriptionDeleteInfoPlain,
+  UserSubscriptionData,
+  UserSubscriptionDataPlain,
 } from "./protocol/Subscriptions";
 
 /**
@@ -136,6 +138,23 @@ export function convertToInboxNotificationData(
 export function convertToSubscriptionData(
   data: SubscriptionDataPlain
 ): SubscriptionData {
+  const createdAt = new Date(data.createdAt);
+
+  return {
+    ...data,
+    createdAt,
+  };
+}
+
+/**
+ * Converts a plain user subscription data object (usually returned by the API) to a user subscription data object that can be used by the client.
+ * This is necessary because the plain data object stores dates as ISO strings, but the client expects them as Date objects.
+ * @param data The plain user subscription data object (usually returned by the API)
+ * @returns The rich user subscription data object that can be used by the client.
+ */
+export function convertToUserSubscriptionData(
+  data: UserSubscriptionDataPlain
+): UserSubscriptionData {
   const createdAt = new Date(data.createdAt);
 
   return {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -54,6 +54,7 @@ export {
   convertToCommentData,
   convertToCommentUserReaction,
   convertToInboxNotificationData,
+  convertToSubscriptionData,
   convertToThreadData,
 } from "./convert-plain-data";
 export type {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -56,6 +56,7 @@ export {
   convertToInboxNotificationData,
   convertToSubscriptionData,
   convertToThreadData,
+  convertToUserSubscriptionData,
 } from "./convert-plain-data";
 export type {
   CreateManagedPoolOptions,
@@ -285,6 +286,8 @@ export type {
   SubscriptionDeleteInfo,
   SubscriptionDeleteInfoPlain,
   SubscriptionKey,
+  UserSubscriptionData,
+  UserSubscriptionDataPlain,
 } from "./protocol/Subscriptions";
 export { getSubscriptionKey } from "./protocol/Subscriptions";
 export type { HistoryVersion } from "./protocol/VersionHistory";

--- a/packages/liveblocks-core/src/protocol/Subscriptions.ts
+++ b/packages/liveblocks-core/src/protocol/Subscriptions.ts
@@ -10,6 +10,13 @@ export type SubscriptionData<K extends keyof DAD = keyof DAD> = {
 
 export type SubscriptionDataPlain = DateToString<SubscriptionData>;
 
+export type UserSubscriptionData<K extends keyof DAD = keyof DAD> =
+  SubscriptionData<K> & {
+    userId: string;
+  };
+
+export type UserSubscriptionDataPlain = DateToString<UserSubscriptionData>;
+
 export type SubscriptionDeleteInfo = {
   type: "deletedSubscription";
   kind: NotificationKind;

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -1012,6 +1012,66 @@ describe("client", () => {
     });
   });
 
+  describe("unsubscribe from thread", () => {
+    test("should not return anything when unsubscribeFromThread receives a successful response", async () => {
+      server.use(
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads/:threadId/unsubscribe`,
+          () => {
+            return HttpResponse.json(undefined, { status: 204 });
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      await expect(
+        client.unsubscribeFromThread({
+          roomId: "room1",
+          threadId: "thread1",
+          data: { userId: "user-1" },
+        })
+      ).resolves.not.toThrow();
+    });
+
+    test("should throw a LiveblocksError when unsubscribeFromThread receives an error response", async () => {
+      const error = {
+        error: "THREAD_NOT_FOUND",
+        message: "Thread not found",
+      };
+
+      server.use(
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads/:threadId/unsubscribe`,
+          () => {
+            return HttpResponse.json(error, { status: 404 });
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      // This should throw a LiveblocksError
+      try {
+        // Attempt to get, which should fail and throw an error.
+        await client.unsubscribeFromThread({
+          roomId: "room1",
+          threadId: "thread1",
+          data: { userId: "user-1" },
+        });
+        // If it doesn't throw, fail the test.
+        expect(true).toBe(false);
+      } catch (err) {
+        expect(err instanceof LiveblocksError).toBe(true);
+        if (err instanceof LiveblocksError) {
+          expect(err.status).toBe(404);
+          expect(err.message).toBe("Thread not found");
+          expect(err.name).toBe("LiveblocksError");
+        }
+      }
+    });
+  });
+
   describe("get comment", () => {
     test("should return the specified comment when getComment receives a successful response", async () => {
       server.use(

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -44,6 +44,8 @@ import type {
   ThreadDataPlain,
   ToImmutable,
   URLSafeString,
+  UserSubscriptionData,
+  UserSubscriptionDataPlain,
 } from "@liveblocks/core";
 import {
   checkBounds,
@@ -53,6 +55,7 @@ import {
   convertToInboxNotificationData,
   convertToSubscriptionData,
   convertToThreadData,
+  convertToUserSubscriptionData,
   createManagedPool,
   createNotificationSettings,
   LiveObject,
@@ -1385,6 +1388,39 @@ export class Liveblocks {
       throw await LiveblocksError.from(res);
     }
     return (await res.json()) as Promise<ThreadParticipants>;
+  }
+
+  /**
+   * Gets a thread's subscriptions.
+   *
+   * @param params.roomId The room ID to get the thread subscriptions from.
+   * @param params.threadId The thread ID to get the subscriptions from.
+   * @param options.signal (optional) An abort signal to cancel the request.
+   * @returns An array of subscriptions.
+   */
+  public async getThreadSubscriptions(
+    params: { roomId: string; threadId: string },
+    options?: RequestOptions
+  ): Promise<{ data: UserSubscriptionData[] }> {
+    const { roomId, threadId } = params;
+
+    const res = await this.#get(
+      url`/v2/rooms/${roomId}/threads/${threadId}/subscriptions`,
+      undefined,
+      options
+    );
+
+    if (!res.ok) {
+      throw await LiveblocksError.from(res);
+    }
+
+    const { data } = (await res.json()) as {
+      data: UserSubscriptionDataPlain[];
+    };
+
+    return {
+      data: data.map(convertToUserSubscriptionData),
+    };
   }
 
   /**

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -38,6 +38,8 @@ import type {
   RoomSubscriptionSettings,
   SerializedCrdt,
   StorageUpdate,
+  SubscriptionData,
+  SubscriptionDataPlain,
   ThreadData,
   ThreadDataPlain,
   ToImmutable,
@@ -49,6 +51,7 @@ import {
   convertToCommentData,
   convertToCommentUserReaction,
   convertToInboxNotificationData,
+  convertToSubscriptionData,
   convertToThreadData,
   createManagedPool,
   createNotificationSettings,
@@ -1610,6 +1613,35 @@ export class Liveblocks {
     }
 
     return convertToThreadData((await res.json()) as ThreadDataPlain<M>);
+  }
+
+  /**
+   * Subscribe a user to a thread.
+   * @param params.roomId The room ID of the thread.
+   * @param params.threadId The thread ID to subscribe to.
+   * @param params.data.userId The user ID of the user to subscribe to the thread.
+   * @param options.signal (optional) An abort signal to cancel the request.
+   * @returns The thread subscription.
+   */
+  public async subscribeToThread(
+    params: { roomId: string; threadId: string; data: { userId: string } },
+    options?: RequestOptions
+  ): Promise<SubscriptionData> {
+    const { roomId, threadId } = params;
+
+    const res = await this.#post(
+      url`/v2/rooms/${roomId}/threads/${threadId}/subscribe`,
+      { userId: params.data.userId },
+      options
+    );
+
+    if (!res.ok) {
+      throw await LiveblocksError.from(res);
+    }
+
+    return convertToSubscriptionData(
+      (await res.json()) as SubscriptionDataPlain
+    );
   }
 
   /**

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -1616,7 +1616,7 @@ export class Liveblocks {
   }
 
   /**
-   * Subscribe a user to a thread.
+   * Subscribes a user to a thread.
    * @param params.roomId The room ID of the thread.
    * @param params.threadId The thread ID to subscribe to.
    * @param params.data.userId The user ID of the user to subscribe to the thread.
@@ -1642,6 +1642,30 @@ export class Liveblocks {
     return convertToSubscriptionData(
       (await res.json()) as SubscriptionDataPlain
     );
+  }
+
+  /**
+   * Unsubscribes a user from a thread.
+   * @param params.roomId The room ID of the thread.
+   * @param params.threadId The thread ID to unsubscribe from.
+   * @param params.data.userId The user ID of the user to unsubscribe from the thread.
+   * @param options.signal (optional) An abort signal to cancel the request.
+   */
+  public async unsubscribeFromThread(
+    params: { roomId: string; threadId: string; data: { userId: string } },
+    options?: RequestOptions
+  ): Promise<void> {
+    const { roomId, threadId } = params;
+
+    const res = await this.#post(
+      url`/v2/rooms/${roomId}/threads/${threadId}/unsubscribe`,
+      { userId: params.data.userId },
+      options
+    );
+
+    if (!res.ok) {
+      throw await LiveblocksError.from(res);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds `@liveblocks/node` methods for the new APIs added with subscribe/unsubscribe:

- [x] `client.subscribeToThread`
- [x] `client.unsubscribeFromThread`
- [x] `client.getThreadSubscriptions`

I'll do the docs afterwards in https://github.com/liveblocks/liveblocks/pull/2323, and I haven't tackled LB-1857, we can do it in a dedicated PR.