### PR TITLE
Attachments fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## vNEXT (not yet published)
 
+## v3.3.1
+
+### `@liveblocks/react-ui`
+
+- Fix `Composer` uploading attachments on drop even when `showAttachments` is
+  set to `false`.
+- Add `disableAttachments` prop to `Composer` primitive to disable attachments.
+  (e.g. dropping, pasting, etc.)
+
 ## v3.3.0
 
 ### `@liveblocks/react-ui`

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -1601,11 +1601,19 @@ occurs when the composer is submitted. You must create your own mutations within
     The composer’s initial attachments.
   </PropertiesListItem>
   <PropertiesListItem
+    name="disableAttachments"
+    type="boolean"
+    defaultValue="false"
+  >
+    Whether to disable attachments.
+  </PropertiesListItem>
+  <PropertiesListItem
     name="pasteFilesAsAttachments"
     type="boolean"
     defaultValue="false"
   >
-    Whether to create attachments when pasting files into the editor.
+    Whether to create attachments when pasting files into the editor. If
+    `disableAttachments` is set to `true`, this will be ignored.
   </PropertiesListItem>
   <PropertiesListItem
     name="preventUnsavedChanges"

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -819,7 +819,8 @@ export const Composer = forwardRef(
           onBlur={handleBlur}
           disabled={disabled || !canComment}
           defaultAttachments={defaultAttachments}
-          pasteFilesAsAttachments={showAttachments}
+          disableAttachments={!showAttachments}
+          pasteFilesAsAttachments
           preventUnsavedChanges={preventUnsavedComposerChanges}
           blurOnSubmit={blurOnSubmit}
           roomId={roomId}

--- a/packages/liveblocks-react-ui/src/primitives/Composer/contexts.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/contexts.ts
@@ -104,6 +104,7 @@ export type ComposerAttachmentsContext = {
   isUploadingAttachments: boolean;
   maxAttachments: number;
   maxAttachmentSize: number;
+  disableAttachments: boolean;
 };
 
 export type ComposerSuggestionsContext = {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/types.ts
@@ -156,12 +156,18 @@ export interface ComposerFormProps extends ComponentPropsWithSlot<"form"> {
   disabled?: boolean;
 
   /**
+   * Whether to disable attachments.
+   */
+  disableAttachments?: boolean;
+
+  /**
    * The composer's initial attachments.
    */
   defaultAttachments?: CommentAttachment[];
 
   /**
    * Whether to create attachments when pasting files into the editor.
+   * If `disableAttachments` is set to `true`, this will be ignored.
    */
   pasteFilesAsAttachments?: boolean;
 


### PR DESCRIPTION
We had a report that dropping a file on a `Composer` which has `showAttachments={false}` was still uploading the file.

This is an oversight on our end: the default `Composer` component uses the `Composer` primitive internally which handles attachments (their state, when files are dropped, when files are pasted, etc). When using the `Composer` primitive directly, attachments are opt-in because you have to manually implement them (add a file picker button with `Composer.AttachFiles`, use `useComposer` to list them, etc), and we added `pasteFilesAsAttachments` prop to allow opting-in to that behavior which happens behind-the-scenes, but we don't have one for dropping files.