### PR TITLE
Rename `toolName` → `name` everywhere

### DIFF
--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -180,7 +180,7 @@ type SetToolResultPair = DefineCmd<
   {
     chatId: ChatId;
     messageId: MessageId;
-    toolCallId: string;
+    invocationId: string;
     result: ToolResultData;
     generationOptions: AiGenerationOptions;
   },
@@ -285,16 +285,16 @@ export type AiToolInvocationPart<
 export type AiReceivingToolInvocationPart = {
   type: "tool-invocation";
   status: "receiving";
-  toolCallId: string;
-  toolName: string;
+  invocationId: string;
+  name: string;
   partialArgs: Json;
 };
 
 export type AiExecutingToolInvocationPart<A extends JsonObject = JsonObject> = {
   type: "tool-invocation";
   status: "executing";
-  toolCallId: string;
-  toolName: string;
+  invocationId: string;
+  name: string;
   args: A;
 };
 
@@ -304,8 +304,8 @@ export type AiExecutedToolInvocationPart<
 > = {
   type: "tool-invocation";
   status: "executed";
-  toolCallId: string;
-  toolName: string;
+  invocationId: string;
+  name: string;
   args: A;
   result: R;
   // isError: boolean  // TODO Consider adopting this field from AiSDK? Would make "result" be treated as an error value or a success value.

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
@@ -458,7 +458,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
     expectType<
       (
         args: JsonObject,
-        context: { toolName: string; toolCallId: string }
+        context: { name: string; invocationId: string }
       ) => Awaitable<Json>
     >(myTool.execute);
   } else {
@@ -472,8 +472,8 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
     // Possible JSX rendering invocation 1
     myTool.render({
       status: "receiving",
-      toolName: "callMyTool",
-      toolCallId: "tc_abc123",
+      name: "callMyTool",
+      invocationId: "tc_abc123",
       partialArgs: {},
       respond: (payload) => {
         expectType<Json>(payload);
@@ -485,8 +485,8 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
     // Possible JSX rendering invocation 2
     myTool.render({
       status: "executing",
-      toolName: "callMyTool",
-      toolCallId: "tc_abc123",
+      name: "callMyTool",
+      invocationId: "tc_abc123",
       args: { a: 1 },
       respond: (payload) => {
         expectType<Json>(payload);
@@ -498,8 +498,8 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
     // Possible JSX rendering invocation 3
     myTool.render({
       status: "executed",
-      toolName: "callMyTool",
-      toolCallId: "tc_abc123",
+      name: "callMyTool",
+      invocationId: "tc_abc123",
       args: { a: 1 },
       result: { b: 2 },
       respond: (payload) => {

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -113,16 +113,13 @@ function AiToolConfirmation<
   className,
   ...props
 }: AiToolConfirmationProps<A, R>) {
-  const { status, args, respond, toolName, toolCallId } =
+  const { status, args, respond, name, invocationId } =
     useAiToolInvocationContext();
   const $ = useOverrides(overrides);
 
   const enabled = status === "executing";
 
-  const context = useMemo(
-    () => ({ toolName, toolCallId }),
-    [toolName, toolCallId]
-  );
+  const context = useMemo(() => ({ name, invocationId }), [name, invocationId]);
 
   const onConfirmClick = useCallback(async () => {
     if (enabled) {
@@ -207,7 +204,7 @@ export const AiTool = Object.assign(
     ) => {
       const {
         status,
-        toolName,
+        name,
         [kInternal]: { execute },
       } = useAiToolInvocationContext();
       const [semiControlledCollapsed, onSemiControlledCollapsed] =
@@ -223,8 +220,8 @@ export const AiTool = Object.assign(
       //       `:empty` pseudo-class to make the content 0px high if it's actually empty.
       const hasContent = Children.count(children) > 0;
       const resolvedTitle = useMemo(() => {
-        return title ?? prettifyString(toolName);
-      }, [title, toolName]);
+        return title ?? prettifyString(name);
+      }, [title, name]);
 
       // `AiTool` uses "collapsed" instead of "open" (like the `Composer` component) because "open"
       // makes sense next to something called "Collapsible" but less so for something called "AiTool".

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -56,29 +56,29 @@ function ToolInvocation({
 }) {
   const client = useClient();
   const ai = client[kInternal].ai;
-  const tool = useSignal(ai.signals.getToolΣ(part.toolName, chatId));
+  const tool = useSignal(ai.signals.getToolΣ(part.name, chatId));
 
   const respond = useCallback(
     (result: ToolResultData) => {
       if (part.status === "receiving") {
         console.log(
-          `Ignoring respond(): tool '${part.toolName}' (${part.toolCallId}) is still receiving`
+          `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
         );
       } else if (part.status === "executed") {
         console.log(
-          `Ignoring respond(): tool '${part.toolName}' (${part.toolCallId}) has already executed`
+          `Ignoring respond(): tool '${part.name}' (${part.invocationId}) has already executed`
         );
       } else {
         ai.setToolResult(
           chatId,
           messageId,
-          part.toolCallId,
+          part.invocationId,
           result
           // TODO Pass in AiGenerationOptions here?
         );
       }
     },
-    [ai, chatId, messageId, part.status, part.toolName, part.toolCallId]
+    [ai, chatId, messageId, part.status, part.name, part.invocationId]
   );
 
   const props = useMemo(() => {
@@ -98,7 +98,7 @@ function ToolInvocation({
     <ErrorBoundary
       fallback={
         <p style={{ color: "red" }}>
-          Failed to render tool call result for ‘{part.toolName}’. See console
+          Failed to render tool call result for ‘{part.name}’. See console
           for details.
         </p>
       }


### PR DESCRIPTION
This PR renames these fields:

- `toolName` → `name`
- `toolCallId` → `invocationId`

"Tool call" is a term that isn't used anywhere in our clients. It's a backend-only concept, but somehow this field "toolCallId" slipped into our public client API now 🥴

```tsx
// ❌ Before
render: ({ toolName, toolCallId }) => {
  ...
}
```

```tsx
// ✅ Now
render: ({ name, invocationId }) => {
  ...
}
```