### PR TITLE
Retry previous action

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -656,7 +656,7 @@ clicked.
     name="overrides"
     type="Partial<GlobalOverrides & AiToolConfirmationOverrides>"
   >
-    Override the component’s strings. It can be used the change the "confirm"
+    Override the component’s strings. It can be used to change the "confirm"
     and "cancel" labels.
   </PropertiesListItem>
 </PropertiesList>
@@ -1129,7 +1129,7 @@ retrieved with [`useThreads`](/docs/api-reference/liveblocks-react#useThreads).
 import { Comment } from "@liveblocks/react-ui";
 import { ThreadData } from "@liveblocks/client";
 
-// Renders a list of comments attach to the specified `thread`
+// Renders a list of comments attached to the specified `thread`
 function Component({ thread }: { thread: ThreadData }) {
   return (
     <>
@@ -2341,7 +2341,7 @@ function MyComposerAttachments() {
     type="function"
     detailedType="(mark: ComposerBodyMark) => void"
   >
-    Remove an attachment by its ID.
+    Toggle the specified mark on/off for the current selection.
   </PropertiesListItem>
   <PropertiesListItem
     name="createMention"


### PR DESCRIPTION
```
<!-- We appreciate your efforts in opening a PR! Your contribution means a lot.
In order to ensure a seamless handling of your PR, we kindly ask you to refer to the checklist sections provided below.
Please select the appropriate checklist that corresponds to the changes you are making:

## For Contributors

### Fixing a bug

- Provide helpful info for reviewer:
  - A clear and concise description of the problem that the bug is causing.
  - Steps to reproduce the issue, if applicable.
  - An explanation of the changes made to fix the bug, including any relevant code snippets.
  - Any new or updated tests that were added to ensure that the bug is fully resolved.
  - A summary of any potential side effects that could result from the bug fix, if any.
  - A list of any other related issues or PRs that may be impacted by the bug fix.

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added
- Documentation added

## For Maintainers

### Description

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Add review comments if necessary to explain to the reviewer the logic behind a change

#### How to test it

- Provide recordings, Looms, or screenshots to help reviewers quickly identify the happy path and what they should test on their side.

#### Related issue(s)

- Add the related issue(s) here:
  - https://github.com/liveblocks/[REPOSITORY]/issues/[ISSUE_NUMBER]
  - ...
  
 -->

## For Contributors

### Fixing a bug

- Provide helpful info for reviewer:
  - A clear and concise description of the problem that the bug is causing.
    Multiple typos and grammatical errors were found in the `liveblocks-react-ui.mdx` documentation file, leading to unclear or incorrect information.
  - Steps to reproduce the issue, if applicable.
    The typos were identified at specific lines in `docs/pages/api-reference/liveblocks-react-ui.mdx`:
    - Line 658: "It can be used the change"
    - Line 1131: "comments attach to"
    - Line 2343: Incorrect description for `toggleMark` function.
  - An explanation of the changes made to fix the bug, including any relevant code snippets.
    Corrected three typos in `docs/pages/api-reference/liveblocks-react-ui.mdx`:
    1.  **Line 658**: Changed "It can be used the change" to "It can be used to change".
    2.  **Line 1131**: Changed "comments attach to" to "comments attached to".
    3.  **Line 2343**: Updated the description for `toggleMark` from "Remove an attachment by its ID." to "Toggle the specified mark on/off for the current selection."
  - Any new or updated tests that were added to ensure that the bug is fully resolved.
    N/A (documentation changes).
  - A summary of any potential side effects that could result from the bug fix, if any.
    None expected. This is a documentation-only change.
  - A list of any other related issues or PRs that may be impacted by the bug fix.
    This PR addresses a request to fix typos on the react-ui docs page.
```

---

[Slack Thread](https://liveblocks.slack.com/archives/D09252AMCRZ/p1752229731543699?thread_ts=1752229731.543699&cid=D09252AMCRZ)