### PR TITLE
Implement `AiMessage.Content` primitive

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
@@ -187,12 +187,15 @@ function AssistantMessageContent({ message }: { message: UiAssistantMessage }) {
     content.every((part) => part.type === "reasoning");
 
   return (
-    <div className="prose whitespace-break-spaces">
+    <div>
       <AiMessage.Content
         message={message}
         components={{
           TextPart: ({ part }) => (
-            <TextPart text={part.text} className="prose" />
+            <TextPart
+              text={part.text}
+              className="prose whitespace-break-spaces"
+            />
           ),
 
           ReasoningPart: ({ part }) => (

--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
@@ -22,7 +22,7 @@ import { ChevronRightIcon } from "../../icons/chevron-right-icon";
 import { CopyIcon } from "../../icons/copy-icon";
 import { CircleAlertIcon } from "../../icons/circle-alert-icon";
 import { TrashIcon } from "../../icons/trash-icon";
-import { AiMessage } from "@liveblocks/react-ui/primitives";
+import { AiMessage } from "@liveblocks/react-ui/_private";
 
 export const AssistantMessage = memo(function AssistantMessage({
   message,

--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
@@ -1,19 +1,9 @@
 "use client";
 
 import { useClient } from "@liveblocks/react/suspense";
+import { HTMLAttributes, memo, useEffect, useMemo, useState } from "react";
 import {
-  HTMLAttributes,
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import {
-  AiAssistantContentPart,
-  AiToolInvocationPart,
   CopilotId,
-  Json,
   kInternal,
   MessageId,
   UiAssistantMessage,
@@ -23,7 +13,6 @@ import {
   type BlockToken,
   BlockTokenComp as BlockTokenCompPrimitive,
 } from "./markdown";
-import { useSignal } from "@liveblocks/react/_private";
 import * as CollapsiblePrimitive from "./collapsible";
 import { RefreshIcon } from "../../icons/refresh-icon";
 import { CheckIcon } from "../../icons/check-icon";
@@ -33,6 +22,7 @@ import { ChevronRightIcon } from "../../icons/chevron-right-icon";
 import { CopyIcon } from "../../icons/copy-icon";
 import { CircleAlertIcon } from "../../icons/circle-alert-icon";
 import { TrashIcon } from "../../icons/trash-icon";
+import { AiMessage } from "@liveblocks/react-ui/primitives";
 
 export const AssistantMessage = memo(function AssistantMessage({
   message,
@@ -133,13 +123,7 @@ export const AssistantMessage = memo(function AssistantMessage({
         </div>
       );
     } else {
-      return (
-        <AssistantMessageContent
-          content={message.contentSoFar}
-          chatId={message.chatId}
-          messageId={message.id}
-        />
-      );
+      return <AssistantMessageContent message={message} />;
     }
   } else if (message.status === "completed") {
     const text: string = message.content.reduce((acc, part) => {
@@ -152,11 +136,7 @@ export const AssistantMessage = memo(function AssistantMessage({
     return (
       <div className="flex flex-col gap-2 group">
         {/* Message content */}
-        <AssistantMessageContent
-          content={message.content}
-          chatId={message.chatId}
-          messageId={message.id}
-        />
+        <AssistantMessageContent message={message} />
 
         {/* Message actions */}
         <MessageActions text={text} />
@@ -174,11 +154,7 @@ export const AssistantMessage = memo(function AssistantMessage({
       return (
         <div className="flex flex-col gap-2 group">
           {/* Message content */}
-          <AssistantMessageContent
-            content={message.contentSoFar}
-            chatId={message.chatId}
-            messageId={message.id}
-          />
+          <AssistantMessageContent message={message} />
           {/* Message actions */}
           <MessageActions text={text} />
         </div>
@@ -187,11 +163,7 @@ export const AssistantMessage = memo(function AssistantMessage({
       return (
         <div className="flex flex-col gap-2 group">
           {/* Message content */}
-          <AssistantMessageContent
-            content={message.contentSoFar}
-            chatId={message.chatId}
-            messageId={message.id}
-          />
+          <AssistantMessageContent message={message} />
 
           <div className="flex flex-row gap-4 items-center rounded-lg bg-red-100/50 p-4 text-sm mt-2 text-red-400 dark:bg-red-900/40 dark:text-red-300">
             <CircleAlertIcon className="size-4" />
@@ -206,15 +178,9 @@ export const AssistantMessage = memo(function AssistantMessage({
   }
 });
 
-function AssistantMessageContent({
-  content,
-  chatId,
-  messageId,
-}: {
-  content: AiAssistantContentPart[];
-  chatId: string;
-  messageId: MessageId;
-}) {
+function AssistantMessageContent({ message }: { message: UiAssistantMessage }) {
+  const content = message.content ?? message.contentSoFar;
+
   // A message is considered to be in "reasoning" state if it only contains reasoning parts and no other parts.
   const isReasoning =
     content.some((part) => part.type === "reasoning") &&
@@ -222,35 +188,18 @@ function AssistantMessageContent({
 
   return (
     <div className="prose whitespace-break-spaces">
-      {content.map((part, index) => {
-        switch (part.type) {
-          case "text": {
-            return <TextPart key={index} text={part.text} className="prose" />;
-          }
-          case "tool-invocation": {
-            return (
-              <ToolInvocationPart
-                key={index}
-                chatId={chatId}
-                messageId={messageId}
-                part={part}
-              />
-            );
-          }
-          case "reasoning": {
-            return (
-              <ReasoningPart
-                key={index}
-                text={part.text}
-                isPending={isReasoning}
-              />
-            );
-          }
-          default: {
-            return null;
-          }
-        }
-      })}
+      <AiMessage.Content
+        message={message}
+        components={{
+          TextPart: ({ part }) => (
+            <TextPart text={part.text} className="prose" />
+          ),
+
+          ReasoningPart: ({ part }) => (
+            <ReasoningPart text={part.text} isPending={isReasoning} />
+          ),
+        }}
+      />
     </div>
   );
 }
@@ -290,51 +239,6 @@ const MemoizedBlockTokenComp = memo(
     return prevToken.raw === nextToken.raw;
   }
 );
-
-function noop() {
-  // Do nothing
-}
-
-function ToolInvocationPart({
-  chatId,
-  messageId,
-  part,
-}: {
-  chatId: string;
-  messageId: MessageId;
-  part: AiToolInvocationPart;
-}) {
-  const client = useClient();
-  const ai = client[kInternal].ai;
-  const tool = useSignal(ai.signals.getToolDefinitionΣ(chatId, part.toolName));
-  const respond = useCallback(
-    (result: Json) => {
-      ai.setToolResult(
-        chatId,
-        messageId,
-        part.toolCallId,
-        result
-        // TODO Pass in AiGenerationOptions here?
-      );
-    },
-    [ai, chatId, messageId, part.toolCallId]
-  );
-
-  if (tool === undefined || tool.render === undefined) return null;
-
-  const { type: _, ...rest } = part;
-  return (
-    <div className="lb-ai-chat-message-tool">
-      <tool.render
-        {...rest}
-        respond={
-          // It only makes sense and is safe to call `respond()` in "executing" state.
-          part.status === "executing" ? respond : noop
-        }
-      />
-    </div>
-  );
-}
 
 function ReasoningPart({
   text,

--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/markdown.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/markdown.tsx
@@ -596,6 +596,7 @@ function InlineTokenComp({
       }
 
       return (
+        // eslint-disable-next-line @next/next/no-img-element
         <img src={href} alt={token.text} title={token.title ?? undefined} />
       );
     }

--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -3,11 +3,12 @@
 import {
   ClientSideSuspense,
   LiveblocksProvider,
+  RegisterAiKnowledge,
 } from "@liveblocks/react/suspense";
+import { AiChat } from "@liveblocks/react-ui";
+
 import { useCallback, useState } from "react";
 import { Popover } from "radix-ui";
-import { AiChat } from "@liveblocks/react-ui";
-import { RegisterAiKnowledge } from "@liveblocks/react";
 
 function DarkModeToggle(_props: { x?: number }) {
   const [mode, setMode] = useState<"light" | "dark">("light");

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -73,7 +73,7 @@ import { PKG_VERSION } from "./version";
 // milliseconds at most.
 const DEFAULT_REQUEST_TIMEOUT = 4_000;
 
-export type AiToolDefinitionRenderProps = Resolve<
+export type AiToolInvocationProps = Resolve<
   DistributiveOmit<AiToolInvocationPart, "type"> & {
     respond: (result: Json) => void;
   }
@@ -89,7 +89,7 @@ export type AiToolDefinition =
     description?: string;
     parameters: JSONSchema4;
     execute?: (args: JsonObject) => Awaitable<Json>;
-    render?: ComponentType<AiToolDefinitionRenderProps>;
+    render?: ComponentType<AiToolInvocationProps>;
   };
 
 export type UiChatMessage = AiChatMessage & {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -326,7 +326,6 @@ export type {
   AiReasoningPart,
   AiTextPart,
   AiToolInvocationPart,
-  AiUploadedImagePart,
   CopilotId,
   Cursor,
   MessageId,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -18,7 +18,7 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export type {
   AiToolDefinition,
-  AiToolDefinitionRenderProps,
+  AiToolInvocationProps,
   UiAssistantMessage,
   UiChatMessage,
   UiUserMessage,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -321,8 +321,12 @@ export type { GetThreadsOptions, UploadAttachmentOptions } from "./room";
 export type {
   AiAssistantContentPart,
   AiChat,
+  AiChatMessage,
   AiKnowledgeSource,
+  AiReasoningPart,
+  AiTextPart,
   AiToolInvocationPart,
+  AiUploadedImagePart,
   CopilotId,
   Cursor,
   MessageId,

--- a/packages/liveblocks-react-ui/src/_private/index.ts
+++ b/packages/liveblocks-react-ui/src/_private/index.ts
@@ -32,6 +32,7 @@ export type {
   AiChatComposerFormProps,
   AiChatComposerSubmitProps,
 } from "../primitives/AiChatComposer/types";
+export * as AiMessage from "../primitives/AiMessage";
 export { capitalize } from "../utils/capitalize";
 export { useInitial } from "../utils/use-initial";
 export { useRefs } from "../utils/use-refs";

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -17,9 +17,9 @@ import {
   CopyIcon,
   SpinnerIcon,
 } from "../icons";
+import { useAiToolDefinitionRenderContext } from "../primitives/AiMessage";
 import * as CollapsiblePrimitive from "../primitives/internal/Collapsible";
 import { classNames } from "../utils/class-names";
-import { useAiToolDefinitionRenderContext } from "./internal/AiChatAssistantMessage";
 
 export interface AiToolProps extends Omit<ComponentProps<"div">, "title"> {
   title?: string;

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -17,7 +17,7 @@ import {
   CopyIcon,
   SpinnerIcon,
 } from "../icons";
-import { useAiToolDefinitionRenderContext } from "../primitives/AiMessage";
+import { useAiToolInvocationContext } from "../primitives/AiMessage";
 import * as CollapsiblePrimitive from "../primitives/internal/Collapsible";
 import { classNames } from "../utils/class-names";
 
@@ -85,7 +85,7 @@ function CodeBlock({ title, code }: { title: ReactNode; code: string }) {
 }
 
 function AiToolInspector({ className, ...props }: AiToolInspectorProps) {
-  const { args, partialArgs, result } = useAiToolDefinitionRenderContext();
+  const { args, partialArgs, result } = useAiToolInvocationContext();
 
   return (
     <div className={classNames("lb-ai-tool-inspector", className)} {...props}>
@@ -108,7 +108,7 @@ function AiToolConfirmation({
   className,
   ...props
 }: AiToolConfirmationProps) {
-  const { status, respond } = useAiToolDefinitionRenderContext();
+  const { status, respond } = useAiToolInvocationContext();
 
   if (status === "executed") {
     return null;
@@ -163,7 +163,7 @@ const noop = () => {};
 export const AiTool = Object.assign(
   forwardRef<HTMLDivElement, AiToolProps>(
     ({ children, title, icon, className, ...props }, forwardedRef) => {
-      const { status, toolName } = useAiToolDefinitionRenderContext();
+      const { status, toolName } = useAiToolInvocationContext();
       const [isOpen, setIsOpen] = useState(true);
       // TODO: If there are children but they render null?
       //       Could we do a 2 levels deep check where we look at `children` and if there are any we look at `children` of the children?

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -66,7 +66,7 @@ export const AiChatAssistantMessage = memo(
       ) {
         if (message.contentSoFar.length === 0) {
           children = (
-            <div className="lb-ai-chat-message-thinking lb-ai-chat-pending">
+            <div className="lb-ai-chat-message-thinking lb-ai-chat-streaming">
               {$.AI_CHAT_MESSAGE_THINKING}
             </div>
           );
@@ -133,13 +133,6 @@ function AssistantMessageContent({
   message: UiAssistantMessage;
   components: Partial<GlobalComponents> | undefined;
 }) {
-  const content = message.content ?? message.contentSoFar;
-
-  // A message is considered to be in "reasoning" state if it only contains reasoning parts and no other parts.
-  const isReasoning =
-    content.some((part) => part.type === "reasoning") &&
-    content.every((part) => part.type === "reasoning");
-
   return (
     <div className="lb-ai-chat-message-content">
       <AiMessage.Content
@@ -153,10 +146,10 @@ function AssistantMessageContent({
             />
           ),
 
-          ReasoningPart: ({ part }) => (
+          ReasoningPart: ({ part, isStreaming }) => (
             <ReasoningPart
               text={part.text}
-              isPending={isReasoning}
+              isStreaming={isStreaming}
               components={components}
             />
           ),
@@ -242,11 +235,11 @@ function CodeBlock({
  * -----------------------------------------------------------------------------------------------*/
 function ReasoningPart({
   text,
-  isPending,
+  isStreaming,
   components,
 }: {
   text: string;
-  isPending: boolean;
+  isStreaming: boolean;
   components: Partial<GlobalComponents> | undefined;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -259,10 +252,10 @@ function ReasoningPart({
       <CollapsiblePrimitive.Trigger
         className={classNames(
           "lb-collapsible-trigger",
-          isPending && "lb-ai-chat-pending"
+          isStreaming && "lb-ai-chat-streaming"
         )}
       >
-        {/* TODO: If `isPending` is true, show "Reasoning…"/"Thinking…", otherwise show "Reasoned/thought for x seconds"? */}
+        {/* TODO: If `isStreaming` is true, show "Reasoning…"/"Thinking…", otherwise show "Reasoned/thought for x seconds"? */}
         Reasoning
         <span className="lb-collapsible-chevron lb-icon-container">
           <ChevronRightIcon />

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -66,7 +66,7 @@ export const AiChatAssistantMessage = memo(
       ) {
         if (message.contentSoFar.length === 0) {
           children = (
-            <div className="lb-ai-chat-message-thinking lb-ai-chat-streaming">
+            <div className="lb-ai-chat-message-thinking lb-ai-chat-pending">
               {$.AI_CHAT_MESSAGE_THINKING}
             </div>
           );
@@ -252,7 +252,7 @@ function ReasoningPart({
       <CollapsiblePrimitive.Trigger
         className={classNames(
           "lb-collapsible-trigger",
-          isStreaming && "lb-ai-chat-streaming"
+          isStreaming && "lb-ai-chat-pending"
         )}
       >
         {/* TODO: If `isStreaming` is true, show "Reasoning…"/"Thinking…", otherwise show "Reasoned/thought for x seconds"? */}

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -161,6 +161,10 @@ function AssistantMessageContent({
               components={components}
             />
           ),
+
+          ToolInvocationPart: ({ children }) => (
+            <div className="lb-ai-chat-message-tool-invocation">{children}</div>
+          ),
         }}
       />
     </div>

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 
-import { Button } from "../../_private";
+import { AiMessage, Button } from "../../_private";
 import { type GlobalComponents, useComponents } from "../../components";
 import { CheckIcon } from "../../icons/Check";
 import { ChevronRightIcon } from "../../icons/ChevronRight";
@@ -20,7 +20,6 @@ import {
   type GlobalOverrides,
   useOverrides,
 } from "../../overrides";
-import { AiMessage } from "../../primitives";
 import * as CollapsiblePrimitive from "../../primitives/internal/Collapsible";
 import {
   type MarkdownComponents,

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
@@ -20,8 +20,11 @@ export interface AiChatUserMessageProps extends ComponentProps<"div"> {
   overrides?: Partial<GlobalOverrides>;
 }
 
-// XXX Not now but when it will become public, each part's props type should be exported to avoid { part: AiTextPart } in user code
-function PlainTextPart({ part }: { part: AiTextPart }) {
+type PlainTextPartProps = {
+  part: AiTextPart;
+};
+
+function PlainTextPart({ part }: PlainTextPartProps) {
   return <p>{part.text}</p>;
 }
 

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
@@ -1,8 +1,9 @@
-import type { UiUserMessage } from "@liveblocks/core";
+import type { AiTextPart, UiUserMessage } from "@liveblocks/core";
 import type { ComponentProps } from "react";
 import { forwardRef, memo } from "react";
 
 import { type GlobalOverrides, useOverrides } from "../../overrides";
+import { AiMessage } from "../../primitives";
 import { classNames } from "../../utils/class-names";
 
 /* -------------------------------------------------------------------------------------------------
@@ -19,14 +20,14 @@ export interface AiChatUserMessageProps extends ComponentProps<"div"> {
   overrides?: Partial<GlobalOverrides>;
 }
 
+function PlainTextPart({ part }: { part: AiTextPart }) {
+  return <p>{part.text}</p>;
+}
+
 export const AiChatUserMessage = memo(
   forwardRef<HTMLDivElement, AiChatUserMessageProps>(
     ({ message, className, overrides }, forwardedRef) => {
       const $ = useOverrides(overrides);
-      const paragraphs = message.content
-        .filter((c) => c.type === "text")
-        .map((c) => c.text);
-
       return (
         <div
           ref={forwardedRef}
@@ -42,10 +43,12 @@ export const AiChatUserMessage = memo(
               </div>
             ) : (
               <div className="lb-ai-chat-message-text">
-                {/* Mimic the structure of assistant messages even though there's no rich text here yet. */}
-                {paragraphs.map((text, index) => (
-                  <p key={index}>{text}</p>
-                ))}
+                <AiMessage.Content
+                  message={message}
+                  components={{
+                    TextPart: PlainTextPart,
+                  }}
+                />
               </div>
             )}
           </div>

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
@@ -2,8 +2,8 @@ import type { AiTextPart, UiUserMessage } from "@liveblocks/core";
 import type { ComponentProps } from "react";
 import { forwardRef, memo } from "react";
 
+import { AiMessage } from "../../_private";
 import { type GlobalOverrides, useOverrides } from "../../overrides";
-import { AiMessage } from "../../primitives";
 import { classNames } from "../../utils/class-names";
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
@@ -20,6 +20,7 @@ export interface AiChatUserMessageProps extends ComponentProps<"div"> {
   overrides?: Partial<GlobalOverrides>;
 }
 
+// XXX Not now but when it will become public, each part's props type should be exported to avoid { part: AiTextPart } in user code
 function PlainTextPart({ part }: { part: AiTextPart }) {
   return <p>{part.text}</p>;
 }

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -1,6 +1,6 @@
 import type {
-  AiToolDefinitionRenderProps,
   AiToolInvocationPart,
+  AiToolInvocationProps,
   Json,
   MessageId,
 } from "@liveblocks/core";
@@ -58,8 +58,9 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
 /* -------------------------------------------------------------------------------------------------
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
-const AiToolInvocationContext =
-  createContext<AiToolDefinitionRenderProps | null>(null);
+const AiToolInvocationContext = createContext<AiToolInvocationProps | null>(
+  null
+);
 
 export function useAiToolInvocationContext() {
   const context = useContext(AiToolInvocationContext);

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -11,6 +11,7 @@ import { Slot } from "@radix-ui/react-slot";
 import {
   createContext,
   forwardRef,
+  Fragment,
   useCallback,
   useContext,
   useMemo,
@@ -51,6 +52,7 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
       </CollapsiblePrimitive.Root>
     );
   },
+  ToolInvocationPart: Fragment,
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -73,7 +75,7 @@ export function useAiToolDefinitionRenderContext() {
   return context;
 }
 
-function ToolInvocationPart({
+function ToolInvocation({
   chatId,
   messageId,
   part,
@@ -134,7 +136,7 @@ function ToolInvocationPart({
 const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
   ({ message, components, style, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
-    const { TextPart, ReasoningPart } = useMemo(
+    const { TextPart, ReasoningPart, ToolInvocationPart } = useMemo(
       () => ({ ...defaultMessageContentComponents, ...components }),
       [components]
     );
@@ -154,12 +156,14 @@ const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
               return <ReasoningPart key={index} part={part} />;
             case "tool-invocation":
               return (
-                <ToolInvocationPart
-                  key={index}
-                  part={part}
-                  chatId={message.chatId}
-                  messageId={message.id}
-                />
+                <ToolInvocationPart key={index} part={part}>
+                  <ToolInvocation
+                    key={index}
+                    part={part}
+                    chatId={message.chatId}
+                    messageId={message.id}
+                  />
+                </ToolInvocationPart>
               );
             default:
               return null;

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -141,6 +141,9 @@ const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
     );
 
     const content = message.content ?? message.contentSoFar;
+    const numParts = content.length;
+    const isGenerating =
+      message.role === "assistant" && message.status === "generating";
     return (
       <Component
         {...props}
@@ -148,14 +151,19 @@ const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
         ref={forwardedRef}
       >
         {content.map((part, index) => {
+          // A part is considered to be still "streaming in" if it's the last
+          // part in the content array, and the message is in "generating"
+          // state.
+          const isStreaming = isGenerating && index === numParts - 1;
+          const extra = { index, isStreaming };
           switch (part.type) {
             case "text":
-              return <TextPart key={index} part={part} />;
+              return <TextPart key={index} part={part} {...extra} />;
             case "reasoning":
-              return <ReasoningPart key={index} part={part} />;
+              return <ReasoningPart key={index} part={part} {...extra} />;
             case "tool-invocation":
               return (
-                <ToolInvocationPart key={index} part={part}>
+                <ToolInvocationPart key={index} part={part} {...extra}>
                   <ToolInvocation
                     key={index}
                     part={part}

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -49,10 +49,6 @@ export function useAiToolDefinitionRenderContext() {
   return context;
 }
 
-function noop() {
-  // Do nothing
-}
-
 function ToolInvocationPart({
   chatId,
   messageId,
@@ -92,12 +88,7 @@ function ToolInvocationPart({
   if (tool === undefined || tool.render === undefined) return null;
 
   const { type: _, ...rest } = part;
-  const props = {
-    ...rest,
-
-    // It only makes sense and is safe to call `respond()` in "executing" state.
-    respond: part.status === "executing" ? respond : noop,
-  };
+  const props = { ...rest, respond };
   return (
     // XXX What to do about this style since this is a primitive?
     // XXX Nimesh thinks to delete it

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -90,13 +90,9 @@ function ToolInvocationPart({
   const { type: _, ...rest } = part;
   const props = { ...rest, respond };
   return (
-    // XXX What to do about this style since this is a primitive?
-    // XXX Nimesh thinks to delete it
-    <div className="lb-ai-chat-message-tool">
-      <AiToolDefinitionRenderContext.Provider value={props}>
-        <tool.render {...props} />
-      </AiToolDefinitionRenderContext.Provider>
-    </div>
+    <AiToolDefinitionRenderContext.Provider value={props}>
+      <tool.render {...props} />
+    </AiToolDefinitionRenderContext.Provider>
   );
 }
 

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -1,0 +1,169 @@
+import type {
+  AiToolDefinitionRenderProps,
+  AiToolInvocationPart,
+  Json,
+  MessageId,
+} from "@liveblocks/core";
+import { kInternal } from "@liveblocks/core";
+import { useClient } from "@liveblocks/react";
+import { useSignal } from "@liveblocks/react/_private";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useMemo,
+} from "react";
+
+import type {
+  AiMessageContentComponents,
+  AiMessageContentProps,
+} from "./types";
+
+const AI_MESSAGE_CONTENT_NAME = "AiMessageContent";
+
+const defaultMessageContentComponents: AiMessageContentComponents = {
+  TextPart: () => "Default TextPart is not implemented yet",
+  ReasoningPart: () => "Default ReasoningPart is not implemented yet",
+  UploadedImagePart: () => "Default UploadedImagePart is not implemented yet",
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * ToolInvocationPart
+ * -----------------------------------------------------------------------------------------------*/
+// XXX Rename to AiToolInvocationContext?
+const AiToolDefinitionRenderContext =
+  createContext<AiToolDefinitionRenderProps | null>(null);
+
+// XXX Rename to useAiToolInvocationContext?
+export function useAiToolDefinitionRenderContext() {
+  const context = useContext(AiToolDefinitionRenderContext);
+
+  if (context === null) {
+    throw new Error(
+      "This component must be used within a tool's render method."
+    );
+  }
+
+  return context;
+}
+
+function noop() {
+  // Do nothing
+}
+
+function ToolInvocationPart({
+  chatId,
+  messageId,
+  part,
+}: {
+  chatId: string;
+  messageId: MessageId;
+  part: AiToolInvocationPart;
+}) {
+  const client = useClient();
+  const ai = client[kInternal].ai;
+  const tool = useSignal(ai.signals.getToolDefinitionΣ(chatId, part.toolName));
+
+  const respond = useCallback(
+    (result: Json) => {
+      if (part.status === "receiving") {
+        console.log(
+          `Ignoring respond(): tool '${part.toolName}' (${part.toolCallId}) is still receiving`
+        );
+      } else if (part.status === "executed") {
+        console.log(
+          `Ignoring respond(): tool '${part.toolName}' (${part.toolCallId}) has already executed`
+        );
+      } else {
+        ai.setToolResult(
+          chatId,
+          messageId,
+          part.toolCallId,
+          result
+          // TODO Pass in AiGenerationOptions here?
+        );
+      }
+    },
+    [ai, chatId, messageId, part.status, part.toolName, part.toolCallId]
+  );
+
+  if (tool === undefined || tool.render === undefined) return null;
+
+  const { type: _, ...rest } = part;
+  const props = {
+    ...rest,
+
+    // It only makes sense and is safe to call `respond()` in "executing" state.
+    respond: part.status === "executing" ? respond : noop,
+  };
+  return (
+    // XXX What to do about this style since this is a primitive?
+    // XXX Nimesh thinks to delete it
+    <div className="lb-ai-chat-message-tool">
+      <AiToolDefinitionRenderContext.Provider value={props}>
+        <tool.render {...props} />
+      </AiToolDefinitionRenderContext.Provider>
+    </div>
+  );
+}
+
+/**
+ * --------------------------------------------------------------------------
+ * @private The API for this component is not yet stable.
+ * --------------------------------------------------------------------------
+ *
+ * Primitive to help display an user or assistant message’s content, which is
+ * an array of parts.
+ *
+ * @example
+ * <AiMessage.Content message={message} components={{ TextPart }} />
+ */
+const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
+  ({ message, components, style, asChild, ...props }, forwardedRef) => {
+    const Component = asChild ? Slot : "div";
+    const { TextPart, ReasoningPart, UploadedImagePart } = useMemo(
+      () => ({ ...defaultMessageContentComponents, ...components }),
+      [components]
+    );
+
+    const content = message.content ?? message.contentSoFar;
+    return (
+      <Component
+        {...props}
+        style={{ whiteSpace: "break-spaces", ...style }}
+        ref={forwardedRef}
+      >
+        {content.map((part, index) => {
+          switch (part.type) {
+            case "text":
+              return <TextPart key={index} part={part} />;
+            case "image":
+              return <UploadedImagePart key={index} part={part} />;
+            case "reasoning":
+              return <ReasoningPart key={index} part={part} />;
+            case "tool-invocation":
+              return (
+                <ToolInvocationPart
+                  key={index}
+                  part={part}
+                  chatId={message.chatId}
+                  messageId={message.id}
+                />
+              );
+            default:
+              return null;
+          }
+        })}
+      </Component>
+    );
+  }
+);
+
+if (process.env.NODE_ENV !== "production") {
+  AiMessageContent.displayName = AI_MESSAGE_CONTENT_NAME;
+}
+
+// NOTE: Every export from this file will be available publicly as AiMessage.*
+export { AiMessageContent as Content };

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -17,7 +17,7 @@ import {
   useState,
 } from "react";
 
-import { ChevronRightIcon } from "../../icons";
+import { ChevronDownIcon, ChevronRightIcon } from "../../icons";
 import * as CollapsiblePrimitive from "../../primitives/internal/Collapsible";
 import { MarkdownWithMemoizedBlocks } from "../internal/Markdown";
 import type {
@@ -42,9 +42,7 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
       <CollapsiblePrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
         <CollapsiblePrimitive.Trigger>
           Reasoning
-          <span>
-            <ChevronRightIcon />
-          </span>
+          {isOpen ? <ChevronDownIcon /> : <ChevronRightIcon />}
         </CollapsiblePrimitive.Trigger>
 
         <CollapsiblePrimitive.Content>

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -58,13 +58,11 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
 /* -------------------------------------------------------------------------------------------------
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
-// XXX Rename to AiToolInvocationContext?
-const AiToolDefinitionRenderContext =
+const AiToolInvocationContext =
   createContext<AiToolDefinitionRenderProps | null>(null);
 
-// XXX Rename to useAiToolInvocationContext?
-export function useAiToolDefinitionRenderContext() {
-  const context = useContext(AiToolDefinitionRenderContext);
+export function useAiToolInvocationContext() {
+  const context = useContext(AiToolInvocationContext);
 
   if (context === null) {
     throw new Error(
@@ -116,9 +114,9 @@ function ToolInvocation({
   const { type: _, ...rest } = part;
   const props = { ...rest, respond };
   return (
-    <AiToolDefinitionRenderContext.Provider value={props}>
+    <AiToolInvocationContext.Provider value={props}>
       <tool.render {...props} />
-    </AiToolDefinitionRenderContext.Provider>
+    </AiToolInvocationContext.Provider>
   );
 }
 

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -14,8 +14,12 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useState,
 } from "react";
 
+import { ChevronRightIcon } from "../../icons";
+import * as CollapsiblePrimitive from "../../primitives/internal/Collapsible";
+import { MarkdownWithMemoizedBlocks } from "../internal/Markdown";
 import type {
   AiMessageContentComponents,
   AiMessageContentProps,
@@ -24,9 +28,31 @@ import type {
 const AI_MESSAGE_CONTENT_NAME = "AiMessageContent";
 
 const defaultMessageContentComponents: AiMessageContentComponents = {
-  TextPart: () => "Default TextPart is not implemented yet",
-  ReasoningPart: () => "Default ReasoningPart is not implemented yet",
-  UploadedImagePart: () => "Default UploadedImagePart is not implemented yet",
+  TextPart: ({ part }) => {
+    return (
+      <div>
+        <MarkdownWithMemoizedBlocks content={part.text} />
+      </div>
+    );
+  },
+  ReasoningPart: ({ part }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <CollapsiblePrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsiblePrimitive.Trigger>
+          Reasoning
+          <span>
+            <ChevronRightIcon />
+          </span>
+        </CollapsiblePrimitive.Trigger>
+
+        <CollapsiblePrimitive.Content>
+          <MarkdownWithMemoizedBlocks content={part.text} />
+        </CollapsiblePrimitive.Content>
+      </CollapsiblePrimitive.Root>
+    );
+  },
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -110,7 +136,7 @@ function ToolInvocationPart({
 const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
   ({ message, components, style, asChild, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
-    const { TextPart, ReasoningPart, UploadedImagePart } = useMemo(
+    const { TextPart, ReasoningPart } = useMemo(
       () => ({ ...defaultMessageContentComponents, ...components }),
       [components]
     );
@@ -126,8 +152,6 @@ const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
           switch (part.type) {
             case "text":
               return <TextPart key={index} part={part} />;
-            case "image":
-              return <UploadedImagePart key={index} part={part} />;
             case "reasoning":
               return <ReasoningPart key={index} part={part} />;
             case "tool-invocation":

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -2,7 +2,6 @@ import type {
   AiChatMessage,
   AiReasoningPart,
   AiTextPart,
-  AiUploadedImagePart,
 } from "@liveblocks/core";
 import type { ComponentType } from "react";
 
@@ -13,11 +12,6 @@ export interface AiMessageContentComponents {
    * The component used to display text parts.
    */
   TextPart: ComponentType<{ part: AiTextPart }>;
-
-  /**
-   * The component used to display uploaded image parts.
-   */
-  UploadedImagePart: ComponentType<{ part: AiUploadedImagePart }>;
 
   /**
    * The component used to display reasoning parts.

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -9,15 +9,27 @@ import type { ComponentType } from "react";
 import type { ComponentPropsWithSlot } from "../../types";
 
 type TextPartProps = {
+  /** @internal */
+  index: number;
+  /** @internal */
+  isStreaming: boolean;
   part: AiTextPart;
 };
 
 type ReasoningPartProps = {
+  /** @internal */
+  index: number;
+  /** @internal */
+  isStreaming: boolean;
   part: AiReasoningPart;
 };
 
 /** @internal */
 type ToolInvocationPartProps = {
+  /** @internal */
+  index: number;
+  /** @internal */
+  isStreaming: boolean;
   part: AiToolInvocationPart;
   children: React.ReactNode;
 };

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -8,26 +8,37 @@ import type { ComponentType } from "react";
 
 import type { ComponentPropsWithSlot } from "../../types";
 
+type TextPartProps = {
+  part: AiTextPart;
+};
+
+type ReasoningPartProps = {
+  part: AiReasoningPart;
+};
+
+/** @internal */
+type ToolInvocationPartProps = {
+  part: AiToolInvocationPart;
+  children: React.ReactNode;
+};
+
 export interface AiMessageContentComponents {
   /**
    * The component used to display text parts.
    */
-  TextPart: ComponentType<{ part: AiTextPart }>;
+  TextPart: ComponentType<TextPartProps>;
 
   /**
    * The component used to display reasoning parts.
    */
-  ReasoningPart: ComponentType<{ part: AiReasoningPart }>;
+  ReasoningPart: ComponentType<ReasoningPartProps>;
 
   /**
    * NOTE that ToolInvocationPart is slightly different.
    * Tool invocations are typically rendered via the render() method instead.
    * @internal
    */
-  ToolInvocationPart: ComponentType<{
-    part: AiToolInvocationPart;
-    children: React.ReactNode;
-  }>;
+  ToolInvocationPart: ComponentType<ToolInvocationPartProps>;
 }
 
 export interface AiMessageContentProps

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -1,0 +1,45 @@
+import type {
+  AiChatMessage,
+  AiReasoningPart,
+  AiTextPart,
+  AiUploadedImagePart,
+} from "@liveblocks/core";
+import type { ComponentType } from "react";
+
+import type { ComponentPropsWithSlot } from "../../types";
+
+export interface AiMessageContentComponents {
+  /**
+   * The component used to display text parts.
+   */
+  TextPart: ComponentType<{ part: AiTextPart }>;
+
+  /**
+   * The component used to display uploaded image parts.
+   */
+  UploadedImagePart: ComponentType<{ part: AiUploadedImagePart }>;
+
+  /**
+   * The component used to display reasoning parts.
+   */
+  ReasoningPart: ComponentType<{ part: AiReasoningPart }>;
+
+  // NOTE: There is no ToolInvocationPart! This is not a bug. It's deliberate.
+  // Tool invocations are typically rendered via the render() method that users
+  // implement on the tool definition instead.
+  /* ToolInvocationPart: never */
+}
+
+export interface AiMessageContentProps
+  extends Omit<ComponentPropsWithSlot<"div">, "children"> {
+  /**
+   * The message contents to display.
+   */
+  message: AiChatMessage;
+
+  /**
+   * Optional overrides for the default components to render each part within
+   * the message content.
+   */
+  components?: Partial<AiMessageContentComponents>;
+}

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -2,6 +2,7 @@ import type {
   AiChatMessage,
   AiReasoningPart,
   AiTextPart,
+  AiToolInvocationPart,
 } from "@liveblocks/core";
 import type { ComponentType } from "react";
 
@@ -18,10 +19,15 @@ export interface AiMessageContentComponents {
    */
   ReasoningPart: ComponentType<{ part: AiReasoningPart }>;
 
-  // NOTE: There is no ToolInvocationPart! This is not a bug. It's deliberate.
-  // Tool invocations are typically rendered via the render() method that users
-  // implement on the tool definition instead.
-  /* ToolInvocationPart: never */
+  /**
+   * NOTE that ToolInvocationPart is slightly different.
+   * Tool invocations are typically rendered via the render() method instead.
+   * @internal
+   */
+  ToolInvocationPart: ComponentType<{
+    part: AiToolInvocationPart;
+    children: React.ReactNode;
+  }>;
 }
 
 export interface AiMessageContentProps

--- a/packages/liveblocks-react-ui/src/primitives/index.ts
+++ b/packages/liveblocks-react-ui/src/primitives/index.ts
@@ -1,7 +1,5 @@
 export type { ComposerBodyMark, ComposerBodyMarks } from "../types";
 export * as AiChatComposer from "./AiChatComposer";
-// XXX Move into /internal instead of exposing it as a Primitive here right now?
-export * as AiMessage from "./AiMessage";
 export * as Comment from "./Comment";
 export type {
   CommentBodyComponents,

--- a/packages/liveblocks-react-ui/src/primitives/index.ts
+++ b/packages/liveblocks-react-ui/src/primitives/index.ts
@@ -1,5 +1,7 @@
 export type { ComposerBodyMark, ComposerBodyMarks } from "../types";
 export * as AiChatComposer from "./AiChatComposer";
+// XXX Move into /internal instead of exposing it as a Primitive here right now?
+export * as AiMessage from "./AiMessage";
 export * as Comment from "./Comment";
 export type {
   CommentBodyComponents,

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2399,6 +2399,10 @@
   }
 }
 
+.lb-ai-chat-message-tool-invocation {
+  margin-block: calc(0.5 * var(--lb-spacing));
+}
+
 .lb-ai-chat-message-deleted {
   position: relative;
   align-items: center;

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2399,10 +2399,6 @@
   }
 }
 
-.lb-ai-chat-message-tool {
-  margin-block: calc(0.5 * var(--lb-spacing));
-}
-
 .lb-ai-chat-message-deleted {
   position: relative;
   align-items: center;

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2561,7 +2561,7 @@
   }
 }
 
-.lb-ai-chat-pending {
+.lb-ai-chat-streaming {
   user-select: none;
   animation: lb-animation-shimmer-small 5s linear infinite;
 }

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2561,7 +2561,7 @@
   }
 }
 
-.lb-ai-chat-streaming {
+.lb-ai-chat-pending {
   user-select: none;
   animation: lb-animation-shimmer-small 5s linear infinite;
 }


### PR DESCRIPTION
This new `<AiMessage.Content />` primitive is introduced as an internal API only for now, but could eventually be made public once we're happy with how it's working. We also reuse it now in the kitchen sink which allowed us to avoid quite a bit of duplication of imporant logic that needs to be correct for setting up the tool invocation context (e.g. how the `respond()` function gets computed and passed into tool invocation instances).

The `AiMessage.Content` component is a primitive, in that it does not interfere with styling. It's mainly used as a helper to loop over the message's `content` (or content-so-far) array, and rendering the provided parts with the provided component slots (e.g. `TextPart`, `UploadedImagePart` (eventually), `ReasoningPart`). The one missing part here that cannot directly displayed is the `ToolInvocationPart`: users will have to use a `render` message on a tool to define those UIs.

@marcbouchenoire Is this looking good to you?
@nimeshnayaju Feel free to take a stab at defining the "default" `TextPart`, etc components (which aren'[t currently implemented yet](https://github.com/liveblocks/liveblocks/blob/bc8d7a28d75f4a791e77180516f99f986d942eff/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx#L27-L29), but which is fine for now as AiChat will provide explicit versions for now internally).

Thanks for all the help here! 🙏
