### PR TITLE
Fix `<AiChat />` not scrolling all the way to the bottom

### DIFF
--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -258,7 +258,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
                 className="lb-ai-chat-scroll-indicator-button"
                 tabIndex={isScrollIndicatorVisible ? 0 : -1}
                 aria-hidden={!isScrollIndicatorVisible}
-                disabled={!isScrollIndicatorVisible}
+                aria-disabled={!isScrollIndicatorVisible}
                 onClick={() => scrollToBottom("smooth")}
               >
                 <span className="lb-icon-container">

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -502,7 +502,6 @@
       opacity: 0;
       transition-duration: calc(3 * var(--lb-transition-duration));
       transition-property: block-size, opacity, content-visibility;
-      content-visibility: hidden;
 
       /* overflow-block: clip; doesn't work as expected */
       /* stylelint-disable-next-line plugin/use-logical-properties-and-values */
@@ -519,7 +518,6 @@
       &:where([data-state="open"]) {
         block-size: auto;
         opacity: 1;
-        content-visibility: auto;
 
         /* overflow-block: auto; doesn't work as expected */
         /* stylelint-disable-next-line plugin/use-logical-properties-and-values */


### PR DESCRIPTION
This PR fixes the following two issues:
1. Pressing 'Scroll to bottom' icon button wouldn't scroll the chat container all the way to the bottom (and leave a small space behind)
2. When a tool call collapsible was the last message in a chat container, and when the chat was refreshed, the chat container wouldn't scroll all the way to the bottom.