### PR TITLE
Add tests for auto `www.` links in comments

### DIFF
--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -310,7 +310,7 @@ test.describe("Composer", () => {
 
       // Fill the editor with text containing URLs
       await editor.pressSequentially(
-        "https://liveblocks.io - https://liveblocksio#test,https://google.com/test https://.com https://liveblocks.io/?test#test"
+        "https://liveblocks.io - https://liveblocksio#test,https://google.com/test https://.com https://liveblocks.io/?test#test www.liveblocks.io"
       );
 
       // ➡️ The editor contains the valid links
@@ -341,6 +341,8 @@ test.describe("Composer", () => {
         { type: "link", url: "https://google.com/test" },
         { text: " https://.com " },
         { type: "link", url: "https://liveblocks.io/?test#test" },
+        { text: " " },
+        { type: "link", url: "www.liveblocks.io" },
         { text: "" },
       ]);
     });

--- a/packages/liveblocks-core/src/comments/__tests__/comment-body.test.ts
+++ b/packages/liveblocks-core/src/comments/__tests__/comment-body.test.ts
@@ -150,6 +150,24 @@ const commentBodyWithMentions: CommentBody = {
   ],
 };
 
+const commentBodyWihValidUrls: CommentBody = {
+  version: 1,
+  content: [
+    {
+      type: "paragraph",
+      children: [
+        { text: "This is a " },
+        { type: "link", url: "https://liveblocks.io", text: "link" },
+        { text: " and " },
+        {
+          type: "link",
+          url: "www.liveblocks.io/docs?query=123#hash",
+        },
+      ],
+    },
+  ],
+};
+
 const commentBodyWihInvalidUrls: CommentBody = {
   version: 1,
   content: [
@@ -399,6 +417,22 @@ describe("stringifyCommentBody", () => {
     ).resolves.toBe(
       "Hello _**\\*\\*world\\*\\***_ and [https://liveblocks.io](https://liveblocks.io)"
     );
+  });
+
+  test("should preserve valid URLs", async () => {
+    await expect(
+      stringifyCommentBody(commentBodyWihValidUrls, { format: "html" })
+    ).resolves.toBe(
+      '<p>This is a <a href="https://liveblocks.io" target="_blank" rel="noopener noreferrer">link</a> and <a href="https://www.liveblocks.io/docs?query=123#hash" target="_blank" rel="noopener noreferrer">www.liveblocks.io/docs?query=123#hash</a></p>'
+    );
+    await expect(
+      stringifyCommentBody(commentBodyWihValidUrls, { format: "markdown" })
+    ).resolves.toBe(
+      "This is a [link](https://liveblocks.io) and [www.liveblocks.io/docs?query=123\\#hash](https://www.liveblocks.io/docs?query=123\\#hash)"
+    );
+    await expect(
+      stringifyCommentBody(commentBodyWihValidUrls, { format: "plain" })
+    ).resolves.toBe("This is a link and www.liveblocks.io/docs?query=123#hash");
   });
 
   test("should replace invalid URLs with plain text", async () => {

--- a/packages/liveblocks-emails/src/__tests__/_helpers.ts
+++ b/packages/liveblocks-emails/src/__tests__/_helpers.ts
@@ -222,6 +222,24 @@ export const commentBodyWithInvalidUrls: CommentBody = {
   ],
 };
 
+export const commentBodyWithValidUrls: CommentBody = {
+  version: 1,
+  content: [
+    {
+      type: "paragraph",
+      children: [
+        { text: "Trying with " },
+        { type: "link", url: "https://liveblocks.io", text: "this link" },
+        { text: " and " },
+        {
+          type: "link",
+          url: "www.liveblocks.io/docs?query=123#hash",
+        },
+      ],
+    },
+  ],
+};
+
 export const makeComment = ({
   userId,
   threadId,

--- a/packages/liveblocks-emails/src/__tests__/comment-body.test.tsx
+++ b/packages/liveblocks-emails/src/__tests__/comment-body.test.tsx
@@ -13,6 +13,7 @@ import {
   commentBodyWithHtml,
   commentBodyWithHtml2,
   commentBodyWithInvalidUrls,
+  commentBodyWithValidUrls,
   resolveUsers,
 } from "./_helpers";
 
@@ -102,6 +103,16 @@ describe("convert comment body", () => {
 
     expect(body1).toEqual(expected1);
     expect(body2).toEqual(expected2);
+  });
+
+  it("should preserve valid URLs", async () => {
+    const body = await convertCommentBody(commentBodyWithValidUrls, {
+      elements,
+    });
+    const expected =
+      '<p>Trying with <a href="https://liveblocks.io" target="_blank" rel="noopener noreferrer">this link</a> and <a href="https://www.liveblocks.io/docs?query=123#hash" target="_blank" rel="noopener noreferrer">www.liveblocks.io/docs?query=123#hash</a></p>';
+
+    expect(body).toEqual(expected);
   });
 
   it("should replace invalid URLs with plain text", async () => {


### PR DESCRIPTION
This PR adds new tests to make sure auto `www.` links are kept as is and not converted to HTTPS URLs.