### PR TITLE
Add public command to close the AI toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### `@liveblocks/tiptap`
 
-- Fix `FloatingToolbar` focus behavior in Safari.
+- Add `closeAi` Tiptap command to manually close the AI toolbar.
 - Fix `AiToolbar` focus behavior in Safari.
+- Fix `FloatingToolbar` focus behavior in Safari.
 
 ### `@liveblocks/lexical`
 

--- a/packages/liveblocks-react-tiptap/src/ai/AiExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/ai/AiExtension.ts
@@ -169,6 +169,12 @@ export const AiExtension = Extension.create<
         return true;
       },
 
+      closeAi: () => () => {
+        (this.editor.commands as unknown as AiCommands).$closeAiToolbar();
+
+        return true;
+      },
+
       $acceptAiToolbarResponse:
         () =>
         ({ tr, view }: CommandProps) => {

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -265,7 +265,15 @@ export type CommentsCommands<ReturnType = boolean> = {
 };
 
 export type AiCommands<ReturnType = boolean> = {
+  /**
+   * Open the AI toolbar, with an optional prompt.
+   */
   askAi: (prompt?: string) => ReturnType;
+
+  /**
+   * Close the AI toolbar.
+   */
+  closeAi: () => ReturnType;
 
   // Transitions (see AiToolbarState)
 


### PR DESCRIPTION
This PR adds a public `closeAi` editor command to trigger the internal `$closeAiToolbar` transition.

Naming-wise, I went with the ambiguous `closeAi` because of the existing "open" command being `askAi` and not `openAiToolbar`. If there are conflicts with other AI Copilots features I feel like `askAi` will need to change as well anyway.