### PR TITLE
Perform synchronization at a debounced interval to update synchronization status for a Y.js document

### DIFF
--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3045,7 +3045,9 @@ export function createRoom<
 
   function yjsStatusDidChange(status: YjsSyncStatus) {
     return syncSourceForYjs.setSyncStatus(
-      status === "synchronizing" ? "synchronizing" : "synchronized"
+      status === "synchronizing" || status === "loading"
+        ? "synchronizing"
+        : "synchronized"
     );
   }
 

--- a/packages/liveblocks-yjs/src/doc.ts
+++ b/packages/liveblocks-yjs/src/doc.ts
@@ -1,16 +1,29 @@
+import { Signal } from "@liveblocks/core";
 import { Base64 } from "js-base64";
 import { Observable } from "lib0/observable";
 import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 
+export enum SyncState {
+  Idle = "Idle",
+  LocalDirty = "LocalDirty",
+  Syncing = "Syncing",
+  Synced = "Synced",
+}
+
 export default class yDocHandler extends Observable<unknown> {
   private unsubscribers: Array<() => void> = [];
 
-  private _synced = false;
   private doc: Y.Doc;
   private updateRoomDoc: (update: Uint8Array) => void;
   private fetchRoomDoc: (vector: string) => void;
   private useV2Encoding: boolean;
+
+  public readonly _isInitialSyncCompleteΣ = new Signal(false);
+  public readonly _syncStateΣ = new Signal<SyncState>(SyncState.Idle);
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private static readonly DEBOUNCE_INTERVAL_MS = 1000;
 
   constructor({
     doc,
@@ -76,11 +89,16 @@ export default class yDocHandler extends Observable<unknown> {
       // now that we've sent our local and received from server, we're in sync
       // calling `syncDoc` again will sync up the documents
       this.synced = true;
+
+      // If there were edits made whiel we were syncing, this remote update may not necessarily have synced the document
+      if (this._syncStateΣ.get() !== SyncState.LocalDirty) {
+        this._syncStateΣ.set(SyncState.Synced);
+      }
     }
   };
 
   public syncDoc = (): void => {
-    this.synced = false;
+    this._syncStateΣ.set(SyncState.Syncing);
 
     // The state vector is sent to the server so it knows what to send back
     // if you don't send it, it returns everything
@@ -88,17 +106,29 @@ export default class yDocHandler extends Observable<unknown> {
     this.fetchRoomDoc(encodedVector);
   };
 
+  private debounceSync() {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.syncDoc();
+      this.debounceTimer = null;
+    }, yDocHandler.DEBOUNCE_INTERVAL_MS);
+  }
+
   // The sync'd property is required by some provider implementations
   get synced(): boolean {
-    return this._synced;
+    return this._isInitialSyncCompleteΣ.get();
   }
 
   set synced(state: boolean) {
-    if (this._synced !== state) {
-      this._synced = state;
+    if (this._isInitialSyncCompleteΣ.get() !== state) {
+      this._isInitialSyncCompleteΣ.set(state);
       this.emit("synced", [state]);
       this.emit("sync", [state]);
     }
+  }
+
+  get syncState(): SyncState {
+    return this._syncStateΣ.get();
   }
 
   private updateHandler = (
@@ -108,11 +138,14 @@ export default class yDocHandler extends Observable<unknown> {
     // don't send updates from indexedb, those will get handled by sync
     const isFromLocal = origin instanceof IndexeddbPersistence;
     if (origin !== "backend" && !isFromLocal) {
+      this._syncStateΣ.set(SyncState.LocalDirty);
       this.updateRoomDoc(update);
+      this.debounceSync();
     }
   };
 
   destroy(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.doc.off("update", this.updateHandler);
     this.unsubscribers.forEach((unsub) => unsub());
     this._observers = new Map();


### PR DESCRIPTION
This PR fixes a bug that was causing sync status to not return the correct value in certain situations (like deletions). We now perform the two step sync at a debounced rate after each local update.

1. Initial status: `Idle`
2. Client performs update. Status → `LocalDirty`
3. Immediately after, another update is made. (no change in status)
5. No updates occur for 200ms; client initiates the two step sync by sending its state vector to server. Status → `Syncing`
6. Client A receives diff from server. Status → `Synced`.

If other clients make update to their document and if those updates are received while syncing is in progress, no change is made to the status.

This is an alternative solution to this [other solution](https://github.com/liveblocks/liveblocks/pull/2535).