### PR TITLE
Add `tenantId` params to all supported methods in `@liveblocks/node`

### DIFF
--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -2052,6 +2052,15 @@ export class Liveblocks {
     return inflateRoomData(data);
   }
 
+  /**
+   * Triggers an inbox notification for a user.
+   * @param params.userId The user ID to trigger the inbox notification for.
+   * @param params.kind The kind of inbox notification to trigger.
+   * @param params.subjectId The subject ID of the triggered inbox notification.
+   * @param params.activityData The activity data of the triggered inbox notification.
+   * @param params.roomId (optional) The room ID to trigger the inbox notification for.
+   * @param options.signal (optional) An abort signal to cancel the request.
+   */
   public async triggerInboxNotification<K extends KDAD>(
     params: {
       userId: string;

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -299,13 +299,15 @@ export type GetRoomsOptions =
 // prettier-ignore
 export type GetInboxNotificationsOptions =
   & InboxNotificationsQueryCriteria
-  & PaginationOptions;
+  & PaginationOptions
+  & { tenantId?: string };
 
 export type CreateRoomOptions = {
   defaultAccesses: RoomPermission;
   groupsAccesses?: RoomAccesses;
   usersAccesses?: RoomAccesses;
   metadata?: RoomMetadata;
+  tenantId?: string;
 };
 
 export type UpdateRoomOptions = {
@@ -426,9 +428,10 @@ export class Liveblocks {
 
   async #delete(
     path: URLSafeString,
+    params?: QueryParams,
     options?: RequestOptions
   ): Promise<Response> {
-    const url = urljoin(this.#baseUrl, path);
+    const url = urljoin(this.#baseUrl, path, params);
     const headers = {
       Authorization: `Bearer ${this.#secret}`,
     };
@@ -664,6 +667,7 @@ export class Liveblocks {
    * @param params.groupsAccesses (optional) The group accesses for the room. Can contain a maximum of 100 entries. Key length has a limit of 40 characters.
    * @param params.usersAccesses (optional) The user accesses for the room. Can contain a maximum of 100 entries. Key length has a limit of 40 characters.
    * @param params.metadata (optional) The metadata for the room. Supports upto a maximum of 50 entries. Key length has a limit of 40 characters. Value length has a limit of 256 characters.
+   * @param params.tenantId (optional) The tenant ID to create the room for.
    * @param options.signal (optional) An abort signal to cancel the request.
    * @returns The created room.
    */
@@ -810,7 +814,11 @@ export class Liveblocks {
     roomId: string,
     options?: RequestOptions
   ): Promise<void> {
-    const res = await this.#delete(url`/v2/rooms/${roomId}`, options);
+    const res = await this.#delete(
+      url`/v2/rooms/${roomId}`,
+      undefined,
+      options
+    );
 
     if (!res.ok) {
       throw await LiveblocksError.from(res);
@@ -985,7 +993,11 @@ export class Liveblocks {
     roomId: string,
     options?: RequestOptions
   ): Promise<void> {
-    const res = await this.#delete(url`/v2/rooms/${roomId}/storage`, options);
+    const res = await this.#delete(
+      url`/v2/rooms/${roomId}/storage`,
+      undefined,
+      options
+    );
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }
@@ -1180,7 +1192,11 @@ export class Liveblocks {
     schemaId: string,
     options?: RequestOptions
   ): Promise<void> {
-    const res = await this.#delete(url`/v2/schemas/${schemaId}`, options);
+    const res = await this.#delete(
+      url`/v2/schemas/${schemaId}`,
+      undefined,
+      options
+    );
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }
@@ -1251,7 +1267,11 @@ export class Liveblocks {
     roomId: string,
     options?: RequestOptions
   ): Promise<void> {
-    const res = await this.#delete(url`/v2/rooms/${roomId}/schema`, options);
+    const res = await this.#delete(
+      url`/v2/rooms/${roomId}/schema`,
+      undefined,
+      options
+    );
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }
@@ -1526,6 +1546,7 @@ export class Liveblocks {
 
     const res = await this.#delete(
       url`/v2/rooms/${roomId}/threads/${threadId}/comments/${commentId}`,
+      undefined,
       options
     );
     if (!res.ok) {
@@ -1583,6 +1604,7 @@ export class Liveblocks {
 
     const res = await this.#delete(
       url`/v2/rooms/${roomId}/threads/${threadId}`,
+      undefined,
       options
     );
 
@@ -1844,13 +1866,14 @@ export class Liveblocks {
    * Returns the inbox notifications for a user.
    * @param params.userId The user ID to get the inbox notifications from.
    * @param params.query The query to filter inbox notifications by. It is based on our query language and can filter by unread.
+   * @param params.tenantId (optional) The tenant ID to get the inbox notifications for.
    * @param options.signal (optional) An abort signal to cancel the request.
    */
   public async getInboxNotifications(
     params: GetInboxNotificationsOptions,
     options?: RequestOptions
   ): Promise<Page<InboxNotificationData>> {
-    const { userId } = params;
+    const { userId, tenantId, limit, startingAfter } = params;
 
     let query: string | undefined;
 
@@ -1864,8 +1887,9 @@ export class Liveblocks {
       url`/v2/users/${userId}/inbox-notifications`,
       {
         query,
-        limit: params?.limit,
-        startingAfter: params?.startingAfter,
+        limit,
+        startingAfter,
+        tenantId,
       },
       options
     );
@@ -1918,19 +1942,21 @@ export class Liveblocks {
   /**
    * Returns all room subscription settings for a user.
    * @param params.userId The user ID to get the room subscription settings from.
+   * @param params.tenantId (optional) The tenant ID to get the room subscription settings for.
    * @param params.startingAfter (optional) The cursor to start the pagination from.
    * @param params.limit (optional) The number of items to return.
    * @param options.signal (optional) An abort signal to cancel the request.
    */
   public async getUserRoomSubscriptionSettings(
-    params: { userId: string } & PaginationOptions,
+    params: { userId: string; tenantId?: string } & PaginationOptions,
     options?: RequestOptions
   ): Promise<Page<UserRoomSubscriptionSettings>> {
-    const { userId, startingAfter, limit } = params;
+    const { userId, tenantId, startingAfter, limit } = params;
 
     const res = await this.#get(
       url`/v2/users/${userId}/room-subscription-settings`,
       {
+        tenantId,
         startingAfter,
         limit,
       },
@@ -2016,6 +2042,7 @@ export class Liveblocks {
 
     const res = await this.#delete(
       url`/v2/rooms/${roomId}/users/${userId}/subscription-settings`,
+      undefined,
       options
     );
     if (!res.ok) {
@@ -2059,6 +2086,7 @@ export class Liveblocks {
    * @param params.subjectId The subject ID of the triggered inbox notification.
    * @param params.activityData The activity data of the triggered inbox notification.
    * @param params.roomId (optional) The room ID to trigger the inbox notification for.
+   * @param params.tenantId (optional) The tenant ID to trigger the inbox notification for.
    * @param options.signal (optional) An abort signal to cancel the request.
    */
   public async triggerInboxNotification<K extends KDAD>(
@@ -2066,6 +2094,7 @@ export class Liveblocks {
       userId: string;
       kind: K;
       roomId?: string;
+      tenantId?: string;
       subjectId: string;
       activityData: DAD[K];
     },
@@ -2099,6 +2128,7 @@ export class Liveblocks {
 
     const res = await this.#delete(
       url`/v2/users/${userId}/inbox-notifications/${inboxNotificationId}`,
+      undefined,
       options
     );
     if (!res.ok) {
@@ -2109,16 +2139,18 @@ export class Liveblocks {
   /**
    * Deletes all inbox notifications for a user.
    * @param params.userId The user ID for which to delete all the inbox notifications.
+   * @param params.tenantId (optional) The tenant ID to delete the inbox notifications for.
    * @param options.signal (optional) An abort signal to cancel the request.
    */
   public async deleteAllInboxNotifications(
-    params: { userId: string },
+    params: { userId: string; tenantId?: string },
     options?: RequestOptions
   ): Promise<void> {
-    const { userId } = params;
+    const { userId, tenantId } = params;
 
     const res = await this.#delete(
       url`/v2/users/${userId}/inbox-notifications`,
+      { tenantId },
       options
     );
     if (!res.ok) {
@@ -2192,6 +2224,7 @@ export class Liveblocks {
     const { userId } = params;
     const res = await this.#delete(
       url`/v2/users/${userId}/notification-settings`,
+      undefined,
       options
     );
     if (!res.ok) {
@@ -2203,7 +2236,7 @@ export class Liveblocks {
    * Create a group
    * @param params.groupId The ID of the group to create.
    * @param params.memberIds The IDs of the members to add to the group.
-   * @param params.tenantId The ID of the tenant to create the group for.
+   * @param params.tenantId (optional) The tenant ID to create the group for.
    * @param options.signal (optional) An abort signal to cancel the request.
    */
   public async createGroup(
@@ -2307,7 +2340,11 @@ export class Liveblocks {
     params: { groupId: string },
     options?: RequestOptions
   ): Promise<void> {
-    const res = await this.#delete(url`/v2/groups/${params.groupId}`, options);
+    const res = await this.#delete(
+      url`/v2/groups/${params.groupId}`,
+      undefined,
+      options
+    );
     if (!res.ok) {
       throw await LiveblocksError.from(res);
     }


### PR DESCRIPTION
This PR adds `tenantId` params to all supported methods in `@liveblocks/node`.

The diff includes unrelated methods because the internal `#delete` didn't support query params, it now mirrors `#get`.