### PR TITLE
3.0: Group mentions groundwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ For full upgrade instructions and codemods, see the
   or
   [`useUpdateNotificationSettings`](/docs/api-reference/liveblocks-react#useUpdateNotificationSettings).
 
+### `@liveblocks/react-ui`
+
+- The `onMentionClick` prop on `Thread` and `Comment` now receives a
+  `MentionData` object instead of a `userId` string.
+- The `Mention` component on the `Comment.Body` and `Composer.Editor` primitives
+  now receives a `mention` prop instead of a `userId` one.
+- The `MentionSuggestions` component on the `Composer.Editor` primitive now
+  receives a `mentions` prop instead of a `userIds` one, and the
+  `selectedUserId` prop has been renamed to `selectedMentionId`.
+- Rename `LiveblocksUIConfig` to `LiveblocksUiConfig` for consistency with other
+  Liveblocks APIs.
+
 ### `@liveblocks/emails`
 
 - Remove deprecated `htmlBody`/`reactBody` properties from
@@ -32,11 +44,21 @@ For full upgrade instructions and codemods, see the
 - Remove `htmlContent`/`reactContent` properties from
   `prepareTextMentionNotificationEmailAsHtml`/`prepareTextMentionNotificationEmailAsReact`,
   use `content` instead.
+- The `prepareTextMentionNotificationEmailAsReact` and
+  `prepareTextMentionNotificationEmailAsHtml` functions’ returned data changed
+  slightly:
+  - The `id` property is now named `textMentionId`, it refers to the mention’s
+    Text Mention ID, not the user ID used for the mention
+  - The `id` property now refers to the mention’s ID, as in the user ID used for
+    the mention
+- The `element` prop received by the `Mention` component in
+  `prepareTextMentionNotificationEmailAsReact` now contains an `id` property
+  instead of `userId`, and a new `kind` property to indicate the mention’s kind.
 
-### `@liveblocks/react-ui`
+### `@liveblocks/client` and `@liveblocks/node`
 
-- Rename `LiveblocksUIConfig` to `LiveblocksUiConfig` for consistency with other
-  Liveblocks APIs.
+- The `getMentionedIdsFromCommentBody` utility has been replaced by
+  `getMentionsFromCommentBody`.
 
 ## v2.24.3
 

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -4820,24 +4820,40 @@ client.resolvers.invalidateMentionSuggestions();
 
 ## Utilities
 
-### getMentionedIdsFromCommentBody [#get-mentioned-ids-from-comment-body]
+### getMentionsFromCommentBody [#get-mentions-from-comment-body]
 
-Returns an array of each user’s ID that has been mentioned in a `CommentBody`
-(found under `comment.body`).
+Returns an array of mentions from a `CommentBody` (found under `comment.body`).
 
 ```ts
-import { getMentionedIdsFromCommentBody } from "@liveblocks/client";
+import { getMentionsFromCommentBody } from "@liveblocks/client";
 
-const mentionedIds = getMentionedIdsFromCommentBody(comment.body);
+const mentions = getMentionsFromCommentBody(comment.body);
+```
+
+An optional second argument can be used to filter the returned mentions. By
+default, if it’s not provided, all mentions are returned, including future
+mention kinds (e.g. group mentions in the future).
+
+```tsx
+// All mentions (same as `getMentionsFromCommentBody(commentBody)`)
+getMentionsFromCommentBody(commentBody);
+
+// Only user mentions with an ID of "123"
+getMentionsFromCommentBody(
+  commentBody,
+  (mention) => mention.kind === "user" && mention.id === "123"
+);
+
+// Only mentions with an ID which starts with "prefix:"
+getMentionsFromCommentBody(commentBody, (mention) => (
+  mention.id.startsWith("prefix:")
+);
 ```
 
 Here’s an example with a custom `CommentBody`.
 
 ```ts
-import {
-  CommentBody,
-  getMentionedIdsFromCommentBody,
-} from "@liveblocks/client";
+import { CommentBody, getMentionsFromCommentBody } from "@liveblocks/client";
 
 // Create a custom `CommentBody`
 const commentBody: CommentBody = {
@@ -4854,16 +4870,16 @@ const commentBody: CommentBody = {
 };
 
 // Get the mentions inside the comment's body
-const mentionedIds = getMentionedIdsFromCommentBody(commentBody);
+const mentions = getMentionsFromCommentBody(commentBody);
 
-// ["chris@example.com"]
-console.log(mentionedIds);
+// [{ kind: "user", id: "chris@example.com" }]
+console.log(mentions);
 ```
 
 <Banner title="Also available from @liveblocks/node">
 
 If you’d like to use this on the server side, it's also available from
-[`@liveblocks/node`](/docs/api-reference/liveblocks-node#get-mentioned-ids-from-comment-body).
+[`@liveblocks/node`](/docs/api-reference/liveblocks-node#get-mentions-from-comment-body).
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-emails.mdx
+++ b/docs/pages/api-reference/liveblocks-emails.mdx
@@ -1073,7 +1073,9 @@ export async function POST(request: Request) {
         url: "https://my-room-url.io"
       },
       mention: {
-        id: "in_oiujhdg...",
+        kind: "user",
+        textMentionId: "in_oiujhdg...",
+        id: "user-0",
         roomId: "my-room-id",
         createdAt: Date <Fri Dec 15 2023 14:15:22 GMT+0000 (Greenwich Mean Time)>,
 
@@ -1355,10 +1357,11 @@ export async function POST(request: Request) {
         url: "https://my-room-url.io"
       },
       mention: {
-        id: "in_oiujhdg...",
+        kind: "user",
+        textMentionId: "in_oiujhdg...",
+        id: "user-0",
         roomId: "my-room-id",
         createdAt: Date <Fri Dec 15 2023 14:15:22 GMT+0000 (Greenwich Mean Time)>,
-        userId: "user_0"
 
         // The formatted content, as an HTML string
         content: { /* ... */}

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -714,8 +714,7 @@ await liveblocks.broadcastEvent("my-room-id", customEvent);
 ```
 
 You can respond to custom events on the front end with
-[`useEventListener`](/docs/api-reference/liveblocks-react#useEventListener)
-and
+[`useEventListener`](/docs/api-reference/liveblocks-react#useEventListener) and
 [`room.subscribe("event")`](/docs/api-reference/liveblocks-client#Room.subscribe.event).
 When receiving an event sent with `Liveblocks.broadcastEvent`, `user` will be
 `null` and `connectionId` will be `-1`.
@@ -2434,15 +2433,34 @@ try {
 
 ## Utilities
 
-### getMentionedIdsFromCommentBody [#get-mentioned-ids-from-comment-body]
+### getMentionsFromCommentBody [#get-mentions-from-comment-body]
 
-Returns an array of each user’s ID that has been mentioned in a `CommentBody`
-(found under `comment.body`).
+Returns an array of mentions from a `CommentBody` (found under `comment.body`).
 
 ```ts
-import { getMentionedIdsFromCommentBody } from "@liveblocks/node";
+import { getMentionsFromCommentBody } from "@liveblocks/node";
 
-const mentionedIds = getMentionedIdsFromCommentBody(comment.body);
+const mentions = getMentionsFromCommentBody(comment.body);
+```
+
+An optional second argument can be used to filter the returned mentions. By
+default, if it’s not provided, all mentions are returned, including future
+mention kinds (e.g. group mentions in the future).
+
+```tsx
+// All mentions (same as `getMentionsFromCommentBody(commentBody)`)
+getMentionsFromCommentBody(commentBody);
+
+// Only user mentions with an ID of "123"
+getMentionsFromCommentBody(
+  commentBody,
+  (mention) => mention.kind === "user" && mention.id === "123"
+);
+
+// Only mentions with an ID which starts with "prefix:"
+getMentionsFromCommentBody(commentBody, (mention) => (
+  mention.id.startsWith("prefix:")
+);
 ```
 
 This is most commonly used in combination with the
@@ -2450,7 +2468,7 @@ This is most commonly used in combination with the
 example [`getComment`](/docs/api-reference/liveblocks-node#get-comment).
 
 ```ts
-import { Liveblocks, getMentionedIdsFromCommentBody } from "@liveblocks/node";
+import { Liveblocks, getMentionsFromCommentBody } from "@liveblocks/node";
 
 // Create a node client
 const liveblocks = new Liveblocks({
@@ -2465,16 +2483,16 @@ const comment = await liveblocks.getComment({
 });
 
 // Get the mentions inside the comment's body
-const mentionedIds = getMentionedIdsFromCommentBody(comment.body);
+const mentions = getMentionsFromCommentBody(comment.body);
 
-// ["marc@example.com", "vincent@example.com", ...]
-console.log(mentionedIds);
+// [{ kind: "user", id: "marc@example.com" }, { kind: "user", id: "vincent@example.com" }, ...]
+console.log(mentions);
 ```
 
 Here’s an example with a custom `CommentBody`.
 
 ```ts
-import { CommentBody, getMentionedIdsFromCommentBody } from "@liveblocks/node";
+import { CommentBody, getMentionsFromCommentBody } from "@liveblocks/node";
 
 // Create a custom `CommentBody`
 const commentBody: CommentBody = {
@@ -2491,16 +2509,16 @@ const commentBody: CommentBody = {
 };
 
 // Get the mentions inside the comment's body
-const mentionedIds = getMentionedIdsFromCommentBody(commentBody);
+const mentions = getMentionsFromCommentBody(commentBody);
 
-// ["chris@example.com"]
-console.log(mentionedIds);
+// [{ kind: "user", id: "chris@example.com" }]
+console.log(mentions);
 ```
 
 <Banner title="Also available from @liveblocks/client">
 
 If you’d like to use this on the client side, it's also available from
-[`@liveblocks/client`](/docs/api-reference/liveblocks-client#get-mentioned-ids-from-comment-body).
+[`@liveblocks/client`](/docs/api-reference/liveblocks-client#get-mentions-from-comment-body).
 
 </Banner>
 

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -177,7 +177,7 @@ about this change in our
   <PropertiesListItem
     name="onMentionClick"
     type="function"
-    detailedType="(userId: string, event: MouseEvent<HTMLElement>) => void"
+    detailedType="(mention: MentionData, event: MouseEvent<HTMLElement>) => void"
   >
     The event handler called when clicking on a mention.
   </PropertiesListItem>
@@ -533,7 +533,7 @@ function Component() {
   <PropertiesListItem
     name="onMentionClick"
     type="function"
-    detailedType="(userId: string, event: MouseEvent<HTMLElement>) => void"
+    detailedType="(mention: MentionData, event: MouseEvent<HTMLElement>) => void"
   >
     The event handler called when clicking on a mention.
   </PropertiesListItem>
@@ -675,20 +675,20 @@ function MyComposer() {
 }
 
 // Render a mention in the composer's editor, e.g. "@Emil Joyce"
-function Mention({ userId }: CommentBodyMentionProps) {
-  return <Comment.Mention>@{userId}</Comment.Mention>;
+function Mention({ mention }: CommentBodyMentionProps) {
+  return <Comment.Mention>@{mention.id}</Comment.Mention>;
 }
 
 // Render a list of mention suggestions, used after typing "@" in the editor
 function MentionSuggestions({
-  userIds,
-  selectedUserId,
+  mentions,
+  selectedMentionId,
 }: ComposerEditorMentionSuggestionsProps) {
   return (
     <Composer.Suggestions>
       <Composer.SuggestionsList>
-        {userIds.map((userId) => (
-          <MentionSuggestion key={userId} userId={userId} />
+        {mentions.map((mention) => (
+          <MentionSuggestion key={mention.id} userId={mention.id} />
         ))}
       </Composer.SuggestionsList>
     </Composer.Suggestions>
@@ -824,7 +824,7 @@ The components displayed within the editor.
     name="Mention"
     type="ComponentType<ComposerEditorMentionProps>"
   >
-    The component used to display mentions. Defaults to the mention’s `userId`
+    The component used to display mentions. Defaults to the mention’s `id`
     prefixed by an @.
   </PropertiesListItem>
   <PropertiesListItem
@@ -832,7 +832,7 @@ The components displayed within the editor.
     type="ComponentType<ComposerEditorMentionSuggestionProps>"
   >
     The component used to display mention suggestions. Defaults to a list of the
-    suggestions’ `userId`.
+    suggested mentions’ `id`.
   </PropertiesListItem>
   <PropertiesListItem name="Link" type="ComponentType<ComposerEditorLinkProps>">
     The component used to display links. Defaults to the link’s `children`
@@ -853,16 +853,16 @@ The component used to display mentions.
 ```tsx
 <Composer.Editor
   components={{
-    Mention: ({ userId, isSelected }) => (
-      <Composer.Mention>@{userId}</Composer.Mention>
+    Mention: ({ mention, isSelected }) => (
+      <Composer.Mention>@{mention.id}</Composer.Mention>
     ),
   }}
 />
 ```
 
 <PropertiesList>
-  <PropertiesListItem name="userId" type="string">
-    The mention’s user ID.
+  <PropertiesListItem name="mention" type="MentionData">
+    The mention to display.
   </PropertiesListItem>
   <PropertiesListItem name="isSelected" type="boolean">
     Whether the mention is selected.
@@ -874,11 +874,11 @@ The component used to display mentions.
 The component used to display mention suggestions.
 
 <PropertiesList>
-  <PropertiesListItem name="userIds" type="string[]">
-    The list of suggested user IDs.
+  <PropertiesListItem name="mentions" type="MentionData[]">
+    The list of suggested mentions.
   </PropertiesListItem>
-  <PropertiesListItem name="selectedUserId" type="string">
-    he currently selected user ID.
+  <PropertiesListItem name="selectedMentionId" type="string">
+    The currently selected mention’s ID.
   </PropertiesListItem>
 </PropertiesList>
 
@@ -939,7 +939,7 @@ Displays a floating toolbar attached to the selection within `Composer.Editor`.
 Displays mentions within `Composer.Editor`.
 
 ```tsx
-<Composer.Mention>@{userId}</Composer.Mention>
+<Composer.Mention>@{mention.id}</Composer.Mention>
 ```
 
 <PropertiesList>
@@ -976,9 +976,9 @@ Displays a list of suggestions within `Composer.Editor`.
 
 ```tsx
 <Composer.SuggestionsList>
-  {userIds.map((userId) => (
-    <Composer.SuggestionsListItem key={userId} value={userId}>
-      @{userId}
+  {mentions.map((mention) => (
+    <Composer.SuggestionsListItem key={mention.id} value={mention.id}>
+      @{mention.id}
     </Composer.SuggestionsListItem>
   ))}
 </Composer.SuggestionsList>
@@ -995,8 +995,8 @@ Displays a list of suggestions within `Composer.Editor`.
 Displays a suggestion within `Composer.SuggestionsList`.
 
 ```tsx
-<Composer.SuggestionsListItem key={userId} value={userId}>
-  @{userId}
+<Composer.SuggestionsListItem key={mention.id} value={mention.id}>
+  @{mention.id}
 </Composer.SuggestionsListItem>
 ```
 
@@ -1121,8 +1121,8 @@ Used to render a single comment.
 ```tsx
 <Comment.Body
   components={{
-    Mention: <Comment.Mention />,
-    Link: <Comment.Link />,
+    Mention: Comment.Mention,
+    Link: Comment.Link,
   }}
 />
 ```
@@ -1158,8 +1158,8 @@ function MyComments({ thread }: { thread: ThreadData }) {
 }
 
 // Render a mention in the comment, e.g. "@Emil Joyce"
-function Mention({ userId }: CommentBodyMentionProps) {
-  return <Comment.Mention>@{userId}</Comment.Mention>;
+function Mention({ mention }: CommentBodyMentionProps) {
+  return <Comment.Mention>@{mention.id}</Comment.Mention>;
 }
 
 // Render a link in the comment, e.g. "https://liveblocks.io"
@@ -1198,7 +1198,7 @@ The components displayed within the comment body.
     name="Mention"
     type="ComponentType<CommentBodyMentionProps>"
   >
-    The component used to display mentions. Defaults to the mention’s `userId`
+    The component used to display mentions. Defaults to the mention’s `id`
     prefixed by an @.
   </PropertiesListItem>
   <PropertiesListItem name="Link" type="ComponentType<CommentBodyLinkProps>">
@@ -1214,14 +1214,14 @@ The component used to display mentions.
 ```tsx
 <Comment.Body
   components={{
-    Mention: ({ userId }) => <Comment.Mention>@{userId}</Comment.Mention>,
+    Mention: ({ mention }) => <Comment.Mention>@{mention.id}</Comment.Mention>,
   }}
 />
 ```
 
 <PropertiesList>
-  <PropertiesListItem name="userId" type="string">
-    The mention’s user ID.
+  <PropertiesListItem name="mention" type="MentionData">
+    The mention to display.
   </PropertiesListItem>
 </PropertiesList>
 
@@ -1253,7 +1253,7 @@ The component used to display links.
 Displays mentions within `Comment.Body`.
 
 ```tsx
-<Comment.Mention>@{userId}</Comment.Mention>
+<Comment.Mention>@{mention.id}</Comment.Mention>
 ```
 
 <PropertiesList>

--- a/docs/pages/platform/upgrading/3.0.mdx
+++ b/docs/pages/platform/upgrading/3.0.mdx
@@ -6,6 +6,8 @@ meta:
 ---
 
 - TODO: Should we also remove/deprecate `nextPage` from the REST API docs?
+- TODO: Do a pass on deprecated sections in the docs, see which ones still make
+  sense to keep
 - TODO: Docs to remove or update:
   - https://liveblocks.io/docs/api-reference/liveblocks-react-lexical#useEditorStatus
   - https://liveblocks.io/docs/api-reference/liveblocks-react#useBatch
@@ -35,8 +37,8 @@ different mention kinds in future releases: user mentions, group mentions, etc.
 
 #### Components
 
-The `onMentionClick` prop on `Comment` now receives a `MentionData` object as
-its first argument instead of a `userId` string.
+The `onMentionClick` prop on [`Thread`][] and [`Comment`][] now receives a
+`MentionData` object as its first argument instead of a `userId` string.
 
 ```tsx
 // ❌ Before
@@ -50,9 +52,11 @@ onMentionClick(mention: MentionData, event: MouseEvent<HTMLElement>) => void;
 
 ### Primitives
 
-When customizing the `Mention` component on the `Comment.Body` and
-`Composer.Editor` primitives, the `userId` prop has been replaced by a `mention`
-one which is a `MentionData` object.
+When customizing the
+[`Mention`](/docs/api-reference/liveblocks-react-ui#primitives-Comment.Body-Mention)
+component on the [`Comment.Body`][] and [`Composer.Editor`][] primitives, the
+`userId` prop has been replaced by a `mention` one which is a `MentionData`
+object.
 
 ```tsx
 import { Comment, Composer } from "@liveblocks/react-ui/primitives";
@@ -94,10 +98,11 @@ import { Comment, Composer } from "@liveblocks/react-ui/primitives";
 />;
 ```
 
-When customizing the `MentionSuggestions` component on the `Composer.Editor`
-primitive, the `userIds` prop has been replaced by a `mentions` one which is an
-array of `MentionData` objects, and the `selectedUserId` prop has been renamed
-to `selectedMentionId`.
+When customizing the
+[`MentionSuggestions`](/docs/api-reference/liveblocks-react-ui#primitives-Composer.Editor-MentionSuggestions)
+component on the [`Composer.Editor`][] primitive, the `userIds` prop has been
+replaced by a `mentions` one which is an array of `MentionData` objects, and the
+`selectedUserId` prop has been renamed to `selectedMentionId`.
 
 ```tsx
 import { Composer } from "@liveblocks/react-ui/primitives";
@@ -147,8 +152,8 @@ import { Composer } from "@liveblocks/react-ui/primitives";
 
 ### `@liveblocks/emails`
 
-The `prepareTextMentionNotificationEmailAsReact` and
-`prepareTextMentionNotificationEmailAsHtml` functions’ returned data changed
+The [`prepareTextMentionNotificationEmailAsReact`][] and
+[`prepareTextMentionNotificationEmailAsHtml`][] functions’ returned data changed
 slightly:
 
 - The `id` property is now named `textMentionId`, it refers to the mention’s
@@ -202,10 +207,11 @@ await prepareTextMentionNotificationEmailAsReact(liveblocks, event);
 // }
 ```
 
-When customizing the `Mention` component in the
-`prepareTextMentionNotificationEmailAsReact` function, the `element` prop’s
-`userId` property has been renamed to `id`, and `element.kind` now indicates the
-mention’s kind.
+When customizing the
+[`Mention`](/docs/api-reference/liveblocks-emails#prepare-text-mention-notification-email-as-react-customizing-components)
+component in the [`prepareTextMentionNotificationEmailAsReact`][] function, the
+`element` prop’s `userId` property has been renamed to `id`, and `element.kind`
+now indicates the mention’s kind.
 
 ```tsx
 await prepareThreadNotificationEmailAsReact(liveblocks, webhookEvent, {
@@ -229,8 +235,10 @@ await prepareThreadNotificationEmailAsReact(liveblocks, webhookEvent, {
 
 #### Utilities
 
-The `getMentionedIdsFromCommentBody` utility (from `@liveblocks/client` and
-`@liveblocks/node`) has been replaced by `getMentionsFromCommentBody`.
+The `getMentionedIdsFromCommentBody` utility (from
+[`@liveblocks/client`](/docs/api-reference/liveblocks-client) and
+[`@liveblocks/node`](/docs/api-reference/liveblocks-node)) has been replaced by
+[`getMentionsFromCommentBody`](/docs/api-reference/liveblocks-client#get-mentions-from-comment-body).
 
 ```tsx
 // ❌ Before
@@ -256,7 +264,7 @@ getMentionsFromCommentBody(commentBody, (mention) => mention.kind === "user");
 ### Notification settings
 
 2.24 [introduced a few naming changes](/docs/platform/upgrading/2.24) around the
-concepts of "notification settings" and "subscription settings" to improve
+concepts of “notification settings” and “subscription settings” to improve
 clarity. 3.0 [removes the aliases for the previous names](#deprecated) but it
 also introduces one change that we couldn’t make in 2.24:
 
@@ -285,7 +293,7 @@ useErrorListener((error) =>
 
 ### `@liveblocks/emails`
 
-The functions which prepare HTML/React emails are now more consistent, using the
+The functions to prepare HTML/React emails are now more consistent, using the
 same `body` and `content` properties instead of `reactBody`/`htmlBody` and
 `reactContent`/`htmlContent`.
 
@@ -359,6 +367,16 @@ multiple versions ago.
   for tracking sync status, it reflects the sync status of all parts of
   Liveblocks.
 
+[`Thread`]: /docs/api-reference/liveblocks-react-ui#Thread
+[`Comment`]: /docs/api-reference/liveblocks-react-ui#Comment
+[`Comment.Body`]:
+  /docs/api-reference/liveblocks-react-ui#primitives-Comment.Body
+[`Composer.Editor`]:
+  /docs/api-reference/liveblocks-react-ui#primitives-Composer.Editor
+[`prepareTextMentionNotificationEmailAsReact`]:
+  /docs/api-reference/liveblocks-emails#prepare-text-mention-notification-email-as-react
+[`prepareTextMentionNotificationEmailAsHtml`]:
+  /docs/api-reference/liveblocks-emails#prepare-text-mention-notification-email-as-html
 [`getRooms`]: /docs/api-reference/liveblocks-node#get-rooms
 [`useSyncStatus`]: /docs/api-reference/liveblocks-react#useSyncStatus
 [`useMutation`]: /docs/api-reference/liveblocks-react#useMutation

--- a/docs/pages/platform/upgrading/3.0.mdx
+++ b/docs/pages/platform/upgrading/3.0.mdx
@@ -28,14 +28,37 @@ versions. The easiest way to do that is to run the following command:
 npx create-liveblocks-app@latest --upgrade
 ```
 
-There are also some **breaking changes** in this update.
+There are some **breaking changes** in this update.
 
-### Mentions
+## Does this affect you? [#does-this-affect-you]
+
+**If you’re using [Comments](/docs/ready-made-features/comments) and/or
+[Text Editor](/docs/ready-made-features/text-editor)**, please read about
+[changes to mentions](#mentions).
+
+**If you’re using [Notifications](/docs/ready-made-features/notifications)**,
+please read about
+[a change related to notification settings](#notification-settings).
+
+**If you’re using
+[`@liveblocks/emails`](/docs/api-reference/liveblocks-emails)**, please read
+about [changes to its returned values](#liveblocks-emails).
+
+**If you’re using
+[`LiveblocksUIConfig`](/docs/api-reference/liveblocks-react-ui#LiveblocksUiConfig)**,
+please read about [its renaming](#liveblocks-ui-config).
+
+**If you’re using any deprecated APIs** (e.g. `useBatch`, `useStorageStatus`,
+`useEditorStatus`…), please read about [the ones being removed](#deprecated).
+
+Otherwise, you can simply upgrade your packages and no changes will affect you.
+
+## Mentions [#mentions]
 
 We’re making some changes to mentions in Comments and Text Editor to support
 different mention kinds in future releases: user mentions, group mentions, etc.
 
-#### Components
+### Components [#mentions-components]
 
 The `onMentionClick` prop on [`Thread`][] and [`Comment`][] now receives a
 `MentionData` object as its first argument instead of a `userId` string.
@@ -50,7 +73,7 @@ onMentionClick(mention: MentionData, event: MouseEvent<HTMLElement>) => void;
 // mention: { kind: "user", id: "user-0" }
 ```
 
-### Primitives
+### Primitives [#mentions-primitives]
 
 When customizing the
 [`Mention`](/docs/api-reference/liveblocks-react-ui#primitives-Comment.Body-Mention)
@@ -150,7 +173,7 @@ import { Composer } from "@liveblocks/react-ui/primitives";
 />;
 ```
 
-### `@liveblocks/emails`
+### `@liveblocks/emails` [#mentions-liveblocks-emails]
 
 The [`prepareTextMentionNotificationEmailAsReact`][] and
 [`prepareTextMentionNotificationEmailAsHtml`][] functions’ returned data changed
@@ -233,7 +256,7 @@ await prepareThreadNotificationEmailAsReact(liveblocks, webhookEvent, {
 });
 ```
 
-#### Utilities
+### Utilities [#utilities]
 
 The `getMentionedIdsFromCommentBody` utility (from
 [`@liveblocks/client`](/docs/api-reference/liveblocks-client) and
@@ -261,7 +284,7 @@ getMentionsFromCommentBody(commentBody);
 getMentionsFromCommentBody(commentBody, (mention) => mention.kind === "user");
 ```
 
-### Notification settings
+## Notification settings [#notification-settings]
 
 2.24 [introduced a few naming changes](/docs/platform/upgrading/2.24) around the
 concepts of “notification settings” and “subscription settings” to improve
@@ -291,7 +314,7 @@ useErrorListener((error) =>
 );
 ```
 
-### `@liveblocks/emails`
+## `@liveblocks/emails` [#liveblocks-emails]
 
 The functions to prepare HTML/React emails are now more consistent, using the
 same `body` and `content` properties instead of `reactBody`/`htmlBody` and
@@ -311,7 +334,7 @@ prepareTextMentionNotificationEmailAsReact(liveblocks, event); // { mention: { c
 prepareTextMentionNotificationEmailAsHtml(liveblocks, event); // { mention: { content: string, ... }, ... }
 ```
 
-### `LiveblocksUiConfig`
+## `LiveblocksUiConfig` [#liveblocks-ui-config]
 
 The
 [`LiveblocksUIConfig`](/docs/api-reference/liveblocks-react-ui#LiveblocksUiConfig)
@@ -324,7 +347,7 @@ Run the following **codemod** or manually make the changes:
 npx @liveblocks/codemod@latest liveblocks-ui-config
 ```
 
-### Removed deprecated APIs [#deprecated]
+## Removed deprecated APIs [#deprecated]
 
 All of the following APIs have been removed in 3.0, as they were deprecated
 multiple versions ago.

--- a/docs/pages/platform/upgrading/3.0.mdx
+++ b/docs/pages/platform/upgrading/3.0.mdx
@@ -28,24 +28,229 @@ npx create-liveblocks-app@latest --upgrade
 
 There are also some **breaking changes** in this update.
 
-### `@liveblocks/emails`
+### Mentions
 
-The functions which prepare HTML/React emails are now more consistent, using the
-same `body` and `content` properties instead of `reactBody`/`htmlBody` and
-`reactContent`/`htmlContent`.
+We’re making some changes to mentions in Comments and Text Editor to support
+different mention kinds in future releases: user mentions, group mentions, etc.
+
+#### Components
+
+The `onMentionClick` prop on `Comment` now receives a `MentionData` object as
+its first argument instead of a `userId` string.
 
 ```tsx
 // ❌ Before
-prepareThreadNotificationEmailAsReact(liveblocks, event); // { comment: { reactBody: ReactNode, ... }, ... }
-prepareThreadNotificationEmailAsHtml(liveblocks, event); // { comment: { htmlBody: string, ... }, ... }
-prepareTextMentionNotificationEmailAsReact(liveblocks, event); // { mention: { reactContent: ReactNode, ... }, ... }
-prepareTextMentionNotificationEmailAsHtml(liveblocks, event); // { mention: { htmlContent: string, ... }, ... }
+onMentionClick(userId: string, event: MouseEvent<HTMLElement>) => void;
+// userId: "user-0"
 
 // ✅ After
-prepareThreadNotificationEmailAsReact(liveblocks, event); // { comment: { body: ReactNode, ... }, ... }
-prepareThreadNotificationEmailAsHtml(liveblocks, event); // { comment: { body: string, ... }, ... }
-prepareTextMentionNotificationEmailAsReact(liveblocks, event); // { mention: { content: ReactNode, ... }, ... }
-prepareTextMentionNotificationEmailAsHtml(liveblocks, event); // { mention: { content: string, ... }, ... }
+onMentionClick(mention: MentionData, event: MouseEvent<HTMLElement>) => void;
+// mention: { kind: "user", id: "user-0" }
+```
+
+### Primitives
+
+When customizing the `Mention` component on the `Comment.Body` and
+`Composer.Editor` primitives, the `userId` prop has been replaced by a `mention`
+one which is a `MentionData` object.
+
+```tsx
+import { Comment, Composer } from "@liveblocks/react-ui/primitives";
+
+// ❌ Before
+<Comment.Body
+  components={{
+    // +++
+    Mention: ({ userId }) => <Comment.Mention>@{userId}</Comment.Mention>,
+    // +++
+  }}
+/>;
+<Composer.Editor
+  components={{
+    // +++
+    Mention: ({ userId, isSelected }) => (
+      <Composer.Mention>@{userId}</Composer.Mention>
+    ),
+    // +++
+  }}
+/>;
+
+// ✅ After
+<Comment.Body
+  components={{
+    // +++
+    Mention: ({ mention }) => <Comment.Mention>@{mention.id}</Comment.Mention>,
+    // +++
+  }}
+/>;
+<Composer.Editor
+  components={{
+    // +++
+    Mention: ({ mention, isSelected }) => (
+      <Composer.Mention>@{mention.id}</Composer.Mention>
+    ),
+    // +++
+  }}
+/>;
+```
+
+When customizing the `MentionSuggestions` component on the `Composer.Editor`
+primitive, the `userIds` prop has been replaced by a `mentions` one which is an
+array of `MentionData` objects, and the `selectedUserId` prop has been renamed
+to `selectedMentionId`.
+
+```tsx
+import { Composer } from "@liveblocks/react-ui/primitives";
+
+// ❌ Before
+<Composer.Editor
+  components={{
+    // +++
+    MentionSuggestions: ({ userIds, selectedUserId }) => (
+      // +++
+      <Composer.Suggestions>
+        <Composer.SuggestionsList>
+          // +++
+          {userIds.map((userId) => (
+            <Composer.SuggestionsListItem key={userId} value={userId}>
+              {userId}
+            </Composer.SuggestionsListItem>
+          ))}
+          // +++
+        </Composer.SuggestionsList>
+      </Composer.Suggestions>
+    ),
+  }}
+/>;
+
+// ✅ After
+<Composer.Editor
+  components={{
+    // +++
+    MentionSuggestions: ({ mentions, selectedMentionId }) => (
+      // +++
+      <Composer.Suggestions>
+        <Composer.SuggestionsList>
+          // +++
+          {mentions.map((mention) => (
+            <Composer.SuggestionsListItem key={mention.id} value={mention.id}>
+              {mention.id}
+            </Composer.SuggestionsListItem>
+          ))}
+          // +++
+        </Composer.SuggestionsList>
+      </Composer.Suggestions>
+    ),
+  }}
+/>;
+```
+
+### `@liveblocks/emails`
+
+The `prepareTextMentionNotificationEmailAsReact` and
+`prepareTextMentionNotificationEmailAsHtml` functions’ returned data changed
+slightly:
+
+- The `id` property is now named `textMentionId`, it refers to the mention’s
+  Text Mention ID, not the user ID used for the mention
+- The `id` property now refers to the mention’s ID, as in the user ID used for
+  the mention
+- The `kind` property now indicates the mention’s kind (e.g. `"user"`,
+  `"group"`, etc.)
+
+```tsx
+await prepareTextMentionNotificationEmailAsReact(liveblocks, event);
+
+// ❌ Before
+// {
+//   mention: {
+// +++
+//     id: "in_xxx",
+// +++
+//     roomId: "123",
+//     createdAt: new Date(),
+//     author: {
+//       id: "user-who-created-the-mention",
+//       info: {
+//         name: "Aurélien",
+//       },
+//     },
+//     content: /* The rendered content */,
+//   },
+//   ...
+// }
+
+// ✅ After
+// {
+//   mention: {
+// +++
+//     textMentionId: "in_xxx",
+//     id: "user-who-is-mentioned",
+//     kind: "user",
+// +++
+//     roomId: "123",
+//     createdAt: new Date(),
+//     author: {
+//       id: "user-who-created-the-mention",
+//       info: {
+//         name: "Aurélien",
+//       },
+//     },
+//     content: /* The rendered content */,
+//   },
+//   ...
+// }
+```
+
+When customizing the `Mention` component in the
+`prepareTextMentionNotificationEmailAsReact` function, the `element` prop’s
+`userId` property has been renamed to `id`, and `element.kind` now indicates the
+mention’s kind.
+
+```tsx
+await prepareThreadNotificationEmailAsReact(liveblocks, webhookEvent, {
+  components: {
+    // ❌ Before
+    Mention: ({ element, user }) => (
+      // +++
+      <span style={{ color: "red" }}>@{element.userId}</span>
+      // +++
+    ),
+
+    // ✅ After
+    Mention: ({ element, user }) => (
+      // +++
+      <span style={{ color: "red" }}>@{element.id}</span>
+      // +++
+    ),
+  },
+});
+```
+
+#### Utilities
+
+The `getMentionedIdsFromCommentBody` utility (from `@liveblocks/client` and
+`@liveblocks/node`) has been replaced by `getMentionsFromCommentBody`.
+
+```tsx
+// ❌ Before
+getMentionedIdsFromCommentBody(commentBody);
+// ["user-1", "user-2"]
+
+// ✅ After
+getMentionsFromCommentBody(commentBody, (mention) => mention.kind === "user");
+// [{ type: "mention", kind: "user", id: "user-1" }, { type: "mention", kind: "user", id: "user-2" }]
+```
+
+By default, if the optional second argument is not provided, all mentions are
+returned, including future mention kinds (e.g. group mentions in the future).
+
+```tsx
+// All mentions
+getMentionsFromCommentBody(commentBody);
+
+// Only user mentions
+getMentionsFromCommentBody(commentBody, (mention) => mention.kind === "user");
 ```
 
 ### Notification settings
@@ -76,6 +281,26 @@ useErrorListener((error) =>
     /* ... */
   }
 );
+```
+
+### `@liveblocks/emails`
+
+The functions which prepare HTML/React emails are now more consistent, using the
+same `body` and `content` properties instead of `reactBody`/`htmlBody` and
+`reactContent`/`htmlContent`.
+
+```tsx
+// ❌ Before
+prepareThreadNotificationEmailAsReact(liveblocks, event); // { comment: { reactBody: ReactNode, ... }, ... }
+prepareThreadNotificationEmailAsHtml(liveblocks, event); // { comment: { htmlBody: string, ... }, ... }
+prepareTextMentionNotificationEmailAsReact(liveblocks, event); // { mention: { reactContent: ReactNode, ... }, ... }
+prepareTextMentionNotificationEmailAsHtml(liveblocks, event); // { mention: { htmlContent: string, ... }, ... }
+
+// ✅ After
+prepareThreadNotificationEmailAsReact(liveblocks, event); // { comment: { body: ReactNode, ... }, ... }
+prepareThreadNotificationEmailAsHtml(liveblocks, event); // { comment: { body: string, ... }, ... }
+prepareTextMentionNotificationEmailAsReact(liveblocks, event); // { mention: { content: ReactNode, ... }, ... }
+prepareTextMentionNotificationEmailAsHtml(liveblocks, event); // { mention: { content: string, ... }, ... }
 ```
 
 ### `LiveblocksUiConfig`

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -476,7 +476,7 @@ test.describe("Composer", () => {
       const output = await getOutputJson(page);
       expect(output?.body.content[0].children).toEqual([
         { text: "Hello " },
-        { type: "mention", id: "user-3" },
+        { type: "mention", kind: "user", id: "user-3" },
         { text: " !" },
       ]);
     });
@@ -511,7 +511,7 @@ test.describe("Composer", () => {
       const output = await getOutputJson(page);
       expect(output?.body.content[0].children).toEqual([
         { text: "" },
-        { type: "mention", id: "user-2" },
+        { type: "mention", kind: "user", id: "user-2" },
         { text: " " },
       ]);
     });

--- a/examples/nextjs-comments-ai/src/app/api/liveblocks-webhook/route.ts
+++ b/examples/nextjs-comments-ai/src/app/api/liveblocks-webhook/route.ts
@@ -2,7 +2,7 @@ import OpenAI from "openai";
 import {
   CommentBodyInlineElement,
   CommentBodyText,
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   Liveblocks,
   stringifyCommentBody,
 } from "@liveblocks/node";
@@ -58,8 +58,11 @@ export async function POST(request: Request) {
   }
 
   // If AI not mentioned in comment, ignore
-  const mentionedIds = getMentionedIdsFromCommentBody(comment.body);
-  if (!mentionedIds.includes(AI_USER_ID)) {
+  const mentions = getMentionsFromCommentBody(
+    comment.body,
+    (mention) => mention.id === AI_USER_ID
+  );
+  if (mentions.length === 0) {
     return new Response("", { status: 200 });
   }
 

--- a/examples/nextjs-comments-audio/src/components/Mention.tsx
+++ b/examples/nextjs-comments-audio/src/components/Mention.tsx
@@ -8,13 +8,13 @@ import { Suspense } from "react";
 import { User } from "./User";
 
 export function Mention({
-  userId,
+  mention,
 }: ComposerEditorMentionProps | CommentBodyMentionProps) {
   return (
     <span className="font-medium text-accent">
       @
       <Suspense fallback="…">
-        <User userId={userId} />
+        <User userId={mention.id} />
       </Suspense>
     </span>
   );

--- a/examples/nextjs-comments-audio/src/components/MentionSuggestions.tsx
+++ b/examples/nextjs-comments-audio/src/components/MentionSuggestions.tsx
@@ -9,13 +9,13 @@ import { Avatar } from "./Avatar";
 import { User } from "./User";
 
 export function MentionSuggestions({
-  userIds,
+  mentions,
 }: ComposerEditorMentionSuggestionsProps) {
   return (
     <Composer.Suggestions className="p-1 bg-white border border-neutral-200 shadow-sm rounded-lg">
       <Composer.SuggestionsList>
-        {userIds.map((userId) => (
-          <MentionSuggestion key={userId} userId={userId} />
+        {mentions.map((mention) => (
+          <MentionSuggestion key={mention.id} userId={mention.id} />
         ))}
       </Composer.SuggestionsList>
     </Composer.Suggestions>

--- a/examples/nextjs-comments-primitives/src/components/Comment.tsx
+++ b/examples/nextjs-comments-primitives/src/components/Comment.tsx
@@ -84,12 +84,12 @@ export function Comment({ comment, className, ...props }: CommentProps) {
         body={comment.body}
         className="prose mt-1.5"
         components={{
-          Mention: ({ userId }) => {
+          Mention: ({ mention }) => {
             return (
               <CommentPrimitive.Mention className="font-semibold text-blue-500">
                 @
-                <Suspense fallback={userId}>
-                  <User userId={userId} />
+                <Suspense fallback={mention.id}>
+                  <User userId={mention.id} />
                 </Suspense>
               </CommentPrimitive.Mention>
             );

--- a/examples/nextjs-comments-primitives/src/components/Composer.tsx
+++ b/examples/nextjs-comments-primitives/src/components/Composer.tsx
@@ -75,24 +75,24 @@ export function Composer({
         placeholder={placeholder}
         className="prose prose-sm min-h-[theme(spacing.9)] max-w-none flex-1 rounded-md px-3 py-1.5 outline outline-1 -outline-offset-1 outline-gray-200 ring-blue-300 ring-offset-2 focus-visible:ring-2 [&_[data-placeholder]]:opacity-50"
         components={{
-          Mention: ({ userId }) => {
+          Mention: ({ mention }) => {
             return (
               <ComposerPrimitive.Mention className="rounded bg-blue-50 px-1 py-0.5 font-semibold text-blue-500 data-[selected]:bg-blue-500 data-[selected]:text-white">
                 @
-                <Suspense fallback={userId}>
-                  <User userId={userId} />
+                <Suspense fallback={mention.id}>
+                  <User userId={mention.id} />
                 </Suspense>
               </ComposerPrimitive.Mention>
             );
           },
-          MentionSuggestions: ({ userIds }) => {
+          MentionSuggestions: ({ mentions }) => {
             return (
               <ComposerPrimitive.Suggestions className="rounded-lg bg-white p-1 shadow-xl">
                 <ComposerPrimitive.SuggestionsList>
-                  {userIds.map((userId) => (
+                  {mentions.map((mention) => (
                     <ComposerPrimitive.SuggestionsListItem
-                      key={userId}
-                      value={userId}
+                      key={mention.id}
+                      value={mention.id}
                       className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm data-[selected]:bg-gray-100"
                     >
                       <Suspense
@@ -100,10 +100,10 @@ export function Composer({
                           <div className="relative aspect-square w-6 flex-none animate-pulse rounded-full bg-gray-100" />
                         }
                       >
-                        <Avatar userId={userId} className="w-5 flex-none" />
+                        <Avatar userId={mention.id} className="w-5 flex-none" />
                       </Suspense>
-                      <Suspense fallback={userId}>
-                        <User userId={userId} />
+                      <Suspense fallback={mention.id}>
+                        <User userId={mention.id} />
                       </Suspense>
                     </ComposerPrimitive.SuggestionsListItem>
                   ))}

--- a/examples/nextjs-comments-video/src/components/Mention.tsx
+++ b/examples/nextjs-comments-video/src/components/Mention.tsx
@@ -9,13 +9,13 @@ import { Suspense } from "react";
 import { User } from "./User";
 
 export function Mention({
-  userId,
+  mention,
 }: ComposerEditorMentionProps | CommentBodyMentionProps) {
   return (
     <span className={styles.mention}>
       @
       <Suspense fallback="…">
-        <User userId={userId} />
+        <User userId={mention.id} />
       </Suspense>
     </span>
   );

--- a/examples/nextjs-comments-video/src/components/MentionSuggestions.tsx
+++ b/examples/nextjs-comments-video/src/components/MentionSuggestions.tsx
@@ -10,13 +10,13 @@ import { Suspense } from "react";
 import { User } from "./User";
 
 export function MentionSuggestions({
-  userIds,
+  mentions,
 }: ComposerEditorMentionSuggestionsProps) {
   return (
     <Composer.Suggestions className={styles.suggestions}>
       <Composer.SuggestionsList>
-        {userIds.map((userId) => (
-          <MentionSuggestion key={userId} userId={userId} />
+        {mentions.map((mention) => (
+          <MentionSuggestion key={mention.id} userId={mention.id} />
         ))}
       </Composer.SuggestionsList>
     </Composer.Suggestions>

--- a/examples/nextjs-lexical-emails-resend/app/api/liveblocks-notifications-as-react/route.tsx
+++ b/examples/nextjs-lexical-emails-resend/app/api/liveblocks-notifications-as-react/route.tsx
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
             ),
             Mention: ({ element, user }) => (
               <span className="text-email-accent font-medium">
-                @{user?.name ?? element.userId}
+                @{user?.name ?? element.id}
               </span>
             ),
           },

--- a/examples/nextjs-lexical-emails-resend/emails/UnreadTextMention.tsx
+++ b/examples/nextjs-lexical-emails-resend/emails/UnreadTextMention.tsx
@@ -28,7 +28,9 @@ const previewProps: UnreadTextMentionProps = {
     url: "https://liveblocks.io/comments?room_id=project-proposal-q4",
   },
   mention: {
-    id: "in_1",
+    kind: "user",
+    id: "user-7",
+    textMentionId: "in_1",
     createdAt: new Date(2024, 2, 4, 4, 6, 47),
     author: {
       id: "user-0",

--- a/examples/nextjs-linear-like-issue-tracker/src/components/Mention.tsx
+++ b/examples/nextjs-linear-like-issue-tracker/src/components/Mention.tsx
@@ -8,13 +8,13 @@ import { Suspense } from "react";
 import { User } from "./User";
 
 export function Mention({
-  userId,
+  mention,
 }: ComposerEditorMentionProps | CommentBodyMentionProps) {
   return (
     <span className="font-medium text-accent">
       @
       <Suspense fallback="…">
-        <User userId={userId} />
+        <User userId={mention.id} />
       </Suspense>
     </span>
   );

--- a/examples/nextjs-linear-like-issue-tracker/src/components/MentionSuggestions.tsx
+++ b/examples/nextjs-linear-like-issue-tracker/src/components/MentionSuggestions.tsx
@@ -9,13 +9,13 @@ import { Avatar } from "./Avatar";
 import { User } from "./User";
 
 export function MentionSuggestions({
-  userIds,
+  mentions,
 }: ComposerEditorMentionSuggestionsProps) {
   return (
     <Composer.Suggestions className="p-1 bg-white border border-neutral-200 shadow-sm rounded-lg">
       <Composer.SuggestionsList>
-        {userIds.map((userId) => (
-          <MentionSuggestion key={userId} userId={userId} />
+        {mentions.map((mention) => (
+          <MentionSuggestion key={mention.id} userId={mention.id} />
         ))}
       </Composer.SuggestionsList>
     </Composer.Suggestions>

--- a/examples/nextjs-notification-settings/app/api/liveblocks-notifications/_emails/text-mention-notification.tsx
+++ b/examples/nextjs-notification-settings/app/api/liveblocks-notifications/_emails/text-mention-notification.tsx
@@ -38,7 +38,7 @@ export async function sendTextMentionNotificationEmail(
           ),
           Mention: ({ element, user }) => (
             <span className="text-email-accent font-medium">
-              @{user?.name ?? element.userId}
+              @{user?.name ?? element.id}
             </span>
           ),
         },

--- a/examples/nextjs-notification-settings/emails/UnreadTextMention.tsx
+++ b/examples/nextjs-notification-settings/emails/UnreadTextMention.tsx
@@ -27,7 +27,9 @@ const previewProps: UnreadTextMentionProps = {
     url: "https://liveblocks.io/comments?room_id=project-proposal-q4",
   },
   mention: {
-    id: "in_1",
+    kind: "user",
+    id: "user-7",
+    textMentionId: "in_1",
     createdAt: new Date(2024, 2, 4, 4, 6, 47),
     author: {
       id: "user-0",

--- a/examples/nextjs-tiptap-emails-resend/app/api/liveblocks-notifications-as-react/route.tsx
+++ b/examples/nextjs-tiptap-emails-resend/app/api/liveblocks-notifications-as-react/route.tsx
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
             ),
             Mention: ({ element, user }) => (
               <span className="text-email-accent font-medium">
-                @{user?.name ?? element.userId}
+                @{user?.name ?? element.id}
               </span>
             ),
           },

--- a/examples/nextjs-tiptap-emails-resend/emails/UnreadTextMention.tsx
+++ b/examples/nextjs-tiptap-emails-resend/emails/UnreadTextMention.tsx
@@ -28,7 +28,9 @@ const previewProps: UnreadTextMentionProps = {
     url: "https://liveblocks.io/comments?room_id=project-proposal-q4",
   },
   mention: {
-    id: "in_1",
+    kind: "user",
+    id: "user-7",
+    textMentionId: "in_1",
     createdAt: new Date(2024, 2, 4, 4, 6, 47),
     author: {
       id: "user-0",

--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -71,7 +71,7 @@ export type {
 } from "@liveblocks/core";
 export {
   createClient,
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   isNotificationChannelEnabled,
   LiveblocksError,
   LiveList,

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -56,6 +56,7 @@ import {
 import type { Awaitable } from "./types/Awaitable";
 import type { LiveblocksErrorContext } from "./types/LiveblocksError";
 import { LiveblocksError } from "./types/LiveblocksError";
+import type { MentionData } from "./types/MentionData";
 
 const MIN_THROTTLE = 16;
 const MAX_THROTTLE = 1_000;
@@ -158,7 +159,7 @@ export type InternalSyncStatus = SyncStatus | "has-local-changes";
  */
 export type PrivateClientApi<U extends BaseUserMeta, M extends BaseMetadata> = {
   readonly currentUserId: Signal<string | undefined>;
-  readonly mentionSuggestionsCache: Map<string, string[]>;
+  readonly mentionSuggestionsCache: Map<string, MentionData[]>;
   readonly resolveMentionSuggestions: ClientOptions<U>["resolveMentionSuggestions"];
   readonly usersStore: BatchStore<U["info"] | undefined, string>;
   readonly roomsInfoStore: BatchStore<DRI | undefined, string>;
@@ -452,11 +453,11 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
   largeMessageStrategy?: LargeMessageStrategy;
   unstable_streamData?: boolean;
   /**
-   * A function that returns a list of user IDs matching a string.
+   * A function that returns a list of mention suggestions matching a string.
    */
   resolveMentionSuggestions?: (
     args: ResolveMentionSuggestionsArgs
-  ) => Awaitable<string[]>;
+  ) => Awaitable<string[] | MentionData[]>;
 
   /**
    * A function that returns user info from user IDs.
@@ -767,7 +768,7 @@ export function createClient<U extends BaseUserMeta = DU>(
     roomsInfoStore.invalidate(roomIds);
   }
 
-  const mentionSuggestionsCache = new Map<string, string[]>();
+  const mentionSuggestionsCache = new Map<string, MentionData[]>();
 
   function invalidateResolvedMentionSuggestions() {
     mentionSuggestionsCache.clear();

--- a/packages/liveblocks-core/src/comments/__tests__/comment-body.test.ts
+++ b/packages/liveblocks-core/src/comments/__tests__/comment-body.test.ts
@@ -1,7 +1,7 @@
 import type { ResolveUsersArgs } from "../../client";
 import type { CommentBody } from "../../protocol/Comments";
 import {
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   stringifyCommentBody,
 } from "../comment-body";
 
@@ -18,7 +18,7 @@ const commentBody: CommentBody = {
         { text: "Hello " },
         { text: "world", bold: true },
         { text: " and " },
-        { type: "mention", id: "chris" },
+        { type: "mention", kind: "user", id: "chris" },
       ],
     },
   ],
@@ -33,7 +33,7 @@ const commentBodyWithMultipleParagraphs: CommentBody = {
         { text: "Hello " },
         { text: "world", italic: true, bold: true },
         { text: " and " },
-        { type: "mention", id: "vincent" },
+        { type: "mention", kind: "user", id: "vincent" },
       ],
     },
     {
@@ -138,14 +138,14 @@ const commentBodyWithMentions: CommentBody = {
       type: "paragraph",
       children: [
         { text: "Hello " },
-        { type: "mention", id: "chris" },
+        { type: "mention", kind: "user", id: "chris" },
         { text: " and " },
-        { type: "mention", id: "vincent" },
+        { type: "mention", kind: "user", id: "vincent" },
       ],
     },
     {
       type: "paragraph",
-      children: [{ type: "mention", id: "nimesh" }],
+      children: [{ type: "mention", kind: "user", id: "nimesh" }],
     },
   ],
 };
@@ -158,12 +158,12 @@ function resolveUsers({ userIds }: ResolveUsersArgs) {
   });
 }
 
-describe("getMentionedIdsFromCommentBody", () => {
-  test("returns an array of all mentions' IDs", () => {
-    expect(getMentionedIdsFromCommentBody(commentBodyWithMentions)).toEqual([
-      "chris",
-      "vincent",
-      "nimesh",
+describe("getMentionsFromCommentBody", () => {
+  test("returns an array of all mentions", () => {
+    expect(getMentionsFromCommentBody(commentBodyWithMentions)).toEqual([
+      { type: "mention", kind: "user", id: "chris" },
+      { type: "mention", kind: "user", id: "vincent" },
+      { type: "mention", kind: "user", id: "nimesh" },
     ]);
   });
 
@@ -186,9 +186,7 @@ describe("getMentionedIdsFromCommentBody", () => {
       ],
     };
 
-    expect(getMentionedIdsFromCommentBody(commentBodyWithoutMentions)).toEqual(
-      []
-    );
+    expect(getMentionsFromCommentBody(commentBodyWithoutMentions)).toEqual([]);
   });
 });
 
@@ -307,7 +305,7 @@ describe("stringifyCommentBody", () => {
           children: [
             { text: "Hello" },
             { text: " " },
-            { type: "mention", id: "user-0" },
+            { type: "mention", kind: "user", id: "user-0" },
             { text: " " },
             { text: "!" },
           ],

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -334,6 +334,7 @@ export type {
 } from "./types/PlainLson";
 export type { User } from "./types/User";
 export { detectDupes };
+export type { MentionData, UserMentionData } from "./types/MentionData";
 
 /**
  * Helper type to help users adopt to Lson types from interface definitions.

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -37,7 +37,7 @@ export type {
   StringifyCommentBodyOptions,
 } from "./comments/comment-body";
 export {
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   html,
   htmlSafe,
   isCommentBodyLink,

--- a/packages/liveblocks-core/src/protocol/Comments.ts
+++ b/packages/liveblocks-core/src/protocol/Comments.ts
@@ -110,8 +110,11 @@ export type CommentBodyParagraph = {
   children: CommentBodyInlineElement[];
 };
 
-export type CommentBodyMention = {
+export type CommentBodyMention = Relax<CommentBodyUserMention>;
+
+type CommentBodyUserMention = {
   type: "mention";
+  kind: "user";
   id: string;
 };
 

--- a/packages/liveblocks-core/src/types/MentionData.ts
+++ b/packages/liveblocks-core/src/types/MentionData.ts
@@ -1,0 +1,8 @@
+import type { Relax } from "../lib/Relax";
+
+export type MentionData = Relax<UserMentionData>;
+
+export type UserMentionData = {
+  kind: "user";
+  id: string;
+};

--- a/packages/liveblocks-emails/src/__tests__/_helpers.ts
+++ b/packages/liveblocks-emails/src/__tests__/_helpers.ts
@@ -83,7 +83,7 @@ export const buildCommentBodyWithMention = ({
       children: [
         { text: "Hello" },
         { text: " " },
-        { type: "mention", id: mentionedUserId },
+        { type: "mention", kind: "user", id: mentionedUserId },
         { text: " " },
         { text: "!" },
       ],

--- a/packages/liveblocks-emails/src/__tests__/liveblocks-text-editor.test.tsx
+++ b/packages/liveblocks-emails/src/__tests__/liveblocks-text-editor.test.tsx
@@ -31,7 +31,8 @@ describe("liveblocks text editor", () => {
         },
         {
           type: "mention",
-          userId,
+          kind: "user",
+          id: userId,
         },
         {
           type: "text",
@@ -87,7 +88,8 @@ describe("liveblocks text editor", () => {
         },
         {
           type: "mention",
-          userId,
+          kind: "user",
+          id: userId,
         },
         {
           type: "text",

--- a/packages/liveblocks-emails/src/__tests__/mention-content.test.tsx
+++ b/packages/liveblocks-emails/src/__tests__/mention-content.test.tsx
@@ -23,7 +23,8 @@ const buildMentionTextEditorNodes = ({
   },
   {
     type: "mention",
-    userId: mentionedUserId,
+    kind: "user",
+    id: mentionedUserId,
   },
   {
     type: "text",
@@ -47,7 +48,7 @@ describe("convert mention content", () => {
     },
     mention: ({ node, user }) => {
       // prettier-ignore
-      return html`<span data-mention>${MENTION_CHARACTER}${user?.name ? html`${user?.name}` :  node.userId}</span>`
+      return html`<span data-mention>${MENTION_CHARACTER}${user?.name ? html`${user?.name}` :  node.id}</span>`
     },
     text: ({ node }) => {
       // Note: construction following the schema 👇
@@ -104,7 +105,8 @@ describe("convert mention content", () => {
       },
       {
         type: "mention",
-        userId: "user-dracula",
+        kind: "user",
+        id: "user-dracula",
       },
       {
         type: "text",
@@ -136,7 +138,8 @@ describe("convert mention content", () => {
       },
       {
         type: "mention",
-        userId: "user-dracula",
+        kind: "user",
+        id: "user-dracula",
       },
       {
         type: "text",
@@ -181,7 +184,8 @@ describe("convert mention content", () => {
         },
         {
           type: "mention",
-          userId: "user-dracula",
+          kind: "user",
+          id: "user-dracula",
         },
       ];
 

--- a/packages/liveblocks-emails/src/__tests__/text-mention-notification.test.tsx
+++ b/packages/liveblocks-emails/src/__tests__/text-mention-notification.test.tsx
@@ -278,7 +278,9 @@ describe("text mention notification", () => {
 
       const base: Omit<TextMentionNotificationEmailData<string>, "roomInfo"> = {
         mention: {
-          id: MENTION_ID_TIPTAP,
+          textMentionId: MENTION_ID_TIPTAP,
+          id: MENTIONED_USER_ID_TIPTAP,
+          kind: "user",
           roomId: room.id,
           author: {
             id: "user-nimesh",
@@ -329,7 +331,9 @@ describe("text mention notification", () => {
 
     const expected1: TextMentionNotificationEmailDataAsHtml = {
       mention: {
-        id: MENTION_ID_TIPTAP,
+        textMentionId: MENTION_ID_TIPTAP,
+        id: MENTIONED_USER_ID_TIPTAP,
+        kind: "user",
         roomId: room.id,
         author: { id: "user-1", info: { name: "user-1" } },
         createdAt: inboxNotification.notifiedAt,
@@ -343,7 +347,9 @@ describe("text mention notification", () => {
 
     const expected2: TextMentionNotificationEmailDataAsHtml = {
       mention: {
-        id: MENTION_ID_TIPTAP,
+        textMentionId: MENTION_ID_TIPTAP,
+        id: MENTIONED_USER_ID_TIPTAP,
+        kind: "user",
         roomId: room.id,
         author: { id: "user-1", info: { name: "Mislav Abha" } },
         createdAt: inboxNotification.notifiedAt,
@@ -411,7 +417,9 @@ describe("text mention notification", () => {
 
     const expected1: TextMentionNotificationEmailDataAsReact = {
       mention: {
-        id: MENTION_ID_TIPTAP,
+        textMentionId: MENTION_ID_TIPTAP,
+        id: MENTIONED_USER_ID_TIPTAP,
+        kind: "user",
         roomId: room.id,
         author: { id: "user-1", info: { name: "user-1" } },
         createdAt: inboxNotification.notifiedAt,

--- a/packages/liveblocks-emails/src/__tests__/text-mention-notification.test.tsx
+++ b/packages/liveblocks-emails/src/__tests__/text-mention-notification.test.tsx
@@ -234,7 +234,7 @@ describe("text mention notification", () => {
     const elements: ConvertMentionContentElements<string, BaseUserMeta> = {
       container: ({ children }) => children.join(""),
       mention: ({ node, user }) =>
-        `${MENTION_CHARACTER}${user?.name ?? node.userId}`,
+        `${MENTION_CHARACTER}${user?.name ?? node.id}`,
       text: ({ node }) => node.text,
     };
 

--- a/packages/liveblocks-emails/src/__tests__/text-mention-notification.test.tsx
+++ b/packages/liveblocks-emails/src/__tests__/text-mention-notification.test.tsx
@@ -222,7 +222,8 @@ describe("text mention notification", () => {
         editor: "tiptap",
         mentionNodeWithContext,
         createdAt: inboxNotification.notifiedAt,
-        userId: inboxNotification.createdBy,
+        userId: MENTIONED_USER_ID_TIPTAP,
+        createdBy: inboxNotification.createdBy,
       };
 
       expect(extracted).toEqual(expected);

--- a/packages/liveblocks-emails/src/liveblocks-text-editor.ts
+++ b/packages/liveblocks-emails/src/liveblocks-text-editor.ts
@@ -8,6 +8,7 @@
 import type {
   Awaitable,
   BaseUserMeta,
+  Relax,
   ResolveUsersArgs,
 } from "@liveblocks/core";
 
@@ -38,9 +39,13 @@ export type LiveblocksTextEditorTextNode = {
   text: string;
 } & LiveblocksTextEditorTextFormat;
 
-export type LiveblocksTextEditorMentionNode = {
+export type LiveblocksTextEditorMentionNode =
+  Relax<LiveblocksTextEditorUserMentionNode>;
+
+type LiveblocksTextEditorUserMentionNode = {
   type: "mention";
-  userId: string;
+  kind: "user";
+  id: string;
 };
 
 /**
@@ -149,7 +154,8 @@ const transformLexicalMentionNodeWithContext = (
       ) {
         textEditorNodes.push({
           type: "mention",
-          userId: node.attributes.__userId,
+          kind: "user",
+          id: node.attributes.__userId,
         });
       }
     }
@@ -158,7 +164,8 @@ const transformLexicalMentionNodeWithContext = (
   transform(before);
   textEditorNodes.push({
     type: "mention",
-    userId: mention.attributes.__userId,
+    kind: "user",
+    id: mention.attributes.__userId,
   });
   transform(after);
 
@@ -213,7 +220,8 @@ const transformTiptapMentionNodeWithContext = (
       } else if (isSerializedTiptapMentionNode(node)) {
         textEditorNodes.push({
           type: "mention",
-          userId: node.attrs.id,
+          kind: "user",
+          id: node.attrs.id,
         });
       }
     }
@@ -222,7 +230,8 @@ const transformTiptapMentionNodeWithContext = (
   transform(before);
   textEditorNodes.push({
     type: "mention",
-    userId: mention.attrs.id,
+    kind: "user",
+    id: mention.attrs.id,
   });
   transform(after);
 
@@ -282,8 +291,8 @@ export const resolveUsersInLiveblocksTextEditorNodes = async <
 
   const mentionedUserIds = new Set<string>();
   for (const node of nodes) {
-    if (node.type === "mention") {
-      mentionedUserIds.add(node.userId);
+    if (node.type === "mention" && node.kind === "user") {
+      mentionedUserIds.add(node.id);
     }
   }
 

--- a/packages/liveblocks-emails/src/mention-content.tsx
+++ b/packages/liveblocks-emails/src/mention-content.tsx
@@ -4,6 +4,7 @@ import type {
   DU,
   ResolveUsersArgs,
 } from "@liveblocks/core";
+import { assertNever } from "@liveblocks/core";
 
 import {
   type LiveblocksTextEditorMentionNode,
@@ -86,8 +87,12 @@ export async function convertMentionContent<T, U extends BaseUserMeta = DU>(
   const blocks: T[] = nodes.map((node, index) => {
     switch (node.type) {
       case "mention": {
+        if (node.kind !== "user") {
+          return assertNever(node.kind, "Unknown mention kind");
+        }
+
         return options.elements.mention(
-          { node, user: resolvedUsers.get(node.userId) },
+          { node, user: resolvedUsers.get(node.id) },
           index
         );
       }

--- a/packages/liveblocks-emails/src/text-mention-notification.tsx
+++ b/packages/liveblocks-emails/src/text-mention-notification.tsx
@@ -5,6 +5,7 @@ import {
   type DU,
   html,
   htmlSafe,
+  type MentionData,
   type ResolveUsersArgs,
 } from "@liveblocks/core";
 import type {
@@ -156,8 +157,11 @@ export const extractTextMentionNotificationData = async ({
   }
 };
 
-export type MentionEmailData<ContentType, U extends BaseUserMeta = DU> = {
-  id: string;
+export type MentionEmailData<
+  ContentType,
+  U extends BaseUserMeta = DU,
+> = MentionData & {
+  textMentionId: string;
   roomId: string;
   author: U; // Author of the mention
   createdAt: Date;
@@ -271,7 +275,10 @@ export async function prepareTextMentionNotificationEmail<
 
   return {
     mention: {
-      id: mentionId,
+      // TODO: When introducing new mention kinds (e.g. group mentions), this should be updated
+      kind: "user",
+      id: data.userId,
+      textMentionId: mentionId,
       roomId,
       author: {
         id: data.userId,

--- a/packages/liveblocks-emails/src/text-mention-notification.tsx
+++ b/packages/liveblocks-emails/src/text-mention-notification.tsx
@@ -348,7 +348,7 @@ const baseComponents: ConvertTextEditorNodesAsReactComponents<BaseUserMeta> = {
   Mention: ({ element, user }) => (
     <span data-mention>
       {MENTION_CHARACTER}
-      {user?.name ?? element.userId}
+      {user?.name ?? element.id}
     </span>
   ),
   Text: ({ element }) => {
@@ -556,7 +556,7 @@ export async function prepareTextMentionNotificationEmailAsHtml(
       },
       mention: ({ node, user }) => {
         // prettier-ignore
-        return html`<span data-mention style="${toInlineCSSString(styles.mention)}">${MENTION_CHARACTER}${user?.name ? html`${user?.name}` :  node.userId}</span>`
+        return html`<span data-mention style="${toInlineCSSString(styles.mention)}">${MENTION_CHARACTER}${user?.name ? html`${user?.name}` :  node.id}</span>`
       },
       text: ({ node }) => {
         // Note: construction following the schema 👇

--- a/packages/liveblocks-emails/src/thread-notification.tsx
+++ b/packages/liveblocks-emails/src/thread-notification.tsx
@@ -12,7 +12,7 @@ import type {
 } from "@liveblocks/core";
 import {
   generateCommentUrl,
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   html,
   htmlSafe,
 } from "@liveblocks/core";
@@ -89,8 +89,11 @@ export const getLastUnreadCommentWithMention = ({
       .reverse()
       .filter((c) => c.userId !== mentionedUserId)
       .find((c) => {
-        const mentionedUserIds = getMentionedIdsFromCommentBody(c.body);
-        return mentionedUserIds.includes(mentionedUserId);
+        const mentions = getMentionsFromCommentBody(
+          c.body,
+          (mention) => mention.kind === "user" && mention.id === mentionedUserId
+        );
+        return mentions.length > 0;
       }) ?? null
   );
 };

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -88,7 +88,7 @@ export type {
   User,
 } from "@liveblocks/core";
 export {
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   isNotificationChannelEnabled,
   LiveList,
   LiveMap,

--- a/packages/liveblocks-react-ui/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/index.test.tsx
@@ -179,6 +179,7 @@ const comment: CommentData = {
           },
           {
             type: "mention",
+            kind: "user",
             id: "user-0",
           },
           {

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -341,27 +341,33 @@ function ComposerMention({ userId }: ComposerEditorMentionProps) {
 }
 
 function ComposerMentionSuggestions({
-  userIds,
+  mentions,
 }: ComposerEditorMentionSuggestionsProps) {
-  return userIds.length > 0 ? (
+  return mentions.length > 0 ? (
     <ComposerPrimitive.Suggestions className="lb-root lb-portal lb-elevation lb-composer-suggestions lb-composer-mention-suggestions">
       <ComposerPrimitive.SuggestionsList className="lb-composer-suggestions-list lb-composer-mention-suggestions-list">
-        {userIds.map((userId) => (
-          <ComposerPrimitive.SuggestionsListItem
-            key={userId}
-            className="lb-composer-suggestions-list-item lb-composer-mention-suggestion"
-            value={userId}
-          >
-            <Avatar
-              userId={userId}
-              className="lb-composer-mention-suggestion-avatar"
-            />
-            <User
-              userId={userId}
-              className="lb-composer-mention-suggestion-user"
-            />
-          </ComposerPrimitive.SuggestionsListItem>
-        ))}
+        {mentions.map((mention) => {
+          if (mention.kind === "user") {
+            return (
+              <ComposerPrimitive.SuggestionsListItem
+                key={mention.id}
+                className="lb-composer-suggestions-list-item lb-composer-mention-suggestion"
+                value={mention.id}
+              >
+                <Avatar
+                  userId={mention.id}
+                  className="lb-composer-mention-suggestion-avatar"
+                />
+                <User
+                  userId={mention.id}
+                  className="lb-composer-mention-suggestion-user"
+                />
+              </ComposerPrimitive.SuggestionsListItem>
+            );
+          }
+
+          return null;
+        })}
       </ComposerPrimitive.SuggestionsList>
     </ComposerPrimitive.Suggestions>
   ) : null;

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -331,13 +331,19 @@ function ComposerAttachFilesEditorAction({
   );
 }
 
-function ComposerMention({ userId }: ComposerEditorMentionProps) {
-  return (
-    <ComposerPrimitive.Mention className="lb-composer-mention">
-      {MENTION_CHARACTER}
-      <User userId={userId} />
-    </ComposerPrimitive.Mention>
-  );
+function ComposerMention({ mention }: ComposerEditorMentionProps) {
+  switch (mention.kind) {
+    case "user":
+      return (
+        <ComposerPrimitive.Mention className="lb-composer-mention">
+          {MENTION_CHARACTER}
+          <User userId={mention.id} />
+        </ComposerPrimitive.Mention>
+      );
+
+    default:
+      return assertNever(mention.kind, "Unhandled mention kind");
+  }
 }
 
 function ComposerMentionSuggestions({

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -6,7 +6,7 @@ import type {
   CommentMixedAttachment,
   DM,
 } from "@liveblocks/core";
-import { Permission } from "@liveblocks/core";
+import { assertNever, Permission } from "@liveblocks/core";
 import { useRoom } from "@liveblocks/react";
 import {
   useCreateRoomComment,
@@ -347,26 +347,28 @@ function ComposerMentionSuggestions({
     <ComposerPrimitive.Suggestions className="lb-root lb-portal lb-elevation lb-composer-suggestions lb-composer-mention-suggestions">
       <ComposerPrimitive.SuggestionsList className="lb-composer-suggestions-list lb-composer-mention-suggestions-list">
         {mentions.map((mention) => {
-          if (mention.kind === "user") {
-            return (
-              <ComposerPrimitive.SuggestionsListItem
-                key={mention.id}
-                className="lb-composer-suggestions-list-item lb-composer-mention-suggestion"
-                value={mention.id}
-              >
-                <Avatar
-                  userId={mention.id}
-                  className="lb-composer-mention-suggestion-avatar"
-                />
-                <User
-                  userId={mention.id}
-                  className="lb-composer-mention-suggestion-user"
-                />
-              </ComposerPrimitive.SuggestionsListItem>
-            );
-          }
+          switch (mention.kind) {
+            case "user":
+              return (
+                <ComposerPrimitive.SuggestionsListItem
+                  key={mention.id}
+                  className="lb-composer-suggestions-list-item lb-composer-mention-suggestion"
+                  value={mention.id}
+                >
+                  <Avatar
+                    userId={mention.id}
+                    className="lb-composer-mention-suggestion-avatar"
+                  />
+                  <User
+                    userId={mention.id}
+                    className="lb-composer-mention-suggestion-user"
+                  />
+                </ComposerPrimitive.SuggestionsListItem>
+              );
 
-          return null;
+            default:
+              return assertNever(mention.kind, "Unhandled mention kind");
+          }
         })}
       </ComposerPrimitive.SuggestionsList>
     </ComposerPrimitive.Suggestions>

--- a/packages/liveblocks-react-ui/src/components/internal/InboxNotificationThread.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/InboxNotificationThread.tsx
@@ -4,7 +4,7 @@ import type {
   InboxNotificationThreadData,
   ThreadData,
 } from "@liveblocks/core";
-import { getMentionedIdsFromCommentBody } from "@liveblocks/core";
+import { getMentionsFromCommentBody } from "@liveblocks/core";
 import type { ComponentProps } from "react";
 
 import {
@@ -144,9 +144,12 @@ function findLastCommentWithMentionedId(
     }
 
     if (comment.body) {
-      const mentionedIds = getMentionedIdsFromCommentBody(comment.body);
+      const mentions = getMentionsFromCommentBody(
+        comment.body,
+        (mention) => mention.kind === "user" && mention.id === mentionedId
+      );
 
-      if (mentionedIds.includes(mentionedId)) {
+      if (mentions.length > 0) {
         return comment;
       }
     }

--- a/packages/liveblocks-react-ui/src/primitives/Comment/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Comment/index.tsx
@@ -23,7 +23,7 @@ const COMMENT_LINK_NAME = "CommentLink";
  * Displays mentions within `Comment.Body`.
  *
  * @example
- * <Comment.Mention>@{userId}</Comment.Mention>
+ * <Comment.Mention>@{mention.id}</Comment.Mention>
  */
 const CommentMention = forwardRef<HTMLSpanElement, CommentMentionProps>(
   ({ children, asChild, ...props }, forwardedRef) => {
@@ -61,11 +61,11 @@ const CommentLink = forwardRef<HTMLAnchorElement, CommentLinkProps>(
 );
 
 const defaultBodyComponents: CommentBodyComponents = {
-  Mention: ({ userId }) => {
+  Mention: ({ mention }) => {
     return (
       <CommentMention>
         {MENTION_CHARACTER}
-        {userId}
+        {mention.id}
       </CommentMention>
     );
   },
@@ -105,8 +105,10 @@ const CommentBody = forwardRef<HTMLDivElement, CommentBodyProps>(
                 <p key={index} style={{ minHeight: "1lh" }}>
                   {block.children.map((inline, index) => {
                     if (isCommentBodyMention(inline)) {
-                      return inline.id ? (
-                        <Mention userId={inline.id} key={index} />
+                      const { type: _, ...mention } = inline;
+
+                      return mention.id ? (
+                        <Mention mention={mention} key={index} />
                       ) : null;
                     }
 

--- a/packages/liveblocks-react-ui/src/primitives/Comment/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Comment/types.ts
@@ -1,4 +1,4 @@
-import type { CommentBody } from "@liveblocks/core";
+import type { CommentBody, MentionData } from "@liveblocks/core";
 import type { ComponentType, ReactNode } from "react";
 
 import type { ComponentPropsWithSlot } from "../../types";
@@ -7,9 +7,9 @@ export type CommentMentionProps = ComponentPropsWithSlot<"span">;
 
 export type CommentBodyMentionProps = {
   /**
-   * The mention's user ID.
+   * The mention.
    */
-  userId: string;
+  mention: MentionData;
 };
 
 export type CommentLinkProps = ComponentPropsWithSlot<"a">;

--- a/packages/liveblocks-react-ui/src/primitives/Comment/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Comment/types.ts
@@ -7,7 +7,7 @@ export type CommentMentionProps = ComponentPropsWithSlot<"span">;
 
 export type CommentBodyMentionProps = {
   /**
-   * The mention.
+   * The mention to display.
    */
   mention: MentionData;
 };

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -600,7 +600,7 @@ function ComposerEditorPlaceholder({
  * Displays mentions within `Composer.Editor`.
  *
  * @example
- * <Composer.Mention>@{userId}</Composer.Mention>
+ * <Composer.Mention>@{mention.id}</Composer.Mention>
  */
 const ComposerMention = forwardRef<HTMLSpanElement, ComposerMentionProps>(
   ({ children, asChild, ...props }, forwardedRef) => {
@@ -690,9 +690,9 @@ const ComposerSuggestions = forwardRef<
  *
  * @example
  * <Composer.SuggestionsList>
- *   {userIds.map((userId) => (
- *     <Composer.SuggestionsListItem key={userId} value={userId}>
- *       @{userId}
+ *   {mentions.map((mention) => (
+ *     <Composer.SuggestionsListItem key={mention.id} value={mention.id}>
+ *       @{mention.id}
  *     </Composer.SuggestionsListItem>
  *   ))}
  * </Composer.SuggestionsList>
@@ -721,8 +721,8 @@ const ComposerSuggestionsList = forwardRef<
  * Displays a suggestion within `Composer.SuggestionsList`.
  *
  * @example
- * <Composer.SuggestionsListItem key={userId} value={userId}>
- *   @{userId}
+ * <Composer.SuggestionsListItem key={mention.id} value={mention.id}>
+ *   @{mention.id}
  * </Composer.SuggestionsListItem>
  */
 const ComposerSuggestionsListItem = forwardRef<
@@ -907,8 +907,10 @@ const ComposerEditor = forwardRef<HTMLDivElement, ComposerEditorProps>(
     const floatingToolbarId = `liveblocks-floating-toolbar-${id}`;
     const suggestionsListId = `liveblocks-suggestions-list-${id}`;
     const suggestionsListItemId = useCallback(
-      (userId?: string) =>
-        userId ? `liveblocks-suggestions-list-item-${id}-${userId}` : undefined,
+      (mentionId?: string) =>
+        mentionId
+          ? `liveblocks-suggestions-list-item-${id}-${mentionId}`
+          : undefined,
       [id]
     );
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/index.tsx
@@ -202,11 +202,12 @@ function ComposerEditorMentionWrapper({
   element,
 }: ComposerEditorMentionWrapperProps) {
   const isSelected = useSelected();
+  const { children: _, ...mention } = element;
 
   return (
     <span {...attributes}>
       {element.id ? (
-        <Mention userId={element.id} isSelected={isSelected} />
+        <Mention mention={mention} isSelected={isSelected} />
       ) : null}
       {children}
     </span>
@@ -817,11 +818,11 @@ const defaultEditorComponents: ComposerEditorComponents = {
   Link: ({ href, children }) => {
     return <ComposerLink href={href}>{children}</ComposerLink>;
   },
-  Mention: ({ userId }) => {
+  Mention: ({ mention }) => {
     return (
       <ComposerMention>
         {MENTION_CHARACTER}
-        {userId}
+        {mention.id}
       </ComposerMention>
     );
   },

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -33,7 +33,7 @@ export interface ComposerEditorMentionProps {
   isSelected: boolean;
 
   /**
-   * The mention.
+   * The mention to display.
    */
   mention: MentionData;
 }

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -1,4 +1,8 @@
-import type { CommentAttachment, CommentBody } from "@liveblocks/core";
+import type {
+  CommentAttachment,
+  CommentBody,
+  MentionData,
+} from "@liveblocks/core";
 import type {
   ComponentPropsWithoutRef,
   ComponentType,
@@ -52,14 +56,14 @@ export interface ComposerEditorLinkProps {
 
 export type ComposerEditorMentionSuggestionsProps = {
   /**
-   * The list of suggested user IDs.
+   * The list of mention suggestions.
    */
-  userIds: string[];
+  mentions: MentionData[];
 
   /**
-   * The currently selected user ID.
+   * The currently selected mention's ID.
    */
-  selectedUserId?: string;
+  selectedMentionId?: string;
 };
 
 export type ComposerEditorFloatingToolbarProps = Record<string, never>;
@@ -223,14 +227,14 @@ export interface ComposerEditorElementProps extends RenderElementProps {
 export interface ComposerEditorMentionSuggestionsWrapperProps {
   dir?: ComposerEditorProps["dir"];
   id: string;
-  itemId: (userId?: string) => string | undefined;
+  itemId: (mentionId?: string) => string | undefined;
   mentionDraft?: MentionDraft;
   setMentionDraft: Dispatch<SetStateAction<MentionDraft | undefined>>;
-  userIds?: string[];
-  selectedUserId?: string;
-  setSelectedUserId: (userId: string) => void;
+  mentions?: MentionData[];
+  selectedMentionId?: string;
+  setSelectedMentionId: (mentionId: string) => void;
   MentionSuggestions: ComponentType<ComposerEditorMentionSuggestionsProps>;
-  onItemSelect: (userId: string) => void;
+  onItemSelect: (mentionId: string) => void;
   position?: FloatingPosition;
   inset?: number;
 }

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -33,9 +33,9 @@ export interface ComposerEditorMentionProps {
   isSelected: boolean;
 
   /**
-   * The mention's user ID.
+   * The mention.
    */
-  userId: string;
+  mention: MentionData;
 }
 
 export interface ComposerEditorLinkProps {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/utils.ts
@@ -66,10 +66,9 @@ import type { FloatingAlignment, FloatingPosition } from "./types";
 export function composerBodyMentionToCommentBodyMention(
   mention: ComposerBodyMention
 ): CommentBodyMention {
-  return {
-    type: "mention",
-    id: mention.id,
-  };
+  const { children: _, ...commentBodyMention } = mention;
+
+  return commentBodyMention;
 }
 
 export function composerBodyAutoLinkToCommentBodyLink(
@@ -95,8 +94,7 @@ export function commentBodyMentionToComposerBodyMention(
   mention: CommentBodyMention
 ): ComposerBodyMention {
   return {
-    type: "mention",
-    id: mention.id,
+    ...mention,
     children: [{ text: "" }],
   };
 }

--- a/packages/liveblocks-react-ui/src/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-ui/src/slate/plugins/mentions.ts
@@ -1,3 +1,4 @@
+import type { MentionData } from "@liveblocks/core";
 import type { Node as SlateNode } from "slate";
 import {
   Editor as SlateEditor,
@@ -72,15 +73,15 @@ export function isComposerBodyMention(
   return SlateElement.isElement(node) && node.type === "mention";
 }
 
-export function insertMention(editor: SlateEditor, userId: string) {
-  const mention: ComposerBodyMention = {
+export function insertMention(editor: SlateEditor, mention: MentionData) {
+  const mentionNode: ComposerBodyMention = {
     type: "mention",
-    id: userId,
+    ...mention,
     children: [{ text: "" }],
   };
 
   // Insert the mention
-  SlateTransforms.insertNodes(editor, mention);
+  SlateTransforms.insertNodes(editor, mentionNode);
   SlateTransforms.move(editor);
 
   const afterCharacter = editor.selection

--- a/packages/liveblocks-react-ui/src/types.ts
+++ b/packages/liveblocks-react-ui/src/types.ts
@@ -1,4 +1,4 @@
-import type { CommentAttachment } from "@liveblocks/core";
+import type { CommentAttachment, Relax } from "@liveblocks/core";
 import type { ComponentPropsWithoutRef, ElementType } from "react";
 
 export type Direction = "ltr" | "rtl";
@@ -43,8 +43,11 @@ export type ComposerBodyCustomLink = {
   children: ComposerBodyText[];
 };
 
-export type ComposerBodyMention = {
+export type ComposerBodyMention = Relax<ComposerBodyUserMention>;
+
+type ComposerBodyUserMention = {
   type: "mention";
+  kind: "user";
   id: string;
   children: [ComposerBodyEmptyText];
 };

--- a/packages/liveblocks-react/src/__tests__/useMentionSuggestions.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMentionSuggestions.test.tsx
@@ -9,6 +9,13 @@ import { act, createContextsForTest } from "./_utils";
 async function defaultResolveMentionSuggestions({
   text,
 }: ResolveMentionSuggestionsArgs) {
+  return text.split("").map((id) => ({ kind: "user" as const, id }));
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+async function legacyResolveMentionSuggestions({
+  text,
+}: ResolveMentionSuggestionsArgs) {
   return text.split("");
 }
 
@@ -47,7 +54,11 @@ describe("useMentionSuggestions", () => {
       expect(result.current.mentionSuggestions).not.toBeUndefined()
     );
 
-    expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"]);
+    expect(result.current.mentionSuggestions).toEqual([
+      { kind: "user", id: "a" },
+      { kind: "user", id: "b" },
+      { kind: "user", id: "c" },
+    ]);
 
     unmount();
   });
@@ -74,18 +85,34 @@ describe("useMentionSuggestions", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
-    expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"]);
+    expect(result.current.mentionSuggestions).toEqual([
+      { kind: "user", id: "a" },
+      { kind: "user", id: "b" },
+      { kind: "user", id: "c" },
+    ]);
 
     rerender({ text: "123" });
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["1", "2", "3"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "1" },
+        { kind: "user", id: "2" },
+        { kind: "user", id: "3" },
+      ])
     );
 
-    expect(result.current.mentionSuggestions).toEqual(["1", "2", "3"]);
+    expect(result.current.mentionSuggestions).toEqual([
+      { kind: "user", id: "1" },
+      { kind: "user", id: "2" },
+      { kind: "user", id: "3" },
+    ]);
 
     unmount();
   });
@@ -94,7 +121,8 @@ describe("useMentionSuggestions", () => {
     const roomId = nanoid();
 
     const resolveMentionSuggestions = jest.fn(
-      ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
+      ({ text }: ResolveMentionSuggestionsArgs) =>
+        text.split("").map((id) => ({ kind: "user" as const, id }))
     );
     const {
       room: { RoomProvider },
@@ -115,7 +143,11 @@ describe("useMentionSuggestions", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
     expect(resolveMentionSuggestions).toHaveBeenCalledWith({
@@ -130,7 +162,8 @@ describe("useMentionSuggestions", () => {
     const roomId = nanoid();
 
     const resolveMentionSuggestions = jest.fn(
-      ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
+      ({ text }: ResolveMentionSuggestionsArgs) =>
+        text.split("").map((id) => ({ kind: "user" as const, id }))
     );
     const {
       room: { RoomProvider },
@@ -151,20 +184,32 @@ describe("useMentionSuggestions", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
     rerender({ text: "123" });
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["1", "2", "3"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "1" },
+        { kind: "user", id: "2" },
+        { kind: "user", id: "3" },
+      ])
     );
 
     // "abc" was already resolved so resolveMentionSuggestions should not be called again
     rerender({ text: "abc" });
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
     expect(resolveMentionSuggestions).toHaveBeenCalledTimes(2);
@@ -186,7 +231,8 @@ describe("useMentionSuggestions", () => {
     const roomId = nanoid();
 
     const resolveMentionSuggestions = jest.fn(
-      ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
+      ({ text }: ResolveMentionSuggestionsArgs) =>
+        text.split("").map((id) => ({ kind: "user" as const, id }))
     );
     const {
       client,
@@ -208,13 +254,21 @@ describe("useMentionSuggestions", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
     rerender({ text: "123" });
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["1", "2", "3"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "1" },
+        { kind: "user", id: "2" },
+        { kind: "user", id: "3" },
+      ])
     );
 
     // Invalidate all mention suggestions
@@ -223,7 +277,11 @@ describe("useMentionSuggestions", () => {
     rerender({ text: "abc" });
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
     expect(resolveMentionSuggestions).toHaveBeenCalledTimes(3);
@@ -250,7 +308,8 @@ describe("useMentionSuggestions", () => {
     const roomId = nanoid();
 
     const resolveMentionSuggestions = jest.fn(
-      ({ text }: ResolveMentionSuggestionsArgs) => text.split("")
+      ({ text }: ResolveMentionSuggestionsArgs) =>
+        text.split("").map((id) => ({ kind: "user" as const, id }))
     );
     const {
       room: { RoomProvider },
@@ -279,7 +338,11 @@ describe("useMentionSuggestions", () => {
     rerender({ text: "abc" });
 
     await waitFor(() =>
-      expect(result.current.mentionSuggestions).toEqual(["a", "b", "c"])
+      expect(result.current.mentionSuggestions).toEqual([
+        { kind: "user", id: "a" },
+        { kind: "user", id: "b" },
+        { kind: "user", id: "c" },
+      ])
     );
 
     expect(resolveMentionSuggestions).toHaveBeenCalledTimes(2);
@@ -293,6 +356,42 @@ describe("useMentionSuggestions", () => {
       text: "abc",
       roomId,
     });
+
+    unmount();
+  });
+
+  test("should still support returning string[] for backward compatibility", async () => {
+    const roomId = nanoid();
+
+    const {
+      room: { RoomProvider },
+    } = createContextsForTest({
+      resolveMentionSuggestions: legacyResolveMentionSuggestions,
+    });
+
+    const { result, unmount } = renderHook(
+      () => ({
+        mentionSuggestions: useMentionSuggestions(roomId, "abc"),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <RoomProvider id={roomId}>{children}</RoomProvider>
+        ),
+      }
+    );
+
+    expect(result.current.mentionSuggestions).toBeUndefined();
+
+    await waitFor(() =>
+      expect(result.current.mentionSuggestions).not.toBeUndefined()
+    );
+
+    // Even though the resolver returns string[], the hook should normalize to MentionData[]
+    expect(result.current.mentionSuggestions).toEqual([
+      { kind: "user", id: "a" },
+      { kind: "user", id: "b" },
+      { kind: "user", id: "c" },
+    ]);
 
     unmount();
   });

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -34,7 +34,7 @@ import {
   createNotificationSettings,
   DefaultMap,
   DerivedSignal,
-  getMentionedIdsFromCommentBody,
+  getMentionsFromCommentBody,
   getSubscriptionKey,
   kInternal,
   MutableSignal,
@@ -2420,9 +2420,12 @@ function isThreadParticipant<M extends BaseMetadata>(
       break;
     }
 
-    const mentionedIds = getMentionedIdsFromCommentBody(comment.body);
+    const mentions = getMentionsFromCommentBody(
+      comment.body,
+      (mention) => mention.kind === "user" && mention.id === userId
+    );
 
-    if (mentionedIds.includes(userId)) {
+    if (mentions.length > 0) {
       isParticipant = true;
 
       break;

--- a/packages/liveblocks-react/src/use-mention-suggestions.ts
+++ b/packages/liveblocks-react/src/use-mention-suggestions.ts
@@ -15,21 +15,15 @@ const MENTION_SUGGESTIONS_DEBOUNCE = 500;
  * but to support multiple mention kinds (user, group, etc), they're now
  * typed as `MentionData[]`.
  */
-function normalizeMentionSuggestions(
-  suggestions: string[] | MentionData[]
+function normalizeMentionSuggestions<T extends string[] | MentionData[]>(
+  suggestions: T
 ): MentionData[] {
-  if (suggestions.length === 0) {
-    return [];
-  }
-
-  if (typeof suggestions[0] === "string") {
-    return (suggestions as string[]).map((id) => ({
-      kind: "user" as const,
-      id,
-    }));
-  }
-
-  return suggestions as MentionData[];
+  return suggestions.map(
+    (suggestion): MentionData =>
+      typeof suggestion === "string"
+        ? { kind: "user" as const, id: suggestion }
+        : suggestion
+  );
 }
 
 /**

--- a/starter-kits/nextjs-starter-kit/app/api/notifications/email/textMentionEmail.tsx
+++ b/starter-kits/nextjs-starter-kit/app/api/notifications/email/textMentionEmail.tsx
@@ -59,9 +59,7 @@ export async function textMentionEmail(
 
           // `user` is the optional data returned from `resolveUsers`
           Mention: ({ element, user }) => (
-            <span style={{ color: "red" }}>
-              @{user?.name ?? element.userId}
-            </span>
+            <span style={{ color: "red" }}>@{user?.name ?? element.id}</span>
           ),
         },
       }


### PR DESCRIPTION
This PR applies all breaking changes needed for us to introduce group mentions later. It also applies a few adjacent non-breaking changes to better prepare the arrival of group mentions (e.g. introducing the `{ kind: "user", id: string }` format everywhere even if there's no other `kind` yet, adding support for returning objects instead of just IDs in `resolveMentionSuggestions` even though it's a backward-compatible change, etc.).

More context on the changes themselves: https://www.notion.so/liveblocks/Group-Mentions-1e482084c8128095a7fbec38fa54ca9f?source=copy_link#1f382084c81280b79cd9c2ce5ab8f03b

### Changes

The [updated 3.0 upgrade guide](https://github.com/liveblocks/liveblocks/pull/2440/files#diff-b0e499270e83973add7b37ebb8d6ad9f3aa7c158bb5e294a7670cc6798aab7ef) is a good human-readable outline of all changes in this PR.

For the Comments side of things, there will be a backend PR before the launch to make sure the new mention format with `kind` is accepted and existing mentions are returned with `kind: "user"`.

### To do

- [ ] The E2E tests are failing because creating a comment/thread with the new `{ type: "mention", kind: "user", id: "123" }` format isn't accepted by the backend yet