### PR TITLE
Fix focus behaviors of Text Editor components in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/tiptap`
+
+- Fix `FloatingToolbar` focus behavior in Safari.
+- Fix `AiToolbar` focus behavior in Safari.
+
+### `@liveblocks/lexical`
+
+- Fix `FloatingToolbar` focus behavior in Safari.
+
 ## v2.23.1
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-react-lexical/src/toolbar/toolbar.tsx
+++ b/packages/liveblocks-react-lexical/src/toolbar/toolbar.tsx
@@ -234,6 +234,9 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           ref={forwardedRef}
           icon={icon}
           aria-label={!children ? name : undefined}
+          // Safari doesn't mark buttons as focusable, which breaks `relatedTarget`
+          // in focus/blur events. https://bugs.webkit.org/show_bug.cgi?id=254655
+          tabIndex={0}
           {...props}
           onKeyDown={handleKeyDown}
         >

--- a/packages/liveblocks-react-tiptap/src/ai/AiToolbar.tsx
+++ b/packages/liveblocks-react-tiptap/src/ai/AiToolbar.tsx
@@ -325,7 +325,7 @@ function AiToolbarCustomPromptContent() {
 
   useLayoutEffect(
     () => {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         const textArea = textAreaRef.current;
 
         if (!textArea) {
@@ -337,7 +337,7 @@ function AiToolbarCustomPromptContent() {
           textArea.value.length,
           textArea.value.length
         );
-      }, 0);
+      });
     },
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );

--- a/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
+++ b/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
@@ -213,6 +213,9 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           ref={forwardedRef}
           icon={icon}
           aria-label={!children ? name : undefined}
+          // Safari doesn't mark buttons as focusable, which breaks `relatedTarget`
+          // in focus/blur events. https://bugs.webkit.org/show_bug.cgi?id=254655
+          tabIndex={0}
           {...props}
           onKeyDown={handleKeyDown}
         >


### PR DESCRIPTION
This PR adds a workaround for [a Safari bug](https://bugs.webkit.org/show_bug.cgi?id=254655) which caused `FloatingToolbar` components to close on click. While I was there, I also fixed the delayed auto focus in `AiToolbar` which also wasn't working in Safari only.