### PR TITLE
inbox notifications add query filter on kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ```
 const inboxNotifications = await client.getInboxNotifications({
   query: {
-    roomId:"room1"
+    roomId:"room1",
+    kind:"thread"
   },
 });
 ```
@@ -21,7 +22,8 @@ const inboxNotifications = await client.getInboxNotifications({
 ```
 const { inboxNotifications } = useInboxNotifications({
   query: {
-     roomId:"room1"
+     roomId:"room1",
+     kind:"thread"
   }
 });
 ```

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -3464,14 +3464,15 @@ console.log(subscriptions);
 #### Filtering by room ID [#filtering-by-room-id]
 
 You can filter inbox notifications by those that are associated with a specific
-room, by passing a `string` to `query.roomId`.
+room or kind, by passing a `string` to `query.roomId` or `query.kind`.
 
 ```ts
-// Filtering for threads that are unresolved
+// Filtering for inbox notifications that are associated with a specific room or kind
 const { inboxNotifications } = await client.getInboxNotifications({
   query: {
     // +++
     roomId: "room1",
+    kind: "thread",
     // +++
   },
 });

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -3695,7 +3695,7 @@ function Inbox() {
 
 It’s possible to return inbox notifications that match a certain query with the
 `query` option. You can filter inbox notifications based on their associated
-roomId.
+roomId or kind.
 
 ```tsx
 // Returns threads that match the entire `query`, e.g. { roomId: "room1", ... }
@@ -3703,6 +3703,8 @@ const { inboxNotifications } = useInboxNotifications({
   query: {
     // Filter for roomId
     roomId: "room1",
+    // Filter for kind
+    kind: "thread",
   },
 });
 ```

--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -400,7 +400,7 @@ export interface RoomHttpApi<M extends BaseMetadata> {
 export interface NotificationHttpApi<M extends BaseMetadata> {
   getInboxNotifications(options?: {
     cursor?: string;
-    query?: { roomId?: string };
+    query?: { roomId?: string; kind?: string };
   }): Promise<{
     inboxNotifications: InboxNotificationData[];
     threads: ThreadData<M>[];
@@ -411,7 +411,7 @@ export interface NotificationHttpApi<M extends BaseMetadata> {
 
   getInboxNotificationsSince(options: {
     since: Date;
-    query?: { roomId?: string };
+    query?: { roomId?: string; kind?: string };
     signal?: AbortSignal;
   }): Promise<{
     inboxNotifications: {
@@ -1512,7 +1512,7 @@ export function createApiClient<M extends BaseMetadata>({
    * -----------------------------------------------------------------------------------------------*/
   async function getInboxNotifications(options?: {
     cursor?: string;
-    query?: { roomId?: string };
+    query?: { roomId?: string; kind?: string };
   }) {
     const PAGE_SIZE = 50;
 
@@ -1553,7 +1553,7 @@ export function createApiClient<M extends BaseMetadata>({
 
   async function getInboxNotificationsSince(options: {
     since: Date;
-    query?: { roomId?: string };
+    query?: { roomId?: string; kind?: string };
     signal?: AbortSignal;
   }) {
     let query: string | undefined;

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -195,7 +195,7 @@ export type NotificationsApi<M extends BaseMetadata> = {
    */
   getInboxNotifications(options?: {
     cursor?: string;
-    query?: { roomId?: string };
+    query?: { roomId?: string; kind?: string };
   }): Promise<{
     inboxNotifications: InboxNotificationData[];
     threads: ThreadData<M>[];
@@ -229,7 +229,7 @@ export type NotificationsApi<M extends BaseMetadata> = {
    */
   getInboxNotificationsSince(options: {
     since: Date;
-    query?: { roomId?: string };
+    query?: { roomId?: string; kind?: string };
     signal?: AbortSignal;
   }): Promise<{
     inboxNotifications: {

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -159,6 +159,12 @@ export type InboxNotificationsQuery = {
    * all the user's inbox notifications will be returned.
    */
   roomId?: string;
+
+  /**
+   * Whether to only return inbox notifications for a specific kind. If not provided,
+   * all the user's inbox notifications will be returned.
+   */
+  kind?: string;
 };
 
 export type UseInboxNotificationsOptions = {


### PR DESCRIPTION
### Description
This PR adds query filters on the get inbox notifications method and react hook.
The first filter supported is roomId.

#### @liveblocks/client
```
const inboxNotifications = await client.getInboxNotifications({
  query: {
    kind:"thread",
  },
});
```

#### @liveblocks/react
```
const { inboxNotifications } = useInboxNotifications({
  query: {
     kind:"thread",
  }
});
```