### PR TITLE
Expose way(s) to control when `AiTool` is collapsed/expanded

### DIFF
--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -205,10 +205,9 @@ export const AiTool = Object.assign(
         [kInternal]: { execute },
       } = useAiToolInvocationContext();
       const [isCollapsed, onCollapsedChange] = useControllableState(
-        false,
+        defaultCollapsed ?? false,
         controlledCollapsed,
-        controlledOnCollapsedChange,
-        defaultCollapsed
+        controlledOnCollapsedChange
       );
       // TODO: This check won't work for cases like:
       //         <AiTool>

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -39,19 +39,19 @@ export interface AiToolProps
   children?: ReactNode;
 
   /**
-   * Whether the collapsible content is initially open. Setting a value will make it uncontrolled.
+   * Whether the content is initially collapsed. Setting a value will make it uncontrolled.
    */
-  defaultOpen?: boolean;
+  defaultCollapsed?: boolean;
 
   /**
-   * Whether the collapsible content is currently open. Setting a value will make it controlled, use `onOpenChange` to.
+   * Whether the content is currently collapsed. Setting a value will make it controlled, use `onCollapsedChange` to update it.
    */
-  open?: boolean;
+  collapsed?: boolean;
 
   /**
-   * The event handler called when the collapsible content is opened or closed.
+   * The event handler called when the content is collapsed or expanded.
    */
-  onOpenChange?: (open: boolean) => void;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
 export type AiToolIconProps = ComponentProps<"div">;
@@ -191,9 +191,9 @@ export const AiTool = Object.assign(
         children,
         title,
         icon,
-        defaultOpen,
-        open: controlledOpen,
-        onOpenChange: controlledOnOpenChange,
+        defaultCollapsed,
+        collapsed: controlledCollapsed,
+        onCollapsedChange: controlledOnCollapsedChange,
         className,
         ...props
       },
@@ -204,11 +204,11 @@ export const AiTool = Object.assign(
         toolName,
         [kInternal]: { execute },
       } = useAiToolInvocationContext();
-      const [isOpen, onOpenChange] = useControllableState(
-        true,
-        controlledOpen,
-        controlledOnOpenChange,
-        defaultOpen
+      const [isCollapsed, onCollapsedChange] = useControllableState(
+        false,
+        controlledCollapsed,
+        controlledOnCollapsedChange,
+        defaultCollapsed
       );
       // TODO: This check won't work for cases like:
       //         <AiTool>
@@ -222,14 +222,23 @@ export const AiTool = Object.assign(
         return title ?? prettifyString(toolName);
       }, [title, toolName]);
 
