### PR TITLE
Alternative syntax for passing down inferred types to `AiTool.Confirmation`

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -214,7 +214,8 @@ export default function Page() {
 
                         render: ({ status, result, $types }) => (
                           <AiTool>
-                            <AiTool.Confirmation<typeof $types>
+                            <AiTool.Confirmation
+                              $types={$types}
                               variant="destructive"
                               confirm={({ ids }) => {
                                 const deletedTitles = todos

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -216,10 +216,10 @@ export default function Page() {
                           additionalProperties: false,
                         },
 
-                        render: ({ status, result, $types }) => (
+                        render: ({ status, result, types }) => (
                           <AiTool>
                             <AiTool.Confirmation
-                              $types={$types}
+                              types={types}
                               variant="destructive"
                               confirm={({ ids }) => {
                                 const deletedTitles = todos

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -135,9 +135,13 @@ export type AiToolInvocationProps<
     respond: (result: R) => void;
 
     /**
-     * Exposes specific inferred types as a "type pack" which we can pass
-     * around statically to components to "bind" them to specific inferred
-     * A and R values. There is no runtime presence for these.
+     * These are the inferred types for your tool call which you can pass down
+     * to UI components, like so:
+     *
+     *     <AiTool.Confirmation<typeof types> />
+     *
+     * This will make your AiTool.Confirmation component aware of the types for
+     * `args` and `result`.
      */
     types: AiToolTypePack<A, R>;
 

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -139,7 +139,7 @@ export type AiToolInvocationProps<
      * around statically to components to "bind" them to specific inferred
      * A and R values. There is no runtime presence for these.
      */
-    $types: AiToolTypePack<A, R>;
+    types: AiToolTypePack<A, R>;
 
     // Private APIs
     [kInternal]: {

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -138,7 +138,12 @@ export type AiToolInvocationProps<
      * These are the inferred types for your tool call which you can pass down
      * to UI components, like so:
      *
-     *     <AiTool.Confirmation<typeof types> />
+     *     <AiTool.Confirmation
+     *       types={types}
+     *       confirm={
+     *         // Now fully type-safe!
+     *         (args) => result
+     *       } />
      *
      * This will make your AiTool.Confirmation component aware of the types for
      * `args` and `result`.

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.tsx
@@ -182,7 +182,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
           respond={(payload) => {
             expectType<Json>(payload);
           }}
-          $types={undefined as never}
+          types={undefined as never}
           {...internal}
         />
         <myTool.render
@@ -193,7 +193,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
           respond={(payload) => {
             expectType<Json>(payload);
           }}
-          $types={undefined as never}
+          types={undefined as never}
           {...internal}
         />
         <myTool.render
@@ -205,7 +205,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
           respond={(payload) => {
             expectType<Json>(payload);
           }}
-          $types={undefined as never}
+          types={undefined as never}
           {...internal}
         />
       </>

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -3,6 +3,7 @@ import {
   type AiToolTypePack,
   type JsonObject,
   kInternal,
+  type NoInfr,
   type ToolResultData,
 } from "@liveblocks/core";
 import type { ComponentProps, ReactNode } from "react";
@@ -54,6 +55,7 @@ export interface AiToolConfirmationProps<
   A extends JsonObject,
   R extends ToolResultData,
 > extends ComponentProps<"div"> {
+  $types?: NoInfr<AiToolTypePack<A, R>>;
   args?: A;
   confirm: AiToolExecuteCallback<A, R>;
   cancel: AiToolExecuteCallback<A, R>;

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -55,7 +55,7 @@ export interface AiToolConfirmationProps<
   A extends JsonObject,
   R extends ToolResultData,
 > extends ComponentProps<"div"> {
-  $types?: NoInfr<AiToolTypePack<A, R>>;
+  types?: NoInfr<AiToolTypePack<A, R>>;
   args?: A;
   confirm: AiToolExecuteCallback<A, R>;
   cancel: AiToolExecuteCallback<A, R>;

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -75,7 +75,7 @@ function ToolInvocation({
   const props = {
     ...rest,
     respond,
-    $types: undefined as never,
+    types: undefined as never,
     [kInternal]: {
       execute: tool.execute,
     },


### PR DESCRIPTION
What do you think? This way of passing down the inferred type information to the `AiTool.Confirmation` feels a bit nicer to me:

```tsx
// ❌ Previously (still supported)
render: ({ $types }) => (
  <AiTool.Confirmation<typeof $types>
    confirm={({ ids }) => ({ ok: true })}
    cancel={() => ({ ok: false })}
    />
)
```

```tsx
// ✅ Alternative, using props, and renamed from $types to types
render: ({ types }) => (
  <AiTool.Confirmation
    types={types}
    confirm={({ ids }) => ({ ok: true })}
    cancel={() => ({ ok: false })}
    />
)
```

I think it would make the example snippets look a ton better.
