### PR TITLE
Fix state loss when using an inlined `render` function

### DIFF
--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -36,7 +36,7 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
 
-function CustomTool(props: {
+function StableRenderFn(props: {
   renderFn: FunctionComponent<
     AiToolInvocationProps<JsonObject, ToolResultData>
   >;
@@ -104,7 +104,7 @@ function ToolInvocation({
       }
     >
       <AiToolInvocationContext.Provider value={props}>
-        <CustomTool
+        <StableRenderFn
           renderFn={
             tool.render as FunctionComponent<
               AiToolInvocationProps<JsonObject, ToolResultData>


### PR DESCRIPTION
We had a bug that would cause state loss when using inlined `render: () => { ... }` functions that would use state. This bug would not happen if you moved it into an external component.

For example, if you would write:

```tsx
render: ({ status, toolCallId }) => {
  const [color] = useState(() => nextColor());
  return (
    <div style={{ color }}>
      Hello world from {toolCallId} ({status})!
    </div>
  );
},
```

Any time this tool would get re-rendered, it would actually get unmounted and remounted, causing its local state to be lost and being assigned a new color, which is not the desired behavior of course.

## Before
❌ Before, when render props would update, local state was lost.
Notice in video: color also changes when status changes.

https://github.com/user-attachments/assets/1e545317-f2b2-467d-b67b-5810ddff013c

## After
✅ Now, when render props would update, the component stays mounted now, keeping local state.
Notice in video: color no longer changes when status changes.

https://github.com/user-attachments/assets/3eb4eca2-b797-4e61-8f28-47e8d0c30156
