### PR TITLE
Use randomized room names in e2e tests

### DIFF
--- a/e2e/node-sandbox/test/node.test.ts
+++ b/e2e/node-sandbox/test/node.test.ts
@@ -1,50 +1,50 @@
 import { LiveList } from "@liveblocks/core";
 import { Liveblocks } from "@liveblocks/node";
 import { config } from "dotenv";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, onTestFinished } from "vitest";
 
 config();
 
-describe("@liveblocks/node package e2e", () => {
-  test("create the room", async () => {
-    const client = new Liveblocks({
-      secret: process.env.LIVEBLOCKS_SECRET_KEY!,
-      // @ts-expect-error hidden config
-      baseUrl:
-        process.env.LIVEBLOCKS_BASE_URL ??
-        process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ??
-        "https://api.liveblocks.io",
-    });
+const client = new Liveblocks({
+  secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  // @ts-expect-error hidden config
+  baseUrl:
+    process.env.LIVEBLOCKS_BASE_URL ??
+    process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ??
+    "https://api.liveblocks.io",
+});
 
-    expect(
-      await client.createRoom(
-        "node-package-e2e",
-        { defaultAccesses: ["room:write"] },
-        { idempotent: true }
-      )
-    ).toBeDefined();
+async function createRandomTestRoom(): Promise<string> {
+  const randomRoomId = `node-package-e2e-${Math.random().toString(36).substring(2, 15)}`;
+
+  // Register cleanup
+  onTestFinished(async () => {
+    await client.deleteRoom(randomRoomId);
   });
 
+  await client.createRoom(
+    randomRoomId,
+    { defaultAccesses: ["room:write"] },
+    { idempotent: true }
+  );
+
+  return randomRoomId;
+}
+
+describe("@liveblocks/node package e2e", () => {
   test("storage mutation should work in node environment", async () => {
-    const client = new Liveblocks({
-      secret: process.env.LIVEBLOCKS_SECRET_KEY!,
-      // @ts-expect-error hidden config
-      baseUrl:
-        process.env.LIVEBLOCKS_BASE_URL ??
-        process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL ??
-        "https://api.liveblocks.io",
-    });
+    const roomId = await createRandomTestRoom();
 
     // delete existing data in the room
     await expect(
-      client.mutateStorage("node-package-e2e", ({ root }) => {
+      client.mutateStorage(roomId, ({ root }) => {
         root.delete("z");
       })
     ).resolves.toBeUndefined();
 
     // add data to the room
     await expect(
-      client.mutateStorage("node-package-e2e", ({ root }) => {
+      client.mutateStorage(roomId, ({ root }) => {
         expect(root.toImmutable()).toEqual({});
         // Mutate it!
         root.set("z", new LiveList([1, 2, 3]));
@@ -53,7 +53,7 @@ describe("@liveblocks/node package e2e", () => {
 
     // add data to the room
     await expect(
-      client.mutateStorage("node-package-e2e", ({ root }) => {
+      client.mutateStorage(roomId, ({ root }) => {
         expect(root.toImmutable()).toEqual({ z: [1, 2, 3] });
       })
     ).resolves.toBeUndefined();


### PR DESCRIPTION
I have a hunch that the recent instability in these tests are isolation related. By generating a random test room ID for each of these, test runs won't interfere when multiple e2e tests are running simultaneously.
