### PR TITLE
Don't show `AiTool` spinner for tools without `execute` methods

### DIFF
--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -140,6 +140,11 @@ export type AiToolInvocationProps<
      * A and R values. There is no runtime presence for these.
      */
     $types: AiToolTypePack<A, R>;
+
+    // Private APIs
+    [kInternal]: {
+      execute: AiToolExecuteCallback<A, R> | undefined;
+    };
   }
 >;
 

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -1,8 +1,9 @@
-import type {
-  AiToolExecuteCallback,
-  AiToolTypePack,
-  JsonObject,
-  ToolResultData,
+import {
+  type AiToolExecuteCallback,
+  type AiToolTypePack,
+  type JsonObject,
+  kInternal,
+  type ToolResultData,
 } from "@liveblocks/core";
 import type { ComponentProps, ReactNode } from "react";
 import { Children, forwardRef, useCallback, useMemo, useState } from "react";
@@ -174,7 +175,11 @@ const noop = () => {};
 export const AiTool = Object.assign(
   forwardRef<HTMLDivElement, AiToolProps>(
     ({ children, title, icon, className, ...props }, forwardedRef) => {
-      const { status, toolName } = useAiToolInvocationContext();
+      const {
+        status,
+        toolName,
+        [kInternal]: { execute },
+      } = useAiToolInvocationContext();
       const [isOpen, setIsOpen] = useState(true);
       // TODO: This check won't work for cases like:
       //         <AiTool>
@@ -210,9 +215,10 @@ export const AiTool = Object.assign(
             <div className="lb-ai-tool-header-status">
               {status === "executed" ? (
                 <CheckCircleFillIcon />
-              ) : (
+              ) : execute !== undefined ? (
+                // Only show a spinner if the tool has an `execute` method.
                 <SpinnerIcon />
-              )}
+              ) : null}
             </div>
           </Collapsible.Trigger>
 

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -76,6 +76,9 @@ function ToolInvocation({
     ...rest,
     respond,
     $types: undefined as never,
+    [kInternal]: {
+      execute: tool.execute,
+    },
   };
   return (
     <ErrorBoundary


### PR DESCRIPTION
This PR hides the `AiTool` "executing" spinner for tools which don't have `execute` methods.

We don't want users to have access to the `execute` callback in `render` since that's counter-intuitive, maybe we could pass its existence like `executable: boolean`, but for now I'm using `kInternal` to keep the callback just for us.