### PR TITLE
Fix tool call signal not being created correctly

### DIFF
--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -326,11 +326,11 @@ function createStore_forTools() {
       return (
         // A tool that's registered and scoped to a specific chat ID...
         (chatId !== undefined
-          ? toolsByChatIdΣ.get(chatId)?.get(name)
+          ? toolsByChatIdΣ.getOrCreate(chatId).getOrCreate(name)
           : undefined
         )?.get() ??
         // ...or a globally registered tool
-        toolsByChatIdΣ.getOrCreate(kWILDCARD).get(name)?.get()
+        toolsByChatIdΣ.getOrCreate(kWILDCARD).getOrCreate(name).get()
       );
     });
   });


### PR DESCRIPTION
This PR updates the tool call signal reading logic so that if a tool call signal is read before it's registered, we still create a signal.