### PR TITLE
Fix HTML tags being hidden in inline code

### DIFF
--- a/e2e/next-ai-kitchen-sink/app/partial-markdown/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/partial-markdown/page.tsx
@@ -41,14 +41,6 @@ const markdownMessage = `
 
 ---
 
-<Markdown>Hello</Markdown>
-
-<Markdown />
-
-\`<Markdown>Hello</Markdown>\`
-
-\`<Markdown />\`
-
 This is a regular paragraph of text. It includes **bold text**, _italic text_, **_bold and italic_**, ~~strikethrough~~, \`inline code\`, **\`bold inline code\`**, and [links](https://liveblocks.io/ "With a title").
 Hello world the rest of the first paragraph is here.
 

--- a/e2e/next-ai-kitchen-sink/app/partial-markdown/page.tsx
+++ b/e2e/next-ai-kitchen-sink/app/partial-markdown/page.tsx
@@ -41,6 +41,14 @@ const markdownMessage = `
 
 ---
 
+<Markdown>Hello</Markdown>
+
+<Markdown />
+
+\`<Markdown>Hello</Markdown>\`
+
+\`<Markdown />\`
+
 This is a regular paragraph of text. It includes **bold text**, _italic text_, **_bold and italic_**, ~~strikethrough~~, \`inline code\`, **\`bold inline code\`**, and [links](https://liveblocks.io/ "With a title").
 Hello world the rest of the first paragraph is here.
 

--- a/packages/liveblocks-react-ui/src/primitives/Markdown.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Markdown.tsx
@@ -29,6 +29,8 @@ const NEWLINE_REGEX = /\r\n?/g;
 const BUFFERED_CHARACTERS_REGEX =
   /(?<!\\)((\*+|_+|~+|`+|\++|-{0,2}|={0,2}|\\|!|<\/?)\s*)$/;
 const SINGLE_CHARACTER_REGEX = /^\s*(\S\s*)$/;
+const LEFT_ANGLE_BRACKET_REGEX = /</g;
+const RIGHT_ANGLE_BRACKET_REGEX = />/g;
 const DEFAULT_PARTIAL_LINK_URL = "#";
 
 type CheckboxToken = {
@@ -1382,7 +1384,10 @@ function completePartialTokens(tokens: Token[]) {
 
 function parseHtmlEntities(input: string) {
   const document = new DOMParser().parseFromString(
-    `<!doctype html><body>${input}`,
+    `<!doctype html><body>${input
+      // Prevent HTML tags from being interpreted as markup.
+      .replace(LEFT_ANGLE_BRACKET_REGEX, "&lt;")
+      .replace(RIGHT_ANGLE_BRACKET_REGEX, "&gt;")}`,
     "text/html"
   );
 

--- a/packages/liveblocks-react-ui/src/primitives/Markdown.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/Markdown.tsx
@@ -718,8 +718,10 @@ export function MarkdownToken({
       return <Separator />;
     }
 
-    // HTML elements/tokens are not supported (yet).
-    case "html":
+    case "html": {
+      return parseHtmlEntities(token.text);
+    }
+
     default: {
       return null;
     }

--- a/packages/liveblocks-react-ui/src/primitives/__tests__/Markdown.test.tsx
+++ b/packages/liveblocks-react-ui/src/primitives/__tests__/Markdown.test.tsx
@@ -803,11 +803,15 @@ describe("Markdown", () => {
           expect(paragraphs).toHaveLength(4);
 
           expect(paragraphs[0]?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is HTML."
+            'The abbreviation for HyperText Markup Language is <abbr title="HyperText Markup Language">HTML</abbr>.'
           );
-          expect(paragraphs[1]?.textContent).toBe("Press Ctrl + C to copy.");
-          expect(paragraphs[2]?.textContent).toBe("This text is highlighted.");
-          expect(paragraphs[3]?.textContent).toBe("E = mc2");
+          expect(paragraphs[1]?.textContent).toBe(
+            "Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to copy."
+          );
+          expect(paragraphs[2]?.textContent).toBe(
+            "This <mark>text is highlighted</mark>."
+          );
+          expect(paragraphs[3]?.textContent).toBe("E = mc<sup>2</sup>");
         }
       );
     });
@@ -1993,18 +1997,7 @@ describe("Markdown", () => {
         `,
         (root) => {
           expect(root?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is "
-          );
-        }
-      );
-
-      assert(
-        `
-          The abbreviation for HyperText Markup Language is <abbr title="HyperText Markup Language">
-        `,
-        (root) => {
-          expect(root?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is "
+            'The abbreviation for HyperText Markup Language is <abbr title="'
           );
         }
       );
@@ -2015,29 +2008,7 @@ describe("Markdown", () => {
         `,
         (root) => {
           expect(root?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is HT"
-          );
-        }
-      );
-
-      assert(
-        `
-          The abbreviation for HyperText Markup Language is <abbr title="HyperText Markup Language">HTML<
-        `,
-        (root) => {
-          expect(root?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is HTML"
-          );
-        }
-      );
-
-      assert(
-        `
-          The abbreviation for HyperText Markup Language is <abbr title="HyperText Markup Language">HTML</
-        `,
-        (root) => {
-          expect(root?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is HTML"
+            'The abbreviation for HyperText Markup Language is <abbr title="HyperText Markup Language">HT'
           );
         }
       );
@@ -2048,7 +2019,7 @@ describe("Markdown", () => {
         `,
         (root) => {
           expect(root?.textContent).toBe(
-            "The abbreviation for HyperText Markup Language is HTML."
+            'The abbreviation for HyperText Markup Language is <abbr title="HyperText Markup Language">HTML</abbr>.'
           );
         }
       );


### PR DESCRIPTION
This PR escapes angle brackets before using `DOMParser` to "unescape" all HTML entities, to prevent `DOMParser` from treating HTML tags as HTML elements and "hiding" them.