### PR TITLE
Improve type inference for defining tool calls

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -126,7 +126,7 @@ export default function Page() {
                   <AiChat
                     chatId="todo"
                     tools={{
-                      listTodos: tool({
+                      listTodos: tool()({
                         description: "List all todos",
                         parameters: {
                           type: "object",
@@ -149,7 +149,7 @@ export default function Page() {
                         },
                       }),
 
-                      addTodos: tool({
+                      addTodos: tool()({
                         description: "Add a new todo item to the list",
                         parameters: {
                           type: "object",
@@ -171,7 +171,7 @@ export default function Page() {
                         },
                       }),
 
-                      toggleTodo: tool({
+                      toggleTodo: tool()({
                         description: "Toggle a todo's completion status",
                         parameters: {
                           type: "object",
@@ -194,7 +194,7 @@ export default function Page() {
                         ),
                       }),
 
-                      deleteTodos: tool({
+                      deleteTodos: tool()({
                         description: "Deletes one or more todo items by ID",
                         parameters: {
                           type: "object",

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { tool } from "@liveblocks/core";
 import {
   ClientSideSuspense,
   LiveblocksProvider,
@@ -125,7 +126,7 @@ export default function Page() {
                   <AiChat
                     chatId="todo"
                     tools={{
-                      listTodos: {
+                      listTodos: tool({
                         description: "List all todos",
                         parameters: {
                           type: "object",
@@ -136,18 +137,19 @@ export default function Page() {
                               items: { type: "number" },
                             },
                           },
+                          required: ["ids"] as const,
                         },
-                        execute: (args) => {
-                          const ids = args!.ids as number[];
+                        execute: async (args) => {
+                          const { ids } = args;
                           if (ids.length === 0) {
                             return todos;
                           } else {
                             return todos.filter((t) => ids.includes(t.id));
                           }
                         },
-                      },
+                      }),
 
-                      addTodos: {
+                      addTodos: tool({
                         description: "Add a new todo item to the list",
                         parameters: {
                           type: "object",
@@ -159,17 +161,17 @@ export default function Page() {
                               items: { type: "string" },
                             },
                           },
+                          required: ["titles"],
                         },
-                        execute: (args) => {
-                          const titles = args!.titles as string[];
+                        execute: ({ titles }) => {
                           for (const title of titles) {
                             addTodo(title);
                           }
                           return { ok: true };
                         },
-                      },
+                      }),
 
-                      toggleTodo: {
+                      toggleTodo: tool({
                         description: "Toggle a todo's completion status",
                         parameters: {
                           type: "object",
@@ -179,10 +181,9 @@ export default function Page() {
                               type: "number",
                             },
                           },
+                          required: ["id"],
                         },
-
-                        execute: (args) => {
-                          const id = args!.id as number;
+                        execute: ({ id }) => {
                           toggleTodo(id);
                           return { ok: true };
                         },
@@ -191,9 +192,9 @@ export default function Page() {
                             <AiTool.Inspector />
                           </AiTool>
                         ),
-                      },
+                      }),
 
-                      deleteTodos: {
+                      deleteTodos: tool({
                         description: "Deletes one or more todo items by ID",
                         parameters: {
                           type: "object",
@@ -203,6 +204,7 @@ export default function Page() {
                               type: "array",
                               items: { type: "number" },
                             },
+                            required: ["ids"],
                           },
                         },
 
@@ -249,7 +251,7 @@ export default function Page() {
                             ) : null}
                           </AiTool>
                         ),
-                      },
+                      }),
                     }}
                     className="rounded-xl"
                   />

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -137,7 +137,7 @@ export default function Page() {
                               items: { type: "number" },
                             },
                           },
-                          required: ["ids"] as const,
+                          required: ["ids"],
                         },
                         execute: async (args) => {
                           const { ids } = args;
@@ -194,7 +194,10 @@ export default function Page() {
                         ),
                       }),
 
-                      deleteTodos: tool()({
+                      deleteTodos: tool<
+                        | { ok: true; deletedTitles: string[] }
+                        | { ok: false; reason: string; hint: string }
+                      >()({
                         description: "Deletes one or more todo items by ID",
                         parameters: {
                           type: "object",
@@ -204,16 +207,17 @@ export default function Page() {
                               type: "array",
                               items: { type: "number" },
                             },
-                            required: ["ids"],
                           },
+                          required: ["ids"],
                         },
 
-                        render: ({ status, args, result }: any) => (
+                        render: ({ status, args, result }) => (
                           <AiTool>
                             <AiTool.Confirmation
+                              args={args}
                               variant="destructive"
-                              confirm={() => {
-                                const ids = args!.ids as number[];
+                              confirm={({ args }) => {
+                                const ids = args.ids;
 
                                 const deletedTitles = todos
                                   .filter((t) => ids.includes(t.id))
@@ -239,7 +243,7 @@ export default function Page() {
                                   Deleted:
                                   <ul>
                                     {result.deletedTitles.map(
-                                      (title: any, i: number) => (
+                                      (title, i: number) => (
                                         <li key={i}>{title}</li>
                                       )
                                     )}

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -211,9 +211,9 @@ export default function Page() {
                           required: ["ids"],
                         },
 
-                        render: ({ status, result }) => (
+                        render: ({ status, result, A, R }) => (
                           <AiTool>
-                            <AiTool.Confirmation
+                            <AiTool.Confirmation<typeof A, typeof R>
                               variant="destructive"
                               confirm={({ args }) => {
                                 const ids = args.ids;

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -211,10 +211,9 @@ export default function Page() {
                           required: ["ids"],
                         },
 
-                        render: ({ status, args, result }) => (
+                        render: ({ status, result }) => (
                           <AiTool>
                             <AiTool.Confirmation
-                              args={args}
                               variant="destructive"
                               confirm={({ args }) => {
                                 const ids = args.ids;

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -81,5 +81,6 @@ export {
   LiveObject,
   shallow,
   stringifyCommentBody,
+  tool,
   toPlainLson,
 } from "@liveblocks/core";

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -120,6 +120,9 @@ export type AiToolInvocationProps<R extends ToolResultData> = Resolve<
   }
 >;
 
+// XXX Rename
+export type AiToolInvocationPropsss = AiToolInvocationProps<ToolResultData>;
+
 export type AiToolDefinition<
   S extends JSONSchema4,
   A extends JsonObject,
@@ -130,6 +133,13 @@ export type AiToolDefinition<
   execute?: (args: A) => Awaitable<R>;
   render?: ComponentType<AiToolInvocationProps<R>>;
 };
+
+// XXX Rename
+export type AiToolDefinitionnn = AiToolDefinition<
+  JSONSchema4,
+  JsonObject,
+  ToolResultData
+>;
 
 /**
  * Helper function to help infer the types of `args`, `render`, and `result`.
@@ -294,7 +304,7 @@ function now(): ISODateString {
 function createStore_forTools() {
   const toolsByChatIdΣ = new DefaultMap((_chatId: string) => {
     return new DefaultMap((_toolName: string) => {
-      return new Signal<AiToolDefinition | undefined>(undefined);
+      return new Signal<AiToolDefinitionnn | undefined>(undefined);
     });
   });
 
@@ -305,7 +315,7 @@ function createStore_forTools() {
   function addToolDefinition(
     chatId: string,
     name: string,
-    definition: AiToolDefinition
+    definition: AiToolDefinitionnn
   ) {
     if (!definition.execute && !definition.render) {
       throw new Error(
@@ -326,7 +336,7 @@ function createStore_forTools() {
 
   function getToolsForChat(chatId: string): {
     name: string;
-    definition: AiToolDefinition;
+    definition: AiToolDefinitionnn;
   }[] {
     const tools = toolsByChatIdΣ.get(chatId);
     if (tools === undefined) return [];
@@ -340,7 +350,7 @@ function createStore_forTools() {
       })
       .filter((tool) => tool !== null) as {
       name: string;
-      definition: AiToolDefinition;
+      definition: AiToolDefinitionnn;
     }[];
   }
 
@@ -833,7 +843,7 @@ export type Ai = {
     getToolDefinitionΣ(
       chatId: string,
       toolName: string
-    ): Signal<AiToolDefinition | undefined>;
+    ): Signal<AiToolDefinitionnn | undefined>;
   };
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   getChatById: (chatId: string) => AiChat | undefined;
@@ -853,7 +863,7 @@ export type Ai = {
   registerChatTool: (
     chatId: string,
     name: string,
-    definition: AiToolDefinition
+    definition: AiToolDefinitionnn
   ) => void;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   unregisterChatTool: (chatId: string, toolName: string) => void;

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -133,6 +133,15 @@ export type AiToolDefinition =
     render?: ComponentType<AiToolInvocationProps>;
   };
 
+/**
+ * Helper function to help infer the types of `args`, `render`, and `result`.
+ * This function has no runtime implementation and is only needed to make it
+ * possible for TypeScript to infer types.
+ */
+export function tool<T>(def: T): T {
+  return def;
+}
+
 export type UiChatMessage = AiChatMessage & {
   navigation: {
     /**

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -129,7 +129,7 @@ export type AiToolInvocationProps<
 >;
 
 // XXX Rename to "Opaque"
-export type AiToolInvocationPropsss = AiToolInvocationProps<
+export type AiOpaqueToolInvocationProps = AiToolInvocationProps<
   JsonObject,
   ToolResultData
 >;
@@ -147,7 +147,7 @@ export type AiToolDefinition<
 };
 
 // XXX Rename to "Opaque"
-export type AiToolDefinitionnn = AiToolDefinition<
+export type AiOpaqueToolDefinition = AiToolDefinition<
   JSONSchema4,
   JsonObject,
   ToolResultData
@@ -165,8 +165,8 @@ export function tool<R extends ToolResultData>() {
       InferFromSchema<S> extends JsonObject ? InferFromSchema<S> : JsonObject,
       R
     >
-  ): AiToolDefinitionnn => {
-    return def as AiToolDefinitionnn;
+  ): AiOpaqueToolDefinition => {
+    return def as AiOpaqueToolDefinition;
   };
 }
 
@@ -320,7 +320,7 @@ function now(): ISODateString {
 function createStore_forTools() {
   const toolsByChatIdΣ = new DefaultMap((_chatId: string) => {
     return new DefaultMap((_toolName: string) => {
-      return new Signal<AiToolDefinitionnn | undefined>(undefined);
+      return new Signal<AiOpaqueToolDefinition | undefined>(undefined);
     });
   });
 
@@ -331,7 +331,7 @@ function createStore_forTools() {
   function addToolDefinition(
     chatId: string,
     name: string,
-    definition: AiToolDefinitionnn
+    definition: AiOpaqueToolDefinition
   ) {
     if (!definition.execute && !definition.render) {
       throw new Error(
@@ -352,7 +352,7 @@ function createStore_forTools() {
 
   function getToolsForChat(chatId: string): {
     name: string;
-    definition: AiToolDefinitionnn;
+    definition: AiOpaqueToolDefinition;
   }[] {
     const tools = toolsByChatIdΣ.get(chatId);
     if (tools === undefined) return [];
@@ -366,7 +366,7 @@ function createStore_forTools() {
       })
       .filter((tool) => tool !== null) as {
       name: string;
-      definition: AiToolDefinitionnn;
+      definition: AiOpaqueToolDefinition;
     }[];
   }
 
@@ -859,7 +859,7 @@ export type Ai = {
     getToolDefinitionΣ(
       chatId: string,
       toolName: string
-    ): Signal<AiToolDefinitionnn | undefined>;
+    ): Signal<AiOpaqueToolDefinition | undefined>;
   };
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   getChatById: (chatId: string) => AiChat | undefined;
@@ -879,7 +879,7 @@ export type Ai = {
   registerChatTool: (
     chatId: string,
     name: string,
-    definition: AiToolDefinitionnn
+    definition: AiOpaqueToolDefinition
   ) => void;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   unregisterChatTool: (chatId: string, toolName: string) => void;

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -125,6 +125,10 @@ export type AiToolInvocationProps<
 > = Resolve<
   DistributiveOmit<AiToolInvocationPart<A, R>, "type"> & {
     respond: (result: R) => void;
+
+    // Expose the inferred types, so we can still read them off
+    A: A;
+    R: R;
   }
 >;
 

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -114,32 +114,34 @@ export type InferFromSchema<T extends JSONSchema4> = T extends {
               ? InferFromSchema<T["items"]>[]
               : unknown;
 
-export type AiToolInvocationProps = Resolve<
+export type AiToolInvocationProps<R extends ToolResultData> = Resolve<
   DistributiveOmit<AiToolInvocationPart, "type"> & {
-    respond: (result: ToolResultData) => void;
+    respond: (result: R) => void;
   }
 >;
 
-// TODO[nvie] Come back here and make the input/output types correlated and nicely typed!
-export type AiToolDefinition =
-  //  <
-  //  // A extends JsonObject = JsonObject,
-  //  // R extends JsonObject = JsonObject,
-  //  >
-  {
-    description?: string;
-    parameters: JSONSchema4;
-    execute?: (args: JsonObject) => Awaitable<ToolResultData>;
-    render?: ComponentType<AiToolInvocationProps>;
-  };
+export type AiToolDefinition<
+  S extends JSONSchema4,
+  A extends JsonObject,
+  R extends ToolResultData,
+> = {
+  description?: string;
+  parameters: S;
+  execute?: (args: A) => Awaitable<R>;
+  render?: ComponentType<AiToolInvocationProps<R>>;
+};
 
 /**
  * Helper function to help infer the types of `args`, `render`, and `result`.
  * This function has no runtime implementation and is only needed to make it
  * possible for TypeScript to infer types.
  */
-export function tool<T>(def: T): T {
-  return def;
+export function tool<R extends ToolResultData>() {
+  return <S extends JSONSchema4, A extends JsonObject>(
+    def: AiToolDefinition<S, A, R>
+  ): AiToolDefinition<S, A, R> => {
+    return def;
+  };
 }
 
 export type UiChatMessage = AiChatMessage & {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -17,10 +17,10 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
  */
 
 export type {
+  AiOpaqueToolDefinition,
+  AiOpaqueToolInvocationProps,
   AiToolDefinition,
-  AiToolDefinitionnn,
   AiToolInvocationProps,
-  AiToolInvocationPropsss,
   InferFromSchema,
   UiAssistantMessage,
   UiChatMessage,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -19,6 +19,7 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 export type {
   AiToolDefinition,
   AiToolInvocationProps,
+  InferFromSchema,
   UiAssistantMessage,
   UiChatMessage,
   UiUserMessage,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -18,7 +18,9 @@ detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export type {
   AiToolDefinition,
+  AiToolDefinitionnn,
   AiToolInvocationProps,
+  AiToolInvocationPropsss,
   InferFromSchema,
   UiAssistantMessage,
   UiChatMessage,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -24,6 +24,7 @@ export type {
   UiChatMessage,
   UiUserMessage,
 } from "./ai";
+export { tool } from "./ai";
 export type {
   Client,
   ClientOptions,

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -286,10 +286,13 @@ export type AiToolDefinition = {
   parameters: JsonObject;
 };
 
-export type AiToolInvocationPart = Relax<
+export type AiToolInvocationPart<
+  A extends JsonObject = JsonObject,
+  R extends ToolResultData = ToolResultData,
+> = Relax<
   | AiReceivingToolInvocationPart
-  | AiExecutingToolInvocationPart
-  | AiExecutedToolInvocationPart
+  | AiExecutingToolInvocationPart<A>
+  | AiExecutedToolInvocationPart<A, R>
 >;
 
 export type AiReceivingToolInvocationPart = {
@@ -300,21 +303,24 @@ export type AiReceivingToolInvocationPart = {
   partialArgs: Json;
 };
 
-export type AiExecutingToolInvocationPart = {
+export type AiExecutingToolInvocationPart<A extends JsonObject = JsonObject> = {
   type: "tool-invocation";
   status: "executing";
   toolCallId: string;
   toolName: string;
-  args: JsonObject;
+  args: A;
 };
 
-export type AiExecutedToolInvocationPart = {
+export type AiExecutedToolInvocationPart<
+  A extends JsonObject = JsonObject,
+  R extends ToolResultData = ToolResultData,
+> = {
   type: "tool-invocation";
   status: "executed";
   toolCallId: string;
   toolName: string;
-  args: JsonObject;
-  result: Json;
+  args: A;
+  result: R;
   // isError: boolean  // TODO Consider adopting this field from AiSDK? Would make "result" be treated as an error value or a success value.
 };
 

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
@@ -1,0 +1,47 @@
+import type { InferFromSchema } from "@liveblocks/core";
+import type { JSONSchema4 } from "json-schema";
+import { expectType } from "tsd";
+
+function infer<T extends JSONSchema4>(x: T): InferFromSchema<T> {
+  return x as any;
+}
+
+{
+  expectType<{
+    name: string;
+    age: number;
+    hobbies?: string[];
+  }>(
+    infer({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+        hobbies: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["name", "age"] as const,
+      //                        ^^^^^^^^ This is super annoying :(
+    })
+  );
+}
+
+{
+  expectType<{
+    ids: number[];
+  }>(
+    infer({
+      type: "object",
+      properties: {
+        ids: {
+          type: "array",
+          description: "The requested todo items to list",
+          items: { type: "number" },
+        },
+      },
+      required: ["ids"] as const,
+    })
+  );
+}

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
@@ -1,4 +1,13 @@
-import type { InferFromSchema } from "@liveblocks/core";
+/* eslint-disable */
+
+import type {
+  AiToolDefinitionnn,
+  Awaitable,
+  InferFromSchema,
+  Json,
+  JsonObject,
+} from "@liveblocks/core";
+import { tool } from "@liveblocks/core";
 import type { JSONSchema4 } from "json-schema";
 import { expectType } from "tsd";
 
@@ -44,4 +53,241 @@ function infer<T extends JSONSchema4>(x: T): InferFromSchema<T> {
       required: ["ids"] as const,
     })
   );
+}
+
+{
+  tool()({
+    description: "List all todos",
+    parameters: {
+      type: "object",
+      properties: {
+        ids: {
+          type: "array",
+          description: "The requested todo items to list",
+          items: { type: "number" },
+        },
+      },
+      required: ["ids"] as const,
+    },
+    execute: async (args) => {
+      expectType<{ ids: number[] }>(args);
+      return { ok: true };
+    },
+  });
+}
+
+{
+  tool()({
+    description: "Add a new todo item to the list",
+    parameters: {
+      type: "object",
+      properties: {
+        titles: {
+          type: "array",
+          description: "The titles of the new items to add to the list",
+          items: { type: "string" },
+        },
+      },
+      required: ["titles"],
+    },
+    execute: (args) => {
+      expectType<{ titles: string[] }>(args);
+      return { ok: true };
+    },
+  });
+}
+
+{
+  tool()({
+    description: "Toggle a todo's completion status",
+    parameters: {
+      type: "object",
+      properties: {
+        id: {
+          description: "The id of the todo to toggle",
+          type: "number",
+        },
+      },
+      // required: ["id"],
+    },
+    execute: (args) => {
+      expectType<{ id?: number }>(args);
+      return { ok: true };
+    },
+    render: () => <h1>JSX</h1>,
+  });
+}
+
+{
+  tool()({
+    description: "Toggle a todo's completion status",
+    parameters: {
+      type: "object",
+      properties: { id: { type: "number" } },
+      required: ["id"],
+    },
+    execute: (args) => {
+      expectType<{ id: number }>(args);
+      return { ok: true };
+    },
+    render: ({ args, partialArgs }) => {
+      if (partialArgs !== undefined) {
+        expectType<undefined>(args);
+      } else {
+        expectType<{ id: number }>(args);
+      }
+      return null;
+    },
+  });
+}
+
+{
+  // Resulting tool definition is opaque
+  const myTool = tool()({
+    description: "First tool",
+    parameters: {
+      type: "object",
+      properties: {
+        foo: { type: "number" },
+      },
+    },
+    execute: (args) => {
+      expectType<{ foo?: number }>(args);
+      return { ok: true };
+    },
+  });
+
+  expectType<string | undefined>(myTool.description);
+  if (myTool.execute) {
+    expectType<(args: JsonObject) => Awaitable<Json>>(myTool.execute);
+  } else {
+    expectType<undefined>(myTool.execute);
+  }
+  if (!myTool.render) {
+    expectType<undefined>(myTool.render);
+  } else {
+    const jsx = (
+      <>
+        {/* Test three different invocations */}
+        <myTool.render
+          status="receiving"
+          toolName="callMyTool"
+          toolCallId="tc_abc123"
+          partialArgs={{}}
+          respond={(payload) => {
+            expectType<Json>(payload);
+          }}
+        />
+        <myTool.render
+          status="executing"
+          toolName="callMyTool"
+          toolCallId="tc_abc123"
+          args={{ a: 1 }}
+          respond={(payload) => {
+            expectType<Json>(payload);
+          }}
+        />
+        <myTool.render
+          status="executed"
+          toolName="callMyTool"
+          toolCallId="tc_abc123"
+          args={{ a: 1 }}
+          result={{ b: 2 }}
+          respond={(payload) => {
+            expectType<Json>(payload);
+          }}
+        />
+      </>
+    );
+    console.log(jsx);
+  }
+}
+
+{
+  // This tests that tool definitions will get locally inferred, not overridden
+  // by the array's *opaque* type they are getting assigned into!
+  const tools: AiToolDefinitionnn[] = [
+    tool()({
+      description: "First tool (execute, no render)",
+      parameters: {
+        type: "object",
+        properties: { foo: { type: "number" } },
+      },
+      execute: (args) => {
+        expectType<{ foo?: number }>(args);
+        return { ok: true };
+      },
+    }),
+
+    tool()({
+      description: "Second tool (execute, no render)",
+      parameters: {
+        type: "object",
+        properties: { bar: { type: "string" } },
+      },
+      execute: (args) => {
+        expectType<{ bar?: string }>(args);
+        return { ok: true };
+      },
+    }),
+
+    tool()({
+      description: "Third tool (execute & render)",
+      parameters: {
+        type: "object",
+        properties: { bar: { type: "string" } },
+      },
+      execute: (args) => {
+        expectType<{ bar?: string }>(args);
+        return { ok: true };
+      },
+      render: ({ status, partialArgs, args, result, respond }) => {
+        expectType<(payload: Json) => void>(respond);
+
+        expectType<"receiving" | "executing" | "executed">(status);
+        if (status === "receiving") {
+          expectType<Json>(partialArgs);
+          expectType<undefined>(args);
+          expectType<undefined>(result);
+        } else if (status === "executing") {
+          expectType<undefined>(partialArgs);
+          expectType<{ bar?: string }>(args);
+          expectType<undefined>(result);
+        } else {
+          expectType<undefined>(partialArgs);
+          expectType<{ bar?: string }>(args);
+          expectType<Json>(result);
+        }
+        return null;
+      },
+    }),
+
+    tool()({
+      description: "Fourth tool (render, no execute)",
+      parameters: {
+        type: "object",
+        properties: { bar: { type: "string" } },
+      },
+      render: ({ status, partialArgs, args, result, respond }) => {
+        expectType<(payload: Json) => void>(respond);
+
+        expectType<"receiving" | "executing" | "executed">(status);
+        if (status === "receiving") {
+          expectType<Json>(partialArgs);
+          expectType<undefined>(args);
+          expectType<undefined>(result);
+        } else if (status === "executing") {
+          expectType<undefined>(partialArgs);
+          expectType<{ bar?: string }>(args);
+          expectType<undefined>(result);
+        } else {
+          expectType<undefined>(partialArgs);
+          expectType<{ bar?: string }>(args);
+          expectType<Json>(result);
+        }
+        return null;
+      },
+    }),
+  ];
+  console.log(tools); // Just use the tools variable
 }

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
@@ -177,6 +177,8 @@ function infer<T extends JSONSchema4>(x: T): InferFromSchema<T> {
           respond={(payload) => {
             expectType<Json>(payload);
           }}
+          A={undefined as never}
+          R={undefined as never}
         />
         <myTool.render
           status="executing"
@@ -186,6 +188,8 @@ function infer<T extends JSONSchema4>(x: T): InferFromSchema<T> {
           respond={(payload) => {
             expectType<Json>(payload);
           }}
+          A={undefined as never}
+          R={undefined as never}
         />
         <myTool.render
           status="executed"
@@ -196,6 +200,8 @@ function infer<T extends JSONSchema4>(x: T): InferFromSchema<T> {
           respond={(payload) => {
             expectType<Json>(payload);
           }}
+          A={undefined as never}
+          R={undefined as never}
         />
       </>
     );

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 import type {
-  AiToolDefinitionnn,
+  AiOpaqueToolDefinition,
   Awaitable,
   InferFromSchema,
   Json,
@@ -206,7 +206,7 @@ function infer<T extends JSONSchema4>(x: T): InferFromSchema<T> {
 {
   // This tests that tool definitions will get locally inferred, not overridden
   // by the array's *opaque* type they are getting assigned into!
-  const tools: AiToolDefinitionnn[] = [
+  const tools: AiOpaqueToolDefinition[] = [
     tool()({
       description: "First tool (execute, no render)",
       parameters: {

--- a/packages/liveblocks-core/tsconfig.json
+++ b/packages/liveblocks-core/tsconfig.json
@@ -6,5 +6,5 @@
     // TODO: Try to get rid of these overrides
     "noUncheckedIndexedAccess": false // OVERWRITTEN to relax a bit
   },
-  "include": ["src", "e2e"]
+  "include": ["src", "test-d", "e2e"]
 }

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -1,6 +1,6 @@
 import type {
   AiKnowledgeSource,
-  AiToolDefinitionnn,
+  AiOpaqueToolDefinition,
   CopilotId,
   MessageId,
   UiChatMessage,
@@ -62,7 +62,7 @@ export interface AiChatProps extends ComponentProps<"div"> {
   /**
    * Tool definitions to make available within this chat. May be used by the assistant when generating responses.
    */
-  tools?: Record<string, AiToolDefinitionnn>;
+  tools?: Record<string, AiOpaqueToolDefinition>;
   /**
    * Override the component's strings.
    */

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -1,6 +1,6 @@
 import type {
   AiKnowledgeSource,
-  AiToolDefinition,
+  AiToolDefinitionnn,
   CopilotId,
   MessageId,
   UiChatMessage,
@@ -62,7 +62,7 @@ export interface AiChatProps extends ComponentProps<"div"> {
   /**
    * Tool definitions to make available within this chat. May be used by the assistant when generating responses.
    */
-  tools?: Record<string, AiToolDefinition>;
+  tools?: Record<string, AiToolDefinitionnn>;
   /**
    * Override the component's strings.
    */

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -1,6 +1,6 @@
 import type {
+  AiOpaqueToolInvocationProps,
   AiToolInvocationPart,
-  AiToolInvocationPropsss,
   MessageId,
   ToolResultData,
 } from "@liveblocks/core";
@@ -58,9 +58,8 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
 /* -------------------------------------------------------------------------------------------------
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
-const AiToolInvocationContext = createContext<AiToolInvocationPropsss | null>(
-  null
-);
+const AiToolInvocationContext =
+  createContext<AiOpaqueToolInvocationProps | null>(null);
 
 export function useAiToolInvocationContext() {
   const context = useContext(AiToolInvocationContext);

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -1,6 +1,6 @@
 import type {
   AiToolInvocationPart,
-  AiToolInvocationProps,
+  AiToolInvocationPropsss,
   MessageId,
   ToolResultData,
 } from "@liveblocks/core";
@@ -58,7 +58,7 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
 /* -------------------------------------------------------------------------------------------------
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
-const AiToolInvocationContext = createContext<AiToolInvocationProps | null>(
+const AiToolInvocationContext = createContext<AiToolInvocationPropsss | null>(
   null
 );
 

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -112,7 +112,12 @@ function ToolInvocation({
   if (tool === undefined || tool.render === undefined) return null;
 
   const { type: _, ...rest } = part;
-  const props = { ...rest, respond };
+  const props = {
+    ...rest,
+    respond,
+    A: undefined as never,
+    R: undefined as never,
+  };
   return (
     <AiToolInvocationContext.Provider value={props}>
       <tool.render {...props} />


### PR DESCRIPTION
This PR implements better TypeScript support for defining tool calls:

```tsx
import { tool } from "@liveblocks/client";

<AiChat
    tools={{
      listTodos: tool()({
      //            ☝️☝️ NOTE the extra pair of parens! Call as tool()({ ... })
        description: "List all todos",
        parameters: {
          type: "object",
          properties: {
            ids: {
              type: "array",
              description: "The requested todo items to list",
              items: { type: "number" },
            },
          },
          required: ["ids"],
        },
        execute: async (args) => {
          const ids = args.ids;
          //    ^^^ 😎 Inferred from schema above, in this case `{ ids: number[] }`
          return { /* Return list of todos */ };
        },
      }),
    }} />
```

Render functions are equally inferred:

```tsx
  render: ({ result, partialArgs, args, result, respond }) => (
    <h1>My tool</h1>
  ),
```

---

Note that the "result" type isn't really inferrable in all cases. However, you can _specify_ the desired type as a type param to the `tool()()` call, using `tool<MyCustomR>()()`, i.e.

```tsx
<AiChat
    tools={{
      listTodos: tool<{ ok: boolean }>()({
      //            ☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️ Ensure that respond() is called with { ok: boolean } shape
        description: "My tool",
        parameters: { /* JSON schema here */ },
        execute: async () => {
          return { notCorrect: 'hi' };
          //       ^^^^^^^^^^ Will be type error (correctly!)
        },
        render: async ({ result, respond }) => {
          if (result.ok) {
          //         ^^ TypeScript knows about the `ok` field here 👍
          }

          respond({ notCorrect: 'hi' });
          //        ^^^^^^^^^^ Will be type error (correctly!)
        },
      }),
    }} />
```

---

### Transferring inferred types to helper components

One issue is with how the `AiTool.Confirmation` helper component works. It expects a `confirm` and `cancel` callback. Those callbacks will only ever get called if the tool invocation is in "executing" status. I've changed their signature a bit to reflect that: the callbacks now receive `{ status: "executing", args: A }` as their input args, where `A` is the type inferred from the JSON schema definition, and `status` is hardcoded to be "executing". So inside the confirm() callback, it's best to unpack `{ status, args }` from the callback directly, rather than using the `{ status, args }` from the outer context:

```tsx
render: ({ status, args }) => {
  //       ^^^^^^^^^^^^ Fine to use here...
  return (
    <AiTool>
      <AiTool.Confirmation
        confirm={({ status, args }) => {
          //      ^^^^^^^^^^^^^^^^
          // ...but here inside `confirm()`, it's preferable to unpack these two from here
          // locally, as their types will better reflect their actual runtime values!
          return { notCorrect: 'hi' };
        }}>
        Custom
      </AiTool.Confirmation>
    </AiTool>
  )
}
```

---

There is still one issue here, though. If you've explicitly annotated your `tool<R>()(...)` return type, then TypeScript should also fail if the return value of `confirm()` doesn't match this annotated type. This is hard to guarantee because there is a disconnect between the `tool<R>()(...)` definition and the callback function passed to `<AiTool.Confirmation />` (since it's generic).

To solve this, I've started experimenting with an idea that allows passing the inferred types down to our helper components, here the `A` and `R` fields gets passed as render props, which can be passed down to the `AiTool.Confirmation` to give it a narrower type. The `A` is of course inferred from the schema, and the `R` is whatever type you annotated above in the `tool<R>()(...)` yourself.

```tsx
tool<{ ok: boolean }>()({
  description: "My HITL tool",
  render: ({ status, args, A, R }) => {
    return (
      <AiTool>
        <AiTool.Confirmation<typeof A, typeof R>
          confirm={({ status, args }) => {
            return { notCorrect: 'hi' };
            //       ^^^^^^^^^^^^^^^^ TypeScript error (correctly!)
          }}>
          Custom
        </AiTool.Confirmation>
      </AiTool>
    )
  }
});
```

Note that, at runtime, fields `A` and `R` are of course `undefined`.

I'm looking for feedback on this idea!

Alternative syntax could be something like:
```tsx
render: ({ status, args, Types }) => (
  return (
    <AiTool>
      <AiTool.Confirmation<typeof Types> />
    </AiTool>
  )
)
```
