### PR TITLE
Allow hiding `@` symbol in default components' mentions 

### DIFF
--- a/packages/liveblocks-react-lexical/src/mentions/mention-component.tsx
+++ b/packages/liveblocks-react-lexical/src/mentions/mention-component.tsx
@@ -29,7 +29,7 @@ export function Mention({
     <span
       onClick={handleClick}
       data-selected={isSelected ? "" : undefined}
-      className="lb-root lb-lexical-mention"
+      className="lb-root lb-mention lb-lexical-mention"
     >
       {children}
     </span>

--- a/packages/liveblocks-react-lexical/src/mentions/mention-node.tsx
+++ b/packages/liveblocks-react-lexical/src/mentions/mention-node.tsx
@@ -101,7 +101,7 @@ export class MentionNode extends DecoratorNode<JSX.Element> {
   decorate(): JSX.Element {
     return (
       <Mention nodeKey={this.getKey()}>
-        {MENTION_CHARACTER}
+        <span className="lb-mention-symbol">{MENTION_CHARACTER}</span>
         <User userId={this.getUserId()} />
       </Mention>
     );

--- a/packages/liveblocks-react-tiptap/src/mentions/Mention.tsx
+++ b/packages/liveblocks-react-tiptap/src/mentions/Mention.tsx
@@ -14,13 +14,13 @@ export const Mention = forwardRef<
   return (
     <NodeViewWrapper
       className={cn(
-        "lb-root lb-tiptap-mention",
+        "lb-root lb-mention lb-tiptap-mention",
         props.selected ? "lb-mention-selected" : null
       )}
       as="span"
       ref={forwardedRef}
     >
-      {MENTION_CHARACTER}
+      <span className="lb-mention-symbol">{MENTION_CHARACTER}</span>
       <User userId={id} />
     </NodeViewWrapper>
   );

--- a/packages/liveblocks-react-ui/src/components/Comment.tsx
+++ b/packages/liveblocks-react-ui/src/components/Comment.tsx
@@ -222,11 +222,11 @@ export function CommentMention({
     case "user":
       return (
         <CommentPrimitive.Mention
-          className={cn("lb-comment-mention", className)}
+          className={cn("lb-mention lb-comment-mention", className)}
           data-self={mention.id === currentId ? "" : undefined}
           {...props}
         >
-          {MENTION_CHARACTER}
+          <span className="lb-mention-symbol">{MENTION_CHARACTER}</span>
           <User userId={mention.id} />
         </CommentPrimitive.Mention>
       );

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -339,8 +339,8 @@ function ComposerMention({ mention }: ComposerEditorMentionProps) {
   switch (mention.kind) {
     case "user":
       return (
-        <ComposerPrimitive.Mention className="lb-composer-mention">
-          {MENTION_CHARACTER}
+        <ComposerPrimitive.Mention className="lb-mention lb-composer-mention">
+          <span className="lb-mention-symbol">{MENTION_CHARACTER}</span>
           <User userId={mention.id} />
         </ComposerPrimitive.Mention>
       );

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -1189,6 +1189,10 @@
   background: var(--lb-accent-subtle);
 }
 
+.lb-mention-symbol {
+  display: contents;
+}
+
 /*************************************
  *             Composer              *
  *************************************/


### PR DESCRIPTION
This PR wraps `@` symbols rendered in mentions within their own `span` so that they can be styled independently (to be hidden for example), and adds a few shared CSS classes across our packages.

**Context:** https://liveblocks.slack.com/archives/C03NG9R49HC/p1755702714607269

```css
/* Hide `@` in mentions everywhere (comments, composers, notifications, text editors, etc.) */
.lb-mention-symbol {
  display: none;
}

/* Only hide `@` in mentions within comments */
.lb-comment-mention .lb-mention-symbol {
  display: none;
}
```