### PR TITLE
Prevent uploading attachments on drop when they are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## vNEXT (not yet published)
 
+## v2.24.4
+
+### `@liveblocks/react-ui`
+
+- Fix `Composer` uploading attachments on drop when `showAttachments` is set to
+  `false`.
+
 ## v2.24.3
 
 ### `@liveblocks/react` and `@liveblocks/react-ui`

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -533,7 +533,7 @@ function ComposerEditorContainer({
   }, [showFormattingControls]);
 
   const [isDraggingOver, dropAreaProps] = useComposerAttachmentsDropArea({
-    disabled: disabled || hasMaxAttachments,
+    disabled: disabled || !showAttachments || hasMaxAttachments,
   });
 
   useLayoutEffect(() => {


### PR DESCRIPTION
This PR is backporting https://github.com/liveblocks/liveblocks/pull/2582 in 2.x (it was released in https://github.com/liveblocks/liveblocks/releases/tag/v3.3.1).