### PR TITLE
Remove `AiChat` gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Expose Markdown components in `AiChat`’s `components` prop to customize the
   rendering of Markdown content.
+- Remove the gradient above `AiChat`’s composer.
 - Add `blurOnSubmit` prop to `Composer` (also available on the `Composer.Form`
   primitive and as `blurComposerOnSubmit` on `Thread`) to control whether a
   composer should lose focus after being submitted.

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2660,11 +2660,11 @@
       content: "";
       position: absolute;
       inset: 0;
-      inset-block-start: calc(-3 * var(--lb-spacing));
+      inset-block-start: 0;
       background: linear-gradient(
         to bottom,
         transparent 0%,
-        var(--lb-background) calc(3.5 * var(--lb-spacing))
+        var(--lb-background) var(--lb-spacing)
       );
       pointer-events: none;
     }


### PR DESCRIPTION
This PR removes the gradient above `AiChat`'s composer (that was only visible with `layout` set to `inset`).

The gradient isn't technically removed because it's used to hide the content below the composer or in case some of the main content is somehow wider than the composer so it would appear cut off at some point. Instead, the gradient is pushed to be fully behind the composer.