### PR TITLE
Avoid exporting "UI" types from core

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
@@ -3,10 +3,11 @@
 import { useClient } from "@liveblocks/react/suspense";
 import { HTMLAttributes, memo, useEffect, useState } from "react";
 import {
+  AiAssistantMessage,
   CopilotId,
   kInternal,
   MessageId,
-  UiAssistantMessage,
+  WithNavigation,
 } from "@liveblocks/core";
 import { RefreshIcon } from "../../icons/refresh-icon";
 import { CheckIcon } from "../../icons/check-icon";
@@ -21,6 +22,8 @@ import {
   Markdown,
   Collapsible,
 } from "@liveblocks/react-ui/_private";
+
+type UiAssistantMessage = WithNavigation<AiAssistantMessage>;
 
 export const AssistantMessage = memo(function AssistantMessage({
   message,

--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/user-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/user-message.tsx
@@ -1,18 +1,21 @@
-import { memo, useState, useEffect, useCallback, FormEvent } from "react";
+import { memo, useState, useEffect, useCallback } from "react";
 import { CheckIcon } from "../../icons/check-icon";
 import { CopyIcon } from "../../icons/copy-icon";
 import { PencilIcon } from "../../icons/pencil-icon";
 import {
+  AiUserMessage,
   CopilotId,
   kInternal,
   MessageId,
-  UiUserMessage,
+  WithNavigation,
 } from "@liveblocks/core";
 import { AiChatComposer } from "@liveblocks/react-ui/_private";
 import { useClient } from "@liveblocks/react";
 import { ChevronLeftIcon } from "../../icons/chevron-left-icon";
 import { ChevronRightIcon } from "../../icons/chevron-right-icon";
 import { TrashIcon } from "../../icons/trash-icon";
+
+type UiUserMessage = WithNavigation<AiUserMessage>;
 
 export const UserMessage = memo(function UserMessage({
   message,

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -27,7 +27,6 @@ import type {
 import type {
   AbortAiResponse,
   AiAssistantDeltaUpdate,
-  AiAssistantMessage,
   AiChat,
   AiChatMessage,
   AiFailedAssistantMessage,
@@ -173,56 +172,24 @@ export function defineAiTool<R extends ToolResultData>() {
   };
 }
 
-export type UiChatMessage = AiChatMessage & {
-  navigation: {
-    /**
-     * The message ID of the parent message, or null if there is no parent.
-     */
-    parent: MessageId | null;
-    /**
-     * The message ID of the left sibling message, or null if there is no left sibling.
-     */
-    prev: MessageId | null;
-    /**
-     * The message ID of the right sibling message, or null if there is no right sibling.
-     */
-    next: MessageId | null;
-  };
+type NavigationInfo = {
+  /**
+   * The message ID of the parent message, or null if there is no parent.
+   */
+  parent: MessageId | null;
+  /**
+   * The message ID of the left sibling message, or null if there is no left sibling.
+   */
+  prev: MessageId | null;
+  /**
+   * The message ID of the right sibling message, or null if there is no right sibling.
+   */
+  next: MessageId | null;
 };
 
-export type UiUserMessage = AiUserMessage & {
-  navigation: {
-    /**
-     * The message ID of the parent message, or null if there is no parent.
-     */
-    parent: MessageId | null;
-    /**
-     * The message ID of the left sibling message, or null if there is no left sibling.
-     */
-    prev: MessageId | null;
-    /**
-     * The message ID of the right sibling message, or null if there is no right sibling.
-     */
-    next: MessageId | null;
-  };
-};
+export type WithNavigation<T> = T & { navigation: NavigationInfo };
 
-export type UiAssistantMessage = AiAssistantMessage & {
-  navigation: {
-    /**
-     * The message ID of the parent message, or null if there is no parent.
-     */
-    parent: MessageId | null;
-    /**
-     * The message ID of the left sibling message, or null if there is no left sibling.
-     */
-    prev: MessageId | null;
-    /**
-     * The message ID of the right sibling message, or null if there is no right sibling.
-     */
-    next: MessageId | null;
-  };
-};
+type UiChatMessage = WithNavigation<AiChatMessage>;
 
 type AiContext = {
   staticSessionInfoSig: Signal<StaticSessionInfo | null>;

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -24,9 +24,7 @@ export type {
   AiToolExecuteContext,
   AiToolInvocationProps,
   AiToolTypePack,
-  UiAssistantMessage,
-  UiChatMessage,
-  UiUserMessage,
+  WithNavigation,
 } from "./ai";
 export { defineAiTool } from "./ai";
 export type {
@@ -326,12 +324,14 @@ export type {
 export type { GetThreadsOptions, UploadAttachmentOptions } from "./room";
 export type {
   AiAssistantContentPart,
+  AiAssistantMessage,
   AiChat,
   AiChatMessage,
   AiKnowledgeSource,
   AiReasoningPart,
   AiTextPart,
   AiToolInvocationPart,
+  AiUserMessage,
   CopilotId,
   Cursor,
   MessageId,

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -1,4 +1,4 @@
-import type { UiAssistantMessage } from "@liveblocks/core";
+import type { AiAssistantMessage, WithNavigation } from "@liveblocks/core";
 import {
   type ComponentProps,
   forwardRef,
@@ -25,6 +25,8 @@ import type {
 import * as Collapsible from "../../primitives/Collapsible";
 import { classNames } from "../../utils/class-names";
 import { Prose } from "./Prose";
+
+type UiAssistantMessage = WithNavigation<AiAssistantMessage>;
 
 /* -------------------------------------------------------------------------------------------------
  * AiChatAssistantMessage

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatComposer.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatComposer.tsx
@@ -1,4 +1,9 @@
-import type { CopilotId, MessageId, UiChatMessage } from "@liveblocks/core";
+import type {
+  AiChatMessage,
+  CopilotId,
+  MessageId,
+  WithNavigation,
+} from "@liveblocks/core";
 import { kInternal } from "@liveblocks/core";
 import { useClient } from "@liveblocks/react";
 import { useSignal } from "@liveblocks/react/_private";
@@ -20,6 +25,8 @@ import * as ComposerPrimitive from "../../primitives/AiChatComposer";
 import { classNames } from "../../utils/class-names";
 import { Button } from "./Button";
 import { ShortcutTooltip, TooltipProvider } from "./Tooltip";
+
+type UiChatMessage = WithNavigation<AiChatMessage>;
 
 /* -------------------------------------------------------------------------------------------------
  * AiChatComposer

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
@@ -1,10 +1,16 @@
-import type { AiTextPart, UiUserMessage } from "@liveblocks/core";
+import type {
+  AiTextPart,
+  AiUserMessage,
+  WithNavigation,
+} from "@liveblocks/core";
 import type { ComponentProps } from "react";
 import { forwardRef, memo } from "react";
 
 import { AiMessage } from "../../_private";
 import { type GlobalOverrides, useOverrides } from "../../overrides";
 import { classNames } from "../../utils/class-names";
+
+type UiUserMessage = WithNavigation<AiUserMessage>;
 
 /* -------------------------------------------------------------------------------------------------
  * AiChatUserMessage

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -15,6 +15,7 @@ import type {
 } from "@liveblocks/client";
 import type {
   AiChat,
+  AiChatMessage,
   AsyncError,
   AsyncLoading,
   AsyncResult,
@@ -40,7 +41,7 @@ import type {
   SyncStatus,
   ThreadData,
   ToImmutable,
-  UiChatMessage,
+  WithNavigation,
 } from "@liveblocks/core";
 import type {
   ComponentType,
@@ -50,6 +51,8 @@ import type {
 } from "react";
 
 import type { RegisterAiKnowledgeProps, RegisterAiToolProps } from "./ai";
+
+type UiChatMessage = WithNavigation<AiChatMessage>;
 
 export type UseSyncStatusOptions = {
   /**


### PR DESCRIPTION
This fixes LB-2037.

While the original plan was to rename `UiChatMessage` → `AiUiChatMessage`, I wasn't really comfortable doing that, because (1) the name is pretty ugly, (2) it might be confusing to understand the differences between `AiChatMessage` and `AiUiChatMessage`, and (3) I didn't feel ready to commit to this name.

Therefore, I'm proposing the following solution:

- We don't export the "Ui" types directly from core, only the "Ai" types
- Instead, we export a helper type `WithNavigation<T>`, which will simply take any object and add the `navigation` field to it.

This way, when using it further down in other projects, it's a bit more explicit that they're "just" the Ai types, but with an extra navigation field on there. For convenience, I'm aliasing those to `UiChatMessage` still in those other projects, but at the very least, the API surface of `@liveblocks/core` doesn't get cluttered this way.

This allows us to kick the can down the road and make the final naming decision a bit later.
