### PR TITLE
Add prop on `Thread` to never show more than `n` comments

### DIFF
--- a/packages/liveblocks-react-ui/src/components/Thread.tsx
+++ b/packages/liveblocks-react-ui/src/components/Thread.tsx
@@ -447,7 +447,7 @@ export const Thread = forwardRef(
                 return (
                   <Fragment key={comment.id}>
                     <button onClick={() => setShowAllComments(true)}>
-                      Show {hiddenComments.count} replies
+                      {$.THREAD_SHOW_MORE_COMMENTS(hiddenComments.count)}
                     </button>
                   </Fragment>
                 );

--- a/packages/liveblocks-react-ui/src/components/Thread.tsx
+++ b/packages/liveblocks-react-ui/src/components/Thread.tsx
@@ -445,11 +445,17 @@ export const Thread = forwardRef(
 
               if (isFirstHiddenComment) {
                 return (
-                  <Fragment key={comment.id}>
-                    <button onClick={() => setShowAllComments(true)}>
+                  <div
+                    key={`${comment.id}-show-more`}
+                    className="lb-thread-show-more"
+                  >
+                    <Button
+                      className="lb-thread-show-more-button"
+                      onClick={() => setShowAllComments(true)}
+                    >
                       {$.THREAD_SHOW_MORE_COMMENTS(hiddenComments.count)}
-                    </button>
-                  </Fragment>
+                    </Button>
+                  </div>
                 );
               }
 

--- a/packages/liveblocks-react-ui/src/components/Thread.tsx
+++ b/packages/liveblocks-react-ui/src/components/Thread.tsx
@@ -233,7 +233,7 @@ export const Thread = forwardRef(
         ? thread.comments.length - 1
         : findLastIndex(thread.comments, (comment) => comment.body);
     }, [showDeletedComments, thread.comments]);
-    const hiddenCommentsIndices = useMemo(() => {
+    const hiddenComments = useMemo(() => {
       const maxVisibleCommentsCount =
         typeof maxVisibleComments === "number"
           ? maxVisibleComments
@@ -263,10 +263,15 @@ export const Thread = forwardRef(
 
       // Always show the first and last comments even if the limit is set to lower than 2.
       if (maxVisibleCommentsCount <= 2) {
+        const firstHiddenCommentIndex =
+          comments[1]?.index ?? firstVisibleComment.index;
+        const lastHiddenCommentIndex =
+          comments[comments.length - 2]?.index ?? lastVisibleComment.index;
+
         return {
-          first: comments[1]?.index ?? firstVisibleComment.index,
-          last:
-            comments[comments.length - 2]?.index ?? lastVisibleComment.index,
+          firstIndex: firstHiddenCommentIndex,
+          lastIndex: lastHiddenCommentIndex,
+          count: comments.slice(1, comments.length - 1).length,
         };
       }
 
@@ -302,8 +307,11 @@ export const Thread = forwardRef(
       }
 
       return {
-        first: firstHiddenComment.index,
-        last: lastHiddenComment.index,
+        firstIndex: firstHiddenComment.index,
+        lastIndex: lastHiddenComment.index,
+        count: thread.comments
+          .slice(firstHiddenComment.index, lastHiddenComment.index + 1)
+          .filter((comment) => showDeletedComments || comment.body).length,
       };
     }, [
       maxVisibleComments,
@@ -429,17 +437,17 @@ export const Thread = forwardRef(
               const isUnread =
                 unreadIndex !== undefined && index >= unreadIndex;
               const isHidden =
-                hiddenCommentsIndices &&
-                index >= hiddenCommentsIndices.first &&
-                index <= hiddenCommentsIndices.last;
+                hiddenComments &&
+                index >= hiddenComments.firstIndex &&
+                index <= hiddenComments.lastIndex;
               const isFirstHiddenComment =
-                isHidden && index === hiddenCommentsIndices.first;
+                isHidden && index === hiddenComments.firstIndex;
 
               if (isFirstHiddenComment) {
                 return (
                   <Fragment key={comment.id}>
                     <button onClick={() => setShowAllComments(true)}>
-                      Show more replies
+                      Show {hiddenComments.count} replies
                     </button>
                   </Fragment>
                 );

--- a/packages/liveblocks-react-ui/src/overrides.tsx
+++ b/packages/liveblocks-react-ui/src/overrides.tsx
@@ -194,7 +194,7 @@ export const defaultOverrides: Overrides = {
   THREAD_NEW_INDICATOR: "New",
   THREAD_NEW_INDICATOR_DESCRIPTION: "New comments",
   THREAD_SHOW_MORE_COMMENTS: (count) =>
-    `Show ${count} ${pluralize(count, "reply", "replies")}`,
+    `Show ${count} more ${pluralize(count, "reply", "replies")}`,
   THREAD_COMPOSER_PLACEHOLDER: "Reply to thread…",
   THREAD_COMPOSER_SEND: "Reply",
   INBOX_NOTIFICATION_MORE: "More",

--- a/packages/liveblocks-react-ui/src/overrides.tsx
+++ b/packages/liveblocks-react-ui/src/overrides.tsx
@@ -85,6 +85,7 @@ export interface ThreadOverrides {
   THREAD_UNSUBSCRIBE: string;
   THREAD_NEW_INDICATOR: string;
   THREAD_NEW_INDICATOR_DESCRIPTION: string;
+  THREAD_SHOW_MORE_COMMENTS: (count: number) => string;
   THREAD_COMPOSER_PLACEHOLDER: string;
   THREAD_COMPOSER_SEND: string;
 }
@@ -192,6 +193,8 @@ export const defaultOverrides: Overrides = {
   THREAD_UNSUBSCRIBE: "Unsubscribe from thread",
   THREAD_NEW_INDICATOR: "New",
   THREAD_NEW_INDICATOR_DESCRIPTION: "New comments",
+  THREAD_SHOW_MORE_COMMENTS: (count) =>
+    `Show ${count} ${pluralize(count, "reply", "replies")}`,
   THREAD_COMPOSER_PLACEHOLDER: "Reply to thread…",
   THREAD_COMPOSER_SEND: "Reply",
   INBOX_NOTIFICATION_MORE: "More",

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -1591,6 +1591,14 @@
   }
 }
 
+.lb-thread-show-more {
+  padding-inline: var(--lb-spacing);
+}
+
+.lb-thread-show-more-button {
+  inline-size: 100%;
+}
+
 .lb-thread-new-indicator {
   position: relative;
   z-index: 1;

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -1611,6 +1611,10 @@
   }
 }
 
+:where(.lb-thread-show-more + .lb-thread-new-indicator) {
+  margin-block-start: calc(0.5 * var(--lb-spacing));
+}
+
 .lb-thread-new-indicator {
   position: relative;
   z-index: 1;

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -1592,11 +1592,23 @@
 }
 
 .lb-thread-show-more {
-  padding-inline: var(--lb-spacing);
-}
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: calc(0.5 * var(--lb-spacing));
+  justify-content: center;
+  align-items: center;
 
-.lb-thread-show-more-button {
-  inline-size: 100%;
+  &::before,
+  &::after {
+    content: "";
+    z-index: 0;
+    flex: 1 0 auto;
+    min-inline-size: var(--lb-spacing);
+    block-size: 0;
+    border-block-start: 1px dashed var(--lb-foreground-subtle);
+    transition-property: border;
+  }
 }
 
 .lb-thread-new-indicator {


### PR DESCRIPTION
This PR introduces a new `maxVisibleComments` prop on `Thread`.

It's not set by default. It can be set as a number or for a more advanced API as an object to control which comments should become hidden.