### PR TITLE
Improvements for read-only users in `Thread` and `Comment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react-ui`
+
+- Disable or hide actions in `Thread` and `Comment` components for users without
+  permission to perform them, such as adding reactions or (un)resolving threads.
+
 ## v2.24.1
 
 ### `@liveblocks/yjs`

--- a/packages/liveblocks-react-ui/src/components/Thread.tsx
+++ b/packages/liveblocks-react-ui/src/components/Thread.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import type {
-  BaseMetadata,
-  CommentData,
-  DM,
-  ThreadData,
+import {
+  type BaseMetadata,
+  type CommentData,
+  type DM,
+  Permission,
+  type ThreadData,
 } from "@liveblocks/core";
 import {
   useMarkRoomThreadAsResolved,
   useMarkRoomThreadAsUnresolved,
+  useRoomPermissions,
   useRoomThreadSubscription,
 } from "@liveblocks/react/_private";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
@@ -241,6 +243,13 @@ export const Thread = forwardRef(
       }
     }, [unreadIndex]);
 
+    const permissions = useRoomPermissions(thread.roomId);
+    const canComment =
+      permissions.size > 0
+        ? permissions.has(Permission.CommentsWrite) ||
+          permissions.has(Permission.Write)
+        : true;
+
     const stopPropagation = useCallback((event: SyntheticEvent) => {
       event.stopPropagation();
     }, []);
@@ -363,6 +372,7 @@ export const Thread = forwardRef(
                                 <ResolveIcon />
                               )
                             }
+                            disabled={!canComment}
                           />
                         </TogglePrimitive.Root>
                       </Tooltip>


### PR DESCRIPTION
We weren't reading permissions in some UI parts within the default Comments components that are permission-based, so interacting with them led to an optimistic update immediately reverted (since the endpoints do read permissions):
- `Thread`: Toggling the resolved status of a thread
- `Comment`: Adding/updating reactions

### Before

![](https://github.com/user-attachments/assets/4bf81649-44cd-4706-960e-909e7e608922)

### After

Buttons are removed (adding a reaction), unless they convey something useful for read-only users (seeing the reactions or the resolved status), in which case they're only disabled.

![](https://github.com/user-attachments/assets/bf7d794e-935a-49a7-b41e-7a73c958568d)

