### PR TITLE
never skip applying updates

### DIFF
--- a/packages/liveblocks-yjs/src/provider.ts
+++ b/packages/liveblocks-yjs/src/provider.ts
@@ -80,35 +80,29 @@ export class LiveblocksYjsProvider
         const { stateVector, update: updateStr, guid, v2 } = message;
         const canWrite = this.room.getSelf()?.canWrite ?? true;
         const update = Base64.toUint8Array(updateStr);
-        let foundPendingUpdate = false;
         const updateId = this.getUniqueUpdateId(update);
         this.pending = this.pending.filter((pendingUpdate) => {
           if (pendingUpdate === updateId) {
-            foundPendingUpdate = true;
             return false;
           }
           return true;
         });
-        // if we found this update in our queue, we don't need to apply it
-        if (!foundPendingUpdate) {
-          // find the right doc and update
-          if (guid !== undefined) {
-            this.subdocHandlers.get(guid)?.handleServerUpdate({
-              update,
-              stateVector,
-              readOnly: !canWrite,
-              v2,
-            });
-          } else {
-            this.rootDocHandler.handleServerUpdate({
-              update,
-              stateVector,
-              readOnly: !canWrite,
-              v2,
-            });
-          }
+        // find the right doc and update
+        if (guid !== undefined) {
+          this.subdocHandlers.get(guid)?.handleServerUpdate({
+            update,
+            stateVector,
+            readOnly: !canWrite,
+            v2,
+          });
+        } else {
+          this.rootDocHandler.handleServerUpdate({
+            update,
+            stateVector,
+            readOnly: !canWrite,
+            v2,
+          });
         }
-
         // notify any listeners that the status has changed
         this.emit("status", [this.getStatus()]);
       })


### PR DESCRIPTION
Fix a bug where clients could become desynchronized after an id collision. 

This fix removes code that was an optimization to avoid applying an update that was already applied, but the optimization is moot because yjs applyUpdate already handles this situation just fine.

This does not fix the id collision, but the result is now only used for the status hooks to track pending state. This is a less bad bug than desync, so I'm pushing this fix while we rethink the way pending state works. 