### PR TITLE
CHANGELOG — WEEK 34

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -18,6 +18,10 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 -->
 
+# Week 34 (2025-08-22)
+
+## Contributors
+
 # Week 33 (2025-08-15)
 
 ## v3.3.4

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,7 +20,13 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 34 (2025-08-22)
 
+## Infrastructure
+
+- Improved LiveList conflict resolution that will keep the conflicting element closer to its intended destination.
+
 ## Contributors
+
+nvie
 
 # Week 33 (2025-08-15)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,13 +20,56 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 34 (2025-08-22)
 
+## v3.4.0
+
+### `@liveblocks/react`
+
+Tool calls will now stream in while under construction. This means that tools
+will render sooner and more often re-render, while `partialArgs` are streaming
+in.
+
+> New behavior (>=3.4):
+>
+> - 1st render: `{ stage: "receiving", partialArgs: {} }`
+> - 2nd render: `{ stage: "receiving", partialArgs: { cities: [] } }`
+> - 3rd render: `{ stage: "receiving", partialArgs: { cities: [""] } }`
+> - 4th render: `{ stage: "receiving", partialArgs: { cities: ["Pa"] } }`
+> - 5th render: `{ stage: "receiving", partialArgs: { cities: ["Paris"] } }`
+> - etc.
+> - Then `{ stage: "executing", args: { cities: "Paris" } }` (same as before)
+> - And `{ stage: "executed", args, result }` (same as before)
+>
+> Before (<3.4):
+>
+> - Stage "receiving" would never happen
+> - 1st render would be with
+>   `{ stage: "executing", args: { cities: ["Paris"] } }`
+> - 2nd render would be with `{ stage: "executed", args, result }`
+
+#### Other changes
+
+- In `RoomProvider`, `initialPresence` and `initialStorage` now get re-evaluated
+  whenever the room ID (the `id` prop) changes.
+
+### `@liveblocks/react-ui`
+
+- Add a minimal appearance to `AiTool` via a new `variant` prop.
+- Improve Markdown rendering during streaming in `AiChat`: incomplete content is
+  now handled gracefully so things like bold, links, or tables all render
+  instantly without seeing partial Markdown syntax first.
+- Render all messages in `AiChat` as Markdown, including ones from the user.
+- Fix Markdown rendering of HTML tags in `AiChat`. (e.g. "Use the `<AiChat />`
+  component" would render as "Use the `` component")
+- Improve shimmer animation visible on elements like the
+  "Thinking…"/"Reasoning…" placeholders in `AiChat`.
+
 ## Infrastructure
 
 - Improved LiveList conflict resolution that will keep the conflicting element closer to its intended destination.
 
 ## Contributors
 
-nvie
+nvie, marcbouchenoire
 
 # Week 33 (2025-08-15)
 


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-34-2025/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 22nd of August.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching. Thank you [@random_dev](https://github.com/random_dev)!

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug.  Thank you [@random_dev](https://github.com/random_dev)!

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.