### PR TITLE
Tiptap comments: filter out orphans

### DIFF
--- a/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/comments/CommentsExtension.ts
@@ -215,10 +215,10 @@ const Comment = Mark.create({
               return;
             }
             const commentMark = node.marks.find(
-              (mark) => mark.type === this.type
+              (mark) => mark.type === this.type && !mark.attrs.orphan
             );
-            // don't allow selecting orphaned threads
-            if (commentMark?.attrs.orphan) {
+            // nothing to select
+            if (!commentMark) {
               selectThread(null);
               return;
             }


### PR DESCRIPTION
Our comment selection was only finding the first mark, whether it was an orphan or not, and this means it would fail to find comments that were marks underneath the clicked node if the parent comment had been deleted.

This was not an issue before, because overlapping marks (comments) were not supported by y-prosemirror, this was fixed earlier this year so this bug becomes relevant.

a quick note on why we keep orphaned comments: sometimes there's a data api error and a comment may not be returned, we don't want to show that comment since it's not returned, but we also don't want to delete the mark because a comment can technically be undeleted or restored. The tiptap extension will un-orphan a found thread id.
