### PR TITLE
Add `filterThreads_experimental` field to TipTap extension to allow filtering of thread annotations

### DIFF
--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -1,5 +1,4 @@
 import type {
-  BaseMetadata,
   BaseUserMeta,
   IUserInfo,
   JsonObject,
@@ -41,10 +40,7 @@ import { LIVEBLOCKS_COMMENT_MARK_TYPE } from "./types";
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
-const DEFAULT_OPTIONS: WithRequired<
-  LiveblocksExtensionOptions<BaseMetadata>,
-  "field"
-> = {
+const DEFAULT_OPTIONS: WithRequired<LiveblocksExtensionOptions, "field"> = {
   field: "default",
   comments: true,
   mentions: true,
@@ -165,8 +161,8 @@ const YChangeMark = Mark.create({
   },
 });
 
-export const useLiveblocksExtension = <M extends BaseMetadata = BaseMetadata>(
-  opts?: LiveblocksExtensionOptions<M>
+export const useLiveblocksExtension = (
+  opts?: LiveblocksExtensionOptions
 ): Extension => {
   const options = {
     ...DEFAULT_OPTIONS,
@@ -192,7 +188,7 @@ export const useLiveblocksExtension = <M extends BaseMetadata = BaseMetadata>(
 
   const isEditorReady = useIsEditorReady();
   const client = useClient();
-  const store = getUmbrellaStoreForClient<M>(client);
+  const store = getUmbrellaStoreForClient(client);
   const roomId = room.id;
   const yjsProvider = useYjsProvider();
 

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -25,7 +25,11 @@ import type { Mark as PMMark } from "@tiptap/pm/model";
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 
 import { AiExtension } from "./ai/AiExtension";
-import { CommentsExtension } from "./comments/CommentsExtension";
+import {
+  areSetsEqual,
+  CommentsExtension,
+  FILTERED_THREADS_PLUGIN_KEY,
+} from "./comments/CommentsExtension";
 import { MentionExtension } from "./mentions/MentionExtension";
 import type {
   LiveblocksExtensionOptions,
@@ -213,6 +217,37 @@ export const useLiveblocksExtension = <M extends BaseMetadata = BaseMetadata>(
   }, [isEditorReady, yjsProvider, options.initialContent]);
 
   useReportTextEditor(textEditorType, options.field ?? DEFAULT_OPTIONS.field);
+
+  const prevThreadsRef = useRef<Set<string> | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isEditorReady) return;
+
+    if (!editor.current) return;
+
+    const newThreads = options.threads_experimental
+      ? new Set(options.threads_experimental.map((t) => t.id))
+      : undefined;
+
+    const hasFilteredThreadsChanged = !areSetsEqual(
+      prevThreadsRef.current,
+      newThreads
+    );
+
+    if (hasFilteredThreadsChanged) {
+      prevThreadsRef.current = newThreads;
+    }
+
+    if (hasFilteredThreadsChanged) {
+      editor.current.view.dispatch(
+        editor.current.state.tr.setMeta(FILTERED_THREADS_PLUGIN_KEY, {
+          filteredThreads: options.threads_experimental
+            ? new Set(options.threads_experimental.map((t) => t.id))
+            : undefined,
+        })
+      );
+    }
+  }, [isEditorReady, options.threads_experimental]);
 
   const createTextMention = useCreateTextMention();
   const deleteTextMention = useDeleteTextMention();

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -39,13 +39,12 @@ type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 const DEFAULT_OPTIONS: WithRequired<
   LiveblocksExtensionOptions<BaseMetadata>,
-  "field" | "filterThreads_experimental"
+  "field"
 > = {
   field: "default",
   comments: true,
   mentions: true,
   offlineSupport_experimental: false,
-  filterThreads_experimental: () => true,
   enablePermanentUserData: false,
 };
 
@@ -291,7 +290,6 @@ export const useLiveblocksExtension = <M extends BaseMetadata = BaseMetadata>(
               store.outputs.threads
                 .get()
                 .findMany(roomId, { resolved: false }, "asc")
-                .filter((thread) => options.filterThreads_experimental(thread))
                 .map((thread) => [thread.id, true])
             );
             function isComment(mark: PMMark): mark is PMMark & {

--- a/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
@@ -213,6 +213,15 @@ const Comment = Mark.create({
               return;
             }
             const threadId = commentMark?.attrs.threadId as string | undefined;
+
+            const filtered = FILTERED_THREADS_PLUGIN_KEY.getState(
+              view.state
+            )?.filteredThreads;
+            if (threadId && filtered && !filtered.has(threadId)) {
+              selectThread(null);
+              return;
+            }
+
             selectThread(threadId ?? null);
           },
         },
@@ -258,6 +267,19 @@ export const CommentsExtension = Extension.create<
         return true;
       },
       selectThread: (id: string | null) => () => {
+        const filtered = FILTERED_THREADS_PLUGIN_KEY.getState(
+          this.editor.state
+        )?.filteredThreads;
+        if (id && filtered && !filtered.has(id)) {
+          this.editor.view.dispatch(
+            this.editor.state.tr.setMeta(THREADS_PLUGIN_KEY, {
+              name: ThreadPluginActions.SET_SELECTED_THREAD_ID,
+              data: null,
+            })
+          );
+          return true;
+        }
+
         this.editor.view.dispatch(
           this.editor.state.tr.setMeta(THREADS_PLUGIN_KEY, {
             name: ThreadPluginActions.SET_SELECTED_THREAD_ID,
@@ -369,6 +391,18 @@ export const CommentsExtension = Extension.create<
                 view.state.doc !== prevState.doc
               ) {
                 syncDom();
+
+                const selected = THREADS_PLUGIN_KEY.getState(
+                  view.state
+                )?.selectedThreadId;
+                if (selected && curr && !curr.has(selected)) {
+                  view.dispatch(
+                    view.state.tr.setMeta(THREADS_PLUGIN_KEY, {
+                      name: ThreadPluginActions.SET_SELECTED_THREAD_ID,
+                      data: null,
+                    })
+                  );
+                }
               }
             },
           };

--- a/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
@@ -360,7 +360,7 @@ export const CommentsExtension = Extension.create<
 
             // Toggle attribute for all comment-mark spans
             const els = view.dom.querySelectorAll<HTMLElement>(
-              "span.lb-root.lb-tiptap-thread-mark[data-lb-thread-id]"
+              "span.lb-tiptap-thread-mark[data-lb-thread-id]"
             );
             els.forEach((el) => {
               const id = el.getAttribute("data-lb-thread-id");

--- a/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
@@ -1,4 +1,3 @@
-import type { ThreadData } from "@liveblocks/core";
 import { Extension, Mark, mergeAttributes } from "@tiptap/core";
 import type { Node } from "@tiptap/pm/model";
 import type { Transaction } from "@tiptap/pm/state";

--- a/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
@@ -1,7 +1,8 @@
+import type { ThreadData } from "@liveblocks/core";
 import { Extension, Mark, mergeAttributes } from "@tiptap/core";
 import type { Node } from "@tiptap/pm/model";
 import type { Transaction } from "@tiptap/pm/state";
-import { Plugin } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { ySyncPluginKey } from "y-prosemirror";
 
@@ -17,6 +18,10 @@ type ThreadPluginAction = {
   name: ThreadPluginActions;
   data: string | null;
 };
+
+export const FILTERED_THREADS_PLUGIN_KEY = new PluginKey<{
+  filteredThreads?: Set<string>;
+}>();
 
 /**
  * Known issues: Overlapping marks are merged when reloading the doc. May be related:
@@ -64,6 +69,22 @@ const Comment = Mark.create({
   },
 
   renderHTML({ HTMLAttributes }: { HTMLAttributes: Record<string, any> }) {
+    const filteredThreads = this.editor
+      ? FILTERED_THREADS_PLUGIN_KEY.getState(this.editor.state)?.filteredThreads
+      : undefined;
+    const threadId = (HTMLAttributes as { ["data-lb-thread-id"]: string })[
+      "data-lb-thread-id"
+    ];
+    if (filteredThreads && !filteredThreads.has(threadId)) {
+      return [
+        "span",
+        mergeAttributes(HTMLAttributes, {
+          class: "lb-root lb-tiptap-thread-mark",
+          "data-hidden": "",
+        }),
+      ];
+    }
+
     return [
       "span",
       mergeAttributes(HTMLAttributes, {
@@ -201,7 +222,7 @@ const Comment = Mark.create({
 });
 
 export const CommentsExtension = Extension.create<
-  never,
+  { filteredThreads?: Set<string> },
   CommentsExtensionStorage
 >({
   name: "liveblocksComments",
@@ -294,6 +315,73 @@ export const CommentsExtension = Extension.create<
           },
         },
       }),
+      new Plugin({
+        key: FILTERED_THREADS_PLUGIN_KEY,
+        state: {
+          init: () => ({
+            filteredThreads: this.options.filteredThreads,
+          }),
+          apply(tr, value) {
+            const meta = tr.getMeta(FILTERED_THREADS_PLUGIN_KEY) as
+              | { filteredThreads?: Set<string> }
+              | undefined;
+            if (meta?.filteredThreads) {
+              return { filteredThreads: meta.filteredThreads };
+            }
+            return value;
+          },
+        },
+        view: (view) => {
+          const syncDom = () => {
+            const filteredThreads = FILTERED_THREADS_PLUGIN_KEY.getState(
+              view.state
+            )?.filteredThreads;
+
+            // Toggle attribute for all comment-mark spans
+            const els = view.dom.querySelectorAll<HTMLElement>(
+              "span.lb-root.lb-tiptap-thread-mark[data-lb-thread-id]"
+            );
+            els.forEach((el) => {
+              const id = el.getAttribute("data-lb-thread-id");
+              if (!id) return;
+              if (!filteredThreads || filteredThreads.has(id)) {
+                el.removeAttribute("data-hidden");
+              } else {
+                el.setAttribute("data-hidden", "");
+              }
+            });
+          };
+
+          queueMicrotask(syncDom);
+
+          return {
+            update: (view, prevState) => {
+              const curr = FILTERED_THREADS_PLUGIN_KEY.getState(
+                view.state
+              )?.filteredThreads;
+              const prev =
+                FILTERED_THREADS_PLUGIN_KEY.getState(
+                  prevState
+                )?.filteredThreads;
+
+              if (
+                !areSetsEqual(prev, curr) ||
+                view.state.doc !== prevState.doc
+              ) {
+                syncDom();
+              }
+            },
+          };
+        },
+      }),
     ];
   },
 });
+
+export function areSetsEqual(a?: Set<string>, b?: Set<string>): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}

--- a/packages/liveblocks-react-tiptap/src/styles/index.css
+++ b/packages/liveblocks-react-tiptap/src/styles/index.css
@@ -120,7 +120,7 @@
  *            Thread mark            *
  *************************************/
 
-:where(.lb-tiptap-thread-mark:not([data-orphan="true"])) {
+:where(.lb-tiptap-thread-mark:not([data-orphan="true"], [data-hidden])) {
   background: var(--lb-accent-subtle);
   color: var(--lb-foreground);
   outline: none;
@@ -132,7 +132,7 @@
 }
 
 :where(
-  .lb-tiptap-thread-mark:not([data-orphan="true"])
+  .lb-tiptap-thread-mark:not([data-orphan="true"], [data-hidden])
     .lb-tiptap-thread-mark-selected
 ) {
   color: var(--lb-accent);

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -1,8 +1,10 @@
 import type {
+  BaseMetadata,
   ContextualPromptContext,
   ContextualPromptResponse,
   Relax,
   TextEditorType,
+  ThreadData,
 } from "@liveblocks/core";
 import type { LiveblocksYjsProvider } from "@liveblocks/yjs";
 import type { Content, Range } from "@tiptap/core";
@@ -82,12 +84,13 @@ export interface AiConfiguration {
   ) => Promise<ContextualPromptResponse>;
 }
 
-export type LiveblocksExtensionOptions = {
+export type LiveblocksExtensionOptions<M extends BaseMetadata> = {
   field?: string;
   comments?: boolean; // | CommentsConfiguration
   mentions?: boolean; // | MentionsConfiguration
   ai?: boolean | AiConfiguration;
   offlineSupport_experimental?: boolean;
+  filterThreads_experimental?: (thread: ThreadData<M>) => boolean;
   initialContent?: Content;
   enablePermanentUserData?: boolean;
   /**

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -1,5 +1,4 @@
 import type {
-  BaseMetadata,
   ContextualPromptContext,
   ContextualPromptResponse,
   Relax,
@@ -84,13 +83,13 @@ export interface AiConfiguration {
   ) => Promise<ContextualPromptResponse>;
 }
 
-export type LiveblocksExtensionOptions<M extends BaseMetadata> = {
+export type LiveblocksExtensionOptions = {
   field?: string;
   comments?: boolean; // | CommentsConfiguration
   mentions?: boolean; // | MentionsConfiguration
   ai?: boolean | AiConfiguration;
   offlineSupport_experimental?: boolean;
-  threads_experimental?: ThreadData<M>[];
+  threads_experimental?: ThreadData[];
   initialContent?: Content;
   enablePermanentUserData?: boolean;
   /**

--- a/packages/liveblocks-react-tiptap/src/types.ts
+++ b/packages/liveblocks-react-tiptap/src/types.ts
@@ -90,7 +90,7 @@ export type LiveblocksExtensionOptions<M extends BaseMetadata> = {
   mentions?: boolean; // | MentionsConfiguration
   ai?: boolean | AiConfiguration;
   offlineSupport_experimental?: boolean;
-  filterThreads_experimental?: (thread: ThreadData<M>) => boolean;
+  threads_experimental?: ThreadData<M>[];
   initialContent?: Content;
   enablePermanentUserData?: boolean;
   /**


### PR DESCRIPTION
This PR adds an experimental option to `useLiveblocksExtension`, called `filterThreads_experimental` to allow users to filter thread annotations that are displayed on the TipTap editor.

https://github.com/user-attachments/assets/6c94840a-a648-49f7-a0bc-b12f446c4d1d
