### PR TITLE
Avoid illegal dependency on React from core

### DIFF
--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -1,5 +1,4 @@
 import type { JSONSchema7 } from "json-schema";
-import type { ComponentType } from "react";
 
 import { getBearerTokenFromAuthValue } from "./api-client";
 import type { AuthValue } from "./auth-manager";
@@ -171,7 +170,7 @@ export type AiToolDefinition<
   description?: string;
   parameters: S;
   execute?: AiToolExecuteCallback<A, R>;
-  render?: ComponentType<AiToolInvocationProps<A, R>>;
+  render?: (props: AiToolInvocationProps<A, R>) => unknown;
 };
 
 export type AiOpaqueToolDefinition = AiToolDefinition<

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -1,5 +1,7 @@
 import type {
   AiToolInvocationPart,
+  AiToolInvocationProps,
+  JsonObject,
   MessageId,
   ToolResultData,
 } from "@liveblocks/core";
@@ -7,6 +9,7 @@ import { kInternal } from "@liveblocks/core";
 import { useClient } from "@liveblocks/react";
 import { useSignal } from "@liveblocks/react/_private";
 import { Slot } from "@radix-ui/react-slot";
+import type { ComponentType } from "react";
 import { forwardRef, useCallback, useMemo } from "react";
 
 import { ErrorBoundary } from "../../utils/ErrorBoundary";
@@ -70,6 +73,9 @@ function ToolInvocation({
   );
 
   if (tool === undefined || tool.render === undefined) return null;
+  const RenderFn = tool.render as ComponentType<
+    AiToolInvocationProps<JsonObject, ToolResultData>
+  >;
 
   const { type: _, ...rest } = part;
   const props = {
@@ -90,7 +96,7 @@ function ToolInvocation({
       }
     >
       <AiToolInvocationContext.Provider value={props}>
-        <tool.render {...props} />
+        <RenderFn {...props} />
       </AiToolInvocationContext.Provider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Open to better ideas for this, because now it no longer enforces that a user's render implementation actually returns valid JSX.