### PR TITLE
Make `AiTool` titles selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT (not yet published)
 
+## v3.6.1
+
 ### `@liveblocks/client`
 
 - Fixes a bug where a specific combination of concurrent LiveList mutations
@@ -10,6 +12,7 @@
 
 - Only show retrieval and reasoning durations in `AiChat` when they are 3
   seconds or longer.
+- Make `AiTool` titles selectable.
 
 ## v3.6.0
 

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2949,6 +2949,8 @@
 
 .lb-ai-tool-header-title {
   @include truncate;
+
+  user-select: auto;
 }
 
 .lb-ai-tool-header-status {


### PR DESCRIPTION
This PR makes `AiTool` titles selectable (especially useful for tools with errors) but not directly to avoid interfering when expanding/collapsing.

https://github.com/user-attachments/assets/31dc8079-2633-4246-ad37-ad4b8b7f5e97

I intend to release this as 3.6.1 right after this PR is merged.