### PR TITLE
Add missing peer dependency on `@liveblocks/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17597,6 +17597,8 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -38492,12 +38494,14 @@
         "@liveblocks/eslint-config": "*",
         "@liveblocks/jest-config": "*",
         "@liveblocks/query-parser": "^0.1.1",
-        "@types/json-schema": "^7.0.15",
         "@types/ws": "^8.5.10",
         "dotenv": "^16.4.5",
         "eslint-plugin-rulesdir": "^0.2.2",
         "msw": "^1.3.5",
         "ws": "^8.17.1"
+      },
+      "peerDependencies": {
+        "@types/json-schema": "^7"
       }
     },
     "packages/liveblocks-emails": {

--- a/packages/liveblocks-core/package.json
+++ b/packages/liveblocks-core/package.json
@@ -50,12 +50,14 @@
     "@liveblocks/eslint-config": "*",
     "@liveblocks/jest-config": "*",
     "@liveblocks/query-parser": "^0.1.1",
-    "@types/json-schema": "^7.0.15",
     "@types/ws": "^8.5.10",
     "dotenv": "^16.4.5",
     "eslint-plugin-rulesdir": "^0.2.2",
     "msw": "^1.3.5",
     "ws": "^8.17.1"
+  },
+  "peerDependencies": {
+    "@types/json-schema": "^7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Chris was building out some examples but was seeing weird TS issues with inference of `args` that I couldn't replicate locally.

Adding this perfectly valid tool call...

```tsx
"write-in-input": defineAiTool()({
  description: "Write in the input",
  parameters: {
    type: "object",
    properties: {
      text: { type: "string" },
    },
    required: ["text"],
  },
  execute: (args) => {
    //      ^^^^ ❌ Incorrectly inferred
    const { text } = args;
    toast.success("You wrote in the input");
    setInput(text);
    return "You ran the tool";
  },
}),
```

Was getting inferred as:

![CleanShot 2025-06-04 at 13 06 41@2x](https://github.com/user-attachments/assets/d57d97ae-bd7b-4e90-ba1c-64b51986a9e5)

After playing with this in a TS playground, I think I found the issue:

| Correct | Incorrect (+ matches Chris' issue exactly) |
|--------|--------|
| ![Screen Shot 2025-06-04 at 15 55 04@2x](https://github.com/user-attachments/assets/92cc1621-6274-474c-9c60-6ae997a88079) | ![Screen Shot 2025-06-04 at 15 55 51@2x](https://github.com/user-attachments/assets/e3def144-fc13-4732-9042-d1e199f49b4f) | 

This led me to believe the issue was related to that missing `json-schema` library, and TS defaulting to `any` if it cannot find the `JSONSchema7` definition.

So this PR adds `@types/json-schema` as a (non-optional) peer dependency.