### PR TITLE
Remove `clientId` from the protocol

### DIFF
--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -43,7 +43,6 @@ import type {
   AskInChatResponse,
   ClearChatResponse,
   ClientAiMsg,
-  ClientId,
   CmdId,
   CreateChatOptions,
   Cursor,
@@ -944,7 +943,6 @@ export function createAi(config: AiConfig): Ai {
     config.enableDebugLogging,
     false // AI doesn't have actors (yet, but it will)
   );
-  const clientId = nanoid(7) as ClientId;
 
   const chatsStore = createStore_forUserAiChats();
   const toolsStore = createStore_forTools();
@@ -1255,7 +1253,6 @@ export function createAi(config: AiConfig): Ai {
       chatId,
       messageId,
       toolCallId,
-      clientId,
       result,
       generationOptions: {
         copilotId: options?.copilotId,
@@ -1317,7 +1314,6 @@ export function createAi(config: AiConfig): Ai {
           chatId,
           sourceMessage: userMessage,
           targetMessageId,
-          clientId,
           generationOptions: {
             copilotId: options?.copilotId,
             stream: options?.stream,

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -21,7 +21,6 @@ type ChatId = string;
 
 export type MessageId = Brand<`ms_${string}`, "MessageId">;
 export type CmdId = Brand<string, "CmdId">;
-export type ClientId = Brand<string, "ClientId">;
 export type CopilotId = Brand<`co_${string}`, "CopilotId">;
 
 // A client WebSocket message is always a command to the server
@@ -158,14 +157,6 @@ type AskInChatPair = DefineCmd<
      */
     targetMessageId: MessageId;
 
-    /**
-     * A client ID unique to this command. Later delta and settle messages will
-     * reference this client ID, which is important to ensure that tool calls
-     * with side effects will only get executed once, and only by the client
-     * that originally made the request that produced the tool call.
-     */
-    clientId: ClientId;
-
     generationOptions: AiGenerationOptions;
   },
   {
@@ -191,7 +182,6 @@ type SetToolResultPair = DefineCmd<
     messageId: MessageId;
     toolCallId: string;
     result: ToolResultData;
-    clientId: ClientId;
     generationOptions: AiGenerationOptions;
   },
   { ok: true; message: AiChatMessage } | { ok: false }
@@ -249,8 +239,6 @@ export type SyncServerEvent = {
 export type DeltaServerEvent = {
   event: "delta";
   id: MessageId;
-  /** The client ID that originally made the request that led to this event */
-  clientId: ClientId;
   delta: AiAssistantDeltaUpdate;
 };
 
@@ -261,8 +249,6 @@ export type DeltaServerEvent = {
  */
 export type SettleServerEvent = {
   event: "settle";
-  /** The client ID that originally made the request that led to this event */
-  clientId: ClientId;
   message:
     | AiAwaitingToolAssistantMessage
     | AiCompletedAssistantMessage


### PR DESCRIPTION
We no longer need clients to send the `clientId`. We should only publish this change once the [backend support](https://github.com/liveblocks/liveblocks-backend/pull/1052) for this has been rolled out.
