### PR TITLE
`AiTool` and reasoning part improvements

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -536,6 +536,10 @@ render: () => (
     Callback fired when the collapsed state changes. Use this to control the
     collapsed state externally.
   </PropertiesListItem>
+  <PropertiesListItem name="collapsible" type="boolean">
+    Whether the tool content can be collapsed. If set to `false`, clicking on it
+    or changing the `collapsed` prop will have no effect.
+  </PropertiesListItem>
   <PropertiesListItem name="className" type="string">
     CSS class name to apply to the tool container.
   </PropertiesListItem>

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -538,7 +538,8 @@ render: () => (
   </PropertiesListItem>
   <PropertiesListItem name="collapsible" type="boolean">
     Whether the tool content can be collapsed. If set to `false`, clicking on it
-    or changing the `collapsed` prop will have no effect.
+    or changing the `collapsed` prop will have no effect. If there's no content,
+    this prop has no effect.
   </PropertiesListItem>
   <PropertiesListItem name="className" type="string">
     CSS class name to apply to the tool container.

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -63,8 +63,11 @@ export interface AiToolProps
 
   /**
    * Whether the content can be collapsed/expanded.
+   *
    * If set to `false`, clicking on it or changing the `collapsed` prop
    * will have no effect.
+   *
+   * If there's no content, this prop has no effect.
    */
   collapsible?: boolean;
 }
@@ -356,7 +359,8 @@ export const AiTool = Object.assign(
       //       For now we're limiting the visual issues caused by the above by using CSS's
       //       `:empty` pseudo-class to make the content 0px high if it's actually empty.
       const hasContent = Children.count(children) > 0;
-      const isCollapsible = collapsible ?? hasContent;
+      // If there's no content, the tool is never collapsible.
+      const isCollapsible = hasContent ? (collapsible ?? true) : false;
       const resolvedTitle = useMemo(() => {
         return title ?? prettifyString(name);
       }, [title, name]);

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -361,12 +361,6 @@ export const AiTool = Object.assign(
         return title ?? prettifyString(name);
       }, [title, name]);
 
-      console.log({
-        collapsible,
-        hasContent,
-        isCollapsible,
-      });
-
       // `AiTool` uses "collapsed" instead of "open" (like the `Composer` component) because "open"
       // makes sense next to something called "Collapsible" but less so for something called "AiTool".
       const handleCollapsibleOpenChange = useCallback(

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -60,6 +60,13 @@ export interface AiToolProps
    * The event handler called when the content is collapsed or expanded by clicking on it.
    */
   onCollapsedChange?: (collapsed: boolean) => void;
+
+  /**
+   * Whether the content can be collapsed/expanded.
+   * If set to `false`, clicking on it or changing the `collapsed` prop
+   * will have no effect.
+   */
+  collapsible?: boolean;
 }
 
 export type AiToolIconProps = ComponentProps<"div">;
@@ -323,6 +330,7 @@ export const AiTool = Object.assign(
         children,
         title,
         icon,
+        collapsible,
         collapsed,
         onCollapsedChange,
         className,
@@ -348,9 +356,16 @@ export const AiTool = Object.assign(
       //       For now we're limiting the visual issues caused by the above by using CSS's
       //       `:empty` pseudo-class to make the content 0px high if it's actually empty.
       const hasContent = Children.count(children) > 0;
+      const isCollapsible = collapsible ?? hasContent;
       const resolvedTitle = useMemo(() => {
         return title ?? prettifyString(name);
       }, [title, name]);
+
+      console.log({
+        collapsible,
+        hasContent,
+        isCollapsible,
+      });
 
       // `AiTool` uses "collapsed" instead of "open" (like the `Composer` component) because "open"
       // makes sense next to something called "Collapsible" but less so for something called "AiTool".
@@ -369,7 +384,7 @@ export const AiTool = Object.assign(
           // Regardless of `semiControlledCollapsed`, the collapsible is closed if there's no content.
           open={hasContent ? !semiControlledCollapsed : false}
           onOpenChange={handleCollapsibleOpenChange}
-          disabled={!hasContent}
+          disabled={!isCollapsible}
           data-result={result?.type}
           data-stage={stage}
         >
@@ -378,7 +393,7 @@ export const AiTool = Object.assign(
               <div className="lb-ai-tool-header-icon-container">{icon}</div>
             ) : null}
             <span className="lb-ai-tool-header-title">{resolvedTitle}</span>
-            {hasContent ? (
+            {isCollapsible ? (
               <span className="lb-collapsible-chevron lb-icon-container">
                 <ChevronRightIcon />
               </span>

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   memo,
   type ReactNode,
+  useEffect,
   useState,
 } from "react";
 
@@ -26,6 +27,7 @@ import type {
 import * as Collapsible from "../../primitives/Collapsible";
 import { classNames } from "../../utils/class-names";
 import { ErrorBoundary } from "../../utils/ErrorBoundary";
+import { useSemiControllableState } from "../../utils/use-controllable-state";
 import { Prose } from "./Prose";
 
 type UiAssistantMessage = WithNavigation<AiAssistantMessage>;
@@ -146,8 +148,17 @@ function ReasoningPart({
   part,
   isStreaming,
 }: AiMessageContentReasoningPartProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  // Start collapsed if reasoning is already done.
+  const [isOpen, setIsOpen] = useState(isStreaming);
   const $ = useOverrides();
+
+  // Auto-collapse when reasoning is done, while still allowing the user to
+  // open/collapse it manually during and after it's done.
+  useEffect(() => {
+    if (!isStreaming) {
+      setIsOpen(false);
+    }
+  }, [isStreaming]);
 
   return (
     <Collapsible.Root

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2798,7 +2798,7 @@
 
 .lb-ai-tool-header {
   display: flex;
-  gap: calc(0.25 * var(--lb-spacing));
+  gap: calc(0.3125 * var(--lb-spacing));
   align-items: center;
   inline-size: 100%;
   block-size: calc($lb-button-size + var(--lb-spacing));
@@ -2832,18 +2832,19 @@
 .lb-ai-tool-header-title {
   @include truncate;
 
+  margin-inline-end: calc(0.25 * var(--lb-spacing));
   color: var(--lb-foreground-secondary);
   font-size: 0.9375em;
 
   &:where(:first-child) {
-    margin-inline-start: calc(0.25 * var(--lb-spacing));
+    margin-inline-start: calc(0.3125 * var(--lb-spacing));
   }
 }
 
 .lb-ai-tool-header-status {
   flex: none;
   margin-inline-start: auto;
-  margin-inline-end: calc(0.25 * var(--lb-spacing));
+  margin-inline-end: calc(0.1875 * var(--lb-spacing));
   color: var(--lb-foreground-moderate);
 }
 


### PR DESCRIPTION
This PR tweaks a few things:
- Reasoning parts now auto-collapse when they're done, and they start collapsed when loading chats with reasoning parts that were already done
- `AiTool` has a new `collapsible` prop which will make `AiTool` no longer collapsible (it stays in its current `collapsed` state
- Improve `AiTool` header spacings

Now that 3.0 is launched, are we going back to regular smaller releases? I added docs changes in this PR but that means they'll be published as soon as this PR lands. I can move them to their own PR but over many small PRs that seems like a recipe to forget about docs changes.