### PR TITLE
Fix AI tool not executing when chat is opened too quickly after sending message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix race condition where AI tools were not always executing. This could happen
   when using `useSendAiMessage` first and then immediately opening the
-  `<AiChat />` afterwards. In those cases, the tool call would not get executed.
+  `<AiChat />` afterwards.
 
 ## v3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/client`
+
+- Fix race condition where AI tools were not always executing. This could happen
+  when using `useSendAiMessage` first and then immediately opening the
+  `<AiChat />` afterwards. In those cases, the tool call would not get executed.
+
 ## v3.3.1
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -1293,6 +1293,7 @@ export function createAi(config: AiConfig): Ai {
         const combinedKnowledge = [...globalKnowledge, ...requestKnowledge];
         const tools = context.toolsStore.getToolDescriptions(chatId);
 
+        messagesStore.markMine(targetMessageId);
         const resp: AskInChatResponse = await sendClientMsgWithResponse({
           cmd: "ask-in-chat",
           chatId,
@@ -1309,7 +1310,6 @@ export function createAi(config: AiConfig): Ai {
             tools: tools.length > 0 ? tools : undefined,
           },
         });
-        messagesStore.markMine(resp.targetMessage.id);
         return resp;
       },
 

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -564,7 +564,12 @@ function createStore_forChatMessages(
           }
         }
       } else {
-        myMessages.delete(message.id);
+        // Clean up the ownership administration
+        if (message.role === "assistant" && message.status === "generating") {
+          // ...unless it's still generating
+        } else {
+          myMessages.delete(message.id);
+        }
       }
     });
   }


### PR DESCRIPTION
AI tools with execute functions wouldn't run when using `useSendAiMessage` followed by immediately opening the chat.

The root cause was a race condition: the client ownership check `myMessages.has(targetMessageId)` failed because `markMine()` was only called after the server response, not when creating the optimistic message. The solution was to move `markMine(targetMessageId)` to happen immediately when `askUserMessageInChat` is called, ensuring the client owns the message before tool execution logic runs.