### PR TITLE
Implement tool-calling support on the client side

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
@@ -4,6 +4,7 @@ import { useClient } from "@liveblocks/react/suspense";
 import { HTMLAttributes, memo, useEffect, useMemo, useState } from "react";
 import {
   AiAssistantContentPart,
+  AiToolInvocationPart,
   CopilotId,
   kInternal,
   MessageId,
@@ -111,7 +112,10 @@ export const AssistantMessage = memo(function AssistantMessage({
         <div className="">This message has been deleted.</div>
       </div>
     );
-  } else if (message.status === "pending") {
+  } else if (
+    message.status === "generating" ||
+    message.status === "awaiting-tool"
+  ) {
     if (message.contentSoFar.length === 0) {
       return (
         <div className="">
@@ -209,14 +213,9 @@ function AssistantMessageContent({
           case "text": {
             return <TextPart key={index} text={part.text} className="prose" />;
           }
-          case "tool-call": {
+          case "tool-invocation": {
             return (
-              <ToolCallPart
-                key={index}
-                chatId={chatId}
-                name={part.toolName}
-                args={part.args}
-              />
+              <ToolInvocationPart key={index} chatId={chatId} part={part} />
             );
           }
           case "reasoning": {
@@ -273,25 +272,23 @@ const MemoizedBlockTokenComp = memo(
   }
 );
 
-function ToolCallPart({
+function ToolInvocationPart({
   chatId,
-  name,
-  args,
+  part,
 }: {
   chatId: string;
-  name: string;
-  args: any;
+  part: AiToolInvocationPart;
 }) {
   const client = useClient();
 
   const tool = useSignal(
-    client[kInternal].ai.signals.getToolDefinitionΣ(chatId, name)
+    client[kInternal].ai.signals.getToolDefinitionΣ(chatId, part.toolName)
   );
-  if (tool === undefined || tool.render === undefined) return null;
+  if (tool?.render === undefined) return null;
 
   return (
     <div className="lb-ai-chat-message-tool">
-      <tool.render args={args as unknown} />
+      <tool.render {...part} />
     </div>
   );
 }

--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/chat-composer.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/chat-composer.tsx
@@ -13,12 +13,12 @@ export function ChatComposer({
   chatId,
   copilotId,
   autoFocus,
-  pendingMessage,
+  abortableMessageId,
   lastMessageId,
   onUserMessageCreate,
 }: {
   chatId: string;
-  pendingMessage: MessageId | null;
+  abortableMessageId: MessageId | null;
   lastMessageId: MessageId | null;
   copilotId?: CopilotId;
   autoFocus?: boolean;
@@ -28,8 +28,7 @@ export function ChatComposer({
 
   const handleComposerSubmit = useCallback(
     (message: { text: string }, event: FormEvent<HTMLFormElement>) => {
-      console.log(pendingMessage);
-      if (pendingMessage !== null) {
+      if (abortableMessageId !== null) {
         event.preventDefault();
         return;
       }
@@ -68,7 +67,7 @@ export function ChatComposer({
       copilotId,
       lastMessageId,
       onUserMessageCreate,
-      pendingMessage,
+      abortableMessageId,
     ]
   );
 
@@ -87,7 +86,7 @@ export function ChatComposer({
 
         <div className="flex items-center px-3 py-4 gap-2">
           <div className="ml-auto">
-            {pendingMessage === null ? (
+            {abortableMessageId === null ? (
               <AiChatComposerSubmit
                 onPointerDown={(event) => event.preventDefault()}
                 aria-label="Send"
@@ -101,7 +100,7 @@ export function ChatComposer({
                 onPointerDown={(event) => event.preventDefault()}
                 onClick={(event) => {
                   event.stopPropagation();
-                  client[kInternal].ai.abort(pendingMessage);
+                  client[kInternal].ai.abort(abortableMessageId);
                 }}
                 className="inline-flex size-7.5 rounded-full items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200"
                 aria-label="Abort"

--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/page.tsx
@@ -187,9 +187,11 @@ function Chat({ chatId }: { chatId: string }) {
             chatId={chatId}
             copilotId={copilotId === "default" ? undefined : copilotId}
             lastMessageId={messages[messages.length - 1]?.id ?? null}
-            pendingMessage={
+            abortableMessageId={
               messages.find(
-                (m) => m.role === "assistant" && m.status === "pending"
+                (m) =>
+                  m.role === "assistant" &&
+                  (m.status === "generating" || m.status === "awaiting-tool")
               )?.id ?? null
             }
             onUserMessageCreate={(id) => {

--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -1,13 +1,130 @@
 "use client";
 
+import type { JSONSchema4 } from "json-schema";
 import {
   ClientSideSuspense,
   LiveblocksProvider,
 } from "@liveblocks/react/suspense";
-import { useCallback, useState } from "react";
+import { ComponentType, useCallback, useEffect, useState } from "react";
 import { Popover } from "radix-ui";
 import { AiChat } from "@liveblocks/react-ui";
-import { RegisterAiKnowledge } from "@liveblocks/react";
+import { RegisterAiKnowledge, useClient } from "@liveblocks/react";
+import { kInternal, Relax, Resolve, wait } from "@liveblocks/core";
+
+// ---------------------------------------------------------------------------------------------
+
+type InferFromJSONSchema<T extends JSONSchema4> = T extends {
+  type: "object";
+  properties: Record<string, JSONSchema4>;
+  required: readonly string[];
+}
+  ? Resolve<
+      {
+        [K in keyof T["properties"] as K extends string
+          ? K extends Extract<K, T["required"][number]>
+            ? K
+            : never
+          : never]: InferFromJSONSchema<T["properties"][K]>;
+      } & {
+        [K in keyof T["properties"] as K extends string
+          ? K extends Extract<K, T["required"][number]>
+            ? never
+            : K
+          : never]?: InferFromJSONSchema<T["properties"][K]>;
+      }
+    >
+  : T extends {
+        type: "object";
+        properties: Record<string, JSONSchema4>;
+      }
+    ? {
+        [K in keyof T["properties"]]?: InferFromJSONSchema<T["properties"][K]>;
+      }
+    : T extends { type: "string" }
+      ? string
+      : T extends { type: "number" }
+        ? number
+        : T extends { type: "boolean" }
+          ? boolean
+          : T extends { type: "null" }
+            ? null
+            : T extends { type: "array"; items: JSONSchema4 }
+              ? InferFromJSONSchema<T["items"]>[]
+              : unknown;
+
+// ---------------------------------------------------------------------------------------------
+
+export type Person = InferFromJSONSchema<{
+  type: "object";
+  properties: {
+    name: { type: "string" };
+    age: { type: "number" };
+    hobbies: {
+      type: "array";
+      items: { type: "string" };
+    };
+  };
+  required: ["name", "age"];
+}>;
+
+// ---------------------------------------------------------------------------------------------
+
+type MakeAiToolOptions<S extends JSONSchema4, R> = {
+  toolName: string;
+  description: string;
+  parameters: S;
+  execute: (options: { args: InferFromJSONSchema<S> }) => Promise<R>;
+  // execute?: () => Awaitable<void>;
+  render?: ComponentType<
+    Relax<
+      | { status: "streaming"; result: Partial<R> }
+      | { status: "resolved"; result: R; respond: () => void }
+      | { status: "error" }
+    >
+  >;
+};
+
+function makeAiTool<S extends JSONSchema4, R>(
+  _options: MakeAiToolOptions<S, R>
+) {
+  return 42 as any;
+}
+
+//
+// TODO: Implement similarly:
+// <RegisterAiTool />
+//
+// XXX Maybe split these tools into multiple components?
+// <RegisterAiChatWidget render={} />
+// <RegisterAiChatImmediateSideEffect execute={} ... />
+// <RegisterAiChatConfirmableSideEffect previewRender={show date picker} confirmedRender={"okay, I picked this date"} deniedRender={"okay, i'll leave you alone"} />
+//
+// <RegisterAiTool
+// render={({ toolCallId, toolName, args, status }) => {
+//    status // "pending" | "confirmed" | "denied"
+// />
+//
+// XXX Move this component into `@liveblocks/react-ui` eventually when done iterating on it
+// function RegisterAiTool(_props: any) {
+//   // useRegisterAiKnowledge(props);
+//   // XXX TODO Implement registering the provided tool
+//   return null;
+// }
+
+// export function Foo() {
+//   const [selectedTool, setSelectedTool] = useState<string | null>("circle");
+//
+//   return selectedTool === "circle" ? (
+//     <>
+//       <RegisterTool key="resizeCircle" description="Available circle tools" />
+//       <RegisterTool key="changeColor" render={(args) => ...} />
+//     </>
+//   ) : (
+//     <>
+//       <RegisterTool key="changeColor" />
+//     </>
+//   );
+// }
 
 function DarkModeToggle(_props: { x?: number }) {
   const [mode, setMode] = useState<"light" | "dark">("light");
@@ -22,6 +139,16 @@ function DarkModeToggle(_props: { x?: number }) {
         description="The current mode of the app"
         value={mode}
       />
+
+      {/* <RegisterAiTool */}
+      {/*   toolName="toggleDarkMode" */}
+      {/*   description="Toggle dark mode" */}
+      {/*   parameters={{}} */}
+      {/*   render={({ toolCallId, toolName, args }) => { */}
+      {/*     toggleDarkMode(); */}
+      {/*     return <h1>...</h1>; */}
+      {/*   }} */}
+      {/* /> */}
 
       <label>
         <input
@@ -90,6 +217,35 @@ function TodoApp() {
         description="A list of todos with id, title and completion status"
         value={todos}
       />
+
+      {/* <RegisterAiTool */}
+      {/*   toolName="displayTodo" */}
+      {/*   description="Display todos" */}
+      {/*   parameters={{ */}
+      {/*     type: "object", */}
+      {/*     properties: { */}
+      {/*       ids: { */}
+      {/*         type: "array", */}
+      {/*         description: "The ids of the todo to display", */}
+      {/*         items: { */}
+      {/*           type: "number", */}
+      {/*         }, */}
+      {/*       }, */}
+      {/*     }, */}
+      {/*   }} */}
+      {/*   render={({ args }: { args: { ids: number[] } }) => { */}
+      {/*     return ( */}
+      {/*       <div className="flex flex-col gap-2 shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] rounded-lg p-4 mt-4"> */}
+      {/*         {args.ids.map((id) => { */}
+      {/*           const todo = todos.find((t) => t.id === id); */}
+      {/*           if (!todo) return null; */}
+      {/**/}
+      {/*           return <div key={todo.id}>{todo.title}</div>; */}
+      {/*         })} */}
+      {/*       </div> */}
+      {/*     ); */}
+      {/*   }} */}
+      {/* /> */}
 
       <input
         type="text"
@@ -169,8 +325,153 @@ function BothApps() {
   );
 }
 
+function Debug() {
+  const knowledge = useClient()[kInternal].ai.debug_getAllKnowledge();
+
+  const [_, setX] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setX((x) => x + 1);
+    }, 200);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return <pre>{JSON.stringify(knowledge, null, 2)}</pre>;
+}
+
 export default function Page() {
   const [selectedTab, setSelectedTab] = useState(1);
+
+  //
+  // XXX Maybe split these tools into multiple components?
+  //
+  // "Weather widget" (today's weather)
+  // <RegisterAiChatWidget render={} />
+  //
+  // "Dark mode" (immediate)
+  // <RegisterAiChatImmediateSideEffect handler={} ... />
+  //      -->  respond('ok')
+  //      -->  respond('I set it to dark mode for you!')
+  //
+  // "HITL" (confirmable)
+  // <RegisterAiChatConfirmableSideEffect previewRender={show date picker} confirmedRender={"okay, I picked this date"} deniedRender={"okay, i'll leave you alone"} />
+  //
+  //
+  // Possible states:
+  //
+  // - "streaming"  (reserved for future use) The AI is streaming in the tool call to the client. We do not use this yet.
+  // - "executing"  The AI has finished making the tool call and is now
+  //      |         awaiting the response, which should be provided by the
+  //      |         client. This phase is up to the user to implement.
+  //      |         Example: AI has described in an assistant message:
+  //      |            { type: "tool-call", toolName: "getWeather", args: { city: "Paris" }, toolId: "xyz" }
+  //      |
+  //      |
+  //    respond(payload)
+  //      |
+  //      v
+  // - "resolved"   The tool call has finished and has a result (= the payload). This is the tool-result.
+  //                Example: We have to respond with { type: "tool-result", toolId: "xyz", data: payload } ("tool" message)
+  //
+  //                In the backend:
+  //                1. Adds a "tool" message to the chat messages with the tool result
+  //                2. Ask AI again? (This is multi-step tool calling!)
+  //                3. AI responds with an assistant message, and we stream that to both clients!
+  //
+
+  // const darkModeToggle = makeAiTool({
+  //   toolName: "darkModeToggle",
+  //   description: "Toggle the dark mode",
+  //   parameters: {},
+  //
+  //   // = what copilotkit calls handler????
+  //   execute: async ({ args /* toolId? */ }) => {
+  //     setDarkMode((x) => !x);
+  //     return "ok";
+  //   },
+  // });
+
+  // const sendInvoice = makeAiTool({
+  //   toolName: "sendInvoice",
+  //   description: "Send an invoice",
+  //   parameters: {
+  //     type: "object",
+  //     properties: {
+  //       invoiceId: { type: "string" },
+  //       customerName: { type: "string" },
+  //       amount: { type: "number" },
+  //     },
+  //     required: ["invoiceId", "customerName", "amount"],
+  //   },
+
+  //   // = what copilotkit calls handler????
+  //   execute: async ({ args /* toolId? */ }) => {
+  //     return "ok";
+  //   },
+  //
+  //   render: ({ status, args, respond }) => {
+  //     // Do send the mail + respond('sent the invoice')
+  //     return <button onClick={() => respond("ok")}>Send it!</button>;
+  //   },
+  // });
+
+  const getWeather = makeAiTool({
+    toolName: "getWeather",
+    description: "Displays the weather in a widget",
+    parameters: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+
+    // = what copilotkit calls handler????
+    execute: async ({ args /* toolId? */ }) => {
+      // During this entire call status === "executing"
+
+      // await callToWeatherService(...)
+      await wait(1000);
+      return {
+        city: args.city,
+        days: [
+          { date: "2025-05-11", temperature: 20, summary: "Sunny" },
+          { date: "2025-05-12", temperature: 22, summary: "Sunny" },
+          { date: "2025-05-13", temperature: 21, summary: "Partially cloudy" },
+          { date: "2025-05-14", temperature: 23, summary: "Sunny" },
+          { date: "2025-05-15", temperature: 25, summary: "Sunny" },
+          { date: "2025-05-16", temperature: 24, summary: "Sunny" },
+          { date: "2025-05-17", temperature: 23, summary: "Sunny" },
+        ],
+      };
+    },
+
+    //render: ({ status }) => status,
+
+    // render: ({ status, result, respond }) => {
+    //   if (status === "streaming") {
+    //     return <div>Loading...</div>;
+    //   } else if (status === "error") {
+    //     return <div>An error happened</div>;
+    //   } else {
+    //     return (
+    //       <div>
+    //         <h1>Weather in {result.city}</h1>
+    //         {result.days.map((day) => (
+    //           <div key={day.date}>
+    //             <div>{new Date(day.date).getDay()}</div>
+    //             <div>
+    //               {day.summary}, {day.temperature}°C
+    //             </div>
+    //           </div>
+    //         ))}
+    //       </div>
+    //     );
+    //   }
+    // },
+  });
+
   return (
     <LiveblocksProvider
       authEndpoint="/api/auth/liveblocks"
@@ -224,6 +525,8 @@ export default function Page() {
           )}
         </div>
 
+        <Debug />
+
         <div className="fixed bottom-8 right-8">
           <Popover.Root>
             <Popover.Trigger className="inline-flex items-center justify-center rounded-full p-4 shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] hover:shadow-[0_0_0_1px_#00000014,0_2px_6px_#00000014,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] dark:hover:shadow-[0_0_0_1px_#ffffff14,0_2px_6px_#ffffff14,0_8px_26px_#ffffff14]">
@@ -249,7 +552,13 @@ export default function Page() {
                 className="flex flex-col w-[450px] h-[600px] shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] dark:hover:shadow-[0_0_0_1px_#ffffff14,0_2px_6px_#ffffff14,0_8px_26px_#ffffff14] rounded-xl"
               >
                 <ClientSideSuspense fallback={null}>
-                  <AiChat chatId="todo125" className="rounded-xl" />
+                  <AiChat
+                    chatId="todo125"
+                    className="rounded-xl"
+                    tools={{
+                      getWeather,
+                    }}
+                  />
                 </ClientSideSuspense>
               </Popover.Content>
             </Popover.Portal>

--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -1,130 +1,13 @@
 "use client";
 
-import type { JSONSchema4 } from "json-schema";
 import {
   ClientSideSuspense,
   LiveblocksProvider,
 } from "@liveblocks/react/suspense";
-import { ComponentType, useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Popover } from "radix-ui";
 import { AiChat } from "@liveblocks/react-ui";
-import { RegisterAiKnowledge, useClient } from "@liveblocks/react";
-import { kInternal, Relax, Resolve, wait } from "@liveblocks/core";
-
-// ---------------------------------------------------------------------------------------------
-
-type InferFromJSONSchema<T extends JSONSchema4> = T extends {
-  type: "object";
-  properties: Record<string, JSONSchema4>;
-  required: readonly string[];
-}
-  ? Resolve<
-      {
-        [K in keyof T["properties"] as K extends string
-          ? K extends Extract<K, T["required"][number]>
-            ? K
-            : never
-          : never]: InferFromJSONSchema<T["properties"][K]>;
-      } & {
-        [K in keyof T["properties"] as K extends string
-          ? K extends Extract<K, T["required"][number]>
-            ? never
-            : K
-          : never]?: InferFromJSONSchema<T["properties"][K]>;
-      }
-    >
-  : T extends {
-        type: "object";
-        properties: Record<string, JSONSchema4>;
-      }
-    ? {
-        [K in keyof T["properties"]]?: InferFromJSONSchema<T["properties"][K]>;
-      }
-    : T extends { type: "string" }
-      ? string
-      : T extends { type: "number" }
-        ? number
-        : T extends { type: "boolean" }
-          ? boolean
-          : T extends { type: "null" }
-            ? null
-            : T extends { type: "array"; items: JSONSchema4 }
-              ? InferFromJSONSchema<T["items"]>[]
-              : unknown;
-
-// ---------------------------------------------------------------------------------------------
-
-export type Person = InferFromJSONSchema<{
-  type: "object";
-  properties: {
-    name: { type: "string" };
-    age: { type: "number" };
-    hobbies: {
-      type: "array";
-      items: { type: "string" };
-    };
-  };
-  required: ["name", "age"];
-}>;
-
-// ---------------------------------------------------------------------------------------------
-
-type MakeAiToolOptions<S extends JSONSchema4, R> = {
-  toolName: string;
-  description: string;
-  parameters: S;
-  execute: (options: { args: InferFromJSONSchema<S> }) => Promise<R>;
-  // execute?: () => Awaitable<void>;
-  render?: ComponentType<
-    Relax<
-      | { status: "streaming"; result: Partial<R> }
-      | { status: "resolved"; result: R; respond: () => void }
-      | { status: "error" }
-    >
-  >;
-};
-
-function makeAiTool<S extends JSONSchema4, R>(
-  _options: MakeAiToolOptions<S, R>
-) {
-  return 42 as any;
-}
-
-//
-// TODO: Implement similarly:
-// <RegisterAiTool />
-//
-// XXX Maybe split these tools into multiple components?
-// <RegisterAiChatWidget render={} />
-// <RegisterAiChatImmediateSideEffect execute={} ... />
-// <RegisterAiChatConfirmableSideEffect previewRender={show date picker} confirmedRender={"okay, I picked this date"} deniedRender={"okay, i'll leave you alone"} />
-//
-// <RegisterAiTool
-// render={({ toolCallId, toolName, args, status }) => {
-//    status // "pending" | "confirmed" | "denied"
-// />
-//
-// XXX Move this component into `@liveblocks/react-ui` eventually when done iterating on it
-// function RegisterAiTool(_props: any) {
-//   // useRegisterAiKnowledge(props);
-//   // XXX TODO Implement registering the provided tool
-//   return null;
-// }
-
-// export function Foo() {
-//   const [selectedTool, setSelectedTool] = useState<string | null>("circle");
-//
-//   return selectedTool === "circle" ? (
-//     <>
-//       <RegisterTool key="resizeCircle" description="Available circle tools" />
-//       <RegisterTool key="changeColor" render={(args) => ...} />
-//     </>
-//   ) : (
-//     <>
-//       <RegisterTool key="changeColor" />
-//     </>
-//   );
-// }
+import { RegisterAiKnowledge } from "@liveblocks/react";
 
 function DarkModeToggle(_props: { x?: number }) {
   const [mode, setMode] = useState<"light" | "dark">("light");
@@ -139,16 +22,6 @@ function DarkModeToggle(_props: { x?: number }) {
         description="The current mode of the app"
         value={mode}
       />
-
-      {/* <RegisterAiTool */}
-      {/*   toolName="toggleDarkMode" */}
-      {/*   description="Toggle dark mode" */}
-      {/*   parameters={{}} */}
-      {/*   render={({ toolCallId, toolName, args }) => { */}
-      {/*     toggleDarkMode(); */}
-      {/*     return <h1>...</h1>; */}
-      {/*   }} */}
-      {/* /> */}
 
       <label>
         <input
@@ -217,35 +90,6 @@ function TodoApp() {
         description="A list of todos with id, title and completion status"
         value={todos}
       />
-
-      {/* <RegisterAiTool */}
-      {/*   toolName="displayTodo" */}
-      {/*   description="Display todos" */}
-      {/*   parameters={{ */}
-      {/*     type: "object", */}
-      {/*     properties: { */}
-      {/*       ids: { */}
-      {/*         type: "array", */}
-      {/*         description: "The ids of the todo to display", */}
-      {/*         items: { */}
-      {/*           type: "number", */}
-      {/*         }, */}
-      {/*       }, */}
-      {/*     }, */}
-      {/*   }} */}
-      {/*   render={({ args }: { args: { ids: number[] } }) => { */}
-      {/*     return ( */}
-      {/*       <div className="flex flex-col gap-2 shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] rounded-lg p-4 mt-4"> */}
-      {/*         {args.ids.map((id) => { */}
-      {/*           const todo = todos.find((t) => t.id === id); */}
-      {/*           if (!todo) return null; */}
-      {/**/}
-      {/*           return <div key={todo.id}>{todo.title}</div>; */}
-      {/*         })} */}
-      {/*       </div> */}
-      {/*     ); */}
-      {/*   }} */}
-      {/* /> */}
 
       <input
         type="text"
@@ -325,153 +169,8 @@ function BothApps() {
   );
 }
 
-function Debug() {
-  const knowledge = useClient()[kInternal].ai.debug_getAllKnowledge();
-
-  const [_, setX] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setX((x) => x + 1);
-    }, 200);
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
-
-  return <pre>{JSON.stringify(knowledge, null, 2)}</pre>;
-}
-
 export default function Page() {
   const [selectedTab, setSelectedTab] = useState(1);
-
-  //
-  // XXX Maybe split these tools into multiple components?
-  //
-  // "Weather widget" (today's weather)
-  // <RegisterAiChatWidget render={} />
-  //
-  // "Dark mode" (immediate)
-  // <RegisterAiChatImmediateSideEffect handler={} ... />
-  //      -->  respond('ok')
-  //      -->  respond('I set it to dark mode for you!')
-  //
-  // "HITL" (confirmable)
-  // <RegisterAiChatConfirmableSideEffect previewRender={show date picker} confirmedRender={"okay, I picked this date"} deniedRender={"okay, i'll leave you alone"} />
-  //
-  //
-  // Possible states:
-  //
-  // - "streaming"  (reserved for future use) The AI is streaming in the tool call to the client. We do not use this yet.
-  // - "executing"  The AI has finished making the tool call and is now
-  //      |         awaiting the response, which should be provided by the
-  //      |         client. This phase is up to the user to implement.
-  //      |         Example: AI has described in an assistant message:
-  //      |            { type: "tool-call", toolName: "getWeather", args: { city: "Paris" }, toolId: "xyz" }
-  //      |
-  //      |
-  //    respond(payload)
-  //      |
-  //      v
-  // - "resolved"   The tool call has finished and has a result (= the payload). This is the tool-result.
-  //                Example: We have to respond with { type: "tool-result", toolId: "xyz", data: payload } ("tool" message)
-  //
-  //                In the backend:
-  //                1. Adds a "tool" message to the chat messages with the tool result
-  //                2. Ask AI again? (This is multi-step tool calling!)
-  //                3. AI responds with an assistant message, and we stream that to both clients!
-  //
-
-  // const darkModeToggle = makeAiTool({
-  //   toolName: "darkModeToggle",
-  //   description: "Toggle the dark mode",
-  //   parameters: {},
-  //
-  //   // = what copilotkit calls handler????
-  //   execute: async ({ args /* toolId? */ }) => {
-  //     setDarkMode((x) => !x);
-  //     return "ok";
-  //   },
-  // });
-
-  // const sendInvoice = makeAiTool({
-  //   toolName: "sendInvoice",
-  //   description: "Send an invoice",
-  //   parameters: {
-  //     type: "object",
-  //     properties: {
-  //       invoiceId: { type: "string" },
-  //       customerName: { type: "string" },
-  //       amount: { type: "number" },
-  //     },
-  //     required: ["invoiceId", "customerName", "amount"],
-  //   },
-
-  //   // = what copilotkit calls handler????
-  //   execute: async ({ args /* toolId? */ }) => {
-  //     return "ok";
-  //   },
-  //
-  //   render: ({ status, args, respond }) => {
-  //     // Do send the mail + respond('sent the invoice')
-  //     return <button onClick={() => respond("ok")}>Send it!</button>;
-  //   },
-  // });
-
-  const getWeather = makeAiTool({
-    toolName: "getWeather",
-    description: "Displays the weather in a widget",
-    parameters: {
-      type: "object",
-      properties: { city: { type: "string" } },
-      required: ["city"],
-    },
-
-    // = what copilotkit calls handler????
-    execute: async ({ args /* toolId? */ }) => {
-      // During this entire call status === "executing"
-
-      // await callToWeatherService(...)
-      await wait(1000);
-      return {
-        city: args.city,
-        days: [
-          { date: "2025-05-11", temperature: 20, summary: "Sunny" },
-          { date: "2025-05-12", temperature: 22, summary: "Sunny" },
-          { date: "2025-05-13", temperature: 21, summary: "Partially cloudy" },
-          { date: "2025-05-14", temperature: 23, summary: "Sunny" },
-          { date: "2025-05-15", temperature: 25, summary: "Sunny" },
-          { date: "2025-05-16", temperature: 24, summary: "Sunny" },
-          { date: "2025-05-17", temperature: 23, summary: "Sunny" },
-        ],
-      };
-    },
-
-    //render: ({ status }) => status,
-
-    // render: ({ status, result, respond }) => {
-    //   if (status === "streaming") {
-    //     return <div>Loading...</div>;
-    //   } else if (status === "error") {
-    //     return <div>An error happened</div>;
-    //   } else {
-    //     return (
-    //       <div>
-    //         <h1>Weather in {result.city}</h1>
-    //         {result.days.map((day) => (
-    //           <div key={day.date}>
-    //             <div>{new Date(day.date).getDay()}</div>
-    //             <div>
-    //               {day.summary}, {day.temperature}°C
-    //             </div>
-    //           </div>
-    //         ))}
-    //       </div>
-    //     );
-    //   }
-    // },
-  });
-
   return (
     <LiveblocksProvider
       authEndpoint="/api/auth/liveblocks"
@@ -525,8 +224,6 @@ export default function Page() {
           )}
         </div>
 
-        <Debug />
-
         <div className="fixed bottom-8 right-8">
           <Popover.Root>
             <Popover.Trigger className="inline-flex items-center justify-center rounded-full p-4 shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] hover:shadow-[0_0_0_1px_#00000014,0_2px_6px_#00000014,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] dark:hover:shadow-[0_0_0_1px_#ffffff14,0_2px_6px_#ffffff14,0_8px_26px_#ffffff14]">
@@ -552,13 +249,7 @@ export default function Page() {
                 className="flex flex-col w-[450px] h-[600px] shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] dark:hover:shadow-[0_0_0_1px_#ffffff14,0_2px_6px_#ffffff14,0_8px_26px_#ffffff14] rounded-xl"
               >
                 <ClientSideSuspense fallback={null}>
-                  <AiChat
-                    chatId="todo125"
-                    className="rounded-xl"
-                    tools={{
-                      getWeather,
-                    }}
-                  />
+                  <AiChat chatId="todo125" className="rounded-xl" />
                 </ClientSideSuspense>
               </Popover.Content>
             </Popover.Portal>

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -6,24 +6,24 @@ import {
 } from "@liveblocks/react/suspense";
 import { useCallback, useState } from "react";
 import { Popover } from "radix-ui";
-import { AiChat } from "@liveblocks/react-ui";
+import { AiChat, AiToolDebugger } from "@liveblocks/react-ui";
 
 export default function Page() {
   const [todos, setTodos] = useState<
     { id: number; title: string; isCompleted: boolean }[]
   >([
     {
-      id: 1,
+      id: 9823,
       title: "Get groceries",
       isCompleted: true,
     },
     {
-      id: 2,
+      id: 72,
       title: "Go to the gym",
       isCompleted: false,
     },
     {
-      id: 3,
+      id: 1313,
       title: "Cook dinner",
       isCompleted: false,
     },
@@ -116,41 +116,47 @@ export default function Page() {
                 <ClientSideSuspense fallback={null}>
                   <AiChat
                     chatId="todo"
-                    knowledge={[
-                      {
-                        description:
-                          "A list of todos with id, title and completion status",
-                        value: `${JSON.stringify(todos)}`,
-                      },
-                    ]}
                     tools={{
-                      displayTodo: {
-                        description: "Display todos",
+                      listTodos: {
+                        description: "List all todos",
                         parameters: {
                           type: "object",
                           properties: {
                             ids: {
                               type: "array",
-                              description: "The ids of the todo to display",
-                              items: {
-                                type: "number",
-                              },
+                              description: "The requested todo items to list",
+                              items: { type: "number" },
                             },
                           },
                         },
-                        render: ({ args }) => {
+                        execute: (args) => {
                           const ids = args!.ids as number[];
-                          return (
-                            <div className="flex flex-col gap-2 shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] rounded-lg p-4 mt-4">
-                              {ids.map((id) => {
-                                const todo = todos.find((t) => t.id === id);
-                                if (!todo) return null;
-
-                                return <div key={todo.id}>{todo.title}</div>;
-                              })}
-                            </div>
-                          );
+                          if (ids.length === 0) {
+                            return todos;
+                          } else {
+                            return todos.filter((t) => ids.includes(t.id));
+                          }
                         },
+                      },
+
+                      toggleTodo: {
+                        description: "Toggle a todo's completion status",
+                        parameters: {
+                          type: "object",
+                          properties: {
+                            id: {
+                              description: "The id of the todo to toggle",
+                              type: "number",
+                            },
+                          },
+                        },
+
+                        execute: (args) => {
+                          const id = args!.id as number;
+                          toggleTodo(id);
+                          return { ok: true };
+                        },
+                        render: AiToolDebugger,
                       },
                     }}
                     className="rounded-xl"

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { wait } from "@liveblocks/core";
 import {
   ClientSideSuspense,
   LiveblocksProvider,
@@ -117,79 +116,16 @@ export default function Page() {
                 <ClientSideSuspense fallback={null}>
                   <AiChat
                     chatId="todo"
+                    knowledge={[
+                      {
+                        description:
+                          "A list of todos with id, title and completion status",
+                        value: `${JSON.stringify(todos)}`,
+                      },
+                    ]}
                     tools={{
-                      getWeather: {
-                        description:
-                          "List the weather in the given city or country",
-                        parameters: {
-                          type: "object",
-                          properties: {
-                            city: {
-                              type: "string",
-                              description: "The city to get the weather for",
-                            },
-                            country: {
-                              type: "string",
-                              description: "The country to get the weather for",
-                            },
-                          },
-                        },
-
-                        execute: async ({ args }) => {
-                          await wait(3000);
-                          return {
-                            city: (args as any)?.city,
-                            forecast: [
-                              { date: "2025-05-19", summary: "Windy" },
-                              { date: "2025-05-20", summary: "Cloudy" },
-                              { date: "2025-05-21", summary: "Sunny" },
-                              { date: "2025-05-22", summary: "Sunny" },
-                              { date: "2025-05-23", summary: "Sunny" },
-                              { date: "2025-05-24", summary: "Sunny" },
-                            ],
-                          };
-                        },
-
-                        render: ({ status }) => {
-                          return status === "executing" ? (
-                            <h1>Looking up the weather...</h1>
-                          ) : null;
-                        },
-                      },
-
-                      toggleTodo: {
-                        description:
-                          "Toggles (mark complete or incomplete) the given todo item",
-                        parameters: {
-                          type: "object",
-                          properties: {
-                            id: {
-                              description: "The id of the todo to display",
-                              type: "number",
-                            },
-                          },
-                        },
-
-                        execute: async (args) => {
-                          await wait(500);
-                          toggleTodo(args.id as any);
-                          await wait(500);
-                          return "toggled successfully";
-                        },
-
-                        render: ({ status, args }) => {
-                          return (
-                            <small style={{ color: "yellow" }}>
-                              {status === "executing"
-                                ? "Toggling..."
-                                : `Toggled item ${args?.id ?? "0"}`}
-                            </small>
-                          );
-                        },
-                      },
-
-                      listTodos: {
-                        description: "List all of my todos",
+                      displayTodo: {
+                        description: "Display todos",
                         parameters: {
                           type: "object",
                           properties: {
@@ -202,10 +138,18 @@ export default function Page() {
                             },
                           },
                         },
+                        render: ({ args }) => {
+                          const ids = args!.ids as number[];
+                          return (
+                            <div className="flex flex-col gap-2 shadow-[0_0_0_1px_#0000000a,0_2px_6px_#0000000f,0_8px_26px_#00000014] dark:shadow-[0_0_0_1px_#ffffff0f] rounded-lg p-4 mt-4">
+                              {ids.map((id) => {
+                                const todo = todos.find((t) => t.id === id);
+                                if (!todo) return null;
 
-                        execute: async () => {
-                          await wait(1000);
-                          return todos;
+                                return <div key={todo.id}>{todo.title}</div>;
+                              })}
+                            </div>
+                          );
                         },
                       },
                     }}

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -13,6 +13,7 @@ import * as console from "./lib/fancy-console";
 import { isDefined } from "./lib/guards";
 import type { Json, JsonObject } from "./lib/Json";
 import { nanoid } from "./lib/nanoid";
+import type { Resolve } from "./lib/Resolve";
 import { shallow, shallow2 } from "./lib/shallow";
 import { batch, DerivedSignal, MutableSignal, Signal } from "./lib/signals";
 import { SortedList } from "./lib/SortedList";
@@ -72,24 +73,24 @@ import { PKG_VERSION } from "./version";
 // milliseconds at most.
 const DEFAULT_REQUEST_TIMEOUT = 4_000;
 
+type AiToolDefinitionRenderProps = Resolve<
+  DistributiveOmit<AiToolInvocationPart, "type"> & {
+    respond: (result: Json) => void;
+  }
+>;
+
 // TODO[nvie] Come back here and make the input/output types correlated and nicely typed!
 export type AiToolDefinition =
   //  <
   //  // A extends JsonObject = JsonObject,
   //  // R extends JsonObject = JsonObject,
   //  >
-  | {
-      description?: string;
-      parameters: JSONSchema4;
-      execute: (args: JsonObject) => Awaitable<Json>;
-      render?: ComponentType<AiToolInvocationPart>;
-    }
-  | {
-      description?: string;
-      parameters: JSONSchema4;
-      execute?: (args: JsonObject) => Awaitable<Json>;
-      render: ComponentType<AiToolInvocationPart>;
-    };
+  {
+    description?: string;
+    parameters: JSONSchema4;
+    execute?: (args: JsonObject) => Awaitable<Json>;
+    render?: ComponentType<AiToolDefinitionRenderProps>;
+  };
 
 export type UiChatMessage = AiChatMessage & {
   navigation: {
@@ -457,7 +458,7 @@ function createStore_forChatMessages(
               // TODO Pass in AiGenerationOptions here, or make the backend use the same options
             ).catch((err) => {
               console.error(
-                `Error trying to respond to tool-call: ${String(err)} (1)`
+                `Error trying to respond to tool-call: ${String(err)} (in respond())`
               );
             });
           };
@@ -471,7 +472,7 @@ function createStore_forChatMessages(
               respondSync(result);
             })().catch((err) => {
               console.error(
-                `Error trying to respond to tool-call: ${String(err)} (2)`
+                `Error trying to respond to tool-call: ${String(err)} (in execute())`
               );
             });
           }

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -73,7 +73,7 @@ import { PKG_VERSION } from "./version";
 // milliseconds at most.
 const DEFAULT_REQUEST_TIMEOUT = 4_000;
 
-type AiToolDefinitionRenderProps = Resolve<
+export type AiToolDefinitionRenderProps = Resolve<
   DistributiveOmit<AiToolInvocationPart, "type"> & {
     respond: (result: Json) => void;
   }

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -17,7 +17,7 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
  */
 
 export type {
-  ClientToolDefinition,
+  AiToolDefinition,
   UiAssistantMessage,
   UiChatMessage,
   UiUserMessage,
@@ -321,6 +321,7 @@ export type {
   AiAssistantContentPart,
   AiChat,
   AiKnowledgeSource,
+  AiToolInvocationPart,
   CopilotId,
   Cursor,
   MessageId,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -18,6 +18,7 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export type {
   AiToolDefinition,
+  AiToolDefinitionRenderProps,
   UiAssistantMessage,
   UiChatMessage,
   UiUserMessage,

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -1,6 +1,6 @@
 import type {
   AiKnowledgeSource,
-  ClientToolDefinition,
+  AiToolDefinition,
   CopilotId,
   MessageId,
   UiChatMessage,
@@ -62,7 +62,7 @@ export interface AiChatProps extends ComponentProps<"div"> {
   /**
    * Tool definitions to make available within this chat. May be used by the assistant when generating responses.
    */
-  tools?: Record<string, ClientToolDefinition>;
+  tools?: Record<string, AiToolDefinition>;
   /**
    * Override the component's strings.
    */

--- a/packages/liveblocks-react-ui/src/components/AiToolDebugger.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiToolDebugger.tsx
@@ -1,4 +1,4 @@
-import type { AiToolInvocationPart } from "@liveblocks/core";
+import type { AiToolDefinitionRenderProps } from "@liveblocks/core";
 
 /**
  * @experimental
@@ -7,7 +7,7 @@ import type { AiToolInvocationPart } from "@liveblocks/core";
  * Simply drop this into your tool definition's `render` property to visually
  * see what's going on with your tool calls.
  */
-export function AiToolDebugger(props: AiToolInvocationPart) {
+export function AiToolDebugger(props: AiToolDefinitionRenderProps) {
   const color =
     props.status === "executed"
       ? "darkgreen"

--- a/packages/liveblocks-react-ui/src/components/AiToolDebugger.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiToolDebugger.tsx
@@ -1,0 +1,48 @@
+import type { AiToolInvocationPart } from "@liveblocks/core";
+
+/**
+ * @experimental
+ * Helper to debug tool invocations.
+ *
+ * Simply drop this into your tool definition's `render` property to visually
+ * see what's going on with your tool calls.
+ */
+export function AiToolDebugger(props: AiToolInvocationPart) {
+  const color =
+    props.status === "executed"
+      ? "darkgreen"
+      : props.status === "executing"
+        ? "orange"
+        : "gray";
+  return (
+    <div
+      className="lb-ai-chat-message-tool"
+      style={{
+        border: `2px solid ${color}`,
+        padding: "1rem",
+      }}
+    >
+      <div>
+        <b>status:</b> <span style={{ color }}>{props.status}</span>
+      </div>
+      <div>
+        <b>name:</b> {props.toolName}
+      </div>
+      <div>
+        {props.partialArgs ? (
+          <>
+            <b>partialArgs:</b> <code>{JSON.stringify(props.partialArgs)}</code>
+          </>
+        ) : (
+          <>
+            <b>args:</b> <code>{JSON.stringify(props.args)}</code>
+          </>
+        )}
+      </div>
+      <div>
+        <b>result:</b>{" "}
+        {props.result ? <code>{JSON.stringify(props.result)}</code> : "—"}
+      </div>
+    </div>
+  );
+}

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -2,6 +2,7 @@ import type {
   AiAssistantContentPart,
   AiToolInvocationPart,
   Json,
+  MessageId,
   UiAssistantMessage,
 } from "@liveblocks/core";
 import { kInternal } from "@liveblocks/core";
@@ -13,6 +14,7 @@ import {
   forwardRef,
   memo,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -86,6 +88,7 @@ export const AiChatAssistantMessage = memo(
             <AssistantMessageContent
               content={message.contentSoFar}
               chatId={message.chatId}
+              messageId={message.id}
               components={components}
             />
           );
@@ -95,6 +98,7 @@ export const AiChatAssistantMessage = memo(
           <AssistantMessageContent
             content={message.content}
             chatId={message.chatId}
+            messageId={message.id}
             components={components}
           />
         );
@@ -105,6 +109,7 @@ export const AiChatAssistantMessage = memo(
             <AssistantMessageContent
               content={message.contentSoFar}
               chatId={message.chatId}
+              messageId={message.id}
               components={components}
             />
           );
@@ -114,6 +119,7 @@ export const AiChatAssistantMessage = memo(
               <AssistantMessageContent
                 content={message.contentSoFar}
                 chatId={message.chatId}
+                messageId={message.id}
                 components={components}
               />
 
@@ -147,10 +153,12 @@ export const AiChatAssistantMessage = memo(
 function AssistantMessageContent({
   content,
   chatId,
+  messageId,
   components,
 }: {
   content: AiAssistantContentPart[];
   chatId: string;
+  messageId: MessageId;
   components: Partial<GlobalComponents> | undefined;
 }) {
   // A message is considered to be in "reasoning" state if it only contains reasoning parts and no other parts.
@@ -174,7 +182,12 @@ function AssistantMessageContent({
           }
           case "tool-invocation": {
             return (
-              <ToolInvocationPart key={index} chatId={chatId} part={part} />
+              <ToolInvocationPart
+                key={index}
+                chatId={chatId}
+                messageId={messageId}
+                part={part}
+              />
             );
           }
           case "reasoning": {
@@ -300,29 +313,50 @@ const MemoizedBlockTokenComp = memo(
   }
 );
 
+function noop() {
+  // Do nothing
+}
+
 /* -------------------------------------------------------------------------------------------------
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
 function ToolInvocationPart({
   chatId,
+  messageId,
   part,
 }: {
   chatId: string;
+  messageId: MessageId;
   part: AiToolInvocationPart;
 }) {
   const client = useClient();
   const ai = client[kInternal].ai;
-
   const tool = useSignal(ai.signals.getToolDefinitionΣ(chatId, part.toolName));
-  if (tool === undefined || tool.render === undefined) return null;
+  const respond = useCallback(
+    (result: Json) => {
+      ai.setToolResult(
+        chatId,
+        messageId,
+        part.toolCallId,
+        result
+        // TODO Pass in AiGenerationOptions here?
+      );
+    },
+    [ai, chatId, messageId, part.toolCallId]
+  );
 
-  // XXX Get the respond() callback here from somewhere
-  const respond = (_result: Json) => {};
+  if (tool === undefined || tool.render === undefined) return null;
 
   const { type: _, ...rest } = part;
   return (
     <div className="lb-ai-chat-message-tool">
-      <tool.render {...rest} respond={respond} />
+      <tool.render
+        {...rest}
+        respond={
+          // It only makes sense and is safe to call `respond()` in "executing" state.
+          part.status === "executing" ? respond : noop
+        }
+      />
     </div>
   );
 }

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -1,6 +1,7 @@
 import type {
   AiAssistantContentPart,
   AiToolInvocationPart,
+  Json,
   UiAssistantMessage,
 } from "@liveblocks/core";
 import { kInternal } from "@liveblocks/core";
@@ -310,15 +311,18 @@ function ToolInvocationPart({
   part: AiToolInvocationPart;
 }) {
   const client = useClient();
+  const ai = client[kInternal].ai;
 
-  const tool = useSignal(
-    client[kInternal].ai.signals.getToolDefinitionΣ(chatId, part.toolName)
-  );
+  const tool = useSignal(ai.signals.getToolDefinitionΣ(chatId, part.toolName));
   if (tool === undefined || tool.render === undefined) return null;
 
+  // XXX Get the respond() callback here from somewhere
+  const respond = (_result: Json) => {};
+
+  const { type: _, ...rest } = part;
   return (
     <div className="lb-ai-chat-message-tool">
-      <tool.render {...part} />
+      <tool.render {...rest} respond={respond} />
     </div>
   );
 }

--- a/packages/liveblocks-react-ui/src/index.ts
+++ b/packages/liveblocks-react-ui/src/index.ts
@@ -6,6 +6,7 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export type { AiChatProps } from "./components/AiChat";
 export { AiChat } from "./components/AiChat";
+export { AiToolDebugger } from "./components/AiToolDebugger";
 export type { CommentProps } from "./components/Comment";
 export { Comment } from "./components/Comment";
 export type { ComposerProps } from "./components/Composer";


### PR DESCRIPTION
This PR lands the client-side updates to match the [backend tool-calling support](https://github.com/liveblocks/liveblocks-backend/pull/1036). I've also added a light example to the todo app, which we can iterate on to improve the way the `execute` / `render` properties will work exactly.

What's **currently implemented**:
- [x] Data types & protocol is stable now
- [x] Support for tool registration via the `<AiChat tools={...} />` prop
- [x] Each tool definition should have an `execute`, or `render` function, or both
- [x] The abort button will show while the assistant message is in either `generating` or `awaiting-tool` status
- [x] Aborting an assistant message while in generating phase will work like before: failing the message itself
- [x] Aborting an assistant message while in awaiting-tool phase will abort all tool calls, _and_ fail the message itself
- [x] The `respond` function is passed to `render`

What's **not implemented yet** (can all be tackled later, no blockers to merge):
All moved to follow-up PRs:
- [ ] Multi-tab support isn't there yet. Currently not only the designated client will execute: any open tab will. If you have two tabs open, both will execute the side effect. This is TBD.
- [ ] Making these APIs nicer to work with.
- [ ] Better TS support via inferred `args` and `result` types.
- [ ] Any other outstanding XXX's for internal clean ups.
