### PR TITLE
Support custom composers in `FloatingComposer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@
 - `useCreateAiChat` now accepts a chat ID as a string instead of
   `{ id: "chat-id" }`.
 
+### `@liveblocks/react-tiptap` and `@liveblocks/react-lexical`
+
+- Allow using custom composers in `FloatingComposer` via the
+  `components={{ Composer }}` prop.
+
+### `@liveblocks/react-lexical`
+
+- Add `ATTACH_THREAD_COMMAND` command to manually create a thread attached to
+  the current selection.
+
 ## v3.2.1
 
 ### `@liveblocks/react-ui`

--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -1061,6 +1061,19 @@ function Toolbar() {
   >
     Override the component’s strings.
   </PropertiesListItem>
+  <PropertiesListItem
+    name="components"
+    type="Partial<FloatingComposerComponents>"
+  >
+    Override the component’s components.
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="components.Composer"
+    type="(props: ComposerProps) => ReactNode"
+  >
+    Override the [`Composer`](/docs/api-reference/liveblocks-react-ui#Composer)
+    component.
+  </PropertiesListItem>
 </PropertiesList>
 
 ### FloatingThreads

--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -1061,14 +1061,14 @@ import { Composer } from "@liveblocks/react-ui/primitives";
 <FloatingComposer
   style={{ width: "350px" }}
   components={{
-    Composer: ({ onComposerSubmit }) => {
-      return (
-        <Composer.Form onComposerSubmit={onComposerSubmit}>
-          <Composer.Editor />
-          <Composer.Submit>Send</Composer.Submit>
-        </Composer.Form>
-      );
-    },
+    // +++
+    Composer: ({ onComposerSubmit }) => (
+      <Composer.Form onComposerSubmit={onComposerSubmit}>
+        <Composer.Editor />
+        <Composer.Submit>Send</Composer.Submit>
+      </Composer.Form>
+    ),
+    // +++
   }}
 />;
 ```
@@ -1083,9 +1083,9 @@ import { Composer } from "@liveblocks/react-ui/primitives";
   editor={editor}
   style={{ width: "350px" }}
   components={{
-    Composer: () => {
-      return (
+    Composer: () => (
         <Composer.Form
+        // +++
           onComposerSubmit={(message, event) => {
             event.preventDefault();
 
@@ -1097,12 +1097,12 @@ import { Composer } from "@liveblocks/react-ui/primitives";
 
             editor.dispatchCommand(ATTACH_THREAD_COMMAND, thread.id);
           }}
+          // +++
         >
           <Composer.Editor />
           <Composer.Submit>Send</Composer.Submit>
         </Composer.Form>
-      );
-    },
+      )
   }}
 />;
 ```

--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -1018,6 +1018,95 @@ function Toolbar() {
 }
 ```
 
