### PR TITLE
Update ToolInvocationPart and fallbacks in AiChat/primitives

### DIFF
--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -3,7 +3,6 @@ import {
   type ComponentProps,
   forwardRef,
   memo,
-  type PropsWithChildren,
   type ReactNode,
   useState,
 } from "react";
@@ -21,9 +20,11 @@ import * as AiMessage from "../../primitives/AiMessage";
 import type {
   AiMessageContentReasoningPartProps,
   AiMessageContentTextPartProps,
+  AiMessageContentToolInvocationPartProps,
 } from "../../primitives/AiMessage/types";
 import * as Collapsible from "../../primitives/Collapsible";
 import { classNames } from "../../utils/class-names";
+import { ErrorBoundary } from "../../utils/ErrorBoundary";
 import { Prose } from "./Prose";
 
 type UiAssistantMessage = WithNavigation<AiAssistantMessage>;
@@ -176,6 +177,29 @@ function ReasoningPart({
 /* -------------------------------------------------------------------------------------------------
  * ToolInvocationPart
  * -----------------------------------------------------------------------------------------------*/
-function ToolInvocationPart({ children }: PropsWithChildren) {
-  return <div className="lb-ai-chat-message-tool-invocation">{children}</div>;
+function ToolInvocationPart({
+  part,
+  message,
+}: AiMessageContentToolInvocationPartProps) {
+  return (
+    <div className="lb-ai-chat-message-tool-invocation">
+      <ErrorBoundary
+        fallback={
+          process.env.NODE_ENV !== "production" ? (
+            <div className="lb-ai-chat-message-error">
+              <span className="lb-icon-container">
+                <WarningIcon />
+              </span>
+              <p>
+                Failed to render tool call result for <code>{part.name}</code>.
+                See console for details.
+              </p>
+            </div>
+          ) : null
+        }
+      >
+        <AiMessage.ToolInvocation part={part} message={message} />
+      </ErrorBoundary>
+    </div>
+  );
 }

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -17,6 +17,7 @@ import {
   useOverrides,
 } from "../../overrides";
 import * as AiMessage from "../../primitives/AiMessage";
+import { AiMessageToolInvocation } from "../../primitives/AiMessage/tool-invocation";
 import type {
   AiMessageContentReasoningPartProps,
   AiMessageContentTextPartProps,
@@ -198,7 +199,7 @@ function ToolInvocationPart({
           ) : null
         }
       >
-        <AiMessage.ToolInvocation part={part} message={message} />
+        <AiMessageToolInvocation part={part} message={message} />
       </ErrorBoundary>
     </div>
   );

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
@@ -13,11 +13,14 @@ import { type FunctionComponent, useCallback, useMemo } from "react";
 
 import { AiToolInvocationContext } from "./contexts";
 
+type OpaqueAiToolInvocationProps = AiToolInvocationProps<
+  JsonObject,
+  ToolResultData
+>;
+
 function StableRenderFn(props: {
-  renderFn: FunctionComponent<
-    AiToolInvocationProps<JsonObject, ToolResultData>
-  >;
-  props: AiToolInvocationProps<JsonObject, ToolResultData>;
+  renderFn: FunctionComponent<OpaqueAiToolInvocationProps>;
+  props: OpaqueAiToolInvocationProps;
 }) {
   return props.renderFn(props.props);
 }
@@ -41,7 +44,7 @@ export function AiMessageToolInvocation({
   const tool = useSignal(ai.signals.getToolΣ(part.name, message.chatId));
 
   const respond = useCallback(
-    (result: ToolResultResponse<ToolResultData>) => {
+    (result: ToolResultResponse) => {
       if (part.stage === "receiving") {
         console.log(
           `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
@@ -79,11 +82,7 @@ export function AiMessageToolInvocation({
   return (
     <AiToolInvocationContext.Provider value={props}>
       <StableRenderFn
-        renderFn={
-          tool.render as FunctionComponent<
-            AiToolInvocationProps<JsonObject, ToolResultData>
-          >
-        }
+        renderFn={tool.render as FunctionComponent<OpaqueAiToolInvocationProps>}
         props={props}
       />
     </AiToolInvocationContext.Provider>

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
@@ -1,0 +1,91 @@
+import {
+  type AiChatMessage,
+  type AiToolInvocationPart,
+  type AiToolInvocationProps,
+  type JsonObject,
+  kInternal,
+  type ToolResultData,
+  type ToolResultResponse,
+} from "@liveblocks/core";
+import { useClient } from "@liveblocks/react";
+import { useSignal } from "@liveblocks/react/_private";
+import { type FunctionComponent, useCallback, useMemo } from "react";
+
+import { AiToolInvocationContext } from "./contexts";
+
+function StableRenderFn(props: {
+  renderFn: FunctionComponent<
+    AiToolInvocationProps<JsonObject, ToolResultData>
+  >;
+  props: AiToolInvocationProps<JsonObject, ToolResultData>;
+}) {
+  return props.renderFn(props.props);
+}
+
+/**
+ * @internal
+ *
+ * This could become publicly exposed as <AiMessage.ToolInvocation /> in the future,
+ * but because namespace exports can't be marked `@internal`, we're keeping it in its
+ * own file for now.
+ */
+export function AiMessageToolInvocation({
+  message,
+  part,
+}: {
+  message: AiChatMessage;
+  part: AiToolInvocationPart;
+}) {
+  const client = useClient();
+  const ai = client[kInternal].ai;
+  const tool = useSignal(ai.signals.getToolΣ(part.name, message.chatId));
+
+  const respond = useCallback(
+    (result: ToolResultResponse<ToolResultData>) => {
+      if (part.stage === "receiving") {
+        console.log(
+          `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
+        );
+      } else if (part.stage === "executed") {
+        console.log(
+          `Ignoring respond(): tool '${part.name}' (${part.invocationId}) has already executed`
+        );
+      } else {
+        ai.setToolResult(
+          message.chatId,
+          message.id,
+          part.invocationId,
+          result.data
+          // TODO Pass in AiGenerationOptions here?
+        );
+      }
+    },
+    [ai, message.chatId, message.id, part.stage, part.name, part.invocationId]
+  );
+
+  const props = useMemo(() => {
+    const { type: _, ...rest } = part;
+    return {
+      ...rest,
+      respond,
+      types: undefined as never,
+      [kInternal]: {
+        execute: tool?.execute,
+      },
+    };
+  }, [part, respond, tool?.execute]);
+
+  if (tool?.render === undefined) return null;
+  return (
+    <AiToolInvocationContext.Provider value={props}>
+      <StableRenderFn
+        renderFn={
+          tool.render as FunctionComponent<
+            AiToolInvocationProps<JsonObject, ToolResultData>
+          >
+        }
+        props={props}
+      />
+    </AiToolInvocationContext.Provider>
+  );
+}

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -25,13 +25,14 @@ export type AiMessageContentReasoningPartProps = {
 };
 
 /** @internal */
-type AiMessageContentToolInvocationPartProps = {
+export type AiMessageContentToolInvocationPartProps = {
   /** @internal */
   index: number;
   /** @internal */
   isStreaming: boolean;
+  /** @internal */
+  message: AiChatMessage;
   part: AiToolInvocationPart;
-  children: React.ReactNode;
 };
 
 export interface AiMessageContentComponents {

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2534,6 +2534,10 @@
     block-size: 1lh;
     color: var(--lb-destructive-secondary);
   }
+
+  :where(code:not(pre > code)) {
+    background: var(--lb-destructive-subtle);
+  }
 }
 
 .lb-ai-chat-message-content {


### PR DESCRIPTION
This PR started because I wanted to hide the `style={{ color: "red" }}` error fallback outside of `AiChat` before the launch.
There's now three error fallback scenarios:
- In `AiChat`:
  - In production: falls back to `null`
  - In development: falls back to a styled error message (see image)
- In primitives:
  - Always falls back to `null`

![](https://github.com/user-attachments/assets/627a21d7-62f7-4ae8-b9b5-180dde19d453)

To do that I changed how `ToolInvocationPart` works and could be publicly used in the future, but for now it stays private and even `@internal`.

