### PR TITLE
Add query options to `useAiChats` and `useAiChatsSuspense`

### DIFF
--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -3,6 +3,7 @@ import type { AuthValue } from "./auth-manager";
 import type { Delegates, Status } from "./connection";
 import { ManagedSocket, StopRetrying } from "./connection";
 import { kInternal } from "./internal";
+import { AiChatDB } from "./lib/AiChatDB";
 import { assertNever } from "./lib/assert";
 import { Promise_withResolvers } from "./lib/controlledPromise";
 import { DefaultMap } from "./lib/DefaultMap";
@@ -13,7 +14,6 @@ import { nanoid } from "./lib/nanoid";
 import type { Resolve } from "./lib/Resolve";
 import { shallow, shallow2 } from "./lib/shallow";
 import { batch, DerivedSignal, MutableSignal, Signal } from "./lib/signals";
-import { SortedList } from "./lib/SortedList";
 import { TreePool } from "./lib/TreePool";
 import type { Brand, DistributiveOmit } from "./lib/utils";
 import { raise, tryParseJson } from "./lib/utils";
@@ -30,6 +30,7 @@ import type {
   AiAssistantDeltaUpdate,
   AiChat,
   AiChatMessage,
+  AiChatsQuery,
   AiFailedAssistantMessage,
   AiGeneratingAssistantMessage,
   AiGenerationOptions,
@@ -43,9 +44,9 @@ import type {
   ClientAiMsg,
   CmdId,
   CreateChatOptions,
-  Cursor,
   DeleteChatResponse,
   DeleteMessageResponse,
+  GetChatsOptions,
   GetChatsResponse,
   GetMessageTreeResponse,
   GetOrCreateChatResponse,
@@ -767,28 +768,18 @@ function createStore_forChatMessages(
 }
 
 function createStore_forUserAiChats() {
-  // The foundation is the mutable signal, which is a simple Map (easy to make
-  // one-off updates to). But externally we expose a derived signal that
-  // produces a new lazy "object" copy of this map any time it changes. This
-  // plays better with React APIs.
-  const allChatsInclDeletedΣ = new MutableSignal(
-    SortedList.with<AiChat>((x, y) => y.createdAt < x.createdAt)
-  );
-  const nonDeletedChatsΣ = DerivedSignal.from(() =>
-    Array.from(allChatsInclDeletedΣ.get()).filter((c) => !c.deletedAt)
-  );
+  const chatsDB = new AiChatDB();
 
   function upsertMany(chats: AiChat[]) {
-    allChatsInclDeletedΣ.mutate((list) => {
+    batch(() => {
       for (const chat of chats) {
-        list.removeBy((c) => c.id === chat.id, 1);
-        list.add(chat);
+        chatsDB.upsert(chat);
       }
-    });
+    })
   }
 
   function upsert(chat: AiChat) {
-    upsertMany([chat]);
+    chatsDB.upsert(chat);
   }
 
   /**
@@ -797,24 +788,21 @@ function createStore_forUserAiChats() {
    * we'll re-render those so they can display the chat is deleted.
    */
   function markDeleted(chatId: string) {
-    allChatsInclDeletedΣ.mutate((list) => {
-      const chat = list.find((c) => c.id === chatId);
-      if (!chat) return false;
-
-      upsert({ ...chat, deletedAt: now() });
-      return undefined;
-    });
+    chatsDB.markDeleted(chatId);
   }
 
   function getChatById(chatId: string) {
-    return Array.from(allChatsInclDeletedΣ.get()).find(
-      (chat) => chat.id === chatId
-    );
+    return chatsDB.get(chatId);
+  }
+
+  function findMany(query: AiChatsQuery): AiChat[] {
+    return chatsDB.signal.get().findMany(query);
   }
 
   return {
-    chatsΣ: nonDeletedChatsΣ,
     getChatById,
+
+    findMany,
 
     // Mutations
     upsert,
@@ -835,7 +823,7 @@ export type Ai = {
   getStatus: () => Status;
 
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
-  getChats: (options?: { cursor?: Cursor }) => Promise<GetChatsResponse>;
+  getChats: (options?: GetChatsOptions) => Promise<GetChatsResponse>;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   getOrCreateChat: (
     /** A unique identifier for the chat. */
@@ -878,7 +866,6 @@ export type Ai = {
   ) => Promise<void>;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   signals: {
-    chatsΣ: DerivedSignal<AiChat[]>;
     getChatMessagesForBranchΣ(
       chatId: string,
       branch?: MessageId
@@ -890,6 +877,8 @@ export type Ai = {
   };
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   getChatById: (chatId: string) => AiChat | undefined;
+  /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
+  queryChats: (query: AiChatsQuery) => AiChat[];
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
   registerKnowledgeLayer: (uniqueLayerId: string) => LayerKey;
   /** @private This API will change, and is not considered stable. DO NOT RELY on it. */
@@ -1192,10 +1181,11 @@ export function createAi(config: AiConfig): Ai {
     );
   }
 
-  function getChats(options: { cursor?: Cursor } = {}) {
+  function getChats(options: GetChatsOptions = {}) {
     return sendClientMsgWithResponse<GetChatsResponse>({
       cmd: "get-chats",
       cursor: options.cursor,
+      query: options.query,
     });
   }
 
@@ -1331,13 +1321,13 @@ export function createAi(config: AiConfig): Ai {
       getStatus: () => managedSocket.getStatus(),
 
       signals: {
-        chatsΣ: context.chatsStore.chatsΣ,
         getChatMessagesForBranchΣ:
           context.messagesStore.getChatMessagesForBranchΣ,
         getToolΣ: context.toolsStore.getToolΣ,
       },
 
       getChatById: context.chatsStore.getChatById,
+      queryChats: context.chatsStore.findMany,
       registerKnowledgeLayer,
       deregisterKnowledgeLayer,
       updateKnowledge,

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -323,6 +323,7 @@ export type {
   AiAssistantMessage,
   AiChat,
   AiChatMessage,
+  AiChatsQuery,
   AiKnowledgeSource,
   AiReasoningPart,
   AiTextPart,

--- a/packages/liveblocks-core/src/lib/AiChatDB.ts
+++ b/packages/liveblocks-core/src/lib/AiChatDB.ts
@@ -1,0 +1,83 @@
+import type { AiChat, AiChatsQuery, ISODateString } from "../types/ai";
+import { MutableSignal } from "./signals";
+import { SortedList } from "./SortedList";
+
+export class AiChatDB {
+  #byId: Map<string, AiChat>; // A map of chat id to chat details
+  #chats: SortedList<AiChat>; // Sorted list of chats, most recent first
+
+  public readonly signal: MutableSignal<this>;
+
+  constructor() {
+    this.#byId = new Map();
+    this.#chats = SortedList.from<AiChat>([], (c1, c2) => {
+      // Sort by 'lastMessageAt' if available, otherwise 'createdAt' (most recent first)
+      const d2 = c2.lastMessageAt ?? c2.createdAt;
+      const d1 = c1.lastMessageAt ?? c1.createdAt;
+      return d2 < d1 ? true : d2 === d1 ? c2.id < c1.id : false;
+    });
+
+    this.signal = new MutableSignal(this);
+  }
+
+  public get(chatId: string): AiChat | undefined {
+    return this.#byId.get(chatId);
+  }
+
+  public markDeleted(chatId: string): void {
+      const chat = this.#byId.get(chatId);
+      if (chat === undefined || chat.deletedAt !== undefined) return;
+      this.upsert({ ...chat, deletedAt: new Date().toISOString() as ISODateString });
+  }
+
+  public upsert(chat: AiChat): void {
+    this.signal.mutate(() => {
+      // If the chat already exists, remove it before deciding whether to add the incoming one
+      const existingThread = this.#byId.get(chat.id);
+      if (existingThread !== undefined) {
+        if (existingThread.deletedAt !== undefined) return false;
+
+        this.#chats.remove(existingThread);
+        this.#byId.delete(existingThread.id);
+      }
+
+      // We only add non-deleted chats to the chat list
+      if (chat.deletedAt === undefined) {
+        this.#chats.add(chat);
+      }
+      this.#byId.set(chat.id, chat);
+      return true;
+    })
+  }
+
+  public findMany(query: AiChatsQuery): AiChat[] {
+    return Array.from(
+      this.#chats.filter((chat) => {
+        // Exclude deleted chats
+        if (chat.deletedAt) return false;
+
+        // If metadata query is not provided, include all chats
+        if (query.metadata === undefined) return true;
+
+        for (const [key, value] of Object.entries(query.metadata)) {
+          // If the metadata key is a string, check for an exact match against the chat's metadata
+          if (typeof value === "string") {
+            if (chat.metadata[key] !== value) return false;
+          }
+          // If the metadata key is an array, ensure all values are present in the chat's metadata array
+          else {
+            const chatValue = chat.metadata[key];
+            if (
+              !Array.isArray(chatValue) ||
+              !value.every((v) => chatValue.includes(v))
+            ) {
+              return false;
+            }
+          }
+        }
+
+        return true;
+      })
+    );
+  }
+}

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -76,7 +76,11 @@ export type SetToolResultResponse = ServerCmdResponse<SetToolResultPair>;
 
 type GetChatsPair = DefineCmd<
   "get-chats",
-  { cursor?: Cursor; pageSize?: number },
+  {
+    cursor?: Cursor;
+    pageSize?: number;
+    query?: { metadata?: Record<string, string | string[]> };
+  },
   { chats: AiChat[]; nextCursor: Cursor | null }
 >;
 
@@ -85,6 +89,26 @@ export type CreateChatOptions = {
   title?: string;
   /** Arbitrary metadata to record for this chat. This can be later used to filter the list of chats by metadata. */
   metadata?: Record<string, string | string[]>;
+};
+
+export type AiChatsQuery = {
+  metadata?: Record<string, string | string[]>;
+};
+
+export type GetChatsOptions = {
+  /**
+   * The cursor to use for pagination.
+   */
+  cursor?: Cursor;
+  /**
+   * The query (including metadata) to filter chats by. If provided, only chats
+   * that match the query will be returned. If not provided, all chats will be returned.
+   * @example
+   * ```
+   * { metadata: { tag: ["urgent"] } }
+   * ```
+   */
+  query?: AiChatsQuery;
 };
 
 type GetOrCreateChatPair = DefineCmd<

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -66,13 +66,18 @@ import type {
   ThreadsAsyncResult,
   ThreadsAsyncSuccess,
   UnreadInboxNotificationsCountAsyncResult,
+  UseAiChatsOptions,
   UserAsyncResult,
   UserAsyncSuccess,
   UseSendAiMessageOptions,
   UseSyncStatusOptions,
   UseUserThreadsOptions,
 } from "./types";
-import { makeUserThreadsQueryKey, UmbrellaStore } from "./umbrella-store";
+import {
+  makeAiChatsQueryKey,
+  makeUserThreadsQueryKey,
+  UmbrellaStore,
+} from "./umbrella-store";
 import { useSignal } from "./use-signal";
 import { useSyncExternalStoreWithSelector } from "./use-sync-external-store-with-selector";
 
@@ -960,14 +965,16 @@ function useRoomInfoSuspense_withClient(client: OpaqueClient, roomId: string) {
  * @example
  * const { chats } = useAiChats();
  */
-function useAiChats(): AiChatsAsyncResult {
+function useAiChats(options?: UseAiChatsOptions): AiChatsAsyncResult {
   const client = useClient();
   const store = getUmbrellaStoreForClient(client);
+
+  const queryKey = makeAiChatsQueryKey(options?.query);
 
   useEnsureAiConnection(client);
 
   useEffect(
-    () => void store.outputs.aiChats.waitUntilLoaded()
+    () => void store.outputs.aiChats.getOrCreate(queryKey).waitUntilLoaded()
 
     // NOTE: Deliberately *not* using a dependency array here!
     //
@@ -979,10 +986,10 @@ function useAiChats(): AiChatsAsyncResult {
     //    *next* render after that, a *new* fetch/promise will get created.
   );
 
-  return useSignal(store.outputs.aiChats.signal, identity, shallow);
+  return useSignal(store.outputs.aiChats.getOrCreate(queryKey).signal, identity, shallow);
 }
 
-function useAiChatsSuspense(): AiChatsAsyncSuccess {
+function useAiChatsSuspense(options?: UseAiChatsOptions): AiChatsAsyncSuccess {
   // Throw error if we're calling this hook server side
   ensureNotServerSide();
 
@@ -991,9 +998,13 @@ function useAiChatsSuspense(): AiChatsAsyncSuccess {
 
   useEnsureAiConnection(client);
 
-  use(store.outputs.aiChats.waitUntilLoaded());
+  const queryKey = makeAiChatsQueryKey(options?.query);
 
-  const result = useAiChats();
+  console.log(queryKey)
+
+  use(store.outputs.aiChats.getOrCreate(queryKey).waitUntilLoaded());
+
+  const result = useAiChats(options);
   assert(!result.error, "Did not expect error");
   assert(!result.isLoading, "Did not expect loading");
   return result;

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   AiChat,
   AiChatMessage,
+  AiChatsQuery,
   AsyncError,
   AsyncLoading,
   AsyncResult,
@@ -74,6 +75,14 @@ export type UseSendAiMessageOptions = {
 
   /** The maximum timeout for the answer to be generated. */
   timeout?: number;
+};
+
+export type UseAiChatsOptions = {
+  /**
+   * The query (including metadata) to filter the chats by. If provided, only chats
+   * that match the query will be returned. If not provided, all chats will be returned.
+   */
+  query?: AiChatsQuery;
 };
 
 export type ThreadsQuery<M extends BaseMetadata> = {
@@ -1320,7 +1329,7 @@ export type LiveblocksContextBundle<
        * @example
        * const { chats, error, isLoading } = useAiChats();
        */
-      useAiChats(): AiChatsAsyncResult;
+      useAiChats(options?: UseAiChatsOptions): AiChatsAsyncResult;
 
       /**
        * (Private beta)  Returns the messages in the given chat.
@@ -1384,7 +1393,7 @@ export type LiveblocksContextBundle<
              * @example
              * const { chats } = useAiChats();
              */
-            useAiChats(): AiChatsAsyncSuccess;
+            useAiChats(options?: UseAiChatsOptions): AiChatsAsyncSuccess;
 
             /**
              * (Private beta) Returns the messages in the given chat.


### PR DESCRIPTION
This PR adds query options to `useAiChats` and `useAiChatsSuspense`. AI chats can now be queried based on metadata.


#### Definition
```tsx
useAiChats(options?: { query?: { metadata?: Record<string, string | string[] | null> } })
```

Filter chats by the absence of metadata fields is also possible by passing `null` as the value. For example, to get all chats that don't have a `category` metadata field:

```tsx
useAiChats({ query: { metadata: { category: null } } })
```

The filtering works as follows:

1. **String value**: Filters for chats where the metadata key exists with that exact value
2. **Array value**: Filters for chats where the metadata key contains all specified values
3. **Null value**: Filters for chats where the metadata key is absent or null