### PR TITLE
Add concept for `RegisterAiTool` component

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -1,17 +1,24 @@
 "use client";
 
+import { defineAiTool } from "@liveblocks/client";
 import {
   ClientSideSuspense,
   LiveblocksProvider,
   RegisterAiKnowledge,
+  RegisterAiTool,
 } from "@liveblocks/react/suspense";
-import { AiChat } from "@liveblocks/react-ui";
+import { AiChat, AiTool } from "@liveblocks/react-ui";
 
 import { useCallback, useState } from "react";
 import { Popover } from "radix-ui";
 
-function DarkModeToggle(_props: { x?: number }) {
-  const [mode, setMode] = useState<"light" | "dark">("light");
+function DarkModeSubApp(_props: { x?: number }) {
+  const [exposed, setExposed] = useState<boolean>(true);
+  const [mode, setMode] = useState<string>("light");
+
+  const toggleExposeTool = useCallback(() => {
+    setExposed((exposeTool) => !exposeTool);
+  }, []);
 
   const toggleDarkMode = useCallback(() => {
     setMode(mode === "dark" ? "light" : "dark");
@@ -19,10 +26,46 @@ function DarkModeToggle(_props: { x?: number }) {
 
   return (
     <div className="flex flex-col mx-auto px-4 max-w-4xl py-8 border-b-1">
-      <RegisterAiKnowledge
-        description="The current mode of the app"
-        value={mode}
-      />
+      <label>
+        <input
+          type="checkbox"
+          checked={exposed}
+          onChange={() => toggleExposeTool()}
+        />{" "}
+        Expose dark mode as knowledge & tool
+      </label>
+
+      {exposed ? (
+        <RegisterAiKnowledge
+          description="The current mode of the app"
+          value={mode}
+        />
+      ) : null}
+
+      {exposed ? (
+        <RegisterAiTool
+          name="changeDarkMode"
+          tool={defineAiTool()({
+            description: "Change the dark mode of the app",
+            parameters: {
+              type: "object",
+              properties: {
+                mode: {
+                  type: "string",
+                  // enum: ["light", "dark"],
+                },
+              },
+              required: ["mode"],
+              additionalProperties: false,
+            },
+            execute: ({ mode }) => {
+              setMode(mode);
+              return { ok: true, message: `Dark mode changed to ${mode}` };
+            },
+            render: () => <AiTool />,
+          })}
+        />
+      ) : null}
 
       <label>
         <input
@@ -180,7 +223,7 @@ export default function Page() {
     >
       <main className="h-screen w-full">
         <MyNickName />
-        <DarkModeToggle />
+        <DarkModeSubApp />
 
         <div className="flex flex-col px-4 max-w-4xl py-8 border-b-1">
           <div className="flex gap-4 mx-auto">

--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -12,7 +12,7 @@ import { AiChat, AiTool } from "@liveblocks/react-ui";
 import { useCallback, useState } from "react";
 import { Popover } from "radix-ui";
 
-function DarkModeSubApp(_props: { x?: number }) {
+function DarkModeToggle(_props: { x?: number }) {
   const [exposed, setExposed] = useState<boolean>(true);
   const [mode, setMode] = useState<string>("light");
 
@@ -223,7 +223,7 @@ export default function Page() {
     >
       <main className="h-screen w-full">
         <MyNickName />
-        <DarkModeSubApp />
+        <DarkModeToggle />
 
         <div className="flex flex-col px-4 max-w-4xl py-8 border-b-1">
           <div className="flex gap-4 mx-auto">

--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -14,7 +14,7 @@ import { Popover } from "radix-ui";
 
 function DarkModeToggle() {
   const [exposed, setExposed] = useState<boolean>(true);
-  const [mode, setMode] = useState<string>("light");
+  const [mode, setMode] = useState<"dark" | "light">("light");
 
   const toggleExposeTool = useCallback(() => {
     setExposed((exposeTool) => !exposeTool);
@@ -52,7 +52,7 @@ function DarkModeToggle() {
               properties: {
                 mode: {
                   type: "string",
-                  // enum: ["light", "dark"],
+                  enum: ["light", "dark"],
                 },
               },
               required: ["mode"],

--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -12,7 +12,7 @@ import { AiChat, AiTool } from "@liveblocks/react-ui";
 import { useCallback, useState } from "react";
 import { Popover } from "radix-ui";
 
-function DarkModeToggle(_props: { x?: number }) {
+function DarkModeToggle() {
   const [exposed, setExposed] = useState<boolean>(true);
   const [mode, setMode] = useState<string>("light");
 

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -925,13 +925,13 @@ export type Ai = {
     key?: string
   ) => void;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
-  registerChatTool: (
+  registerTool: (
     chatId: string,
     name: string,
     tool: AiOpaqueToolDefinition
   ) => void;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
-  unregisterChatTool: (chatId: string, tool: string) => void;
+  unregisterTool: (chatId: string, tool: string) => void;
 };
 
 /** @internal */
@@ -1346,8 +1346,8 @@ export function createAi(config: AiConfig): Ai {
       deregisterKnowledgeLayer,
       updateKnowledge,
 
-      registerChatTool: context.toolsStore.addToolDefinition,
-      unregisterChatTool: context.toolsStore.removeToolDefinition,
+      registerTool: context.toolsStore.addToolDefinition,
+      unregisterTool: context.toolsStore.removeToolDefinition,
     } satisfies Ai,
     kInternal,
     { enumerable: false }

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -383,6 +383,8 @@ function createStore_forTools() {
     }
 
     toolsByChatIdΣ.getOrCreate(chatId).getOrCreate(name).set(tool);
+
+    return () => removeToolDefinition(chatId, name);
   }
 
   function removeToolDefinition(chatId: string, name: string) {
@@ -414,7 +416,6 @@ function createStore_forTools() {
 
     getToolDefinitionΣ,
     addToolDefinition,
-    removeToolDefinition,
   };
 }
 
@@ -929,9 +930,7 @@ export type Ai = {
     chatId: string,
     name: string,
     tool: AiOpaqueToolDefinition
-  ) => void;
-  /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
-  unregisterTool: (chatId: string, tool: string) => void;
+  ) => () => void;
 };
 
 /** @internal */
@@ -1357,7 +1356,6 @@ export function createAi(config: AiConfig): Ai {
       updateKnowledge,
 
       registerTool: context.toolsStore.addToolDefinition,
-      unregisterTool: context.toolsStore.removeToolDefinition,
     } satisfies Ai,
     kInternal,
     { enumerable: false }

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -370,6 +370,11 @@ function createStore_forTools() {
     name: string,
     definition: AiOpaqueToolDefinition
   ) {
+    if (String(true)) {
+      // XXX Remove again later
+      console.warn(`👋 Getting here in addToolDefinition: ${name}`);
+    }
+
     if (!definition.execute && !definition.render) {
       throw new Error(
         "A tool definition must have an execute() function, a render() function, or both."
@@ -380,6 +385,11 @@ function createStore_forTools() {
   }
 
   function removeToolDefinition(chatId: string, toolName: string) {
+    if (String(true)) {
+      // XXX Remove again later
+      console.warn(`💨 Getting here in removeToolDefinition: ${name}`);
+    }
+
     const tools = toolsByChatIdΣ.get(chatId);
     if (tools === undefined) return;
     const tool = tools.get(toolName);

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -1253,6 +1253,8 @@ export function createAi(config: AiConfig): Ai {
     options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
   ): Promise<SetToolResultResponse> {
     const knowledge = context.knowledge.get();
+    const tools = context.toolsStore.getToolDescriptionsForChat(chatId);
+
     const resp: SetToolResultResponse = await sendClientMsgWithResponse({
       cmd: "set-tool-result",
       chatId,
@@ -1263,8 +1265,11 @@ export function createAi(config: AiConfig): Ai {
         copilotId: options?.copilotId,
         stream: options?.stream,
         timeout: options?.timeout,
+
+        // Knowledge and tools aren't coming from the options, but retrieved
+        // from the global context
         knowledge: knowledge.length > 0 ? knowledge : undefined,
-        tools: context.toolsStore.getToolDescriptionsForChat(chatId),
+        tools: tools.length > 0 ? tools : undefined,
       },
     });
     if (resp.ok) {
@@ -1310,6 +1315,8 @@ export function createAi(config: AiConfig): Ai {
         options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
       ): Promise<AskInChatResponse> => {
         const knowledge = context.knowledge.get();
+        const tools = context.toolsStore.getToolDescriptionsForChat(chatId);
+
         const resp: AskInChatResponse = await sendClientMsgWithResponse({
           cmd: "ask-in-chat",
           chatId,
@@ -1319,8 +1326,11 @@ export function createAi(config: AiConfig): Ai {
             copilotId: options?.copilotId,
             stream: options?.stream,
             timeout: options?.timeout,
+
+            // Knowledge and tools aren't coming from the options, but retrieved
+            // from the global context
             knowledge: knowledge.length > 0 ? knowledge : undefined,
-            tools: context.toolsStore.getToolDescriptionsForChat(chatId),
+            tools: tools.length > 0 ? tools : undefined,
           },
         });
         messagesStore.allowAutoExecuteToolCall(resp.targetMessage.id);

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -410,10 +410,13 @@ function createStore_forTools() {
     tool.set(undefined);
   }
 
-  function getToolDescriptionsForChat(chatId: string): AiToolDescription[] {
-    const toolsByNameΣ = toolsByChatIdΣ.get(chatId);
-    if (toolsByNameΣ === undefined) return [];
-    return Array.from(toolsByNameΣ.entries()).flatMap(([name, toolΣ]) => {
+  function getToolDescriptions(chatId: string): AiToolDescription[] {
+    const globalToolsΣ = toolsByChatIdΣ.get(kWILDCARD);
+    const scopedToolsΣ = toolsByChatIdΣ.get(chatId);
+    return Array.from([
+      ...(globalToolsΣ?.entries() ?? []),
+      ...(scopedToolsΣ?.entries() ?? []),
+    ]).flatMap(([name, toolΣ]) => {
       const tool = toolΣ.get();
       return tool
         ? [{ name, description: tool.description, parameters: tool.parameters }]
@@ -422,7 +425,7 @@ function createStore_forTools() {
   }
 
   return {
-    getToolDescriptionsForChat,
+    getToolDescriptions,
 
     getToolDefinitionΣ,
     addToolDefinition,
@@ -1262,7 +1265,7 @@ export function createAi(config: AiConfig): Ai {
     options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
   ): Promise<SetToolResultResponse> {
     const knowledge = context.knowledge.get();
-    const tools = context.toolsStore.getToolDescriptionsForChat(chatId);
+    const tools = context.toolsStore.getToolDescriptions(chatId);
 
     const resp: SetToolResultResponse = await sendClientMsgWithResponse({
       cmd: "set-tool-result",
@@ -1324,7 +1327,7 @@ export function createAi(config: AiConfig): Ai {
         options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
       ): Promise<AskInChatResponse> => {
         const knowledge = context.knowledge.get();
-        const tools = context.toolsStore.getToolDescriptionsForChat(chatId);
+        const tools = context.toolsStore.getToolDescriptions(chatId);
 
         const resp: AskInChatResponse = await sendClientMsgWithResponse({
           cmd: "ask-in-chat",

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -372,7 +372,7 @@ function createStore_forTools() {
     return toolsByChatIdΣ.getOrCreate(chatId).getOrCreate(toolName);
   }
 
-  function addToolDefinition(
+  function registerTool(
     name: string,
     tool: AiOpaqueToolDefinition,
     chatId?: string
@@ -391,13 +391,10 @@ function createStore_forTools() {
     const key = chatId ?? kWILDCARD;
     toolsByChatIdΣ.getOrCreate(key).getOrCreate(name).set(tool);
 
-    return () => removeToolDefinition(key, name);
+    return () => unregisterTool(key, name);
   }
 
-  function removeToolDefinition(
-    chatId: string | typeof kWILDCARD,
-    name: string
-  ) {
+  function unregisterTool(chatId: string | typeof kWILDCARD, name: string) {
     if (String(true)) {
       // XXX Remove again later
       console.warn(`💨 Getting here in removeToolDefinition: ${name}`);
@@ -428,7 +425,7 @@ function createStore_forTools() {
     getToolDescriptions,
 
     getToolDefinitionΣ,
-    addToolDefinition,
+    registerTool,
   };
 }
 
@@ -1368,7 +1365,7 @@ export function createAi(config: AiConfig): Ai {
       deregisterKnowledgeLayer,
       updateKnowledge,
 
-      registerTool: context.toolsStore.addToolDefinition,
+      registerTool: context.toolsStore.registerTool,
     } satisfies Ai,
     kInternal,
     { enumerable: false }

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -404,11 +404,6 @@ function createStore_forTools() {
     tool: AiOpaqueToolDefinition,
     chatId?: string
   ) {
-    if (String(true)) {
-      // XXX Remove again later
-      console.warn(`👋 Getting here in addToolDefinition: ${name}`);
-    }
-
     if (!tool.execute && !tool.render) {
       throw new Error(
         "A tool definition must have an execute() function, a render() function, or both."
@@ -422,11 +417,6 @@ function createStore_forTools() {
   }
 
   function unregisterTool(chatId: string | typeof kWILDCARD, name: string) {
-    if (String(true)) {
-      // XXX Remove again later
-      console.warn(`💨 Getting here in removeToolDefinition: ${name}`);
-    }
-
     const tools = toolsByChatIdΣ.get(chatId);
     if (tools === undefined) return;
     const tool = tools.get(name);

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -127,6 +127,16 @@ export type AiToolTypePack<
   R: R;
 };
 
+export type AskUserMessageInChatOptions = Omit<
+  AiGenerationOptions,
+  "tools" | "knowledge"
+>;
+
+export type SetToolResultOptions = Omit<
+  AiGenerationOptions,
+  "tools" | "knowledge"
+>;
+
 export type AiToolInvocationProps<
   A extends JsonObject,
   R extends ToolResultData,
@@ -453,7 +463,7 @@ function createStore_forChatMessages(
     messageId: MessageId,
     toolCallId: string,
     result: ToolResultData,
-    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
+    options?: SetToolResultOptions
   ) => Promise<SetToolResultResponse>
 ) {
   // Keeps track of all message IDs that this client instance is allowed to
@@ -916,7 +926,7 @@ export type Ai = {
           content: AiUserContentPart[];
         },
     targetMessageId: MessageId,
-    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
+    options?: AskUserMessageInChatOptions
   ) => Promise<AskInChatResponse>;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   abort: (messageId: MessageId) => Promise<AbortAiResponse>;
@@ -926,7 +936,7 @@ export type Ai = {
     messageId: MessageId,
     toolCallId: string,
     result: ToolResultData,
-    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
+    options?: SetToolResultOptions
   ) => Promise<SetToolResultResponse>;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   signals: {
@@ -1276,7 +1286,7 @@ export function createAi(config: AiConfig): Ai {
     messageId: MessageId,
     toolCallId: string,
     result: ToolResultData,
-    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
+    options?: SetToolResultOptions
   ): Promise<SetToolResultResponse> {
     const knowledge = context.knowledge.get();
     const tools = context.toolsStore.getToolDescriptions(chatId);
@@ -1338,7 +1348,7 @@ export function createAi(config: AiConfig): Ai {
               content: AiUserContentPart[];
             },
         targetMessageId: MessageId,
-        options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
+        options?: AskUserMessageInChatOptions
       ): Promise<AskInChatResponse> => {
         const knowledge = context.knowledge.get();
         const tools = context.toolsStore.getToolDescriptions(chatId);

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -107,17 +107,22 @@ export type InferFromSchema<T extends JSONSchema7> =
               T["properties"][K]
             >;
           }
-        : T extends { type: "string" }
-          ? string
-          : T extends { type: "number" }
-            ? number
-            : T extends { type: "boolean" }
-              ? boolean
-              : T extends { type: "null" }
-                ? null
-                : T extends { type: "array"; items: JSONSchema7 }
-                  ? InferFromSchema<T["items"]>[]
-                  : unknown;
+        : T extends {
+              type: "string" | "number" | "boolean";
+              enum: readonly (infer U)[];
+            }
+          ? U
+          : T extends { type: "string" }
+            ? string
+            : T extends { type: "number" }
+              ? number
+              : T extends { type: "boolean" }
+                ? boolean
+                : T extends { type: "null" }
+                  ? null
+                  : T extends { type: "array"; items: JSONSchema7 }
+                    ? InferFromSchema<T["items"]>[]
+                    : unknown;
 
 export type AiToolTypePack<
   A extends JsonObject = JsonObject,

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -372,7 +372,7 @@ function createStore_forTools() {
   ) {
     if (!definition.execute && !definition.render) {
       throw new Error(
-        "A tool definition must have an execute() function, a render property, or both."
+        "A tool definition must have an execute() function, a render() function, or both."
       );
     }
 

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -432,7 +432,7 @@ function createStore_forChatMessages(
     messageId: MessageId,
     toolCallId: string,
     result: ToolResultData,
-    options?: AiGenerationOptions
+    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
   ) => Promise<SetToolResultResponse>
 ) {
   // Keeps track of all message IDs that this client instance is allowed to
@@ -895,7 +895,7 @@ export type Ai = {
           content: AiUserContentPart[];
         },
     targetMessageId: MessageId,
-    options?: AiGenerationOptions
+    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
   ) => Promise<AskInChatResponse>;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   abort: (messageId: MessageId) => Promise<AbortAiResponse>;
@@ -905,7 +905,7 @@ export type Ai = {
     messageId: MessageId,
     toolCallId: string,
     result: ToolResultData,
-    options?: AiGenerationOptions
+    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
   ) => Promise<SetToolResultResponse>;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   signals: {
@@ -1257,7 +1257,7 @@ export function createAi(config: AiConfig): Ai {
     messageId: MessageId,
     toolCallId: string,
     result: ToolResultData,
-    options?: AiGenerationOptions
+    options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
   ): Promise<SetToolResultResponse> {
     const knowledge = context.knowledge.get();
     const resp: SetToolResultResponse = await sendClientMsgWithResponse({
@@ -1320,7 +1320,7 @@ export function createAi(config: AiConfig): Ai {
               content: AiUserContentPart[];
             },
         targetMessageId: MessageId,
-        options?: AiGenerationOptions
+        options?: AiGenerationOptions // XXX Rename to AskUserMessageInChatOptions!
       ): Promise<AskInChatResponse> => {
         const knowledge = context.knowledge.get();
         const resp: AskInChatResponse = await sendClientMsgWithResponse({

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
@@ -55,6 +55,22 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
 }
 
 {
+  expectType<{
+    mode: "dark" | "light";
+    favNumber: 3 | 7 | 13 | 42;
+  }>(
+    infer({
+      type: "object",
+      properties: {
+        mode: { type: "string", enum: ["dark", "light"] },
+        favNumber: { type: "number", enum: [3, 7, 13, 42] },
+      },
+      required: ["mode", "favNumber"],
+    })
+  );
+}
+
+{
   defineAiTool()({
     description: "List all todos",
     parameters: {

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -4,11 +4,10 @@ import type {
   CopilotId,
   MessageId,
 } from "@liveblocks/core";
-import { kInternal } from "@liveblocks/core";
 import {
   RegisterAiKnowledge,
+  RegisterAiTool,
   useAiChatMessages,
-  useClient,
 } from "@liveblocks/react";
 import { useLayoutEffect } from "@liveblocks/react/_private";
 import {
@@ -149,9 +148,6 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
     const isScrollIndicatorVisible =
       isLoading || error ? false : !isScrollAtBottom;
 
-    const client = useClient();
-    const ai = client[kInternal].ai;
-
     const [lastSentMessageId, setLastSentMessageId] =
       useState<MessageId | null>(null);
 
@@ -160,18 +156,6 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
       () => containerRef.current,
       []
     );
-
-    // Register the provided tools to the chat on mount and unregister them on unmount
-    useEffect(() => {
-      Object.entries(tools).map(([key, value]) =>
-        ai.registerChatTool(chatId, key, value)
-      );
-      return () => {
-        Object.entries(tools).map(([key]) =>
-          ai.unregisterChatTool(chatId, key)
-        );
-      };
-    }, [ai, chatId, tools]);
 
     const scrollToBottomCallbackRef =
       useRef<(behavior: "instant" | "smooth") => void>(undefined);
@@ -212,6 +196,11 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
               />
             ))
           : null}
+
+        {Object.entries(tools).map(([name, tool]) => (
+          <RegisterAiTool key={name} chatId={chatId} name={name} tool={tool} />
+        ))}
+
         <div className="lb-ai-chat-content">
           {isLoading ? (
             <Loading />

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -47,7 +47,7 @@ function ToolInvocation({
 }) {
   const client = useClient();
   const ai = client[kInternal].ai;
-  const tool = useSignal(ai.signals.getToolDefinitionΣ(chatId, part.toolName));
+  const tool = useSignal(ai.signals.getToolΣ(part.toolName, chatId));
 
   const respond = useCallback(
     (result: ToolResultData) => {

--- a/packages/liveblocks-react/src/ai.tsx
+++ b/packages/liveblocks-react/src/ai.tsx
@@ -1,4 +1,7 @@
-import type { AiKnowledgeSource } from "@liveblocks/core";
+import type {
+  AiKnowledgeSource,
+  AiOpaqueToolDefinition,
+} from "@liveblocks/core";
 import { kInternal, nanoid } from "@liveblocks/core";
 import { memo, useEffect, useId, useState } from "react";
 
@@ -74,38 +77,26 @@ export const RegisterAiKnowledge = memo(function RegisterAiKnowledge(
 
 export type RegisterAiToolProps = {
   name: string;
+  tool: AiOpaqueToolDefinition;
+
+  // XXX Remove this chatId prop?
+  chatId: string;
 };
 
-export const RegisterAiTool = memo(function RegisterAiTool(props: {
-  name: string;
-}) {
-  console.error(`TODO: Register tool named "${props.name}" here`);
-  // const layerId = useId();
-  // const ai = useAi();
-  // const { description, value } = props;
-  //
-  // const [layerKey, setLayerKey] = useState<
-  //   ReturnType<typeof ai.registerKnowledgeLayer> | undefined
-  // >();
-  //
-  // // Executes at mount / unmount
-  // useEffect(() => {
-  //   const layerKey = ai.registerKnowledgeLayer(layerId);
-  //   setLayerKey(layerKey);
-  //   return () => {
-  //     ai.deregisterKnowledgeLayer(layerKey);
-  //     setLayerKey(undefined);
-  //   };
-  // }, [ai, layerId]);
-  //
-  // // Executes every render (if the props have changed)
-  // const randomKey = useRandom();
-  // const knowledgeKey = props.id ?? randomKey;
-  // useEffect(() => {
-  //   if (layerKey !== undefined) {
-  //     ai.updateKnowledge(layerKey, { description, value }, knowledgeKey);
-  //   }
-  // }, [ai, layerKey, knowledgeKey, description, value]);
+export const RegisterAiTool = memo(function RegisterAiTool({
+  chatId,
+  name,
+  tool,
+}: RegisterAiToolProps) {
+  // Register the provided tools to the chat on mount and unregister them on unmount
+  const client = useClient();
+  const ai = client[kInternal].ai;
+  useEffect(() => {
+    ai.registerChatTool(chatId, name, tool);
+    return () => {
+      ai.unregisterChatTool(chatId, name);
+    };
+  }, [ai, chatId, name, tool]);
 
   return null;
 });

--- a/packages/liveblocks-react/src/ai.tsx
+++ b/packages/liveblocks-react/src/ai.tsx
@@ -69,3 +69,37 @@ export const RegisterAiKnowledge = memo(function RegisterAiKnowledge(
 
   return null;
 });
+
+export const RegisterAiTool = memo(function RegisterAiTool(props: {
+  name: string;
+}) {
+  console.error(`TODO: Register tool named "${props.name}" here`);
+  // const layerId = useId();
+  // const ai = useAi();
+  // const { description, value } = props;
+  //
+  // const [layerKey, setLayerKey] = useState<
+  //   ReturnType<typeof ai.registerKnowledgeLayer> | undefined
+  // >();
+  //
+  // // Executes at mount / unmount
+  // useEffect(() => {
+  //   const layerKey = ai.registerKnowledgeLayer(layerId);
+  //   setLayerKey(layerKey);
+  //   return () => {
+  //     ai.deregisterKnowledgeLayer(layerKey);
+  //     setLayerKey(undefined);
+  //   };
+  // }, [ai, layerId]);
+  //
+  // // Executes every render (if the props have changed)
+  // const randomKey = useRandom();
+  // const knowledgeKey = props.id ?? randomKey;
+  // useEffect(() => {
+  //   if (layerKey !== undefined) {
+  //     ai.updateKnowledge(layerKey, { description, value }, knowledgeKey);
+  //   }
+  // }, [ai, layerKey, knowledgeKey, description, value]);
+
+  return null;
+});

--- a/packages/liveblocks-react/src/ai.tsx
+++ b/packages/liveblocks-react/src/ai.tsx
@@ -92,10 +92,7 @@ export const RegisterAiTool = memo(function RegisterAiTool({
   const client = useClient();
   const ai = client[kInternal].ai;
   useEffect(() => {
-    ai.registerTool(chatId, name, tool);
-    return () => {
-      ai.unregisterTool(chatId, name);
-    };
+    return ai.registerTool(chatId, name, tool);
   }, [ai, chatId, name, tool]);
 
   return null;

--- a/packages/liveblocks-react/src/ai.tsx
+++ b/packages/liveblocks-react/src/ai.tsx
@@ -12,6 +12,15 @@ function useRandom() {
   return useState(nanoid)[0];
 }
 
+export type RegisterAiKnowledgeProps = AiKnowledgeSource & {
+  /**
+   * An optional unique key for this knowledge source. If multiple components
+   * register knowledge under the same key, the last one to mount takes
+   * precedence.
+   */
+  id?: string;
+};
+
 /**
  * Make knowledge about your application state available to any AI used in
  * a chat or a one-off request.
@@ -31,14 +40,7 @@ function useRandom() {
  * It can choose to use or ignore this knowledge in its responses.
  */
 export const RegisterAiKnowledge = memo(function RegisterAiKnowledge(
-  props: AiKnowledgeSource & {
-    /**
-     * An optional unique key for this knowledge source. If multiple components
-     * register knowledge under the same key, the last one to mount takes
-     * precedence.
-     */
-    id?: string;
-  }
+  props: RegisterAiKnowledgeProps
 ) {
   const layerId = useId();
   const ai = useAi();
@@ -69,6 +71,10 @@ export const RegisterAiKnowledge = memo(function RegisterAiKnowledge(
 
   return null;
 });
+
+export type RegisterAiToolProps = {
+  name: string;
+};
 
 export const RegisterAiTool = memo(function RegisterAiTool(props: {
   name: string;

--- a/packages/liveblocks-react/src/ai.tsx
+++ b/packages/liveblocks-react/src/ai.tsx
@@ -79,8 +79,12 @@ export type RegisterAiToolProps = {
   name: string;
   tool: AiOpaqueToolDefinition;
 
-  // XXX Remove this chatId prop?
-  chatId: string;
+  /**
+   * When provided, the tool will only be available for this chatId. If not
+   * provided, this tool will globally be made available to any AiChat
+   * instance.
+   */
+  chatId?: string;
 };
 
 export const RegisterAiTool = memo(function RegisterAiTool({
@@ -92,7 +96,7 @@ export const RegisterAiTool = memo(function RegisterAiTool({
   const client = useClient();
   const ai = client[kInternal].ai;
   useEffect(() => {
-    return ai.registerTool(chatId, name, tool);
+    return ai.registerTool(name, tool, chatId);
   }, [ai, chatId, name, tool]);
 
   return null;

--- a/packages/liveblocks-react/src/ai.tsx
+++ b/packages/liveblocks-react/src/ai.tsx
@@ -92,9 +92,9 @@ export const RegisterAiTool = memo(function RegisterAiTool({
   const client = useClient();
   const ai = client[kInternal].ai;
   useEffect(() => {
-    ai.registerChatTool(chatId, name, tool);
+    ai.registerTool(chatId, name, tool);
     return () => {
-      ai.unregisterChatTool(chatId, name);
+      ai.unregisterTool(chatId, name);
     };
   }, [ai, chatId, name, tool]);
 

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -16,6 +16,7 @@ export type { Json, JsonObject } from "@liveblocks/client";
 export { shallow, isNotificationChannelEnabled } from "@liveblocks/client";
 
 // Export all the top-level hooks
+export type { RegisterAiKnowledgeProps, RegisterAiToolProps } from "./ai";
 export { RegisterAiKnowledge, RegisterAiTool } from "./ai";
 export { ClientContext, RoomContext, useClient } from "./contexts";
 export {

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -16,7 +16,7 @@ export type { Json, JsonObject } from "@liveblocks/client";
 export { shallow, isNotificationChannelEnabled } from "@liveblocks/client";
 
 // Export all the top-level hooks
-export { RegisterAiKnowledge } from "./ai";
+export { RegisterAiKnowledge, RegisterAiTool } from "./ai";
 export { ClientContext, RoomContext, useClient } from "./contexts";
 export {
   createLiveblocksContext,

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -35,7 +35,7 @@ import {
   useSyncExternalStore,
 } from "react";
 
-import { RegisterAiKnowledge } from "./ai";
+import { RegisterAiKnowledge, RegisterAiTool } from "./ai";
 import { config } from "./config";
 import {
   ClientContext,
@@ -1190,6 +1190,7 @@ export function createSharedContext<U extends BaseUserMeta>(
       useErrorListener,
       useSyncStatus,
       RegisterAiKnowledge,
+      RegisterAiTool,
     },
     suspense: {
       useClient,
@@ -1200,6 +1201,7 @@ export function createSharedContext<U extends BaseUserMeta>(
       useErrorListener,
       useSyncStatus,
       RegisterAiKnowledge,
+      RegisterAiTool,
     },
   };
 }

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -17,7 +17,7 @@ export { shallow, isNotificationChannelEnabled } from "@liveblocks/client";
 
 // Export all the top-level hooks
 export { ClientContext, RoomContext, useClient } from "./contexts";
-export { RegisterAiKnowledge } from "./ai";
+export { RegisterAiKnowledge, RegisterAiTool } from "./ai";
 export {
   LiveblocksProvider,
   useInboxNotificationThread,

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -377,6 +377,8 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
         id?: string;
       }
     >;
+
+    RegisterAiTool: ComponentType<{ name: string }>;
   };
 
   suspense: {
@@ -461,6 +463,8 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
         id?: string;
       }
     >;
+
+    RegisterAiTool: ComponentType<{ name: string }>;
   };
 };
 

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -15,7 +15,6 @@ import type {
 } from "@liveblocks/client";
 import type {
   AiChat,
-  AiKnowledgeSource,
   AsyncError,
   AsyncLoading,
   AsyncResult,
@@ -49,6 +48,8 @@ import type {
   PropsWithChildren,
   ReactNode,
 } from "react";
+
+import type { RegisterAiKnowledgeProps, RegisterAiToolProps } from "../ai";
 
 export type UseSyncStatusOptions = {
   /**
@@ -367,18 +368,9 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * By unmounting this component, the AI will no longer have access to it.
      * It can choose to use or ignore this knowledge in its responses.
      */
-    RegisterAiKnowledge: ComponentType<
-      AiKnowledgeSource & {
-        /**
-         * An optional unique key for this knowledge source. If multiple components
-         * register knowledge under the same key, the last one to mount takes
-         * precedence.
-         */
-        id?: string;
-      }
-    >;
+    RegisterAiKnowledge: ComponentType<RegisterAiKnowledgeProps>;
 
-    RegisterAiTool: ComponentType<{ name: string }>;
+    RegisterAiTool: ComponentType<RegisterAiToolProps>;
   };
 
   suspense: {
@@ -453,18 +445,9 @@ export type SharedContextBundle<U extends BaseUserMeta> = {
      * By unmounting this component, the AI will no longer have access to it.
      * It can choose to use or ignore this knowledge in its responses.
      */
-    RegisterAiKnowledge: ComponentType<
-      AiKnowledgeSource & {
-        /**
-         * An optional unique key for this knowledge source. If multiple components
-         * register knowledge under the same key, the last one to mount takes
-         * precedence.
-         */
-        id?: string;
-      }
-    >;
+    RegisterAiKnowledge: ComponentType<RegisterAiKnowledgeProps>;
 
-    RegisterAiTool: ComponentType<{ name: string }>;
+    RegisterAiTool: ComponentType<RegisterAiToolProps>;
   };
 };
 


### PR DESCRIPTION
Like we have support for `<RegisterAiKnowledge />`, this PR adds a similar `<RegisterAiTool />` helper.

The current API looks like this:

```tsx
// Globally
<RegisterAiTool name="listTodos" tool={defineAiTool()({ /* ... */ })} />

// Scoped to a single chatId
<RegisterAiTool name="listTodos" tool={defineAiTool()({ /* ... */ })} chatId="my-chat" />
```

### Behavior

The behavior should be pretty intuitive:

1. If you provide a `chatId`, then it will only be made available to that `AiChat` instance. Other AiChat instances for different chat IDs will not have access to these tools.
2. If you do not provide a `chatId`, then it will be made available to all `AiChat` instances.
3. Mounting this component registers the tool.
4. Unmounting it removes the tool.
5. Registering tools via `<AiChat chatId={chatId} tools={{ ... }} />` is also still possible. Internally it just uses this component to register them now (scoped to its `chatId`).

If there are existing tool invocations in a chat but the AiChat instance doesn't have access to the tool because it isn't registered, or it only registered for another chat ID, then the chat will not render anything. (This is the normal behavior for missing/unknown tool invocations.)

### The `tool={}` prop

Notice how I had to use a `tool={defineAiTool()({ ... })}` prop here unfortunately for now 😞

For the same type inference reasons that we need the double-parens approach to `defineAiTool()()`, I could not directly offer this API:

```tsx
// ❌ Not possible unless we would sacrifice type inference support
<RegisterAiTool
  name="listTodos"
  description="List todos"
  execute={() => {}}
  render={() => {}}
  />
```
