### PR TITLE
Implement tool call streaming for AI protocol V5

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/page.tsx
@@ -26,6 +26,9 @@ export default function Home() {
         <Link href="/styles" className="underline">
           Default styles playground
         </Link>
+        <Link href="/toolcall-streaming" className="underline">
+          Tool call streaming
+        </Link>
       </div>
     </main>
   );

--- a/e2e/next-ai-kitchen-sink/app/toolcall-streaming/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/toolcall-streaming/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { defineAiTool } from "@liveblocks/core";
+import {
+  ClientSideSuspense,
+  LiveblocksProvider,
+  useSendAiMessage,
+} from "@liveblocks/react/suspense";
+import {
+  AiChat,
+  AiChatComponentsEmptyProps,
+  AiTool,
+} from "@liveblocks/react-ui";
+
+export default function HtmlStreamingPage() {
+  return (
+    <main className="h-screen w-full">
+      <LiveblocksProvider
+        authEndpoint="/api/auth/liveblocks"
+        // @ts-expect-error
+        baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+      >
+        <ClientSideSuspense fallback={null}>
+          <AiChat
+            chatId="html-streaming"
+            components={{
+              Empty: AiChatEmptyComponent,
+            }}
+            tools={{
+              displayHtml: defineAiTool()({
+                description: "Display HTML content in a preview pane",
+                parameters: {
+                  type: "object",
+                  properties: {
+                    author: {
+                      type: "string",
+                      description: "Author of the content",
+                    },
+                    title: {
+                      type: "string",
+                      description: "Suggested title for the page",
+                    },
+                    rawHTML: {
+                      type: "string",
+                      description: "The HTML content to display",
+                    },
+                  },
+                  required: ["author", "title", "rawHTML"],
+                  additionalProperties: false,
+                },
+                execute: () => {
+                  return { data: { success: true } };
+                },
+                render: () => {
+                  return (
+                    <AiTool>
+                      <AiTool.Inspector />
+                    </AiTool>
+                  );
+                },
+              }),
+            }}
+            className="h-screen"
+          />
+        </ClientSideSuspense>
+      </LiveblocksProvider>
+    </main>
+  );
+}
+
+const CHAT_SUGGESTIONS = [
+  {
+    label: "Simple marketing page",
+    message: "Create a simple marketing page for a SaaS product",
+  },
+  {
+    label: "Landing page with hero",
+    message:
+      "Generate a landing page with a hero section, features, and footer",
+  },
+  {
+    label: "Product showcase",
+    message:
+      "Create an HTML page showcasing a new product with images and descriptions",
+  },
+  {
+    label: "Contact page",
+    message: "Build a contact page with a form and company information",
+  },
+];
+
+function AiChatEmptyComponent({ chatId }: AiChatComponentsEmptyProps) {
+  const sendMessage = useSendAiMessage(chatId);
+
+  return (
+    <div className="justify-end h-full flex flex-col gap-4 px-6 pb-4">
+      <h2 className="text-xl font-semibold">HTML Streaming Test</h2>
+      <p className="text-sm text-gray-600">
+        Ask me to generate HTML and watch it stream in real-time!
+      </p>
+
+      {/* Suggestion Tags */}
+      <div className="flex flex-wrap gap-2">
+        {CHAT_SUGGESTIONS.map(({ label, message }) => (
+          <button
+            key={label}
+            onClick={() => sendMessage(message)}
+            className="text-sm rounded-full border border-[var(--lb-foreground-subtle)] px-4 py-2 font-medium"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/liveblocks-core/src/__tests__/ai.test.ts
+++ b/packages/liveblocks-core/src/__tests__/ai.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "vitest";
 
 import { KnowledgeStack } from "../ai";
+import type {
+  AiAssistantContentPart,
+  AiExecutingToolInvocationPart,
+  AiReasoningDelta,
+  AiReceivingToolInvocationPart,
+  AiTextDelta,
+} from "../types/ai";
+import { patchContentWithDelta } from "../types/ai";
 
 describe("KnowledgeStack", () => {
   test("should be empty by default", () => {
@@ -143,5 +151,243 @@ describe("KnowledgeStack", () => {
     stack.deregisterLayer(key2);
     stack.deregisterLayer(key1);
     expect(stack.get()).toEqual([]);
+  });
+});
+
+describe("patchContentWithDelta", () => {
+  describe("text-delta", () => {
+    test("should append text delta to existing text part", () => {
+      const content: AiAssistantContentPart[] = [
+        { type: "text", text: "Hello " },
+      ];
+      const delta: AiTextDelta = { type: "text-delta", textDelta: "world!" };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([{ type: "text", text: "Hello world!" }]);
+    });
+
+    test("should create new text part if last part is not text", () => {
+      const content: AiAssistantContentPart[] = [
+        { type: "reasoning", text: "Some reasoning" },
+      ];
+      const delta: AiTextDelta = { type: "text-delta", textDelta: "Hello" };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([
+        { type: "reasoning", text: "Some reasoning" },
+        { type: "text", text: "Hello" },
+      ]);
+    });
+
+    test("should create new text part when content is empty", () => {
+      const content: AiAssistantContentPart[] = [];
+      const delta: AiTextDelta = { type: "text-delta", textDelta: "Hello" };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([{ type: "text", text: "Hello" }]);
+    });
+  });
+
+  describe("reasoning-delta", () => {
+    test("should append reasoning delta to existing reasoning part", () => {
+      const content: AiAssistantContentPart[] = [
+        { type: "reasoning", text: "Let me think " },
+      ];
+      const delta: AiReasoningDelta = {
+        type: "reasoning-delta",
+        textDelta: "about this...",
+      };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([
+        { type: "reasoning", text: "Let me think about this..." },
+      ]);
+    });
+
+    test("should create new reasoning part if last part is not reasoning", () => {
+      const content: AiAssistantContentPart[] = [
+        { type: "text", text: "Some text" },
+      ];
+      const delta: AiReasoningDelta = {
+        type: "reasoning-delta",
+        textDelta: "Thinking",
+      };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([
+        { type: "text", text: "Some text" },
+        { type: "reasoning", text: "Thinking" },
+      ]);
+    });
+  });
+
+  describe("tool-invocation", () => {
+    test("should add new receiving tool invocation when none exists", () => {
+      const content: AiAssistantContentPart[] = [];
+      const delta: AiReceivingToolInvocationPart = {
+        type: "tool-invocation",
+        stage: "receiving",
+        invocationId: "inv-123",
+        name: "search",
+        partialArgs: { query: "hello" },
+      };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([delta]);
+    });
+
+    test("should replace existing tool invocation with same invocationId", () => {
+      const content: AiAssistantContentPart[] = [
+        { type: "text", text: "Some text" },
+        {
+          type: "tool-invocation",
+          stage: "receiving",
+          invocationId: "inv-123",
+          name: "search",
+          partialArgs: { query: "he" },
+        },
+        { type: "text", text: "More text" },
+      ];
+      const delta: AiReceivingToolInvocationPart = {
+        type: "tool-invocation",
+        stage: "receiving",
+        invocationId: "inv-123",
+        name: "search",
+        partialArgs: { query: "hello world" },
+      };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toEqual([
+        { type: "text", text: "Some text" },
+        {
+          type: "tool-invocation",
+          stage: "receiving",
+          invocationId: "inv-123",
+          name: "search",
+          partialArgs: { query: "hello world" },
+        },
+        { type: "text", text: "More text" },
+      ]);
+    });
+
+    test("should replace tool invocation (even if it's not the last part)", () => {
+      const content: AiAssistantContentPart[] = [
+        {
+          type: "tool-invocation",
+          stage: "receiving",
+          invocationId: "inv-123",
+          name: "search",
+          partialArgs: { query: "" },
+        },
+        { type: "text", text: "Some text" },
+      ];
+
+      const delta: AiExecutingToolInvocationPart = {
+        type: "tool-invocation",
+        stage: "executing",
+        invocationId: "inv-123",
+        name: "search",
+        args: { query: "final" },
+      };
+
+      patchContentWithDelta(content, delta);
+
+      // Should replace the rightmost (last) tool invocation with matching ID
+      expect(content).toEqual([
+        {
+          type: "tool-invocation",
+          stage: "executing",
+          invocationId: "inv-123",
+          name: "search",
+          args: { query: "final" },
+        },
+        { type: "text", text: "Some text" },
+      ]);
+    });
+
+    test("should add multiple tool invocations with different IDs", () => {
+      const content: AiAssistantContentPart[] = [];
+
+      const delta1: AiReceivingToolInvocationPart = {
+        type: "tool-invocation",
+        stage: "receiving",
+        invocationId: "inv-1",
+        name: "search",
+        partialArgs: { query: "first" },
+      };
+      const delta2: AiReceivingToolInvocationPart = {
+        type: "tool-invocation",
+        stage: "receiving",
+        invocationId: "inv-2",
+        name: "calculator",
+        partialArgs: { expression: "1 + 1" },
+      };
+
+      patchContentWithDelta(content, delta1);
+      patchContentWithDelta(content, delta2);
+
+      expect(content).toEqual([delta1, delta2]);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should mutate the original content array", () => {
+      const content: AiAssistantContentPart[] = [];
+      const originalContent = content;
+      const delta: AiTextDelta = { type: "text-delta", textDelta: "Hello" };
+
+      patchContentWithDelta(content, delta);
+
+      expect(content).toBe(originalContent);
+      expect(content).toEqual([{ type: "text", text: "Hello" }]);
+    });
+
+    test("should handle complex mixed content updates", () => {
+      const content: AiAssistantContentPart[] = [
+        { type: "text", text: "Initial " },
+        { type: "reasoning", text: "Let me " },
+      ];
+
+      // Append to reasoning (last part) - should append to existing reasoning
+      patchContentWithDelta(content, {
+        type: "reasoning-delta",
+        textDelta: "think more",
+      });
+
+      // Add text-delta (should create new text part since last part is reasoning)
+      patchContentWithDelta(content, {
+        type: "text-delta",
+        textDelta: "message",
+      });
+
+      // Add tool invocation
+      patchContentWithDelta(content, {
+        type: "tool-invocation",
+        stage: "receiving",
+        invocationId: "inv-mixed",
+        name: "helper",
+        partialArgs: {},
+      });
+
+      expect(content).toEqual([
+        { type: "text", text: "Initial " },
+        { type: "reasoning", text: "Let me think more" },
+        { type: "text", text: "message" },
+        {
+          type: "tool-invocation",
+          stage: "receiving",
+          invocationId: "inv-mixed",
+          name: "helper",
+          partialArgs: {},
+        },
+      ]);
+    });
   });
 });

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -1361,7 +1361,7 @@ export function makeCreateSocketDelegateForAi(
 
     const url = new URL(baseUrl);
     url.protocol = url.protocol === "http:" ? "ws" : "wss";
-    url.pathname = "/ai/v4";
+    url.pathname = "/ai/v5";
     // TODO: don't allow public key to do this
     if (authValue.type === "secret") {
       url.searchParams.set("tok", authValue.token.raw);

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -56,7 +56,7 @@ import type {
   SetToolResultResponse,
   ToolResultResponse,
 } from "./types/ai";
-import { appendDelta } from "./types/ai";
+import { patchContentWithDelta } from "./types/ai";
 import type { Awaitable } from "./types/Awaitable";
 import type {
   InferFromSchema,
@@ -579,7 +579,7 @@ function createStore_forChatMessages(
       const message = lut.get(messageId);
       if (message === undefined) return false;
 
-      appendDelta(message.contentSoFar, delta);
+      patchContentWithDelta(message.contentSoFar, delta);
       lut.set(messageId, message);
       return true;
     });

--- a/packages/liveblocks-core/src/ai.ts
+++ b/packages/liveblocks-core/src/ai.ts
@@ -28,6 +28,7 @@ import type {
 import type {
   AbortAiResponse,
   AiAssistantDeltaUpdate,
+  AiAssistantMessage,
   AiChat,
   AiChatMessage,
   AiChatsQuery,
@@ -120,6 +121,7 @@ export type AiToolInvocationProps<
     // Private APIs
     [kInternal]: {
       execute: AiToolExecuteCallback<A, R> | undefined;
+      messageStatus: AiAssistantMessage["status"];
     };
   }
 >;

--- a/packages/liveblocks-core/src/lib/__tests__/parsePartialJsonObject.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/parsePartialJsonObject.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+
+import { parsePartialJsonObject as p } from "../parsePartialJsonObject";
+
+describe("parsePartialJsonObject", () => {
+  test("basic cases", () => {
+    expect(p("")).toEqual({});
+    expect(p(" ")).toEqual({});
+    expect(p("{")).toEqual({});
+    expect(p('{"key"')).toEqual({});
+    expect(p('{"key')).toEqual({});
+    expect(p('{"key":')).toEqual({});
+    expect(p('{"key":""')).toEqual({ key: "" });
+    expect(p('{"key":"')).toEqual({ key: "" });
+    expect(p('{"key":0')).toEqual({ key: 0 });
+    expect(p('{"key":"hi')).toEqual({ key: "hi" });
+    expect(p('{"key":"value"')).toEqual({ key: "value" });
+    expect(p('{"key":"value"}')).toEqual({ key: "value" });
+  });
+
+  test("arrays", () => {
+    expect(p('{"arr":[')).toEqual({ arr: [] });
+    expect(p('{"arr":[1')).toEqual({ arr: [1] });
+    expect(p('{"arr":[1,')).toEqual({ arr: [1] });
+    expect(p('{"arr":["hi')).toEqual({ arr: ["hi"] });
+    expect(p('{"arr":["hi"')).toEqual({ arr: ["hi"] });
+    expect(p('{"arr":["hi"]')).toEqual({ arr: ["hi"] });
+    expect(p('{"arr":[1,2,3')).toEqual({ arr: [1, 2, 3] });
+  });
+
+  test("nested structures", () => {
+    expect(p('{"arr":[')).toEqual({ arr: [] });
+    expect(p('{"arr":[{')).toEqual({ arr: [{}] });
+    expect(p('{"arr":[{"nested"')).toEqual({ arr: [{}] });
+    expect(p('{"arr":[{"nested":')).toEqual({ arr: [{}] });
+    expect(p('{"arr":[{"nested":42')).toEqual({ arr: [{ nested: 42 }] });
+  });
+
+  test("mixed nesting", () => {
+    expect(p('{"a":[1,{"b":')).toEqual({ a: [1, {}] });
+    expect(p('{"a":[1,{"b":[')).toEqual({ a: [1, { b: [] }] });
+    expect(p('{"a":{"b":["c"')).toEqual({ a: { b: ["c"] } });
+  });
+
+  test("strings with special characters", () => {
+    expect(p('{"key":"val\\n')).toEqual({ key: "val\n" });
+    expect(p('{"key":"val\\"')).toEqual({ key: 'val"' });
+    expect(p('{"key":"val with spaces')).toEqual({ key: "val with spaces" });
+    expect(p('{"unicode":"café')).toEqual({ unicode: "café" });
+  });
+
+  test("numbers", () => {
+    expect(p('{"num":123')).toEqual({ num: 123 });
+    expect(p('{"num":123.')).toEqual({ num: 123 });
+    expect(p('{"num":-42')).toEqual({ num: -42 });
+    expect(p('{"pi":3.')).toEqual({ pi: 3 });
+    expect(p('{"pi":3.14')).toEqual({ pi: 3.14 });
+  });
+
+  test("complex real-world examples", () => {
+    expect(p('{"users":[{"id":1,"name":"John')).toEqual({
+      users: [{ id: 1, name: "John" }],
+    });
+    expect(p('{"config":{"debug":true,"timeout":')).toEqual({
+      config: { debug: true },
+    });
+    expect(p('{"data":[{"items":[{"type":"text","content":')).toEqual({
+      data: [{ items: [{ type: "text" }] }],
+    });
+  });
+
+  test("edge cases for coverage", () => {
+    // Test properly closed nested objects to trigger stack.pop for '}'
+    expect(p('{"a":{"b":{}}')).toEqual({ a: { b: {} } });
+    expect(p('{"nested":{"deep":{"obj":{}}}}')).toEqual({
+      nested: { deep: { obj: {} } },
+    });
+
+    // Test escaped characters at end of incomplete strings
+    expect(p('{"key":"val\\"')).toEqual({ key: 'val"' });
+    expect(p('{"key":"val\\\\"')).toEqual({ key: "val\\" });
+    expect(p('{"esc":"test\\\\')).toEqual({ esc: "test\\" });
+
+    // Test combination of escapes and incomplete structure
+    expect(p('{"a":"b\\\\","c":')).toEqual({ a: "b\\" });
+
+    // Test to cover escape handling in backtracking (lines 120, 122)
+    expect(p('{"a":"test\\\\value:')).toEqual({ a: "test\\value:" });
+    expect(p('{"a":"test\\\\value":')).toEqual({});
+
+    // Test to cover the false branch of line 113 (endsWith('"') after removing ':')
+    // Input ending with number followed by colon (rare but possible in malformed JSON)
+    expect(p('{"a":1:')).toEqual({ a: 1 });
+  });
+});

--- a/packages/liveblocks-core/src/lib/parsePartialJsonObject.ts
+++ b/packages/liveblocks-core/src/lib/parsePartialJsonObject.ts
@@ -1,0 +1,142 @@
+import type { JsonObject } from "./Json";
+import { tryParseJson } from "./utils";
+
+export function parsePartialJsonObject(partial: string): JsonObject {
+  partial = partial.trimStart();
+
+  if (partial.charAt(0) !== "{") {
+    // Not an object, don't even try to parse it
+    return {};
+  }
+
+  // If it's already valid JSON, return as-is
+  {
+    const quickCheck = tryParseJson(partial);
+    if (quickCheck) {
+      // Due to the '{' check above, we can safely assume it's an object
+      return quickCheck as JsonObject;
+    }
+  }
+
+  let result = partial;
+
+  // 1. Fix unclosed strings by appending a '"' if needed
+  let quoteCount = 0;
+  let escaped = false;
+  for (let i = 0; i < result.length; i++) {
+    const char = result[i];
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === '"') {
+      quoteCount++;
+    }
+  }
+
+  if (quoteCount % 2 === 1) {
+    result += '"';
+  }
+
+  // 2. Trim whitespace at the end
+  result = result.trimEnd();
+
+  // 3. If the last char is a ',', strip it
+  if (result.endsWith(",")) {
+    result = result.slice(0, -1);
+  }
+
+  // 4. If the last char is a '.', strip it
+  if (result.endsWith(".")) {
+    result = result.slice(0, -1);
+  }
+
+  // 5. Go from left to right and collect '[' and '{' in a stack
+  const stack: string[] = [];
+  let inString = false;
+  escaped = false;
+
+  for (let i = 0; i < result.length; i++) {
+    const char = result[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+    } else {
+      if (char === '"') {
+        inString = true;
+      } else if (char === "{") {
+        stack.push("}");
+      } else if (char === "[") {
+        stack.push("]");
+      } else if (
+        char === "}" &&
+        stack.length > 0 &&
+        stack[stack.length - 1] === "}"
+      ) {
+        stack.pop();
+      } else if (
+        char === "]" &&
+        stack.length > 0 &&
+        stack[stack.length - 1] === "]"
+      ) {
+        stack.pop();
+      }
+    }
+  }
+
+  // 6. Build the suffix string from the stack
+  const suffix = stack.reverse().join("");
+
+  // 7. Attempt to "just" add the missing ] and }'s.
+  {
+    const attempt = tryParseJson(result + suffix);
+    if (attempt) {
+      // If it parses, return the result
+      return attempt as JsonObject;
+    }
+  }
+
+  // 8. If there is a parse failure, it's likely because we're missing a "value" for a key in an object.
+
+  // a. if the last char is a ":" remove it
+  if (result.endsWith(":")) {
+    result = result.slice(0, -1);
+  }
+
+  // b. if the last char now is a '"', remove that last string
+  if (result.endsWith('"')) {
+    let pos = result.length - 2; // Start before the closing quote
+    escaped = false;
+
+    // Scan back to find the opening quote, accounting for escaping
+    while (pos >= 0) {
+      if (escaped) {
+        escaped = false;
+      } else if (result[pos] === "\\") {
+        escaped = true;
+      } else if (result[pos] === '"') {
+        // Found the opening quote
+        result = result.slice(0, pos);
+        break;
+      }
+      pos--;
+    }
+  }
+
+  // c. if the last char now is a ',', strip it
+  if (result.endsWith(",")) {
+    result = result.slice(0, -1);
+  }
+
+  // Re-add the missing brackets/braces
+  result += suffix;
+
+  // 10. Run JSON.parse on the result again. it should now work!
+  return (tryParseJson(result) as JsonObject | undefined) ?? {}; // Still invalid JSON
+}

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -333,6 +333,7 @@ export type AiReceivingToolInvocationPart = {
   stage: "receiving";
   invocationId: string;
   name: string;
+  /** @internal */
   partialArgsText: string; // The raw, partial JSON text value
   partialArgs: JsonObject; // The interpreted, partial JSON value
 };

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -332,7 +332,7 @@ export type AiReceivingToolInvocationPart = {
   stage: "receiving";
   invocationId: string;
   name: string;
-  partialArgs: Json;
+  partialArgs: JsonObject;
 };
 
 export type AiExecutingToolInvocationPart<A extends JsonObject = JsonObject> = {

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -484,7 +484,7 @@ export type AiKnowledgeSource = {
 
 // --------------------------------------------------------------------------------------------------
 
-export function appendDelta(
+export function patchContentWithDelta(
   content: AiAssistantContentPart[],
   delta: AiAssistantDeltaUpdate
 ): void {

--- a/packages/liveblocks-core/src/types/ai.ts
+++ b/packages/liveblocks-core/src/types/ai.ts
@@ -376,12 +376,17 @@ export type AiReasoningDelta = Relax<
   | { type: "reasoning-delta"; signature: string }
 >;
 
+// Available since protocol V5, this is the start of a tool invocation stream
 export type AiToolInvocationStreamStart = {
   type: "tool-stream";
   invocationId: string;
   name: string;
 };
 
+// Available since protocol V5, this is a partial tool invocation that is being
+// constructed by the server and sent to the client as a delta. The client will
+// append this delta to the last tool invocation stream's partial JSON buffer
+// that will eventually become the full `args` value when JSON.parse()'ed.
 export type AiToolInvocationDelta = {
   type: "tool-delta";
   /**
@@ -418,7 +423,7 @@ export type AiAssistantDeltaUpdate =
   | AiReasoningDelta // a delta appended to the last part (if reasoning)
   | AiExecutingToolInvocationPart // a tool invocation ready to be executed by the client
 
-  // Since protocol v5, if tool-call-streaming is enabled
+  // Since protocol V5, if tool-call-streaming is enabled
   | AiToolInvocationStreamStart // the start of a new tool-call stream
   | AiToolInvocationDelta; // a partial/under-construction tool invocation (since protocol V5)
 
@@ -510,7 +515,7 @@ export type AiKnowledgeSource = {
 /**
  * Polyfill for Array.prototype.findLastIndex()
  */
-function findLastIndex<T>(
+export function findLastIndex<T>(
   arr: T[],
   predicate: (value: T, index: number, obj: T[]) => boolean
 ): number {

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
@@ -559,7 +559,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
 
         expectType<"receiving" | "executing" | "executed">(stage);
         if (stage === "receiving") {
-          expectType<Json>(partialArgs);
+          expectType<JsonObject>(partialArgs);
           expectType<undefined>(args);
           expectType<undefined>(result);
         } else if (stage === "executing") {
@@ -587,7 +587,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
 
         expectType<"receiving" | "executing" | "executed">(stage);
         if (stage === "receiving") {
-          expectType<Json>(partialArgs);
+          expectType<JsonObject>(partialArgs);
           expectType<undefined>(args);
           expectType<undefined>(result);
         } else if (stage === "executing") {

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
@@ -476,7 +476,6 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
       stage: "receiving",
       name: "callMyTool",
       invocationId: "tc_abc123",
-      partialArgsText: "{}",
       partialArgs: {},
       respond: (payload) => {
         expectType<ToolResultResponse | undefined>(payload);

--- a/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
+++ b/packages/liveblocks-core/test-d/InferFromSchema.test-d.ts
@@ -476,6 +476,7 @@ function infer<const T extends JSONSchema7>(x: T): InferFromSchema<T> {
       stage: "receiving",
       name: "callMyTool",
       invocationId: "tc_abc123",
+      partialArgsText: "{}",
       partialArgs: {},
       respond: (payload) => {
         expectType<ToolResultResponse | undefined>(payload);

--- a/packages/liveblocks-react-ui/src/components/AiTool.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiTool.tsx
@@ -337,7 +337,7 @@ export const AiTool = Object.assign(
         stage,
         result,
         name,
-        [kInternal]: { execute },
+        [kInternal]: { execute, messageStatus },
       } = useAiToolInvocationContext();
       const [semiControlledCollapsed, onSemiControlledCollapsed] =
         useSemiControllableState(collapsed ?? false, onCollapsedChange);
@@ -397,8 +397,10 @@ export const AiTool = Object.assign(
                 ) : result.type === "cancelled" ? (
                   <MinusCircleIcon />
                 ) : null
-              ) : execute !== undefined ? (
-                // Only show a spinner if the tool has an `execute` method.
+              ) : execute !== undefined &&
+                (stage !== "receiving" || messageStatus === "generating") ? (
+                // Only show a spinner if the tool has an `execute` method and
+                // either the tool is not in "receiving" state or the message is still "generating"
                 <SpinnerIcon />
               ) : null}
             </div>

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
@@ -87,9 +87,10 @@ export function AiMessageToolInvocation({
       types: undefined as never,
       [kInternal]: {
         execute: tool?.execute,
+        messageStatus: message.status,
       },
     };
-  }, [part, respond, tool?.execute]);
+  }, [part, respond, tool?.execute, message.status]);
 
   if (tool?.render === undefined) return null;
   return (

--- a/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/AiMessage/tool-invocation.tsx
@@ -79,7 +79,15 @@ export function AiMessageToolInvocation({
     ]
   );
 
+  const partialArgs = part?.partialArgs;
   const props = useMemo(() => {
+    // NOTE: Not really used, but necessary to trick useMemo into re-evaluating
+    // when it changes. Without this trick, tool call streaming won't
+    // re-render. The reason this is needed is that `part` gets mutated
+    // in-place by the delta handling, rather than part being replaced by a new
+    // object on every chunk.
+    partialArgs;
+
     const { type: _, ...rest } = part;
     return {
       ...rest,
@@ -90,7 +98,7 @@ export function AiMessageToolInvocation({
         messageStatus: message.status,
       },
     };
-  }, [part, respond, tool?.execute, message.status]);
+  }, [part, respond, tool?.execute, message.status, partialArgs]);
 
   if (tool?.render === undefined) return null;
   return (


### PR DESCRIPTION
## Summary
- Upgraded AI protocol from V4 to V5 to support tool call streaming
- Implemented real-time streaming of tool invocations as they're being built
- Added comprehensive delta handling for text, reasoning, and tool invocation updates
- Created test page in e2e/next-ai-kitchen-sink for testing tool call streaming functionality

## Key Changes
- **Protocol upgrade**: Bumped AI WebSocket endpoint from `/ai/v4` to `/ai/v5`
- **Delta processing**: Implemented `patchContentWithDelta` function to handle streaming updates
- **Tool streaming**: Added support for `tool-stream`, `tool-delta`, and progressive tool invocation updates
- **JSON parsing**: Added `parsePartialJsonObject` utility for handling incomplete JSON during streaming
- **UI improvements**: Fixed spinner behavior during tool call receiving state
- **Test infrastructure**: Added comprehensive test suite with 30+ test cases covering all streaming scenarios

## Technical Implementation
- Tool invocations now progress through stages: `receiving` → `executing` → `executed`
- Partial JSON arguments are built progressively as deltas arrive
- Content updates are applied in-place to maintain React state consistency
- Backwards compatible with existing non-streaming tool implementations

## Test plan
- [x] All existing tests pass
- [x] New comprehensive test suite covers delta handling edge cases
- [x] Manual testing with tool call streaming test page
- [x] Verified streaming works with complex nested JSON tool arguments

🤖 Generated with [Claude Code](https://claude.ai/code)