### PR TITLE
Add 2.24.2 changelog header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT (not yet published)
 
+## v2.24.2
+
 ### `@liveblocks/react-ui`
 
 - Disable or hide actions in `Thread` and `Comment` components for users without


### PR DESCRIPTION
The last commit of https://github.com/liveblocks/liveblocks/pull/2408 was named "Update CHANGELOG.md" so I forgot to push my other "Update CHANGELOG.md" commit for the version header…