### PR TITLE
Fix partial Markdown not enabled in text parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## vNEXT (not yet published)
 
+## v3.4.2
+
+### `@liveblocks/react-ui`
+
+- Fix improved Markdown streaming in `AiChat` only being enabled in reasoning
+  blocks, it’s now enabled for all Markdown.
+
 ## v3.4.1
 
 ### `@liveblocks/core`

--- a/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiChatAssistantMessage.tsx
@@ -173,12 +173,13 @@ function AssistantMessageContent({
 /* -------------------------------------------------------------------------------------------------
  * TextPart
  * -----------------------------------------------------------------------------------------------*/
-function TextPart({ part, components }: TextPartProps) {
+function TextPart({ part, components, isStreaming }: TextPartProps) {
   return (
     <Prose
       content={part.text}
       className="lb-ai-chat-message-text"
       components={components}
+      partial={isStreaming}
     />
   );
 }


### PR DESCRIPTION
The new partial Markdown rendering (added in 3.4) was not enabled for text parts in assistant messages, only reasoning parts 🙈