### PR TITLE
Add stop icon to `AiToolbar`

### DIFF
--- a/packages/liveblocks-react-tiptap/src/ai/AiToolbar.tsx
+++ b/packages/liveblocks-react-tiptap/src/ai/AiToolbar.tsx
@@ -23,6 +23,7 @@ import {
   ShortenIcon,
   SparklesIcon,
   SparklesTextIcon,
+  StopIcon,
   TooltipProvider,
   UndoIcon,
   useRefs,
@@ -486,7 +487,7 @@ function AiToolbarThinking() {
               className="lb-tiptap-ai-toolbar-action"
               variant="secondary"
               aria-label="Cancel"
-              icon={<UndoIcon />}
+              icon={<StopIcon />}
               onClick={handleCancel}
             />
           </ShortcutTooltip>

--- a/packages/liveblocks-react-ui/src/icon.ts
+++ b/packages/liveblocks-react-ui/src/icon.ts
@@ -36,6 +36,7 @@ export {
   ShortenIcon as Shorten,
   SparklesIcon as Sparkles,
   SparklesTextIcon as SparklesText,
+  StopIcon as Stop,
   StrikethroughIcon as Strikethrough,
   TextIcon as Text,
   TranslateIcon as Translate,

--- a/packages/liveblocks-react-ui/src/icons/Stop.tsx
+++ b/packages/liveblocks-react-ui/src/icons/Stop.tsx
@@ -1,0 +1,11 @@
+import type { ComponentProps } from "react";
+
+import { Icon } from "../components/internal/Icon";
+
+export function StopIcon(props: ComponentProps<"svg">) {
+  return (
+    <Icon {...props}>
+      <rect x={5} y={5} width={10} height={10} rx={1} fill="currentColor" />
+    </Icon>
+  );
+}

--- a/packages/liveblocks-react-ui/src/icons/index.ts
+++ b/packages/liveblocks-react-ui/src/icons/index.ts
@@ -37,6 +37,7 @@ export { ShortenIcon } from "./Shorten";
 export { SparklesIcon } from "./Sparkles";
 export { SparklesTextIcon } from "./SparklesText";
 export { SpinnerIcon } from "./Spinner";
+export { StopIcon } from "./Stop";
 export { StrikethroughIcon } from "./Strikethrough";
 export { TextIcon } from "./Text";
 export { TranslateIcon } from "./Translate";


### PR DESCRIPTION
This PR adds an actual "stop" icon to the `AiToolbar` instead of an "undo" arrow, and we can use it in the chat components too. Unlike most of our other icons it has a fill color because it's one of those icons that don't really work with just a stroke (imo).

### Before

![](https://github.com/user-attachments/assets/a2b0f839-597d-4b79-9336-273903095473)

### After

https://github.com/user-attachments/assets/d27347cc-134f-41a8-a696-3a1318e9a3a2

