### PR TITLE
Fix Y.js provider synchronization status check with remote snapshot and fallback two step sync method

### DIFF
--- a/packages/liveblocks-core/src/protocol/ServerMsg.ts
+++ b/packages/liveblocks-core/src/protocol/ServerMsg.ts
@@ -223,7 +223,7 @@ export type YDocUpdateServerMsg = {
   readonly stateVector: string | null; // server's state vector, sent in response to fetch
   readonly guid?: string; // an optional guid to identify which subdoc this update to
   readonly v2?: boolean; // whether this is a v2 update
-  readonly remoteSnapshot: string; // The snapshot of server's document. Used to detect if the client has the latest version of the document.
+  readonly remoteSnapshot?: string; // The snapshot of server's document. Used to detect if the client has the latest version of the document.
 };
 
 /**

--- a/packages/liveblocks-yjs/src/provider.ts
+++ b/packages/liveblocks-yjs/src/provider.ts
@@ -69,6 +69,7 @@ export class LiveblocksYjsProvider
     this.unsubscribers.push(
       this.room.events.status.subscribe((status) => {
         if (status === "connected") {
+          this.rootDocHandler.synced = false;
           this.rootDocHandler.syncDoc();
         } else {
           this.rootDocHandler.synced = false;
@@ -103,7 +104,9 @@ export class LiveblocksYjsProvider
               stateVector,
               readOnly: !canWrite,
               v2,
-              remoteSnapshot: Base64.toUint8Array(remoteSnapshot),
+              remoteSnapshot: remoteSnapshot
+                ? Base64.toUint8Array(remoteSnapshot)
+                : undefined,
             });
         } else {
           this.rootDocHandler.handleServerUpdate({
@@ -111,7 +114,9 @@ export class LiveblocksYjsProvider
             stateVector,
             readOnly: !canWrite,
             v2,
-            remoteSnapshot: Base64.toUint8Array(remoteSnapshot),
+            remoteSnapshot: remoteSnapshot
+              ? Base64.toUint8Array(remoteSnapshot)
+              : undefined,
           });
         }
       })
@@ -154,6 +159,7 @@ export class LiveblocksYjsProvider
       return "synchronized";
     });
 
+    this.emit("status", [this.getStatus()]);
     this.unsubscribers.push(
       this.syncStatusΣ.subscribe(() => {
         this.emit("status", [this.getStatus()]);


### PR DESCRIPTION
This PR builds on top of https://github.com/liveblocks/liveblocks/pull/2535 and adds a fallback sync status checking mechanism. `remoteSnapshot` is now an optional part of the protocol and if it's not present, we fallback to syncing with the server after a debounce.

This is so that, in future if we decide to not support `remoteSnapshot` in our protocol, there's backwards compatibility.