### PR TITLE
Enforce return type constraints on execute()

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/knowledge/page.tsx
@@ -60,7 +60,9 @@ function DarkModeToggle() {
             },
             execute: ({ mode }) => {
               setMode(mode);
-              return { ok: true, message: `Dark mode changed to ${mode}` };
+              return {
+                data: { ok: true, message: `Dark mode changed to ${mode}` },
+              };
             },
             render: () => <AiTool />,
           })}

--- a/e2e/next-ai-kitchen-sink/app/todo/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/todo/page.tsx
@@ -153,9 +153,13 @@ export default function Page() {
                         execute: async (args) => {
                           const { ids } = args;
                           if (ids.length === 0) {
-                            return todos;
+                            return { data: { todos } };
                           } else {
-                            return todos.filter((t) => ids.includes(t.id));
+                            return {
+                              data: {
+                                todos: todos.filter((t) => ids.includes(t.id)),
+                              },
+                            };
                           }
                         },
                       }),
@@ -179,7 +183,7 @@ export default function Page() {
                           for (const title of titles) {
                             addTodo(title);
                           }
-                          return { ok: true };
+                          return { data: { ok: true } };
                         },
                       }),
 
@@ -198,7 +202,7 @@ export default function Page() {
                         },
                         execute: ({ id }) => {
                           toggleTodo(id);
-                          return { ok: true };
+                          return { data: { ok: true } };
                         },
                         render: () => (
                           <AiTool>
@@ -236,13 +240,15 @@ export default function Page() {
                                   .map((todo) => todo.title);
 
                                 deleteTodos(ids);
-                                return { ok: true, deletedTitles };
+                                return { data: { ok: true, deletedTitles } };
                               }}
                               cancel={() => {
                                 return {
-                                  ok: false,
-                                  reason: "deny",
-                                  hint: "Do not respond with further text",
+                                  data: {
+                                    ok: false,
+                                    reason: "deny",
+                                    hint: "Do not respond with further text",
+                                  },
                                 };
                               }}
                             >

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -53,6 +53,7 @@ import type {
   ServerAiMsg,
   SetToolResultResponse,
   ToolResultData,
+  ToolResultResponse,
 } from "./types/ai";
 import { appendDelta } from "./types/ai";
 import type { Awaitable } from "./types/Awaitable";
@@ -98,7 +99,7 @@ export type AiToolInvocationProps<
   R extends ToolResultData,
 > = Resolve<
   DistributiveOmit<AiToolInvocationPart<A, R>, "type"> & {
-    respond: (result: R) => void;
+    respond: (result: ToolResultResponse<R>) => void;
 
     /**
      * These are the inferred types for your tool call which you can pass down
@@ -136,7 +137,10 @@ export type AiToolExecuteContext = {
 export type AiToolExecuteCallback<
   A extends JsonObject,
   R extends ToolResultData,
-> = (args: A, context: AiToolExecuteContext) => Awaitable<R>;
+> = (
+  args: A,
+  context: AiToolExecuteContext
+) => Awaitable<ToolResultResponse<R>>;
 
 export type AiToolDefinition<
   S extends JSONObjectSchema7,
@@ -531,12 +535,14 @@ function createStore_forChatMessages(
             .getToolΣ(toolCall.name, message.chatId)
             .get();
 
-          const respondSync = (result: ToolResultData) => {
+          const respondSync = <R extends ToolResultData>(
+            result: ToolResultResponse<R>
+          ) => {
             setToolResult(
               message.chatId,
               message.id,
               toolCall.invocationId,
-              result
+              result.data
               // TODO Pass in AiGenerationOptions here, or make the backend use the same options
             ).catch((err) => {
               console.error(

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -336,6 +336,7 @@ export type {
   Cursor,
   MessageId,
   ToolResultData,
+  ToolResultResponse,
 } from "./types/ai";
 export type { Awaitable } from "./types/Awaitable";
 export type { Immutable } from "./types/Immutable";

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -173,7 +173,8 @@ type AbortAiPair = DefineCmd<
 
 // TODO[nvie] Maybe layer, consider making this a more structured output, like:
 // { ok: true, hintForAi: "bla bla bla", data: { /* for client */ } } ?
-export type ToolResultData = Json;
+export type ToolResultData = JsonObject;
+export type ToolResultResponse<R extends ToolResultData> = { data: R };
 
 type SetToolResultPair = DefineCmd<
   "set-tool-result",
@@ -181,7 +182,7 @@ type SetToolResultPair = DefineCmd<
     chatId: ChatId;
     messageId: MessageId;
     invocationId: string;
-    result: ToolResultData;
+    result: ToolResultData; // TODO Change to ToolResultResponse in protocol V4 soon
     generationOptions: AiGenerationOptions;
   },
   { ok: true; message: AiChatMessage } | { ok: false }

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -4,6 +4,7 @@ import type {
   JsonObject,
   MessageId,
   ToolResultData,
+  ToolResultResponse,
 } from "@liveblocks/core";
 import { kInternal } from "@liveblocks/core";
 import { useClient } from "@liveblocks/react";
@@ -59,7 +60,7 @@ function ToolInvocation({
   const tool = useSignal(ai.signals.getToolΣ(part.name, chatId));
 
   const respond = useCallback(
-    (result: ToolResultData) => {
+    (result: ToolResultResponse<ToolResultData>) => {
       if (part.stage === "receiving") {
         console.log(
           `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
@@ -73,7 +74,7 @@ function ToolInvocation({
           chatId,
           messageId,
           part.invocationId,
-          result
+          result.data
           // TODO Pass in AiGenerationOptions here?
         );
       }


### PR DESCRIPTION
This PR enforces a change to the return value of `execute()`, `confirm()` and `cancel()`.

1. The returned value _MUST_ be an object with a top-level `data` key.
2. The returned data _MUST_ be a JSON object itself.
3. The value of `result` which gets passed back into `render: ({ result }) => ...` will be whatever value is provided under `data`.

The most minimal return value of `execute` now therefore is:

```tsx
execute: () => {
  return { data: {} };
}
```

This is how `result` will come out:

```tsx
execute: () => {
  return { data: { foo: "bar" } };
},
render: ({ stage, result }) => {
  // Result is now, conveniently, { foo: string } | undefined
  if (stage === "executed") {
    // In here, result will be { foo: string }
  }

  // This means, you can now also refine on `result` directly (without checking `stage` explicitly)
  if (result) {
    // In here, stage === "executed"
    result.foo  // "bar"
  }
}
```

This design gives both us and our customers some future-compatibility guarantees:

1. By enforcing `data` top-level field, we get room to iterate on adding more fields, like `hint`, etc distinguish errors from ok results, etc.
2. By enforcing `data` itself to be an object, our customers will be less likely to run into migration issues, because objects are easy to extend over time.
