### PR TITLE
Fix: ensure unique session is always assigned correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## vNEXT (not yet published)
 
+## v2.23.1
+
+### `@liveblocks/node`
+
+- Fix bug in `.mutateStorage()` and `.massMutateStorage()` where mutating
+  storage with this API could potentially corrupt the storage tree.
+
 ## v2.23.0
 
 ### `@liveblocks/node`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### `@liveblocks/node`
 
-- Fix bug in `.mutateStorage()` and `.massMutateStorage()` where mutating
-  storage with this API could potentially corrupt the storage tree.
+- Fix a bug in `.mutateStorage()` and `.massMutateStorage()` where mutating storage could potentially corrupt the storage tree.
 
 ## v2.23.0
 

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -52,6 +52,7 @@ import {
   convertToThreadData,
   createManagedPool,
   createUserNotificationSettings,
+  isPlainObject,
   LiveObject,
   makeAbortController,
   objectToQuery,
@@ -944,14 +945,14 @@ export class Liveblocks {
 
     // Read the first element from the NDJson stream and interpret it as the response data
     const iter = stream[Symbol.asyncIterator]();
-    const { actor } = (await iter.next()).value as Record<string, unknown>;
-    if (typeof actor !== "number") {
+    const first = (await iter.next()).value;
+    if (!isPlainObject(first) || typeof first.actor !== "number") {
       throw new Error("Failed to obtain a unique session");
     }
 
     // The rest of the stream are all the Storage nodes
     const nodes = (await asyncConsume(iter)) as IdTuple<SerializedCrdt>[];
-    return { actor, nodes };
+    return { actor: first.actor, nodes };
   }
 
   /**

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -944,7 +944,10 @@ export class Liveblocks {
 
     // Read the first element from the NDJson stream and interpret it as the response data
     const iter = stream[Symbol.asyncIterator]();
-    const { actor } = (await iter.next()) as unknown as { actor: number };
+    const { actor } = (await iter.next()).value as Record<string, unknown>;
+    if (typeof actor !== "number") {
+      throw new Error("Failed to obtain a unique session");
+    }
 
     // The rest of the stream are all the Storage nodes
     const nodes = (await asyncConsume(iter)) as IdTuple<SerializedCrdt>[];


### PR DESCRIPTION
This fixes an issue with the newly introduced `.mutateStorage()` and `.massMutateStorage()` APIs, where the transient session's unique actor ID wasn't read correctly, and which could lead to storage corruptions.
