### PR TITLE
Fix starter kit

### DIFF
--- a/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
@@ -138,9 +138,41 @@ function EmailNotificationSettings() {
   );
 }
 
+function RoomNotificationSettings() {
+  const initialDocument = useInitialDocument();
+
+  return (
+    <>
+      <h3>In this document, receive thread notifications for… </h3>
+      <Suspense
+        fallback={
+          <div className={clsx(styles.switchBox, styles.loading)}>
+            <Spinner />
+          </div>
+        }
+      >
+        <ThreadsSubscriptionSettings />
+      </Suspense>
+      {initialDocument.type === "text" || initialDocument.type === "note" ? (
+        <>
+          <h3>In this document, receive text mentions notifications for… </h3>
+          <Suspense
+            fallback={
+              <div className={clsx(styles.switchBox, styles.loading)}>
+                <Spinner />
+              </div>
+            }
+          >
+            <TextMentionsSubscriptionSettings />
+          </Suspense>
+        </>
+      ) : null}
+    </>
+  );
+}
+
 export function InboxSettingsDialog({ children }: { children: ReactNode }) {
   const isInsideRoom = useIsInsideRoom();
-  const initialDocument = useInitialDocument();
 
   return (
     <Dialog
@@ -148,37 +180,7 @@ export function InboxSettingsDialog({ children }: { children: ReactNode }) {
       content={
         <div className={styles.dialog}>
           <div className={styles.switches}>
-            {isInsideRoom ? (
-              <>
-                <h3>In this document, receive thread notifications for… </h3>
-                <Suspense
-                  fallback={
-                    <div className={clsx(styles.switchBox, styles.loading)}>
-                      <Spinner />
-                    </div>
-                  }
-                >
-                  <ThreadsSubscriptionSettings />
-                </Suspense>
-                {initialDocument.type === "text" ||
-                initialDocument.type === "note" ? (
-                  <>
-                    <h3>
-                      In this document, receive text mentions notifications for…{" "}
-                    </h3>
-                    <Suspense
-                      fallback={
-                        <div className={clsx(styles.switchBox, styles.loading)}>
-                          <Spinner />
-                        </div>
-                      }
-                    >
-                      <TextMentionsSubscriptionSettings />
-                    </Suspense>
-                  </>
-                ) : null}
-              </>
-            ) : null}
+            {isInsideRoom ? <RoomNotificationSettings /> : null}
             <h3>In all documents, receive emails for…</h3>
             <Suspense
               fallback={

--- a/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
+++ b/starter-kits/nextjs-starter-kit/components/Inbox/InboxSettingsDialog.tsx
@@ -138,7 +138,7 @@ function EmailNotificationSettings() {
   );
 }
 
-function RoomNotificationSettings() {
+function RoomSubscriptionSettings() {
   const initialDocument = useInitialDocument();
 
   return (
@@ -180,7 +180,7 @@ export function InboxSettingsDialog({ children }: { children: ReactNode }) {
       content={
         <div className={styles.dialog}>
           <div className={styles.switches}>
-            {isInsideRoom ? <RoomNotificationSettings /> : null}
+            {isInsideRoom ? <RoomSubscriptionSettings /> : null}
             <h3>In all documents, receive emails for…</h3>
             <Suspense
               fallback={


### PR DESCRIPTION
`InboxSettingsDialog` and the inbox popover in general are rendered even in the dashboard view but `useInitialDocument` throws if it's not in a document so currently the dashboard crashes when you open the popover. 