### PR TITLE
Avoid using `Symbol.dispose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## v2.23.1
 
+### `@liveblocks/client`
+
+- Fix potential runtime error in browsers that do not support `Symbol.dispose`
+  yet.
+
 ### `@liveblocks/node`
 
-- Fix a bug in `.mutateStorage()` and `.massMutateStorage()` where mutating storage could potentially corrupt the storage tree.
+- Fix a bug in `.mutateStorage()` and `.massMutateStorage()` where mutating
+  storage could potentially corrupt the storage tree.
 
 ## v2.23.0
 

--- a/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.ts
+++ b/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.ts
@@ -156,7 +156,7 @@ export class MockWebSocketServer {
    * those behaviors.
    */
   public onConnection(callback: (conn: Connection) => void): void {
-    this.#newConnectionCallbacks[Symbol.dispose]();
+    this.#newConnectionCallbacks.dispose();
     this.#newConnectionCallbacks.subscribe(callback);
   }
 

--- a/packages/liveblocks-core/src/lib/EventSource.ts
+++ b/packages/liveblocks-core/src/lib/EventSource.ts
@@ -47,7 +47,9 @@ export type EventSource<T> = Observable<T> & {
    * Be careful when using this API, because the subscribers may not have any
    * idea they won't be notified anymore.
    */
-  [Symbol.dispose](): void;
+  // NOTE: This can eventually become [Symbol.dispose] when it's widely
+  // available in all browsers
+  dispose(): void;
 };
 
 export type BufferableEventSource<T> = EventSource<T> & {
@@ -135,7 +137,7 @@ export function makeEventSource<T>(): EventSource<T> {
 
     waitUntil,
 
-    [Symbol.dispose]: (): void => {
+    dispose(): void {
       _observers.clear();
     },
 
@@ -183,8 +185,8 @@ export function makeBufferableEventSource<T>(): BufferableEventSource<T> {
     pause,
     unpause,
 
-    [Symbol.dispose]: (): void => {
-      eventSource[Symbol.dispose]();
+    dispose(): void {
+      eventSource.dispose();
       if (_buffer !== null) {
         _buffer.length = 0;
       }

--- a/packages/liveblocks-core/src/lib/signals.ts
+++ b/packages/liveblocks-core/src/lib/signals.ts
@@ -155,8 +155,8 @@ abstract class AbstractSignal<T> implements ISignal<T>, Observable<void> {
     this.subscribeOnce = this.subscribeOnce.bind(this);
   }
 
-  [Symbol.dispose](): void {
-    this.#eventSource[Symbol.dispose]();
+  dispose(): void {
+    this.#eventSource.dispose();
 
     // @ts-expect-error make disposed object completely unusable
     this.#eventSource = "(disposed)";
@@ -241,8 +241,8 @@ export class Signal<T> extends AbstractSignal<T> {
     this.#value = freeze(value);
   }
 
-  [Symbol.dispose](): void {
-    super[Symbol.dispose]();
+  dispose(): void {
+    super.dispose();
     // @ts-expect-error make disposed object completely unusable
     this.#value = "(disposed)";
   }
@@ -339,7 +339,7 @@ export class DerivedSignal<T> extends AbstractSignal<T> {
     this.#transform = transform;
   }
 
-  [Symbol.dispose](): void {
+  dispose(): void {
     for (const src of this.#sources) {
       src.removeSink(this as DerivedSignal<unknown>);
     }
@@ -448,8 +448,8 @@ export class MutableSignal<T extends object> extends AbstractSignal<T> {
     this.#state = initialState;
   }
 
-  [Symbol.dispose](): void {
-    super[Symbol.dispose]();
+  dispose(): void {
+    super.dispose();
     // @ts-expect-error make disposed object completely unusable
     this.#state = "(disposed)";
   }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3080,7 +3080,7 @@ export function createRoom<
         const { roomWillDestroy, ...eventsExceptDestroy } = eventHub;
         // Unregister all registered callbacks
         for (const source of Object.values(eventsExceptDestroy)) {
-          source[Symbol.dispose]();
+          source.dispose();
         }
         eventHub.roomWillDestroy.notify();
         context.yjsProvider?.off("status", yjsStatusDidChange);
@@ -3090,7 +3090,7 @@ export function createRoom<
         managedSocket.destroy();
 
         // cleanup will destroy listener
-        roomWillDestroy[Symbol.dispose]();
+        roomWillDestroy.dispose();
       },
 
       // Presence


### PR DESCRIPTION
Fixes an issue where [some browsers have not implemented support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#:~:text=11-,dispose,-Experimental) for this well-known symbol yet.

This could lead to runtime issues like this in some browsers:
![image (2)](https://github.com/user-attachments/assets/c6eda17e-50ff-4e3f-9a3b-fc7cf02b6162)
