### PR TITLE
Rename `status` -> `stage` on InvocationPart types

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -225,7 +225,7 @@ export default function Page() {
                           additionalProperties: false,
                         },
 
-                        render: ({ status, result, types }) => (
+                        render: ({ stage, result, types }) => (
                           <AiTool>
                             <AiTool.Confirmation
                               types={types}
@@ -249,7 +249,7 @@ export default function Page() {
                               Okay to delete?
                             </AiTool.Confirmation>
 
-                            {status === "executed" ? (
+                            {stage === "executed" ? (
                               result.ok ? (
                                 <div>
                                   Deleted:

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -518,7 +518,7 @@ function createStore_forChatMessages(
       if (message.role === "assistant" && message.status === "awaiting-tool") {
         for (const toolCall of message.contentSoFar.filter(
           (part) =>
-            part.type === "tool-invocation" && part.status === "executing"
+            part.type === "tool-invocation" && part.stage === "executing"
         )) {
           if (seenToolCallIds.has(toolCall.invocationId)) {
             // Do nothing, we already know of it
@@ -1355,7 +1355,7 @@ export function makeCreateSocketDelegateForAi(
 
     const url = new URL(baseUrl);
     url.protocol = url.protocol === "http:" ? "ws" : "wss";
-    url.pathname = "/ai/v2";
+    url.pathname = "/ai/v3";
     // TODO: don't allow public key to do this
     if (authValue.type === "secret") {
       url.searchParams.set("tok", authValue.token.raw);

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -284,7 +284,7 @@ export type AiToolInvocationPart<
 
 export type AiReceivingToolInvocationPart = {
   type: "tool-invocation";
-  status: "receiving";
+  stage: "receiving";
   invocationId: string;
   name: string;
   partialArgs: Json;
@@ -292,7 +292,7 @@ export type AiReceivingToolInvocationPart = {
 
 export type AiExecutingToolInvocationPart<A extends JsonObject = JsonObject> = {
   type: "tool-invocation";
-  status: "executing";
+  stage: "executing";
   invocationId: string;
   name: string;
   args: A;
@@ -303,7 +303,7 @@ export type AiExecutedToolInvocationPart<
   R extends ToolResultData = ToolResultData,
 > = {
   type: "tool-invocation";
-  status: "executed";
+  stage: "executed";
   invocationId: string;
   name: string;
   args: A;

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -113,11 +113,11 @@ function AiToolConfirmation<
   className,
   ...props
 }: AiToolConfirmationProps<A, R>) {
-  const { status, args, respond, name, invocationId } =
+  const { stage, args, respond, name, invocationId } =
     useAiToolInvocationContext();
   const $ = useOverrides(overrides);
 
-  const enabled = status === "executing";
+  const enabled = stage === "executing";
 
   const context = useMemo(() => ({ name, invocationId }), [name, invocationId]);
 
@@ -135,7 +135,7 @@ function AiToolConfirmation<
 
   // If there's no content and the tool has been executed (so there's no
   // confirmation UI displayed either), don't render anything.
-  if (status === "executed" && !children) {
+  if (stage === "executed" && !children) {
     return null;
   }
 
@@ -147,7 +147,7 @@ function AiToolConfirmation<
       {children ? (
         <div className="lb-ai-tool-confirmation-content">{children}</div>
       ) : null}
-      {status !== "executed" && (
+      {stage !== "executed" && (
         <div className="lb-ai-tool-confirmation-footer">
           <div className="lb-ai-tool-confirmation-actions">
             <Button
@@ -203,7 +203,7 @@ export const AiTool = Object.assign(
       forwardedRef
     ) => {
       const {
-        status,
+        stage,
         name,
         [kInternal]: { execute },
       } = useAiToolInvocationContext();
@@ -253,7 +253,7 @@ export const AiTool = Object.assign(
               </span>
             ) : null}
             <div className="lb-ai-tool-header-status">
-              {status === "executed" ? (
+              {stage === "executed" ? (
                 <CheckCircleFillIcon />
               ) : execute !== undefined ? (
                 // Only show a spinner if the tool has an `execute` method.

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -60,11 +60,11 @@ function ToolInvocation({
 
   const respond = useCallback(
     (result: ToolResultData) => {
-      if (part.status === "receiving") {
+      if (part.stage === "receiving") {
         console.log(
           `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
         );
-      } else if (part.status === "executed") {
+      } else if (part.stage === "executed") {
         console.log(
           `Ignoring respond(): tool '${part.name}' (${part.invocationId}) has already executed`
         );
@@ -78,7 +78,7 @@ function ToolInvocation({
         );
       }
     },
-    [ai, chatId, messageId, part.status, part.name, part.invocationId]
+    [ai, chatId, messageId, part.stage, part.name, part.invocationId]
   );
 
   const props = useMemo(() => {
@@ -98,8 +98,8 @@ function ToolInvocation({
     <ErrorBoundary
       fallback={
         <p style={{ color: "red" }}>
-          Failed to render tool call result for ‘{part.name}’. See console
-          for details.
+          Failed to render tool call result for ‘{part.name}’. See console for
+          details.
         </p>
       }
     >


### PR DESCRIPTION
Fixes LB-2080.

Using `stage` implies there's only a one-way change direction:
- `receiving` → `executing` → `executed`

Unlike a status, which might "change back" to a previous status.

Thanks for the excellent name suggestion, @CTNicholas! 🙏
