### PR TITLE
Pass 'copilotId' to `set-tool-call-result` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## vNEXT (not yet published)
 
+## v3.1.4
+
+### `@liveblocks/react-ui`
+
+- Fix copilot id not being passed to 'set-tool-call-result' command that is
+  dispatched when a tool call is responded to. Previously, we were using the
+  default copilot to generate messages from the tool call result.
+
 ## v3.1.3
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -236,6 +236,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
                         message={message}
                         overrides={overrides}
                         components={components}
+                        copilotId={copilotId}
                       />
                     );
                   } else {

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -49,11 +49,20 @@ export interface AiChatAssistantMessageProps extends ComponentProps<"div"> {
    * Override the component's components.
    */
   components?: Partial<GlobalComponents>;
+
+  /**
+   * @internal
+   * The id of the copilot to use to set tool call result.
+   */
+  copilotId?: string;
 }
 
 export const AiChatAssistantMessage = memo(
   forwardRef<HTMLDivElement, AiChatAssistantMessageProps>(
-    ({ message, className, overrides, components, ...props }, forwardedRef) => {
+    (
+      { message, className, overrides, components, copilotId, ...props },
+      forwardedRef
+    ) => {
       const $ = useOverrides(overrides);
 
       let children: ReactNode = null;
@@ -75,18 +84,27 @@ export const AiChatAssistantMessage = memo(
             </div>
           );
         } else {
-          children = <AssistantMessageContent message={message} />;
+          children = (
+            <AssistantMessageContent message={message} copilotId={copilotId} />
+          );
         }
       } else if (message.status === "completed") {
-        children = <AssistantMessageContent message={message} />;
+        children = (
+          <AssistantMessageContent message={message} copilotId={copilotId} />
+        );
       } else if (message.status === "failed") {
         // Do not include the error message if the user aborted the request.
         if (message.errorReason === "Aborted by user") {
-          children = <AssistantMessageContent message={message} />;
+          children = (
+            <AssistantMessageContent message={message} copilotId={copilotId} />
+          );
         } else {
           children = (
             <>
-              <AssistantMessageContent message={message} />
+              <AssistantMessageContent
+                message={message}
+                copilotId={copilotId}
+              />
 
               <div className="lb-ai-chat-message-error">
                 <span className="lb-icon-container">
@@ -119,7 +137,13 @@ export const AiChatAssistantMessage = memo(
   )
 );
 
-function AssistantMessageContent({ message }: { message: UiAssistantMessage }) {
+function AssistantMessageContent({
+  message,
+  copilotId,
+}: {
+  message: UiAssistantMessage;
+  copilotId?: string;
+}) {
   return (
     <AiMessage.Content
       message={message}
@@ -128,6 +152,7 @@ function AssistantMessageContent({ message }: { message: UiAssistantMessage }) {
         ReasoningPart,
         ToolInvocationPart,
       }}
+      copilotId={copilotId}
       className="lb-ai-chat-message-content"
     />
   );
@@ -191,6 +216,7 @@ function ReasoningPart({
 function ToolInvocationPart({
   part,
   message,
+  copilotId,
 }: AiMessageContentToolInvocationPartProps) {
   return (
     <div className="lb-ai-chat-message-tool-invocation">
@@ -207,7 +233,11 @@ function ToolInvocationPart({
           </div>
         }
       >
-        <AiMessageToolInvocation part={part} message={message} />
+        <AiMessageToolInvocation
+          part={part}
+          message={message}
+          copilotId={copilotId}
+        />
       </ErrorBoundary>
     </div>
   );

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -39,7 +39,7 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
  * <AiMessage.Content message={message} components={{ TextPart }} />
  */
 const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
-  ({ message, components, asChild, ...props }, forwardedRef) => {
+  ({ message, components, asChild, copilotId, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
     const { TextPart, ReasoningPart, ToolInvocationPart } = useMemo(
       () => ({ ...defaultMessageContentComponents, ...components }),
@@ -70,6 +70,7 @@ const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
                   part={part}
                   {...extra}
                   message={message}
+                  copilotId={copilotId}
                 />
               );
             default:

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
@@ -2,6 +2,7 @@ import type {
   AiChatMessage,
   AiToolInvocationPart,
   AiToolInvocationProps,
+  CopilotId,
   JsonObject,
   ToolResultResponse,
 } from "@liveblocks/core";
@@ -34,9 +35,11 @@ function StableRenderFn(props: {
 export function AiMessageToolInvocation({
   message,
   part,
+  copilotId,
 }: {
   message: AiChatMessage;
   part: AiToolInvocationPart;
+  copilotId?: string;
 }) {
   const client = useClient();
   const ai = client[kInternal].ai;
@@ -59,8 +62,8 @@ export function AiMessageToolInvocation({
           message.chatId,
           message.id,
           part.invocationId,
-          result ?? { data: {} }
-          // TODO Pass in AiGenerationOptions here?
+          result ?? { data: {} },
+          { copilotId: copilotId as CopilotId }
         );
       }
     },
@@ -72,6 +75,7 @@ export function AiMessageToolInvocation({
       part.invocationId,
       part.name,
       part.stage,
+      copilotId,
     ]
   );
 

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -33,6 +33,8 @@ export type AiMessageContentToolInvocationPartProps = {
   /** @internal */
   message: AiChatMessage;
   part: AiToolInvocationPart;
+  /** @internal */
+  copilotId?: string;
 };
 
 export interface AiMessageContentComponents {
@@ -65,4 +67,10 @@ export interface AiMessageContentProps extends ComponentPropsWithSlot<"div"> {
    * the message content.
    */
   components?: Partial<AiMessageContentComponents>;
+
+  /**
+   * @internal
+   * The id of the copilot to use to set tool call result.
+   */
+  copilotId?: string;
 }


### PR DESCRIPTION
Fix copilot id not being passed to 'set-tool-call-result' command that is dispatched when a tool call is responded to. Previously, we were using the default copilot to generate messages from the tool call result.


See `generationOptions` in the screenshot:

<img width="715" height="288" alt="Screenshot 2025-07-18 at 3 20 49 PM" src="https://github.com/user-attachments/assets/08b05a7c-e1fe-47f5-8a42-30ba3a743721" />
