### PR TITLE
Use Liveblocks groups in the starter kit

### DIFF
--- a/starter-kits/nextjs-starter-kit/lib/actions/syncLiveblocksGroups.ts
+++ b/starter-kits/nextjs-starter-kit/lib/actions/syncLiveblocksGroups.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { LiveblocksError } from "@liveblocks/node";
+import { liveblocks } from "@/liveblocks.server.config";
+import { getGroups } from "@/lib/database";
+
+/**
+ * Sync Groups with Liveblocks
+ *
+ * Groups on Liveblocks are currently used for group mentions in comments and text editors.
+ */
+export async function syncLiveblocksGroups() {
+  const groups = (await getGroups()).filter((group) => group !== null);
+
+  for (const group of groups) {
+    const localMemberIds = new Set(group.memberIds ?? []);
+
+    // Sync group members if the group already exists on Liveblocks
+    try {
+      const liveblocksMemberIds = new Set(
+        (await liveblocks.getGroup({ groupId: group.id })).members.map(
+          (member) => member.id
+        )
+      );
+      const memberIdsToAdd: string[] = [];
+      const memberIdsToRemove: string[] = [];
+
+      for (const memberId of localMemberIds) {
+        if (!liveblocksMemberIds.has(memberId)) {
+          memberIdsToAdd.push(memberId);
+        }
+      }
+
+      for (const memberId of liveblocksMemberIds) {
+        if (!localMemberIds.has(memberId)) {
+          memberIdsToRemove.push(memberId);
+        }
+      }
+
+      if (memberIdsToAdd.length > 0) {
+        await liveblocks.addGroupMembers({
+          groupId: group.id,
+          memberIds: memberIdsToAdd,
+        });
+      }
+
+      if (memberIdsToRemove.length > 0) {
+        await liveblocks.removeGroupMembers({
+          groupId: group.id,
+          memberIds: memberIdsToRemove,
+        });
+      }
+    } catch (error) {
+      // Let unrelated and unknown errors through
+      if (!(error instanceof LiveblocksError && error.status === 404)) {
+        throw error;
+      }
+
+      // Create the group on Liveblocks if it doesn't already exist
+      await liveblocks.createGroup({
+        groupId: group.id,
+        memberIds: Array.from(localMemberIds),
+      });
+    }
+  }
+}

--- a/starter-kits/nextjs-starter-kit/lib/database/getGroups.ts
+++ b/starter-kits/nextjs-starter-kit/lib/database/getGroups.ts
@@ -1,10 +1,15 @@
 import { groups } from "@/data/groups";
 import { Group } from "@/types";
 import { getGroup } from "./getGroup";
+import { users } from "@/data/users";
 
 type Props = {
   groupIds?: string[];
   search?: string;
+};
+
+type GroupWithMembers = Group & {
+  memberIds: string[];
 };
 
 /**
@@ -15,10 +20,9 @@ type Props = {
  * @param groupIds - The group ids to get
  * @param search - The term to filter your users by, checks users' ids and names
  */
-export async function getGroups({
-  groupIds,
-  search,
-}: Props): Promise<(Group | null)[]> {
+export async function getGroups({ groupIds, search }: Props = {}): Promise<
+  (GroupWithMembers | null)[]
+> {
   const groupsPromises: Promise<Group | null>[] = [];
 
   // Filter by userIds or get all users
@@ -28,18 +32,19 @@ export async function getGroups({
     }
   } else {
     const allGroupIds = groups.map((group) => group.id);
+
     for (const groupId of allGroupIds) {
       groupsPromises.push(getGroup(groupId));
     }
   }
 
-  const groupList = await Promise.all(groupsPromises);
+  let groupList = await Promise.all(groupsPromises);
 
   // If search term, check if term is included in name or id, and filter
   if (search) {
     const term = search.toLowerCase();
 
-    return groupList.filter((group) => {
+    groupList = groupList.filter((group) => {
       if (!group) {
         return false;
       }
@@ -51,5 +56,14 @@ export async function getGroups({
     });
   }
 
-  return groupList;
+  return groupList.map((group) =>
+    group
+      ? {
+          ...group,
+          memberIds: users
+            .filter((user) => user.groupIds.includes(group.id))
+            .map((user) => user.id),
+        }
+      : group
+  );
 }

--- a/starter-kits/nextjs-starter-kit/lib/database/getUsers.ts
+++ b/starter-kits/nextjs-starter-kit/lib/database/getUsers.ts
@@ -15,7 +15,7 @@ type Props = {
  * @param userIds - The user ids to get
  * @param search - The term to filter your users by, checks users' ids and names
  */
-export async function getUsers({ userIds, search }: Props) {
+export async function getUsers({ userIds, search }: Props = {}) {
   const usersPromises: Promise<User | null>[] = [];
 
   // Filter by userIds or get all users


### PR DESCRIPTION
The starter kit already contains its own "database" dummy groups, and this PR syncs them with Liveblocks. They're synced once per session and only during development.