### PR TITLE
Add more overrides

### DIFF
--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -271,7 +271,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
             key={chatId}
             chatId={chatId}
             copilotId={copilotId as CopilotId}
-            overrides={$}
+            overrides={overrides}
             autoFocus={autoFocus}
             onUserMessageCreate={({ id }) => setLastSentMessageId(id)}
             className={

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -11,6 +11,11 @@ import { Children, forwardRef, useCallback, useMemo, useState } from "react";
 
 import { Button } from "../_private";
 import { CheckCircleFillIcon, ChevronRightIcon, SpinnerIcon } from "../icons";
+import {
+  type AiToolConfirmationOverrides,
+  type GlobalOverrides,
+  useOverrides,
+} from "../overrides";
 import { useAiToolInvocationContext } from "../primitives/AiMessage/contexts";
 import * as Collapsible from "../primitives/Collapsible";
 import { classNames } from "../utils/class-names";
@@ -60,9 +65,7 @@ export interface AiToolConfirmationProps<
   confirm: AiToolExecuteCallback<A, R>;
   cancel: AiToolExecuteCallback<A, R>;
   variant?: "default" | "destructive";
-
-  // TODO: Use existing overrides API to allow customizing the "Confirm" and "Cancel" labels
-  // overrides?: Partial<GlobalOverrides & AiToolConfirmationOverrides>;
+  overrides?: Partial<GlobalOverrides & AiToolConfirmationOverrides>;
 }
 
 function AiToolIcon({ className, ...props }: AiToolIconProps) {
@@ -96,11 +99,13 @@ function AiToolConfirmation<
   variant = "default",
   confirm,
   cancel,
+  overrides,
   className,
   ...props
 }: AiToolConfirmationProps<A, R>) {
   const { status, args, respond, toolName, toolCallId } =
     useAiToolInvocationContext();
+  const $ = useOverrides(overrides);
 
   const enabled = status === "executing";
 
@@ -143,14 +148,14 @@ function AiToolConfirmation<
               onClick={onCancelClick}
               variant="secondary"
             >
-              Cancel
+              {$.AI_TOOL_CONFIRMATION_CANCEL}
             </Button>
             <Button
               disabled={!enabled}
               onClick={onConfirmClick}
               variant={variant === "destructive" ? "destructive" : "primary"}
             >
-              Confirm
+              {$.AI_TOOL_CONFIRMATION_CONFIRM}
             </Button>
           </div>
         </div>
@@ -194,6 +199,8 @@ export const AiTool = Object.assign(
       //         </AiTool>
       //       One solution could be to check the DOM on every render with `useLayoutEffect`
       //       to see if there's any actual content.
+      //       For now we're limiting the visual issues caused by the above by using CSS's
+      //       `:empty` pseudo-class to make the content 0px high if it's actually empty.
       const hasContent = Children.count(children) > 0;
       const resolvedTitle = useMemo(() => {
         return title ?? prettifyString(toolName);

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -14,6 +14,7 @@ import { WarningIcon } from "../../icons/Warning";
 import {
   type AiChatMessageOverrides,
   type GlobalOverrides,
+  OverridesProvider,
   useOverrides,
 } from "../../overrides";
 import * as AiMessage from "../../primitives/AiMessage";
@@ -102,9 +103,11 @@ export const AiChatAssistantMessage = memo(
           {...props}
           ref={forwardedRef}
         >
-          <ComponentsProvider components={components}>
-            {children}
-          </ComponentsProvider>
+          <OverridesProvider overrides={overrides}>
+            <ComponentsProvider components={components}>
+              {children}
+            </ComponentsProvider>
+          </OverridesProvider>
         </div>
       );
     }

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -143,6 +143,8 @@ function ReasoningPart({
   isStreaming,
 }: AiMessageContentReasoningPartProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const $ = useOverrides();
+
   return (
     <Collapsible.Root
       className="lb-collapsible lb-ai-chat-message-reasoning"
@@ -155,8 +157,8 @@ function ReasoningPart({
           isStreaming && "lb-ai-chat-pending"
         )}
       >
-        {/* TODO: If `isStreaming` is true, show "Reasoning…"/"Thinking…", otherwise show "Reasoned/thought for x seconds"? */}
-        Reasoning
+        {/* TODO: Show duration as "Reasoned for x seconds"? */}
+        {$.AI_CHAT_MESSAGE_REASONING(isStreaming)}
         <span className="lb-collapsible-chevron lb-icon-container">
           <ChevronRightIcon />
         </span>

--- a/packages/liveblocks-react-ui/src/components/internal/CodeBlock.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/CodeBlock.tsx
@@ -2,6 +2,8 @@ import type { ComponentProps } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { CheckIcon, CopyIcon } from "../../icons";
+import type { GlobalOverrides } from "../../overrides";
+import { useOverrides } from "../../overrides";
 import { Button } from "./Button";
 import { Tooltip, TooltipProvider } from "./Tooltip";
 
@@ -10,9 +12,11 @@ const COPY_DELAY = 1500;
 interface CodeBlockProps extends Omit<ComponentProps<"div">, "title"> {
   title: string;
   code: string;
+  overrides?: Partial<GlobalOverrides>;
 }
 
-export function CodeBlock({ title, code }: CodeBlockProps) {
+export function CodeBlock({ title, code, overrides }: CodeBlockProps) {
+  const $ = useOverrides(overrides);
   const [isCopied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -45,11 +49,12 @@ export function CodeBlock({ title, code }: CodeBlockProps) {
         <div className="lb-code-block-header">
           <span className="lb-code-block-title">{title}</span>
           <div className="lb-code-block-header-actions">
-            <Tooltip content={isCopied ? null : "Copy"}>
+            <Tooltip content={isCopied ? null : $.COPY_TO_CLIPBOARD}>
               <Button
                 className="lb-code-block-header-action"
                 icon={isCopied ? <CheckIcon /> : <CopyIcon />}
                 onClick={handleCopy}
+                aria-label={$.COPY_TO_CLIPBOARD}
               />
             </Tooltip>
           </div>

--- a/packages/liveblocks-react-ui/src/overrides.tsx
+++ b/packages/liveblocks-react-ui/src/overrides.tsx
@@ -25,6 +25,7 @@ export interface GlobalOverrides {
   EMOJI_PICKER_CHANGE_SKIN_TONE: string;
   ATTACHMENT_TOO_LARGE: (maxSize?: string) => string;
   ATTACHMENT_ERROR: (error: Error) => string;
+  COPY_TO_CLIPBOARD: string;
 }
 
 export interface CommentOverrides {
@@ -221,6 +222,7 @@ export const defaultOverrides: Overrides = {
   AI_CHAT_MESSAGE_THINKING: "Thinking…",
   AI_CHAT_MESSAGES_ERROR: () =>
     "There was an error while getting the messages.",
+  COPY_TO_CLIPBOARD: "Copy",
 };
 
 export const OverridesContext = createContext<Overrides | undefined>(undefined);

--- a/packages/liveblocks-react-ui/src/overrides.tsx
+++ b/packages/liveblocks-react-ui/src/overrides.tsx
@@ -66,6 +66,7 @@ export interface AiChatComposerOverrides {
 export interface AiChatMessageOverrides {
   AI_CHAT_MESSAGE_DELETED: string;
   AI_CHAT_MESSAGE_THINKING: string;
+  AI_CHAT_MESSAGE_REASONING: (isStreaming: boolean) => string;
 }
 
 export interface AiChatOverrides {
@@ -220,6 +221,8 @@ export const defaultOverrides: Overrides = {
   AI_CHAT_COMPOSER_ABORT: "Abort response",
   AI_CHAT_MESSAGE_DELETED: "This message has been deleted.",
   AI_CHAT_MESSAGE_THINKING: "Thinking…",
+  AI_CHAT_MESSAGE_REASONING: (isStreaming) =>
+    isStreaming ? "Reasoning…" : "Reasoning",
   AI_CHAT_MESSAGES_ERROR: () =>
     "There was an error while getting the messages.",
   COPY_TO_CLIPBOARD: "Copy",

--- a/packages/liveblocks-react-ui/src/overrides.tsx
+++ b/packages/liveblocks-react-ui/src/overrides.tsx
@@ -57,6 +57,11 @@ export interface ComposerOverrides {
   COMPOSER_TOGGLE_MARK: (mark: ComposerBodyMark) => string;
 }
 
+export interface AiToolConfirmationOverrides {
+  AI_TOOL_CONFIRMATION_CONFIRM: string;
+  AI_TOOL_CONFIRMATION_CANCEL: string;
+}
+
 export interface AiChatComposerOverrides {
   AI_CHAT_COMPOSER_PLACEHOLDER: string;
   AI_CHAT_COMPOSER_SEND: string;
@@ -119,7 +124,8 @@ export type Overrides = LocalizationOverrides &
   HistoryVersionPreviewOverrides &
   AiChatComposerOverrides &
   AiChatMessageOverrides &
-  AiChatOverrides;
+  AiChatOverrides &
+  AiToolConfirmationOverrides;
 
 type OverridesProviderProps = PropsWithChildren<{
   overrides?: Partial<Overrides>;
@@ -130,6 +136,7 @@ export const defaultOverrides: Overrides = {
   dir: "ltr",
   USER_SELF: "you",
   USER_UNKNOWN: "Anonymous",
+  COPY_TO_CLIPBOARD: "Copy",
   LIST_REMAINING: (count) => `${count} more`,
   LIST_REMAINING_USERS: (count) => `${count} ${pluralize(count, "other")}`,
   LIST_REMAINING_COMMENTS: (count) =>
@@ -225,7 +232,8 @@ export const defaultOverrides: Overrides = {
     isStreaming ? "Reasoning…" : "Reasoning",
   AI_CHAT_MESSAGES_ERROR: () =>
     "There was an error while getting the messages.",
-  COPY_TO_CLIPBOARD: "Copy",
+  AI_TOOL_CONFIRMATION_CONFIRM: "Confirm",
+  AI_TOOL_CONFIRMATION_CANCEL: "Cancel",
 };
 
 export const OverridesContext = createContext<Overrides | undefined>(undefined);


### PR DESCRIPTION
This PR adds a few more overrides for the launch:
- A global "Copy to clipboard": We use it in the code block but it's not AI-related, we can use anytime we need to show "copy to clipboard"
- "Reasoning…" in `AiChat` assistant messages: It's a functional one to allow different labels for during and after, later we could pass it the duration to display "Reasoned for x seconds"
- "Confirm"/"Cancel" in `AiTool.Confirmation`: Allowing different labels for the `AiTool.Confirmation` built-in buttons

```tsx
// Option 1
<AiTool.Confirmation
  /* ... */
  overrides={{
    AI_TOOL_CONFIRMATION_CONFIRM: "Delete",
  }}
>
  Okay to delete?
</AiTool.Confirmation>

// Option 2
<LiveblocksUiConfig
  overrides={{
    AI_TOOL_CONFIRMATION_CONFIRM: "Bevestigen", // 🇳🇱, "Confirmer" 🇫🇷, …
  }}
>
  <MyApp />
</LiveblocksUiConfig>
```

![delete](https://github.com/user-attachments/assets/ef2ef0c1-8307-42c7-b628-402e16e213f1)