### PR TITLE
Add high-concurrency E2E tests for node client

### DIFF
--- a/e2e/node-sandbox/test/node.test.ts
+++ b/e2e/node-sandbox/test/node.test.ts
@@ -19,6 +19,7 @@ async function createRandomTestRoom(): Promise<string> {
 
   // Register cleanup
   onTestFinished(async () => {
+    await client.deleteStorageDocument(randomRoomId);
     await client.deleteRoom(randomRoomId);
   });
 

--- a/e2e/node-sandbox/test/node.test.ts
+++ b/e2e/node-sandbox/test/node.test.ts
@@ -19,6 +19,7 @@ async function createRandomTestRoom(): Promise<string> {
 
   // Register cleanup
   onTestFinished(async () => {
+    console.log(`Cleaning up room: ${randomRoomId}`);
     await client.deleteStorageDocument(randomRoomId);
     await client.deleteRoom(randomRoomId);
   });
@@ -28,6 +29,7 @@ async function createRandomTestRoom(): Promise<string> {
     { defaultAccesses: ["room:write"] },
     { idempotent: true }
   );
+  console.log(`Created room: ${randomRoomId}`);
 
   return randomRoomId;
 }
@@ -66,6 +68,7 @@ describe("@liveblocks/node package e2e", () => {
   test("concurrent LiveList mutations should preserve all items", async () => {
     const numberOfItemsToInsert = 75;
     const roomId = await createRandomTestRoom();
+    console.log(`Testing with roomId: ${roomId}`);
 
     // Initialize storage with empty list
     await client.mutateStorage(roomId, ({ root }) => {


### PR DESCRIPTION
This adds a new E2E test for the Node client that performs many concurrent storage mutations, ensuring that the room's storage content is eventually consistent. To get these E2E tests to pass, it will require [this backend fix](https://github.com/liveblocks/liveblocks-backend/pull/1165) to be deployed to prod first.