+#### Customization [#FloatingComposer-customization]
+
+The `FloatingComposer` components acts as a wrapper around a [`Composer`][],
+near the current selection. You can treat the component like you would a `form`,
+using classes, listeners, and more.
+
+```tsx
+<FloatingComposer style={{ width: "350px" }} className="my-floating-composer" />
+```
+
+To apply styling to the composer, you can pass a custom `Composer` property to
+`components` and modify this in any way.
+
+```tsx
+import { Composer } from "@liveblocks/react-ui";
+
+<FloatingComposer
+  style={{ width: "350px" }}
+  // +++
+  components={{
+    Composer: (props) => (
+      <Composer
+        {...props}
+        className="border shadow"
+        style={{ width: "300px" }}
+      />
+    ),
+  }}
+  // +++
+/>;
+```
+
+You can return any custom `ReactNode` here, including anything from a simple
+wrapper around `Composer`, up to a full custom `Composer` component built using
+our
+[Composer primitives](/docs/api-reference/liveblocks-react-ui#primitives-Composer).
+
+```tsx
+import { Composer } from "@liveblocks/react-ui/primitives";
+
+<FloatingComposer
+  style={{ width: "350px" }}
+  components={{
+    Composer: ({ onComposerSubmit }) => {
+      return (
+        <Composer.Form onComposerSubmit={onComposerSubmit}>
+          <Composer.Editor />
+          <Composer.Submit>Send</Composer.Submit>
+        </Composer.Form>
+      );
+    },
+  }}
+/>;
+```
+
+You can also customize submission behavior by passing a custom
+`onComposerSubmit` function to the `Composer.Form` component.
+
+```tsx
+import { Composer } from "@liveblocks/react-ui/primitives";
+
+<FloatingComposer
+  editor={editor}
+  style={{ width: "350px" }}
+  components={{
+    Composer: () => {
+      return (
+        <Composer.Form
+          onComposerSubmit={(message, event) => {
+            event.preventDefault();
+
+            const thread = createThread({
+              body: comment.body,
+              attachments: comment.attachments,
+              metadata: ...,
+            });
+
+            editor.dispatchCommand(ATTACH_THREAD_COMMAND, thread.id);
+          }}
+        >
+          <Composer.Editor />
+          <Composer.Submit>Send</Composer.Submit>
+        </Composer.Form>
+      );
+    },
+  }}
+/>;
+```
+
 #### Props [#FloatingComposer-props]
 
 <PropertiesList>

--- a/docs/pages/api-reference/liveblocks-react-tiptap.mdx
+++ b/docs/pages/api-reference/liveblocks-react-tiptap.mdx
@@ -936,6 +936,101 @@ function Toolbar({ editor }: { editor: Editor | null }) {
 }
 ```
 
+#### Customization [#FloatingComposer-customization]
+
+The `FloatingComposer` components acts as a wrapper around a [`Composer`][],
+near the current selection. You can treat the component like you would a `form`,
+using classes, listeners, and more.
+
+```tsx
+<FloatingComposer
+  editor={editor}
+  style={{ width: "350px" }}
+  className="my-floating-composer"
+/>
+```
+
+To apply styling to the composer, you can pass a custom `Composer` property to
+`components` and modify this in any way.
+
+```tsx
+import { Composer } from "@liveblocks/react-ui";
+
+<FloatingComposer
+  editor={editor}
+  style={{ width: "350px" }}
+  // +++
+  components={{
+    Composer: (props) => (
+      <Composer
+        {...props}
+        className="border shadow"
+        style={{ width: "300px" }}
+      />
+    ),
+  }}
+  // +++
+/>;
+```
+
+You can return any custom `ReactNode` here, including anything from a simple
+wrapper around `Composer`, up to a full custom `Composer` component built using
+our
+[Composer primitives](/docs/api-reference/liveblocks-react-ui#primitives-Composer).
+
+```tsx
+import { Composer } from "@liveblocks/react-ui/primitives";
+
+<FloatingComposer
+  editor={editor}
+  style={{ width: "350px" }}
+  components={{
+    Composer: ({ onComposerSubmit }) => {
+      return (
+        <Composer.Form onComposerSubmit={onComposerSubmit}>
+          <Composer.Editor />
+          <Composer.Submit>Send</Composer.Submit>
+        </Composer.Form>
+      );
+    },
+  }}
+/>;
+```
+
+You can also customize submission behavior by passing a custom
+`onComposerSubmit` function to the `Composer.Form` component.
+
+```tsx
+import { Composer } from "@liveblocks/react-ui/primitives";
+
+<FloatingComposer
+  editor={editor}
+  style={{ width: "350px" }}
+  components={{
+    Composer: () => {
+      return (
+        <Composer.Form
+          onComposerSubmit={(message, event) => {
+            event.preventDefault();
+
+            const thread = createThread({
+              body: comment.body,
+              attachments: comment.attachments,
+              metadata: ...,
+            });
+
+            editor.commands.addComment(thread.id);
+          }}
+        >
+          <Composer.Editor />
+          <Composer.Submit>Send</Composer.Submit>
+        </Composer.Form>
+      );
+    },
+  }}
+/>;
+```
+
 #### Props [#FloatingComposer-props]
 
 <PropertiesList>

--- a/docs/pages/api-reference/liveblocks-react-tiptap.mdx
+++ b/docs/pages/api-reference/liveblocks-react-tiptap.mdx
@@ -985,14 +985,14 @@ import { Composer } from "@liveblocks/react-ui/primitives";
   editor={editor}
   style={{ width: "350px" }}
   components={{
-    Composer: ({ onComposerSubmit }) => {
-      return (
-        <Composer.Form onComposerSubmit={onComposerSubmit}>
-          <Composer.Editor />
-          <Composer.Submit>Send</Composer.Submit>
-        </Composer.Form>
-      );
-    },
+    Composer: ({ onComposerSubmit }) => (
+      // +++
+      <Composer.Form onComposerSubmit={onComposerSubmit}>
+        <Composer.Editor />
+        <Composer.Submit>Send</Composer.Submit>
+      </Composer.Form>
+      // +++
+    ),
   }}
 />;
 ```
@@ -1007,9 +1007,9 @@ import { Composer } from "@liveblocks/react-ui/primitives";
   editor={editor}
   style={{ width: "350px" }}
   components={{
-    Composer: () => {
-      return (
+    Composer: () => (
         <Composer.Form
+        // +++
           onComposerSubmit={(message, event) => {
             event.preventDefault();
 
@@ -1021,12 +1021,12 @@ import { Composer } from "@liveblocks/react-ui/primitives";
 
             editor.commands.addComment(thread.id);
           }}
+          // +++
         >
           <Composer.Editor />
           <Composer.Submit>Send</Composer.Submit>
         </Composer.Form>
-      );
-    },
+      ),
   }}
 />;
 ```

--- a/docs/pages/api-reference/liveblocks-react-tiptap.mdx
+++ b/docs/pages/api-reference/liveblocks-react-tiptap.mdx
@@ -979,6 +979,19 @@ function Toolbar({ editor }: { editor: Editor | null }) {
   >
     Override the component’s strings.
   </PropertiesListItem>
+  <PropertiesListItem
+    name="components"
+    type="Partial<FloatingComposerComponents>"
+  >
+    Override the component’s components.
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="components.Composer"
+    type="(props: ComposerProps) => ReactNode"
+  >
+    Override the [`Composer`](/docs/api-reference/liveblocks-react-ui#Composer)
+    component.
+  </PropertiesListItem>
 </PropertiesList>
 
 ### FloatingThreads

--- a/packages/liveblocks-react-lexical/src/comments/floating-threads.tsx
+++ b/packages/liveblocks-react-lexical/src/comments/floating-threads.tsx
@@ -42,7 +42,7 @@ import {
 } from "./comment-plugin-provider";
 import { ThreadToNodesContext } from "./comment-plugin-provider";
 
-type ThreadPanelComponents = {
+type FloatingThreadsComponents = {
   Thread: ComponentType<ThreadProps>;
 };
 
@@ -56,7 +56,7 @@ export interface FloatingThreadsProps<M extends BaseMetadata = DM>
   /**
    * Override the component's components.
    */
-  components?: Partial<ThreadPanelComponents>;
+  components?: Partial<FloatingThreadsComponents>;
 }
 
 export function FloatingThreads({

--- a/packages/liveblocks-react-lexical/src/index.ts
+++ b/packages/liveblocks-react-lexical/src/index.ts
@@ -9,6 +9,7 @@ export { AnchoredThreads } from "./comments/anchored-threads";
 export { useIsThreadActive } from "./comments/comment-plugin-provider";
 export type { FloatingComposerProps } from "./comments/floating-composer";
 export {
+  ATTACH_THREAD_COMMAND,
   FloatingComposer,
   OPEN_FLOATING_COMPOSER_COMMAND,
 } from "./comments/floating-composer";

--- a/packages/liveblocks-react-tiptap/src/comments/AnchoredThreads.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/AnchoredThreads.tsx
@@ -34,8 +34,9 @@ export interface AnchoredThreadsProps<M extends BaseMetadata = DM>
    * Override the component's components.
    */
   components?: Partial<AnchoredThreadsComponents>;
+
   /**
-   * The tiptap editor
+   * The Tiptap editor.
    */
   editor: Editor | null;
 }

--- a/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/FloatingComposer.tsx
@@ -59,15 +59,7 @@ export const FloatingComposer = forwardRef<
   HTMLFormElement,
   FloatingComposerProps
 >(function FloatingComposer(
-  {
-    editor,
-    onComposerSubmit,
-    onKeyDown,
-    onClick,
-    components,
-    metadata,
-    ...props
-  },
+  { editor, onComposerSubmit, onKeyDown, onClick, components, ...props },
   forwardedRef
 ) {
   const Composer = components?.Composer ?? DefaultComposer;
@@ -147,11 +139,11 @@ export const FloatingComposer = forwardRef<
       const thread = createThread({
         body: comment.body,
         attachments: comment.attachments,
-        metadata: metadata ?? {},
+        metadata: props.metadata ?? {},
       });
       editor.commands.addComment(thread.id);
     },
-    [onComposerSubmit, editor, createThread, metadata]
+    [onComposerSubmit, editor, createThread, props.metadata]
   );
 
   const handleKeyDown = useCallback(

--- a/packages/liveblocks-react-tiptap/src/comments/FloatingThreads.tsx
+++ b/packages/liveblocks-react-tiptap/src/comments/FloatingThreads.tsx
@@ -29,7 +29,7 @@ import { createPortal } from "react-dom";
 
 import { THREADS_PLUGIN_KEY } from "../types";
 
-type ThreadPanelComponents = {
+type FloatingThreadsComponents = {
   Thread: ComponentType<ThreadProps>;
 };
 
@@ -43,10 +43,10 @@ export interface FloatingThreadsProps<M extends BaseMetadata = DM>
   /**
    * Override the component's components.
    */
-  components?: Partial<ThreadPanelComponents>;
+  components?: Partial<FloatingThreadsComponents>;
 
   /**
-   * The tiptap editor
+   * The Tiptap editor.
    */
   editor: Editor | null;
 }


### PR DESCRIPTION
This PR adds `components={{ Composer }}` to `FloatingComposer` components for Tiptap and Lexical, to match `components={{ Thread }}` on `FloatingThreads`/`AnchoredThreads`.

Props passed to `FloatingComposer` are applied to the composer itself, not the floating/portal `div` around it, unlike `FloatingThreads`. We can't change this without a breaking change.

When calling `createThread` manually with `onComposerSubmit` in the passed custom composer, you need to tell the editor that it was created. `@liveblocks/react-tiptap` already had `editor.commands.addComment(thread.id)` and this PR adds `editor.dispatchCommand(ATTACH_THREAD_COMMAND, thread.id)` to do the same in `@liveblocks/react-lexical`. The commands in both package are already different so I didn't use the same name.

```tsx
<FloatingComposer
  components={{
    Composer: () => {
      return (
        <ComposerPrimitive.Form
          onComposerSubmit={(message, event) => {
            event.preventDefault();

            const thread = createThread({
              body: comment.body,
              attachments: comment.attachments,
              metadata: ...,
            });

            // Tiptap
            editor.commands.addComment(thread.id);

            // Lexical
            editor.dispatchCommand(ATTACH_THREAD_COMMAND, thread.id);
          }}
        >
          <ComposerPrimitive.Editor />
          {/* ... */}
        </ComposerPrimitive.Form>
      );
    },
  }}
/>;
```

The above is only needed if you use your own `onComposerSubmit` logic, because even if you use a custom composer built with primitives, you case use the incoming props' `onComposerSubmit` and the submission/attachment will work.

```tsx
<FloatingComposer
  components={{
    Composer: ({ onComposerSubmit }) => {
      return (
        <ComposerPrimitive.Form
          onComposerSubmit={onComposerSubmit}
        >
          <ComposerPrimitive.Editor />
          {/* ... */}
        </ComposerPrimitive.Form>
      );
    },
  }}
/>;
```