### PR TITLE
Improve Mention nodes in `@liveblocks/react-lexical` and `@liveblocks/node-lexical`

### DIFF
--- a/packages/liveblocks-react-lexical/src/mentions/mention-node.tsx
+++ b/packages/liveblocks-react-lexical/src/mentions/mention-node.tsx
@@ -54,8 +54,13 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
     return {
       span: () => ({
         conversion: (element) => {
-          const value = atob(element.getAttribute("data-lexical-lb-mention")!);
-          const node = $createMentionNode(value);
+          const userId = element.getAttribute("data-lexical-lb-mention");
+
+          if (!userId) {
+            return null;
+          }
+
+          const node = $createMentionNode(userId);
           return { node };
         },
         priority: 1,
@@ -65,9 +70,8 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
 
   exportDOM(): DOMExportOutput {
     const element = document.createElement("span");
-    const value = this.getTextContent();
-    element.setAttribute("data-lexical-lb-mention", btoa(value));
-    element.textContent = this.getTextContent();
+    element.setAttribute("data-lexical-lb-mention", this.getUserId());
+    element.textContent = this.getUserId();
     return { element };
   }
 
@@ -101,6 +105,10 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
         <User userId={this.getUserId()} />
       </Mention>
     );
+  }
+
+  getTextContent(): string {
+    return MENTION_CHARACTER + this.getUserId();
   }
 }
 


### PR DESCRIPTION
While working on https://github.com/liveblocks/liveblocks/pull/2489, I found a few issues in the existing Mention nodes for Lexical, in both `@liveblocks/react-lexical` and `@liveblocks/node-lexical`.

- The two nodes weren't JSON serialized in the same way (one used `value` and the other `userId`), I'm still not entirely sure what that meant in practice or whether the ID behind `value` is a user ID or an inbox notification ID.
- The `@liveblocks/react-lexical` didn't convert to the DOM format correctly.