### PR TITLE
Prepare `AiMessage` primitive

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
+++ b/e2e/next-ai-kitchen-sink/app/chats/[chatId]/assistant-message.tsx
@@ -191,15 +191,14 @@ function AssistantMessageContent({ message }: { message: UiAssistantMessage }) {
     <div>
       <AiMessage.Content
         message={message}
-        components={{
-          TextPart: ({ part }) => (
+        parts={{
+          Text: ({ part }) => (
             <TextPart
               text={part.text}
               className="prose whitespace-break-spaces"
             />
           ),
-
-          ReasoningPart: ({ part }) => (
+          Reasoning: ({ part }) => (
             <ReasoningPart text={part.text} isPending={isReasoning} />
           ),
         }}

--- a/packages/liveblocks-react-ui/src/_private/index.ts
+++ b/packages/liveblocks-react-ui/src/_private/index.ts
@@ -26,7 +26,7 @@ export type {
 } from "../primitives/AiChatComposer/types";
 export * as AiMessage from "../primitives/AiMessage";
 export type {
-  AiMessageContentComponents,
+  AiMessageContentParts,
   AiMessageContentProps,
   AiMessageContentReasoningPartProps,
   AiMessageContentTextPartProps,

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -176,12 +176,12 @@ function AssistantMessageContent({
   return (
     <AiMessage.Content
       message={message}
-      components={{
-        TextPart: (props) => <TextPart {...props} components={components} />,
-        ReasoningPart: (props) => (
+      parts={{
+        Text: (props) => <TextPart {...props} components={components} />,
+        Reasoning: (props) => (
           <ReasoningPart {...props} components={components} />
         ),
-        ToolInvocationPart,
+        ToolInvocation: ToolInvocationPart,
       }}
       copilotId={copilotId}
       className="lb-ai-chat-message-content"

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatUserMessage.tsx
@@ -55,8 +55,8 @@ export const AiChatUserMessage = memo(
             <div className="lb-ai-chat-message-content">
               <AiMessage.Content
                 message={message}
-                components={{
-                  TextPart: PlainTextPart,
+                parts={{
+                  Text: PlainTextPart,
                 }}
                 className="lb-prose lb-ai-chat-message-text"
               />

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/index.tsx
@@ -4,21 +4,18 @@ import { forwardRef, useMemo } from "react";
 import { ErrorBoundary } from "../../utils/ErrorBoundary";
 import { Markdown } from "../Markdown";
 import { AiMessageToolInvocation } from "./tool-invocation";
-import type {
-  AiMessageContentComponents,
-  AiMessageContentProps,
-} from "./types";
+import type { AiMessageContentParts, AiMessageContentProps } from "./types";
 
 const AI_MESSAGE_CONTENT_NAME = "AiMessageContent";
 
-const defaultMessageContentComponents: AiMessageContentComponents = {
-  TextPart: ({ part }) => {
+const defaultMessageContentParts: AiMessageContentParts = {
+  Text: ({ part }) => {
     return <Markdown content={part.text} />;
   },
-  ReasoningPart: ({ part }) => {
+  Reasoning: ({ part }) => {
     return <Markdown content={part.text} />;
   },
-  ToolInvocationPart: ({ part, message }) => {
+  ToolInvocation: ({ part, message }) => {
     return (
       <ErrorBoundary fallback={null}>
         <AiMessageToolInvocation part={part} message={message} />
@@ -36,14 +33,14 @@ const defaultMessageContentComponents: AiMessageContentComponents = {
  * an array of parts.
  *
  * @example
- * <AiMessage.Content message={message} components={{ TextPart }} />
+ * <AiMessage.Content message={message} parts={{ Text: ({ part }) => <p>{part.text}</p> }} />
  */
 const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
-  ({ message, components, asChild, copilotId, ...props }, forwardedRef) => {
+  ({ message, parts, asChild, copilotId, ...props }, forwardedRef) => {
     const Component = asChild ? Slot : "div";
-    const { TextPart, ReasoningPart, ToolInvocationPart } = useMemo(
-      () => ({ ...defaultMessageContentComponents, ...components }),
-      [components]
+    const { Text, Reasoning, ToolInvocation } = useMemo(
+      () => ({ ...defaultMessageContentParts, ...parts }),
+      [parts]
     );
 
     const content = message.content ?? message.contentSoFar;
@@ -60,12 +57,12 @@ const AiMessageContent = forwardRef<HTMLDivElement, AiMessageContentProps>(
           const extra = { index, isStreaming };
           switch (part.type) {
             case "text":
-              return <TextPart key={index} part={part} {...extra} />;
+              return <Text key={index} part={part} {...extra} />;
             case "reasoning":
-              return <ReasoningPart key={index} part={part} {...extra} />;
+              return <Reasoning key={index} part={part} {...extra} />;
             case "tool-invocation":
               return (
-                <ToolInvocationPart
+                <ToolInvocation
                   key={index}
                   part={part}
                   {...extra}

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/types.ts
@@ -37,36 +37,35 @@ export type AiMessageContentToolInvocationPartProps = {
   copilotId?: string;
 };
 
-export interface AiMessageContentComponents {
+export interface AiMessageContentParts {
   /**
    * The component used to display text parts.
    */
-  TextPart: ComponentType<AiMessageContentTextPartProps>;
+  Text: ComponentType<AiMessageContentTextPartProps>;
 
   /**
    * The component used to display reasoning parts.
    */
-  ReasoningPart: ComponentType<AiMessageContentReasoningPartProps>;
+  Reasoning: ComponentType<AiMessageContentReasoningPartProps>;
 
   /**
    * NOTE that ToolInvocationPart is slightly different.
    * Tool invocations are typically rendered via the render() method instead.
    * @internal
    */
-  ToolInvocationPart: ComponentType<AiMessageContentToolInvocationPartProps>;
+  ToolInvocation: ComponentType<AiMessageContentToolInvocationPartProps>;
 }
 
 export interface AiMessageContentProps extends ComponentPropsWithSlot<"div"> {
   /**
-   * The message contents to display.
+   * The message to display.
    */
   message: AiChatMessage;
 
   /**
-   * Optional overrides for the default components to render each part within
-   * the message content.
+   * Override specific message parts.
    */
-  components?: Partial<AiMessageContentComponents>;
+  parts?: Partial<AiMessageContentParts>;
 
   /**
    * @internal


### PR DESCRIPTION
- [x] Rename `components` prop to `parts`
  - Similar to how `InboxNotification` uses `kinds` and not `components`, I think `components` works well as a default unless there's a specific common aspect like `kinds` or `parts` in which case imo these are easier to understand
- [ ] Make the "tool invocation" part public? And usable as a standalone `AiMessage.ToolInvocation` in case you want to loop through `message.parts` yourself?
  - [ ] Find an API for it where it's hard to shoot yourself in the foot with it, given how much logic this component holds (it executes/orchestrates the tools)
  - [ ] Avoid needing to pass `copilotId` to it 