### PR TITLE
Fix bug where calling `respond()` inside `render()` would potentially make multiple network calls

### DIFF
--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -400,7 +400,9 @@ function createStore_forChatMessages(
   // auto-execute the execute() function for.
   const autoExecutableMessages = new Set<MessageId>();
 
-  const seenToolCallIds = new Set<string>();
+  // Used to keep track of any tool invocation that should be kicked off by
+  // this client instance.
+  const seenToolInvocationIds = new Set<string>();
 
   // We maintain a Map with mutable signals. Each such signal contains
   // a mutable automatically-sorted list of chat messages by chat ID.
@@ -528,12 +530,12 @@ function createStore_forChatMessages(
           (part) =>
             part.type === "tool-invocation" && part.stage === "executing"
         )) {
-          if (seenToolCallIds.has(toolCall.invocationId)) {
+          if (seenToolInvocationIds.has(toolCall.invocationId)) {
             // Do nothing, we already know of it
             continue;
           }
 
-          seenToolCallIds.add(toolCall.invocationId);
+          seenToolInvocationIds.add(toolCall.invocationId);
 
           const toolDef = toolsStore
             .getToolΣ(toolCall.name, message.chatId)

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -526,19 +526,19 @@ function createStore_forChatMessages(
       // - and only if the current client ID is the designated client ID
       //
       if (message.role === "assistant" && message.status === "awaiting-tool") {
-        for (const toolCall of message.contentSoFar.filter(
+        for (const toolInvocation of message.contentSoFar.filter(
           (part) =>
             part.type === "tool-invocation" && part.stage === "executing"
         )) {
-          if (seenToolInvocationIds.has(toolCall.invocationId)) {
+          if (seenToolInvocationIds.has(toolInvocation.invocationId)) {
             // Do nothing, we already know of it
             continue;
           }
 
-          seenToolInvocationIds.add(toolCall.invocationId);
+          seenToolInvocationIds.add(toolInvocation.invocationId);
 
           const toolDef = toolsStore
-            .getToolΣ(toolCall.name, message.chatId)
+            .getToolΣ(toolInvocation.name, message.chatId)
             .get();
 
           const respondSync = <R extends JsonObject>(
@@ -548,7 +548,7 @@ function createStore_forChatMessages(
             setToolResult(
               message.chatId,
               message.id,
-              toolCall.invocationId,
+              toolInvocation.invocationId,
               result ?? { data: {} }
               // TODO Pass in AiGenerationOptions here, or make the backend use the same options
             ).catch((err) => {
@@ -561,9 +561,9 @@ function createStore_forChatMessages(
           const executeFn = toolDef?.execute;
           if (executeFn && autoExecutableMessages.has(message.id)) {
             (async () => {
-              const result = await executeFn(toolCall.args, {
-                name: toolCall.name,
-                invocationId: toolCall.invocationId,
+              const result = await executeFn(toolInvocation.args, {
+                name: toolInvocation.name,
+                invocationId: toolInvocation.invocationId,
               });
               respondSync(result ?? undefined);
             })().catch((err) => {

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -388,7 +388,7 @@ function createStore_forTools() {
 
 function createStore_forChatMessages(
   toolsStore: ReturnType<typeof createStore_forTools>,
-  setToolResult: (
+  setToolResultFn: (
     chatId: string,
     messageId: MessageId,
     invocationId: string,
@@ -546,7 +546,7 @@ function createStore_forChatMessages(
             ...args: OptionalTupleUnless<R, [result: ToolResultResponse<R>]>
           ) => {
             const [result] = args;
-            setToolResult(
+            setToolResultFn(
               message.chatId,
               message.id,
               toolInvocation.invocationId,

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -447,7 +447,7 @@ export type AiFailedAssistantMessage = {
   _optimistic?: true; // Only set by clients, never by server
 };
 
-export type AiChatMessage = AiUserMessage | AiAssistantMessage;
+export type AiChatMessage = Relax<AiUserMessage | AiAssistantMessage>;
 
 export type AiKnowledgeSource = {
   description: string;

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
@@ -44,10 +44,12 @@ export function AiMessageToolInvocation({
 
   const respond = useCallback(
     (result: ToolResultResponse | undefined) => {
-      if (part.stage === "receiving") {
-        console.log(
-          `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
-        );
+      if (message.status !== "awaiting-tool") {
+        // console.log("Ignoring respond(): message not awaiting tool result");
+      } else if (part.stage === "receiving") {
+        // console.log(
+        //   `Ignoring respond(): tool '${part.name}' (${part.invocationId}) is still receiving`
+        // );
       } else if (part.stage === "executed") {
         console.log(
           `Ignoring respond(): tool '${part.name}' (${part.invocationId}) has already executed`
@@ -62,7 +64,15 @@ export function AiMessageToolInvocation({
         );
       }
     },
-    [ai, message.chatId, message.id, part.stage, part.name, part.invocationId]
+    [
+      ai,
+      message.chatId,
+      message.id,
+      message.status,
+      part.invocationId,
+      part.name,
+      part.stage,
+    ]
   );
 
   const props = useMemo(() => {

--- a/packages/liveblocks-react/scripts/check-exports.ts
+++ b/packages/liveblocks-react/scripts/check-exports.ts
@@ -7,9 +7,10 @@ import { sorted } from "itertools";
 // Configuration
 const ALLOW_NO_JSDOCS = [
   "MutationContext",
-  "UseThreadsOptions",
   "RegisterAiKnowledgeProps",
   "RegisterAiToolProps",
+  "UseSendAiMessageOptions",
+  "UseThreadsOptions",
 ];
 
 // Add any hooks here that are allowed to have a different doc string between
@@ -43,9 +44,10 @@ const ALLOW_NO_FACTORY = [
   "Json",
   "JsonObject",
   "MutationContext",
-  "UseThreadsOptions",
   "RegisterAiKnowledgeProps",
   "RegisterAiToolProps",
+  "UseSendAiMessageOptions",
+  "UseThreadsOptions",
 ];
 
 /**

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -5,7 +5,11 @@ import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
 detectDupes(PKG_NAME, PKG_VERSION, PKG_FORMAT);
 
 export { ClientSideSuspense } from "./ClientSideSuspense";
-export type { MutationContext, UseThreadsOptions } from "./types";
+export type {
+  MutationContext,
+  UseSendAiMessageOptions,
+  UseThreadsOptions,
+} from "./types";
 
 // Re-exports from @liveblocks/client, for convenience
 export type { Json, JsonObject } from "@liveblocks/client";


### PR DESCRIPTION
Fixes LB-2113.

It should only ever make a network call once, and immediately become a no-op for any subsequent calls.
