### PR TITLE
Fix typos in react-ui documentation

### DIFF
--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -1346,7 +1346,7 @@ function MyComposer() {
     { body, attachments }: ComposerSubmitComment,
     event: FormEvent<HTMLFormElement>
   ) {
-    event.preventdefault();
+    event.preventDefault();
 
     // Create a new thread
     // +++

--- a/docs/pages/ready-made-features/comments/hooks.mdx
+++ b/docs/pages/ready-made-features/comments/hooks.mdx
@@ -142,7 +142,7 @@ function MyComposer() {
     { body }: ComposerSubmitComment,
     event: FormEvent<HTMLFormElement>
   ) {
-    event.preventdefault();
+    event.preventDefault();
 
     const thread = createThread({
       body,

--- a/docs/pages/ready-made-features/comments/primitives.mdx
+++ b/docs/pages/ready-made-features/comments/primitives.mdx
@@ -184,7 +184,7 @@ function MyComposer() {
   return (
     <Composer.Form
       onComposerSubmit={({ body }, event) => {
-        event.preventdefault();
+        event.preventDefault();
         const thread = createThread({
           body,
           metadata: {},


### PR DESCRIPTION
```
<!-- We appreciate your efforts in opening a PR! Your contribution means a lot.
In order to ensure a seamless handling of your PR, we kindly ask you to refer to the checklist sections provided below.
Please select the appropriate checklist that corresponds to the changes you are making:

## For Contributors

### Fixing a bug

- Provide helpful info for reviewer:
  - A clear and concise description of the problem that the bug is causing.
  - An explanation of the changes made to fix the bug, including any relevant code snippets.

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added
- Documentation added

## For Maintainers

### Description

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Add review comments if necessary to explain to the reviewer the logic behind a change

#### How to test it

- Provide recordings, Looms, or screenshots to help reviewers quickly identify the happy path and what they should test on their side.

#### Related issue(s)

- Add the related issue(s) here:
  - https://github.com/liveblocks/[REPOSITORY]/issues/[ISSUE_NUMBER]
  - ...
  
 -->

### Fixing a bug

- **Description of the problem:**
  The JavaScript method `event.preventDefault()` was consistently misspelled as `event.preventdefault()` in code examples within the React UI documentation. This could lead to confusion or incorrect copy-pasting by users.

- **Explanation of changes:**
  Corrected all instances of `preventdefault` to `preventDefault` in the following documentation files:
  - `docs/pages/api-reference/liveblocks-react-ui.mdx`
  - `docs/pages/ready-made-features/comments/hooks.mdx`
  - `docs/pages/ready-made-features/comments/primitives.mdx`
```

---

[Slack Thread](https://liveblocks.slack.com/archives/D09252AMCRZ/p1752230970684949?thread_ts=1752230970.684949&cid=D09252AMCRZ)