### PR TITLE
Change `LiveblocksUIConfig` casing

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -2140,16 +2140,16 @@ import { Icon } from "@liveblocks/react-ui";
 Find a full list of available icons in
 [our GitHub repo](https://github.com/liveblocks/liveblocks/blob/main/packages/liveblocks-react-ui/src/icon.ts).
 
-#### LiveblocksUIConfig
+#### LiveblocksUiConfig
 
 Set configuration options for all `@liveblocks/react-ui` components, such as
 [overrides](#overrides).
 
 ```tsx
-<LiveblocksUIConfig overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme" }} />
+<LiveblocksUiConfig overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme" }} />
 ```
 
-##### Props [#LiveblocksUIConfig-props]
+##### Props [#LiveblocksUiConfig-props]
 
 <PropertiesList>
   <PropertiesListItem name="overrides" type="Partial<Overrides>">
@@ -2392,18 +2392,18 @@ ignoring their containers. You can either target specific floating elements
 Overrides can be used to customize components’ strings and localization-related
 properties, such as locale and reading direction.
 
-They can be set globally for all components using `LiveblocksUIConfig`:
+They can be set globally for all components using `LiveblocksUiConfig`:
 
 ```tsx
-import { LiveblocksUIConfig } from "@liveblocks/react-ui";
+import { LiveblocksUiConfig } from "@liveblocks/react-ui";
 
 export function App() {
   return (
-    <LiveblocksUIConfig
+    <LiveblocksUiConfig
       overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme" /* ... */ }}
     >
       {/* ... */}
-    </LiveblocksUIConfig>
+    </LiveblocksUiConfig>
   );
 }
 ```

--- a/docs/pages/platform/upgrading/3.0.mdx
+++ b/docs/pages/platform/upgrading/3.0.mdx
@@ -5,4 +5,11 @@ meta:
   description: "Guide to upgrade to Liveblocks version 3.0"
 ---
 
-...
+TODO: List of changes to document
+
+- Removed deprecated things from
+  [the 2.24 "notification settings"/"subscription settings" renames](https://liveblocks.io/docs/platform/upgrading/2.24)
+  - Related, the `UPDATE_USER_NOTIFICATION_SETTINGS_ERROR` is now called
+    `UPDATE_NOTIFICATION_SETTINGS_ERROR`, which was the previous name of
+    `UPDATE_ROOM_SUBSCRIPTION_SETTINGS_ERROR`
+- `LiveblocksUIConfig` → `LiveblocksUiConfig`

--- a/docs/pages/ready-made-features/comments/styling-and-customization.mdx
+++ b/docs/pages/ready-made-features/comments/styling-and-customization.mdx
@@ -80,15 +80,15 @@ localization. In this example, we’re globally switching the word _Anonymous_ t
 _Anonyme_ for French users.
 
 ```tsx
-import { LiveblocksUIConfig } from "@liveblocks/react-ui";
+import { LiveblocksUiConfig } from "@liveblocks/react-ui";
 
 export function App() {
   return (
-    <LiveblocksUIConfig
+    <LiveblocksUiConfig
       overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme" /* ... */ }}
     >
       {/* ... */}
-    </LiveblocksUIConfig>
+    </LiveblocksUiConfig>
   );
 }
 ```

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -37,7 +37,7 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import { useLiveblocksUIConfig } from "../config";
+import { useLiveblocksUiConfig } from "../config";
 import { FLOATING_ELEMENT_SIDE_OFFSET } from "../constants";
 import { AttachmentIcon } from "../icons/Attachment";
 import { BoldIcon } from "../icons/Bold";
@@ -662,7 +662,7 @@ export const Composer = forwardRef(
     const createThread = useCreateRoomThread(roomId);
     const createComment = useCreateRoomComment(roomId);
     const editComment = useEditRoomComment(roomId);
-    const { preventUnsavedComposerChanges } = useLiveblocksUIConfig();
+    const { preventUnsavedComposerChanges } = useLiveblocksUiConfig();
     const hasResolveMentionSuggestions =
       useResolveMentionSuggestions() !== undefined;
     const isEmptyRef = useRef(true);

--- a/packages/liveblocks-react-ui/src/components/internal/Dropdown.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Dropdown.tsx
@@ -4,7 +4,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import type { ReactNode } from "react";
 import { forwardRef } from "react";
 
-import { useLiveblocksUIConfig } from "../../config";
+import { useLiveblocksUiConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -37,7 +37,7 @@ export function Dropdown({
   ...props
 }: DropdownProps) {
   const $ = useOverrides();
-  const { portalContainer } = useLiveblocksUIConfig();
+  const { portalContainer } = useLiveblocksUiConfig();
 
   return (
     <DropdownMenuPrimitive.Root

--- a/packages/liveblocks-react-ui/src/components/internal/EmojiPicker.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/EmojiPicker.tsx
@@ -10,7 +10,7 @@ import {
 import type { ComponentPropsWithoutRef, SyntheticEvent } from "react";
 import { forwardRef, useCallback, useState } from "react";
 
-import { useLiveblocksUIConfig } from "../../config";
+import { useLiveblocksUiConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -77,7 +77,7 @@ export const EmojiPicker = forwardRef<HTMLDivElement, EmojiPickerProps>(
     forwardedRef
   ) => {
     const [isOpen, setOpen] = useState(false);
-    const { portalContainer, emojibaseUrl } = useLiveblocksUIConfig();
+    const { portalContainer, emojibaseUrl } = useLiveblocksUiConfig();
     const $ = useOverrides();
 
     const handleOpenChange = useCallback(

--- a/packages/liveblocks-react-ui/src/components/internal/Tooltip.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/Tooltip.tsx
@@ -4,7 +4,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import type { ComponentProps, ReactNode } from "react";
 import { forwardRef, useMemo } from "react";
 
-import { useLiveblocksUIConfig } from "../../config";
+import { useLiveblocksUiConfig } from "../../config";
 import {
   FLOATING_ELEMENT_COLLISION_PADDING,
   FLOATING_ELEMENT_SIDE_OFFSET,
@@ -75,7 +75,7 @@ function getShortcutKbdFromKeymap(keymap: string) {
 
 export const Tooltip = forwardRef<HTMLButtonElement, TooltipProps>(
   ({ children, content, multiline, className, ...props }, forwardedRef) => {
-    const { portalContainer } = useLiveblocksUIConfig();
+    const { portalContainer } = useLiveblocksUiConfig();
 
     return (
       <TooltipPrimitive.Root disableHoverableContent>

--- a/packages/liveblocks-react-ui/src/config.tsx
+++ b/packages/liveblocks-react-ui/src/config.tsx
@@ -7,7 +7,7 @@ import { type Components, ComponentsProvider } from "./components";
 import type { Overrides } from "./overrides";
 import { OverridesProvider } from "./overrides";
 
-type LiveblocksUIConfigProps = PropsWithChildren<{
+type LiveblocksUiConfigProps = PropsWithChildren<{
   /**
    * Override the components' strings.
    */
@@ -52,35 +52,35 @@ type LiveblocksUIConfigProps = PropsWithChildren<{
   emojibaseUrl?: string;
 }>;
 
-interface LiveblocksUIConfigContext {
+interface LiveblocksUiConfigContext {
   portalContainer?: HTMLElement;
   preventUnsavedComposerChanges?: boolean;
   emojibaseUrl?: string;
 }
 
-const LiveblocksUIConfigContext = createContext<LiveblocksUIConfigContext>({});
+const LiveblocksUiConfigContext = createContext<LiveblocksUiConfigContext>({});
 
-export function useLiveblocksUIConfig() {
-  return useContext(LiveblocksUIConfigContext);
+export function useLiveblocksUiConfig() {
+  return useContext(LiveblocksUiConfigContext);
 }
 
 /**
  * Set configuration options for all components.
  *
  * @example
- * <LiveblocksUIConfig overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme", ... }}>
+ * <LiveblocksUiConfig overrides={{ locale: "fr", USER_UNKNOWN: "Anonyme", ... }}>
  *   <App />
- * </LiveblocksUIConfig>
+ * </LiveblocksUiConfig>
  */
-export function LiveblocksUIConfig({
+export function LiveblocksUiConfig({
   overrides,
   components,
   portalContainer,
   preventUnsavedComposerChanges = true,
   emojibaseUrl,
   children,
-}: LiveblocksUIConfigProps) {
-  const liveblocksUIConfig = useMemo(
+}: LiveblocksUiConfigProps) {
+  const liveblocksUiConfig = useMemo(
     () => ({
       portalContainer,
       preventUnsavedComposerChanges,
@@ -90,12 +90,12 @@ export function LiveblocksUIConfig({
   );
 
   return (
-    <LiveblocksUIConfigContext.Provider value={liveblocksUIConfig}>
+    <LiveblocksUiConfigContext.Provider value={liveblocksUiConfig}>
       <OverridesProvider overrides={overrides}>
         <ComponentsProvider components={components}>
           {children}
         </ComponentsProvider>
       </OverridesProvider>
-    </LiveblocksUIConfigContext.Provider>
+    </LiveblocksUiConfigContext.Provider>
   );
 }

--- a/packages/liveblocks-react-ui/src/index.ts
+++ b/packages/liveblocks-react-ui/src/index.ts
@@ -28,7 +28,7 @@ export type { InboxNotificationListProps } from "./components/InboxNotificationL
 export { InboxNotificationList } from "./components/InboxNotificationList";
 export type { ThreadProps } from "./components/Thread";
 export { Thread } from "./components/Thread";
-export { LiveblocksUIConfig } from "./config";
+export { LiveblocksUiConfig } from "./config";
 export * as Icon from "./icon";
 export type {
   CommentOverrides,

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -65,7 +65,7 @@ import {
   withReact,
 } from "slate-react";
 
-import { useLiveblocksUIConfig } from "../../config";
+import { useLiveblocksUiConfig } from "../../config";
 import { withAutoFormatting } from "../../slate/plugins/auto-formatting";
 import { withAutoLinks } from "../../slate/plugins/auto-links";
 import { withCustomLinks } from "../../slate/plugins/custom-links";
@@ -246,7 +246,7 @@ function ComposerEditorMentionSuggestionsWrapper({
   const editor = useSlateStatic();
   const { onEditorChange } = useComposerEditorContext();
   const { isFocused } = useComposer();
-  const { portalContainer } = useLiveblocksUIConfig();
+  const { portalContainer } = useLiveblocksUiConfig();
   const [contentRef, contentZIndex] = useContentZIndex();
   const isOpen =
     isFocused && mentionDraft?.range !== undefined && userIds !== undefined;
@@ -364,7 +364,7 @@ function ComposerEditorFloatingToolbarWrapper({
   const editor = useSlateStatic();
   const { onEditorChange } = useComposerEditorContext();
   const { isFocused } = useComposer();
-  const { portalContainer } = useLiveblocksUIConfig();
+  const { portalContainer } = useLiveblocksUiConfig();
   const [contentRef, contentZIndex] = useContentZIndex();
   const [isPointerDown, setPointerDown] = useState(false);
   const isOpen = isFocused && !isPointerDown && hasFloatingToolbarRange;


### PR DESCRIPTION
I noticed that we didn't stick to Pascal case for this niche context provider, with 3.0 and all the upcoming `Ai*` things, it feels like a good time to fix that. Or do you think the breaking change is not worth it? If it was a main API I would vote for keeping the inconsistency to lower the upgrade cost, but this one being really niche/advanced makes me think it's fine.