### PR TITLE
`AiChat`: Instantly scroll to bottom on initial render when messages are already in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## v3.1.2
 
-### `@liveblocks/react-ui` and `@liveblocks/emails`
+### `@liveblocks/react-ui`
+
+- Improve URL sanitization in comments.
+- Fix `AiChat` component not scrolling instantly to the bottom on render when
+  messages are already loaded.
+
+### `@liveblocks/emails`
 
 - Improve URL sanitization in comments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## vNEXT (not yet published)
 
-## v3.1.2
+## v3.1.3
 
 ### `@liveblocks/react-ui`
 
-- Improve URL sanitization in comments.
 - Fix `AiChat` component not scrolling instantly to the bottom on render when
   messages are already loaded.
 
-### `@liveblocks/emails`
+## v3.1.2
+
+### `@liveblocks/react-ui` and `@liveblocks/emails`
 
 - Improve URL sanitization in comments.
 

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -178,6 +178,13 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
     }
     const scrollToBottom = scrollToBottomCallbackRef.current;
 
+    useEffect(() => {
+      if (messages === undefined) return;
+      scrollToBottom("instant");
+      // If the messages are already loaded during the initial render, we want to scroll to the bottom immediately.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     return (
       <div
         ref={containerRef}
@@ -312,6 +319,7 @@ function AutoScrollHandler({
 
   // Scroll to bottom when sending a new message
   useEffect(() => {
+    if (lastSentMessageId === null) return;
     scrollToBottom("smooth");
   }, [lastSentMessageId, scrollToBottom]);
 

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -9,7 +9,6 @@ import {
   RegisterAiTool,
   useAiChatMessages,
 } from "@liveblocks/react";
-import { useLayoutEffect } from "@liveblocks/react/_private";
 import {
   type ComponentProps,
   type ComponentType,
@@ -178,13 +177,6 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
     }
     const scrollToBottom = scrollToBottomCallbackRef.current;
 
-    useEffect(() => {
-      if (messages === undefined) return;
-      scrollToBottom("instant");
-      // If the messages are already loaded during the initial render, we want to scroll to the bottom immediately.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
     return (
       <div
         ref={containerRef}
@@ -313,7 +305,7 @@ function AutoScrollHandler({
   scrollToBottom: (behavior: "instant" | "smooth") => void;
 }) {
   // Scroll to bottom when the component first mounts
-  useLayoutEffect(() => {
+  useEffect(() => {
     scrollToBottom("instant");
   }, [scrollToBottom]);
 


### PR DESCRIPTION
The `AiChat` component would scroll instantly to bottom once chat messages were loaded - this was thanks to the `AutoScrollHandler` component that would only be mounted when the messages were rendered, which would normally happen after `AiChat` container was mounted because messages would took a short while to be fetched.

But in case when the messages are already in cache or loaded, the `AutoScrollHandler` would mount even before the `AiChat` container, so the following code logic would not run as expected because `containerRef.current` wasn't populated.

```ts
const container = containerRef.current;
if (container === null) return;

container.scrollTo({
  top: container.scrollHeight,
  behavior,
});
```

This PR fixes that by running a `useEffect` that runs when `AiChat` is mounted and only scrolls to bottom on initial render if messages wasn't empty.