### PR TITLE
Export `Deque` data structure as an internal helper

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -120,6 +120,7 @@ export {
   errorIf,
   throwUsageError,
 } from "./lib/deprecation";
+export { Deque } from "./lib/Deque";
 export type {
   EventSource,
   Observable,


### PR DESCRIPTION
I have a use case for `Deque` in the backend, and would love to not have to duplicate this implementation.
