### PR TITLE
Fix small issues from 2.24

### DIFF
--- a/docs/pages/platform/upgrading/2.24.mdx
+++ b/docs/pages/platform/upgrading/2.24.mdx
@@ -166,7 +166,7 @@ await liveblocks.deleteRoomSubscriptionSettings(/* ... */);
 
 #### REST API
 
-```bash
+```shell
 # ❌ Before
 https://api.liveblocks.io/v2/rooms/:roomId/users/:userId/notification-settings
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1011,7 +1011,7 @@ export type Room<
   ): Promise<RoomSubscriptionSettings>;
 
   /**
-   * @deprecated Renamed to `getSubscriptionSettings`
+   * @deprecated Renamed to `updateSubscriptionSettings`
    *
    * Updates the user's subscription settings for the current room.
    */


### PR DESCRIPTION
I found a couple of small issues from 2.24 that slipped through the cracks:
- One of the `@deprecated` JSDoc notices was wrong
- `bash` code blocks are treated differently in liveblocks.io and that looked weird for one before/after code block, `shell` has the same highlighting benefits (comments being lighter) but not the CLI look

### Before

![bash](https://github.com/user-attachments/assets/06532824-1ede-4272-8bd4-adab365c55b7)

### After

![shell](https://github.com/user-attachments/assets/acb7754c-632f-4d91-b6ba-c61456b76c24)
