### PR TITLE
Use CJS outputs in nested package.json for subpath imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## v2.24.3
 
-This release fixes an issue with subpath imports (e.g.
-`@liveblocks/react/suspense`) and CommonJS in our packages which could happen
-with certain bundlers.
+### `@liveblocks/react` and `@liveblocks/react-ui`
+
+- Fix an issue with subpath imports (e.g. `@liveblocks/react/suspense`) and
+  CommonJS in our packages which could happen with certain bundlers.
 
 ## v2.24.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet published)
 
+## v2.24.3
+
+This release fixes an issue with subpath imports (e.g.
+`@liveblocks/react/suspense`) and CommonJS in our packages which could happen
+with certain bundlers.
+
 ## v2.24.2
 
 ### `@liveblocks/react-ui`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### `@liveblocks/react` and `@liveblocks/react-ui`
 
 - Fix an issue with subpath imports (e.g. `@liveblocks/react/suspense`) and
-  CommonJS in our packages which could happen with certain bundlers.
+  CommonJS which could happen with certain bundlers.
 
 ## v2.24.2
 

--- a/packages/liveblocks-react-ui/_private/package.json
+++ b/packages/liveblocks-react-ui/_private/package.json
@@ -1,4 +1,4 @@
 {
-  "main": "../dist/_private/index.js",
-  "types": "../dist/_private/index.d.ts"
+  "main": "../dist/_private/index.cjs",
+  "types": "../dist/_private/index.d.cts"
 }

--- a/packages/liveblocks-react-ui/primitives/package.json
+++ b/packages/liveblocks-react-ui/primitives/package.json
@@ -1,4 +1,4 @@
 {
-  "main": "../dist/primitives/index.js",
-  "types": "../dist/primitives/index.d.ts"
+  "main": "../dist/primitives/index.cjs",
+  "types": "../dist/primitives/index.d.cts"
 }

--- a/packages/liveblocks-react/_private/package.json
+++ b/packages/liveblocks-react/_private/package.json
@@ -1,4 +1,4 @@
 {
-  "main": "../dist/_private.js",
-  "types": "../dist/_private.d.ts"
+  "main": "../dist/_private.cjs",
+  "types": "../dist/_private.d.cts"
 }

--- a/packages/liveblocks-react/suspense/package.json
+++ b/packages/liveblocks-react/suspense/package.json
@@ -1,4 +1,4 @@
 {
-  "main": "../dist/suspense.js",
-  "types": "../dist/suspense.d.ts"
+  "main": "../dist/suspense.cjs",
+  "types": "../dist/suspense.d.cts"
 }


### PR DESCRIPTION
This PR fixes https://github.com/liveblocks/liveblocks/issues/2425.

### Context

Some of our packages use subpath imports and to support them with TypeScript's `node` module resolution we added [nested `package.json` files](https://github.com/liveblocks/liveblocks/blob/main/packages/liveblocks-react/suspense).

In 2.19, we moved our packages to `"type": "module"`, moving our `.js` outputs from CJS to ESM, but we still shipped CJS as `.cjs` correctly including for subpath imports, [via the `"exports"` field in our packages' root `package.json`](https://github.com/liveblocks/liveblocks/blob/1eb7d94e6355e093c39c53f5ffa22be9baa32e96/packages/liveblocks-react/package.json#L9-L43).

But it appears that some tools like Jest incorrectly read from the nested `package.json` files when dealing with subpath imports instead of reading `"exports"` in the root `package.json`. Since 2.19, these `package.json` files are pointing to ESM `.js` files and so they break in CJS environments.

### Fix

We update the nested `package.json` files to point to `.cjs` files.