+      // `AiTool` uses "collapsed" instead of "open" (like the `Composer` component) because "open"
+      // makes sense next to something called "Collapsible" but less so for something called "AiTool".
+      const handleCollapsibleOpenChange = useCallback(
+        (open: boolean) => {
+          onCollapsedChange(!open);
+        },
+        [onCollapsedChange]
+      );
+
       return (
         <Collapsible.Root
           ref={forwardedRef}
           className={classNames("lb-collapsible lb-ai-tool", className)}
           {...props}
           // Regardless of the controlled/uncontrolled props, the collapsible is closed if there's no content.
-          open={hasContent ? isOpen : false}
-          onOpenChange={onOpenChange}
+          open={hasContent ? !isCollapsed : false}
+          onOpenChange={handleCollapsibleOpenChange}
           disabled={!hasContent}
         >
           <Collapsible.Trigger className="lb-collapsible-trigger lb-ai-tool-header">

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -668,10 +668,8 @@ export const Composer = forwardRef(
     const isEmojiPickerOpenRef = useRef(false);
     const $ = useOverrides(overrides);
     const [isCollapsed, onCollapsedChange] = useControllableState(
-      // If the composer is neither controlled nor uncontrolled, it defaults to controlled as uncollapsed.
-      controlledCollapsed === undefined && defaultCollapsed === undefined
-        ? false
-        : controlledCollapsed,
+      false,
+      controlledCollapsed,
       controlledOnCollapsedChange,
       defaultCollapsed
     );

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -668,10 +668,9 @@ export const Composer = forwardRef(
     const isEmojiPickerOpenRef = useRef(false);
     const $ = useOverrides(overrides);
     const [isCollapsed, onCollapsedChange] = useControllableState(
-      false,
+      defaultCollapsed ?? false,
       controlledCollapsed,
-      controlledOnCollapsedChange,
-      defaultCollapsed
+      controlledOnCollapsedChange
     );
 
     const canCommentFallback = useSyncExternalStore(

--- a/packages/liveblocks-react-ui/src/primitives/Collapsible/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Collapsible/index.tsx
@@ -40,10 +40,9 @@ const CollapsibleRoot = forwardRef<HTMLDivElement, RootProps>(
     forwardedRef
   ) => {
     const [isOpen, onOpenChange] = useControllableState(
-      true,
+      defaultOpen ?? true,
       controlledOpen,
-      controlledOnOpenChange,
-      defaultOpen
+      controlledOnOpenChange
     );
     const Component = asChild ? Slot : "div";
     const id = useId();

--- a/packages/liveblocks-react-ui/src/primitives/Collapsible/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Collapsible/index.tsx
@@ -40,10 +40,8 @@ const CollapsibleRoot = forwardRef<HTMLDivElement, RootProps>(
     forwardedRef
   ) => {
     const [isOpen, onOpenChange] = useControllableState(
-      // If the collapsible is neither controlled nor uncontrolled, it defaults to controlled as open.
-      controlledOpen === undefined && defaultOpen === undefined
-        ? true
-        : controlledOpen,
+      true,
+      controlledOpen,
       controlledOnOpenChange,
       defaultOpen
     );

--- a/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
@@ -2,11 +2,29 @@ import { console } from "@liveblocks/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useControllableState<T>(
+  /**
+   * The value used as an uncontrolled fallback if neither `value` nor `defaultValue` are provided.
+   */
+  fallbackValue: T,
+
+  /**
+   * The controlled value.
+   */
   value?: T,
+
+  /**
+   * The event handler called when the value changes, if the value is controlled.
+   */
   onChange?: (value: T) => void,
+
+  /**
+   * The default uncontrolled value.
+   */
   defaultValue?: T
 ) {
-  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const [uncontrolledValue, setUncontrolledValue] = useState(
+    defaultValue ?? fallbackValue
+  );
   const isControlled = value !== undefined;
   const wasControlled = useRef(isControlled);
 

--- a/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
@@ -139,12 +139,7 @@ export function useSemiControllableState<T>(
   /**
    * The event handler called when the uncontrolled value changes.
    */
-  onChange: ((value: T) => void) | undefined,
-
-  /**
-   * An optional comparison function.
-   */
-  isEqual: (a: T, b: T) => boolean = Object.is
+  onChange: ((value: T) => void) | undefined
 ) {
   const [uncontrolledValue, setUncontrolledValue] = useState(value);
   const lastChange = useRef<"uncontrolled" | "controlled">("controlled");
@@ -153,7 +148,7 @@ export function useSemiControllableState<T>(
 
   // Listen to `value` changes during the render phase to avoid
   // having to always sync `uncontrolledValue` on every change.
-  if (!isEqual(lastValue.current, value)) {
+  if (!Object.is(lastValue.current, value)) {
     lastValue.current = value;
     lastChange.current = "controlled";
   }

--- a/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
@@ -3,28 +3,24 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useControllableState<T>(
   /**
-   * The value used as an uncontrolled fallback if neither `value` nor `defaultValue` are provided.
+   * The default uncontrolled value.
    */
-  fallbackValue: T,
+  defaultValue: T,
 
   /**
    * The controlled value.
+   *
+   * If `undefined`, the returned value is uncontrolled.
+   * If set, this controlled value is used and returned as is.
    */
-  value?: T,
+  value: T | undefined,
 
   /**
-   * The event handler called when the value changes, if the value is controlled.
+   * The event handler called when the value changes.
    */
-  onChange?: (value: T) => void,
-
-  /**
-   * The default uncontrolled value.
-   */
-  defaultValue?: T
+  onChange: ((value: T) => void) | undefined
 ) {
-  const [uncontrolledValue, setUncontrolledValue] = useState(
-    defaultValue ?? fallbackValue
-  );
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
   const isControlled = value !== undefined;
   const wasControlled = useRef(isControlled);
 

--- a/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
+++ b/packages/liveblocks-react-ui/src/utils/use-controllable-state.ts
@@ -1,6 +1,11 @@
 import { console } from "@liveblocks/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useRerender } from "./use-rerender";
+
+/**
+ * Hold a state in a "controlled" or "uncontrolled" way.
+ */
 export function useControllableState<T>(
   /**
    * The default uncontrolled value.
@@ -31,7 +36,7 @@ export function useControllableState<T>(
     ) {
       console.warn(
         `A component is changing from ${
-          wasControlled ? "controlled" : "uncontrolled"
+          wasControlled.current ? "controlled" : "uncontrolled"
         } to ${isControlled ? "controlled" : "uncontrolled"}.`
       );
     }
@@ -53,6 +58,123 @@ export function useControllableState<T>(
     },
     [isControlled, onChange]
   );
+
+  return [currentValue, setValue] as const;
+}
+
+/**
+ * @experimental
+ *
+ * Hold a value in a "semi-controlled" way: a controlled value that can be
+ * overridden by uncontrolled changes in a "most recent wins" way.
+ *
+ * @example
+ *
+ * A `Collapsible` component uses `useSemiControllableState` to control
+ * its "open" state, it accepts two optional props: `open` and `onOpenChange`.
+ *
+ * Internally, it passes them to `useSemiControllableState`:
+ *
+ * ```tsx
+ * const [isOpen, setIsOpen] = useSemiControllableState(
+ *   open ?? true, // Defaults to `true` if `open` is not provided
+ *   onOpenChange
+ * );
+ *
+ * // ... `isOpen` and `setIsOpen` are used in the component's implementation ...
+ * ```
+ *
+ * And finally here's how it could be used in a "semi-controlled" way:
+ *
+ * ```tsx
+ * const status: `"loading" | "success" | "error"`;
+ *
+ * <Collapsible open={status === "success"} />
+ * ```
+ *
+ * Like with a traditional controlled value, the collapsible will start closed
+ * and will automatically open when `status` becomes `"success"`.
+ *
+ * But unlike with a traditional controlled value, the collapsible can still
+ * open/close when it's clicked on by the user, overriding `open={status === "success"}`.
+ *
+ * It's possible to use it as a traditional uncontrolled value:
+ *
+ * ```tsx
+ * const defaultOpen = false;
+ *
+ * <Collapsible open={defaultOpen} />
+ * ```
+ *
+ * Or to sync the uncontrolled value like with a traditional uncontrolled value:
+ *
+ * ```tsx
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * // `isOpen` is synced with the uncontrolled value when the user clicks
+ * <Collapsible open={isOpen} onOpenChange={setIsOpen} />
+ * ```
+ *
+ * But with the caveat that it will still be possible to change the
+ * uncontrolled value:
+ *
+ * ```tsx
+ * const open = false;
+ *
+ * // Clicking on the collapsible will still open/close it, unlike with a
+ * // traditional controlled value.
+ * <Collapsible open={open} />
+ * ```
+ */
+export function useSemiControllableState<T>(
+  /**
+   * The controlled value.
+   *
+   * When this value changes, it becomes the current value.
+   * But unlike a traditional controlled value, it can be overridden by
+   * uncontrolled changes.
+   */
+  value: T,
+
+  /**
+   * The event handler called when the uncontrolled value changes.
+   */
+  onChange: ((value: T) => void) | undefined,
+
+  /**
+   * An optional comparison function.
+   */
+  isEqual: (a: T, b: T) => boolean = Object.is
+) {
+  const [uncontrolledValue, setUncontrolledValue] = useState(value);
+  const lastChange = useRef<"uncontrolled" | "controlled">("controlled");
+  const lastValue = useRef(value);
+  const [rerender] = useRerender();
+
+  // Listen to `value` changes during the render phase to avoid
+  // having to always sync `uncontrolledValue` on every change.
+  if (!isEqual(lastValue.current, value)) {
+    lastValue.current = value;
+    lastChange.current = "controlled";
+  }
+
+  const setValue = useCallback(
+    (value: T) => {
+      lastChange.current = "uncontrolled";
+      setUncontrolledValue(value);
+
+      // If the new `uncontrolledValue` is the same as last time it was the "last change",
+      // `setUncontrolledValue` won't trigger a re-render, but the fact that it's becoming
+      // uncontrolled again is a change that needs a re-render.
+      rerender();
+
+      onChange?.(value);
+    },
+    [onChange, rerender]
+  );
+
+  const currentValue =
+    lastChange.current === "uncontrolled" ? uncontrolledValue : value;
 
   return [currentValue, setValue] as const;
 }


### PR DESCRIPTION
I started this PR wanting to expose `open`/`defaultOpen`/`onOpenChange` on `AiTool` to control its internal `Collapsible`, but I went through 2 questions about that:

### ~~Question 1: Naming~~
I remembered that on the `Composer` component, I opted for the opposite of "open" with "collapsed" at the time, the main reason being that "open" is clear when there's the name "collapsible" next to it (that's why [most](https://ui.shadcn.com/docs/components/collapsible) [UI](https://www.radix-ui.com/primitives/docs/components/collapsible) [libraries](https://base-ui.com/react/components/collapsible) use it), but less so when it's next to "AiTool" or "Composer".

Does that make sense?

**Answer:** We're going with "collapsed".

### ~~Question 2: A possible simpler/higher-level API~~

As I started using the props myself, I realized that we already have some state with the `status` value and it could make building a "AiTool starts expanded to show details about what it's doing, then collapses when it's done" behavior really easy.

```
<AiChat
  tools={{
    slowTool: defineAiTool()({
      parameters: { /* ... */ },
      execute: async ({ id }) => {
          await wait(5000)
          return { ok: true };
       },
       render: ({ status }) => (
          <AiTool collapsed={status === "executed"}>
             <AiTool.Inspector />
          </AiTool>
       ),
    }),
  }}
/>
```

The issue with that is that `collapsed` is a controlled value, and because `status` won't change and isn't tied to `onCollapsedChange`, this `AiTool` won't expand on click after it's collapsed. What if we would make a mixed API between controlled and uncontrolled where a prop like `collapsed` would collapse/expand when it changes, **but** we would internally also collapse/expand based on clicks. Is that too weird? Or confusing? 

**Answer:** This PR implements this idea of `collapsed` being "semi-controlled".