### PR TITLE
Update documentation for `Liveblocks.updateRoomId` to clarify parameter naming from `roomId` to `currentRoomId`.

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -644,15 +644,16 @@ await liveblocks.deleteRoom("my-room-id");
 
 #### Liveblocks.updateRoomId [#post-rooms-update-roomId]
 
-Permanently updates a room’s ID. `newRoomId` will replace `roomId`. Note that
-this will disconnect connected users from the room, but this can be worked
-around. Throws an error if the room isn’t found. This is a wrapper around the
+Permanently updates a room’s ID. `newRoomId` will replace `currentRoomId`. Note
+that this will disconnect connected users from the room, but this currentRoomId
+be worked around. Throws an error if the room isn’t found. This is a wrapper
+around the
 [Update Room API](/docs/api-reference/rest-api-endpoints#post-rooms-update-roomId)
 and returns the same response.
 
 ```ts
 const room = await liveblocks.updateRoomId({
-  roomId: "my-room-id",
+  currentRoomId: "my-room-id",
   newRoomId: "new-room-id",
 });
 


### PR DESCRIPTION
We have a typo in our documentation for the node method `updateRoomId`. This PR fixes the typo so that we correctly use the term `currentRoomId` instead of `roomId`.