### PR TITLE
Unintuitive behavior around calling .undo() while history is paused?

### DIFF
--- a/packages/liveblocks-core/src/__tests__/room.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.test.ts
@@ -1177,6 +1177,23 @@ describe("room", () => {
     expect(room.getPresence()).toEqual({ x: 0 });
   });
 
+  test("undoing while history is paused", () => {
+    const { room } = createTestableRoom({});
+
+    room.updatePresence({ x: 0 }, { addToHistory: true });
+    room.updatePresence({ x: 1 }, { addToHistory: true });
+    expect(room.getPresence()).toEqual({ x: 1 });
+
+    room.history.pause();
+    room.updatePresence({ x: 2 }, { addToHistory: true });
+    expect(room.getPresence()).toEqual({ x: 2 });
+
+    room.history.undo();
+
+    expect(room.getPresence()).toEqual({ x: 0 });
+    //                                      ^ NOTE: Without the .pause() call, this would be 1
+  });
+
   test("undo redo with presence that do not impact presence", () => {
     const { room } = createTestableRoom({});
     // room.connect();  // Seems not even needed?


### PR DESCRIPTION
Added this test case to show the current behavior of `.undo()` while history is paused, which might be unintuitive. The "solution" is to always call `.resume()` right before `.undo()`, but I'm considering if we should just make this the default behavior instead of making users responsible for this.

For example, take this sequence / undo stack:
- Change A
- Change B
- `.pause()`
- Change C1
- Change C2
- `.undo()`

Calling the `.undo()` here will currently first "wipe" the C1 and C2 changes, then undo B, resulting in A. I think this is a little unintuitive at least. Is there an actual use case for this behavior, or was it an oversight?

If we'd change `.undo()` to always call `.resume()` first, the behavior would be that the changes since the last `.pause()` would be undone instead, resulting in B.

Other edge cases would also be fine I think:
- Calling `.resume()` while there is no paused history is a no-op
- Calling `.resume()` while there is a paused history but it does not contain any changes will also be a no-op. In that case, it would also still undo B.

Thoughts?
