### PR TITLE
Add `useAiChatStatus()` convenience hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## vNEXT (not yet published)
+## v3.8.0 (not yet published)
+
+### `@liveblocks/react`
+
+- Add new hook
+  [`useAiChatStatus`](https://liveblocks.io/docs/api-reference/liveblocks-react#useAiChatStatus)
+  that offers a convenient way to get the current generation status for an AI
+  chat, indicating whether the chat is idle, currently generating contents, and,
+  if so, what type of content is currently generating.
 
 ## v3.7.1
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -1598,6 +1598,25 @@ import { useAiChatMessages } from "@liveblocks/react";
 const { messages, error, isLoading } = useAiChatMessages("my-chat-id");
 ```
 
+### useAiChatStatus
+
+Returns the status of an AI chat, indicating whether it’s idle or actively
+generating content. This is a convenience hook that derives its state from the
+latest assistant message in the chat.
+
+```tsx
+import { useAiChatStatus } from "@liveblocks/react";
+
+const { status, partType, toolName } = useAiChatStatus("my-chat-id");
+```
+
+The hook returns an object with the following properties:
+
+- `status`: The current status (`"loading"` | `"idle"` | `"generating"`)
+- `partType`: The type of content being generated (`"text"` |
+  `"tool-invocation"` | etc.)
+- `toolName`: The name of the tool being invoked (if applicable)
+
 ### RegisterAiKnowledge
 
 Adds knowledge to all AI features on the page. AI will understand the

--- a/packages/liveblocks-react/scripts/check-exports.ts
+++ b/packages/liveblocks-react/scripts/check-exports.ts
@@ -51,6 +51,7 @@ const ALLOW_NO_FACTORY = [
   "UseSendAiMessageOptions",
   "UseThreadsOptions",
   "SendAiMessageOptions",
+  "AiChatStatus",
 ];
 
 /**

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -97,4 +97,7 @@ export {
   useAiChat,
   useAiChats,
   useAiChatMessages,
+  useAiChatStatus,
 } from "./liveblocks";
+
+export type { AiChatStatus } from "./types/ai";

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -18,7 +18,11 @@ export { shallow, isNotificationChannelEnabled } from "@liveblocks/client";
 
 // Export all the top-level hooks
 export { RegisterAiKnowledge, RegisterAiTool } from "./ai";
-export type { RegisterAiKnowledgeProps, RegisterAiToolProps } from "./types/ai";
+export type {
+  AiChatStatus,
+  RegisterAiKnowledgeProps,
+  RegisterAiToolProps,
+} from "./types/ai";
 export { ClientContext, RoomContext, useClient } from "./contexts";
 export {
   createLiveblocksContext,
@@ -99,5 +103,3 @@ export {
   useAiChatMessages,
   useAiChatStatus,
 } from "./liveblocks";
-
-export type { AiChatStatus } from "./types/ai";

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -60,6 +60,7 @@ import type {
   AiChatMessagesAsyncSuccess,
   AiChatsAsyncResult,
   AiChatsAsyncSuccess,
+  AiChatStatus,
   CreateAiChatOptions,
   GroupInfoAsyncResult,
   GroupInfoAsyncSuccess,
@@ -448,6 +449,7 @@ function makeLiveblocksContextBundle<
     useAiChats,
     useAiChat,
     useAiChatMessages,
+    useAiChatStatus,
     useCreateAiChat,
     useDeleteAiChat,
     useSendAiMessage,
@@ -480,6 +482,7 @@ function makeLiveblocksContextBundle<
       useAiChats: useAiChatsSuspense,
       useAiChat: useAiChatSuspense,
       useAiChatMessages: useAiChatMessagesSuspense,
+      useAiChatStatus,
       useCreateAiChat,
       useDeleteAiChat,
       useSendAiMessage,
@@ -1332,6 +1335,89 @@ function useDeleteAiChat() {
   );
 }
 
+const LOADING = Object.freeze({ status: "loading" });
+const IDLE = Object.freeze({ status: "idle" });
+
+/**
+ * Returns the status of an AI chat, indicating whether it's idle or actively
+ * generating content. This is a convenience hook that derives its state from
+ * the latest assistant message in the chat.
+ *
+ * Re-renders whenever any of the relevant fields change.
+ *
+ * @param chatId - The ID of the chat to monitor
+ * @returns The current status of the AI chat
+ *
+ * @example
+ * ```tsx
+ * import { useAiChatStatus } from "@liveblocks/react";
+ *
+ * function ChatStatus() {
+ *   const { status, partType, toolName } = useAiChatStatus("my-chat");
+ *   console.log(status);          // "loading" | "idle" | "generating"
+ *   console.log(status.partType); // "text" | "tool-invocation" | ...
+ *   console.log(status.toolName); // string | undefined
+ * }
+ * ```
+ */
+function useAiChatStatus(
+  chatId: string,
+  /** @internal */
+  branchId?: MessageId
+): AiChatStatus {
+  const client = useClient();
+  const store = getUmbrellaStoreForClient(client);
+
+  useEnsureAiConnection(client);
+
+  useEffect(
+    () =>
+      void store.outputs.messagesByChatId
+        .getOrCreate(chatId)
+        .getOrCreate(branchId ?? null)
+        .waitUntilLoaded()
+  );
+
+  return useSignal(
+    // Signal
+    store.outputs.messagesByChatId
+      .getOrCreate(chatId)
+      .getOrCreate(branchId ?? null).signal,
+
+    // Selector
+    (result) => {
+      if (result.isLoading) return LOADING;
+      if (result.error) return IDLE;
+
+      const messages = result.messages;
+      const lastMessage = messages[messages.length - 1];
+
+      if (lastMessage?.role !== "assistant") return IDLE;
+      if (
+        lastMessage.status !== "generating" &&
+        lastMessage.status !== "awaiting-tool"
+      )
+        return IDLE;
+
+      const contentSoFar = lastMessage.contentSoFar;
+      const lastPart = contentSoFar[contentSoFar.length - 1];
+
+      if (lastPart?.type === "tool-invocation") {
+        return {
+          status: "generating",
+          partType: "tool-invocation",
+          toolName: lastPart.name,
+        };
+      } else {
+        return { status: "generating", partType: lastPart?.type };
+      }
+    },
+
+    // Consider { status: "generating", partType: "text" } and { status: "generating", partType: "text" } equal
+    shallow
+  );
+}
+
 /**
  * Returns a function to send a message in an AI chat.
  *
@@ -2161,6 +2247,7 @@ export {
   _useAiChatSuspense as useAiChatSuspense,
   _useAiChatMessages as useAiChatMessages,
   _useAiChatMessagesSuspense as useAiChatMessagesSuspense,
+  useAiChatStatus,
   useCreateAiChat,
   useDeleteAiChat,
   useSendAiMessage,

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -19,7 +19,7 @@ export { shallow, isNotificationChannelEnabled } from "@liveblocks/client";
 // Export all the top-level hooks
 export { ClientContext, RoomContext, useClient } from "./contexts";
 export { RegisterAiKnowledge, RegisterAiTool } from "./ai";
-export type { RegisterAiKnowledgeProps, RegisterAiToolProps } from "./types/ai";
+export type { AiChatStatus, RegisterAiKnowledgeProps, RegisterAiToolProps } from "./types/ai";
 export {
   LiveblocksProvider,
   useInboxNotificationThread,
@@ -94,4 +94,5 @@ export {
   useAiChatsSuspense as useAiChats,
   useAiChatMessagesSuspense as useAiChatMessages,
   useAiChatSuspense as useAiChat,
+  useAiChatStatus,
 } from "./liveblocks";

--- a/packages/liveblocks-react/src/types/ai.ts
+++ b/packages/liveblocks-react/src/types/ai.ts
@@ -1,6 +1,8 @@
 import type {
+  AiAssistantContentPart,
   AiKnowledgeSource,
   AiOpaqueToolDefinition,
+  Relax,
 } from "@liveblocks/core";
 
 export type RegisterAiKnowledgeProps = AiKnowledgeSource & {
@@ -31,3 +33,19 @@ export type RegisterAiToolProps = {
    */
   enabled?: boolean;
 };
+
+/**
+ * Simplified status for the requested chat.
+ * This hook offers a convenient way to update the UI while an AI chat
+ * generation is in progress.
+ */
+export type AiChatStatus = Relax<
+  | { status: "loading" }
+  | { status: "idle" }
+  | { status: "generating" } // Still generating, but there is no content yet
+  | {
+      status: "generating";
+      partType: Exclude<AiAssistantContentPart["type"], "tool-invocation">;
+    }
+  | { status: "generating"; partType: "tool-invocation"; toolName: string }
+>;

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -1495,10 +1495,26 @@ export type LiveblocksContextBundle<
       useAiChat(chatId: string): AiChatAsyncResult;
 
       /**
-       * (Private beta) Returns the status of the requested chat.
+       * Returns the status of an AI chat, indicating whether it's idle or actively
+       * generating content. This is a convenience hook that derives its state from
+       * the latest assistant message in the chat.
+       *
+       * Re-renders whenever any of the relevant fields change.
+       *
+       * @param chatId - The ID of the chat to monitor
+       * @returns The current status of the AI chat
        *
        * @example
-       * const { status, partType, toolName } = useAiChatStatus("my-chat");
+       * ```tsx
+       * import { useAiChatStatus } from "@liveblocks/react";
+       *
+       * function ChatStatus() {
+       *   const { status, partType, toolName } = useAiChatStatus("my-chat");
+       *   console.log(status);          // "loading" | "idle" | "generating"
+       *   console.log(status.partType); // "text" | "tool-invocation" | ...
+       *   console.log(status.toolName); // string | undefined
+       * }
+       * ```
        */
       useAiChatStatus(chatId: string, branchId?: MessageId): AiChatStatus;
 
@@ -1571,10 +1587,26 @@ export type LiveblocksContextBundle<
             useAiChat(chatId: string): AiChatAsyncSuccess;
 
             /**
-             * (Private beta) Returns the status of the requested chat.
+             * Returns the status of an AI chat, indicating whether it's idle or actively
+             * generating content. This is a convenience hook that derives its state from
+             * the latest assistant message in the chat.
+             *
+             * Re-renders whenever any of the relevant fields change.
+             *
+             * @param chatId - The ID of the chat to monitor
+             * @returns The current status of the AI chat
              *
              * @example
-             * const { status, partType, toolName } = useAiChatStatus("my-chat");
+             * ```tsx
+             * import { useAiChatStatus } from "@liveblocks/react";
+             *
+             * function ChatStatus() {
+             *   const { status, partType, toolName } = useAiChatStatus("my-chat");
+             *   console.log(status);          // "loading" | "idle" | "generating"
+             *   console.log(status.partType); // "text" | "tool-invocation" | ...
+             *   console.log(status.toolName); // string | undefined
+             * }
+             * ```
              */
             useAiChatStatus(chatId: string, branchId?: MessageId): AiChatStatus;
           }

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -34,6 +34,7 @@ import type {
   HistoryVersion,
   InboxNotificationData,
   LiveblocksError,
+  MessageId,
   NotificationSettings,
   PartialNotificationSettings,
   PartialUnless,
@@ -55,7 +56,7 @@ import type {
   ReactNode,
 } from "react";
 
-import type { RegisterAiKnowledgeProps, RegisterAiToolProps } from "./ai";
+import type { AiChatStatus, RegisterAiKnowledgeProps, RegisterAiToolProps } from "./ai";
 
 type UiChatMessage = WithNavigation<AiChatMessage>;
 
@@ -273,6 +274,8 @@ export type AiChatAsyncResult = AsyncResult<AiChat, "chat">; // prettier-ignore
 
 export type AiChatMessagesAsyncSuccess = AsyncSuccess<readonly UiChatMessage[], "messages">; // prettier-ignore
 export type AiChatMessagesAsyncResult = AsyncResult<readonly UiChatMessage[], "messages">; // prettier-ignore
+
+export type { AiChatStatus };
 
 export type RoomProviderProps<P extends JsonObject, S extends LsonObject> =
   // prettier-ignore
@@ -1491,6 +1494,14 @@ export type LiveblocksContextBundle<
        */
       useAiChat(chatId: string): AiChatAsyncResult;
 
+      /**
+       * (Private beta) Returns the status of the requested chat.
+       *
+       * @example
+       * const { status, partType, toolName } = useAiChatStatus("my-chat");
+       */
+      useAiChatStatus(chatId: string, branchId?: MessageId): AiChatStatus;
+
       suspense: Resolve<
         LiveblocksContextBundleCommon<M> &
           SharedContextBundle<U>["suspense"] & {
@@ -1558,6 +1569,14 @@ export type LiveblocksContextBundle<
              * const { chat, error, isLoading } = useAiChat("my-chat");
              */
             useAiChat(chatId: string): AiChatAsyncSuccess;
+
+            /**
+             * (Private beta) Returns the status of the requested chat.
+             *
+             * @example
+             * const { status, partType, toolName } = useAiChatStatus("my-chat");
+             */
+            useAiChatStatus(chatId: string, branchId?: MessageId): AiChatStatus;
           }
       >;
     }

--- a/packages/liveblocks-react/test-d/augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/augmentation.test-d.tsx
@@ -1091,3 +1091,83 @@ declare global {
   expectType<void>(update({})); // empty {} because of partial definition
 }
 // ---------------------------------------------------------
+
+// The useAiChatStatus() hook
+{
+  const status = classic.useAiChatStatus("chat-id");
+  expectType<"idle" | "loading" | "generating">(status.status);
+  if (status.status === "generating") {
+    // The partType might not exist if there's no content yet
+    expectType<
+      "text" | "reasoning" | "retrieval" | "tool-invocation" | undefined
+    >(status.partType);
+    if (status.partType === "tool-invocation") {
+      expectType<string>(status.toolName);
+    } else {
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook (suspense)
+{
+  const status = suspense.useAiChatStatus("chat-id");
+  expectType<"idle" | "loading" | "generating">(status.status);
+  if (status.status === "generating") {
+    // The partType might not exist if there's no content yet
+    expectType<
+      "text" | "reasoning" | "retrieval" | "tool-invocation" | undefined
+    >(status.partType);
+    if (status.partType === "tool-invocation") {
+      expectType<string>(status.toolName);
+    } else {
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook with optional branchId
+{
+  const status = classic.useAiChatStatus("chat-id", "ms_branch" as any);
+  if (status.status === "generating") {
+    // The partType might not exist if there's no content yet
+    expectType<
+      "text" | "reasoning" | "retrieval" | "tool-invocation" | undefined
+    >(status.partType);
+    if (status.partType === "tool-invocation") {
+      expectType<string>(status.toolName);
+    } else {
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook with optional branchId (suspense)
+{
+  const status = suspense.useAiChatStatus("chat-id", "ms_branch" as any);
+  if (status.status === "generating") {
+    // The partType might not exist if there's no content yet
+    expectType<
+      "text" | "reasoning" | "retrieval" | "tool-invocation" | undefined
+    >(status.partType);
+    if (status.partType === "tool-invocation") {
+      expectType<string>(status.toolName);
+    } else {
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -6,7 +6,11 @@ import type {
 } from "@liveblocks/client";
 import { LiveList, LiveMap, LiveObject } from "@liveblocks/client";
 import { createClient } from "@liveblocks/client";
-import { createLiveblocksContext, createRoomContext } from "@liveblocks/react";
+import {
+  createLiveblocksContext,
+  createRoomContext,
+  type AiChatStatus,
+} from "@liveblocks/react";
 import { expectAssignable, expectError, expectType } from "tsd";
 
 type MyPresence = {
@@ -1253,4 +1257,92 @@ ctx.useOthersListener(({ user, type }) => {
   expectType<NotificationSettings | undefined>(settings);
   expectType<void>(update({})); // empty {} because of partial definition
 }
+// ---------------------------------------------------------
+
+// The useAiChatStatus() hook
+{
+  const status = lbctx.useAiChatStatus("chat-123");
+  expectType<AiChatStatus>(status);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook (suspense)
+{
+  const status = lbctx.suspense.useAiChatStatus("chat-123");
+  expectType<AiChatStatus>(status);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook with branchId parameter
+{
+  const status = lbctx.useAiChatStatus("chat-123", "ms_branch" as any);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook (suspense) with branchId parameter
+{
+  const status = lbctx.suspense.useAiChatStatus("chat-123", "ms_branch" as any);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
 // ---------------------------------------------------------

--- a/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
+++ b/packages/liveblocks-react/test-d/no-augmentation.test-d.tsx
@@ -7,6 +7,7 @@ import type {
 import { LiveObject, LiveList } from "@liveblocks/client";
 import * as classic from "@liveblocks/react";
 import * as suspense from "@liveblocks/react/suspense";
+import type { AiChatStatus } from "@liveblocks/react";
 import { expectAssignable, expectError, expectType } from "tsd";
 
 // LiveblocksProvider
@@ -970,4 +971,93 @@ import { expectAssignable, expectError, expectType } from "tsd";
   expectType<NotificationSettings>(settings);
   expectType<void>(update({})); // empty {} because of partial definition
 }
+// ---------------------------------------------------------
+
+// The useAiChatStatus() hook
+{
+  const status = classic.useAiChatStatus("chat-123");
+  expectType<AiChatStatus>(status);
+
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook (suspense)
+{
+  const status = suspense.useAiChatStatus("chat-123");
+  expectType<AiChatStatus>(status);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook with branchId parameter
+{
+  const status = classic.useAiChatStatus("chat-123", "ms_branch" as any);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
+// The useAiChatStatus() hook with branchId parameter
+{
+  const status = suspense.useAiChatStatus("chat-123", "ms_branch" as any);
+  if (status.status === "generating") {
+    expectType<"generating">(status.status);
+    if (status.partType === "tool-invocation") {
+      expectType<"tool-invocation">(status.partType);
+      expectType<string>(status.toolName);
+    } else {
+      expectType<"text" | "reasoning" | "retrieval" | undefined>(
+        status.partType
+      );
+      expectType<undefined>(status.toolName);
+    }
+  } else {
+    expectType<"loading" | "idle">(status.status);
+    expectType<undefined>(status.partType);
+    expectType<undefined>(status.toolName);
+  }
+}
+
 // ---------------------------------------------------------


### PR DESCRIPTION
This PR adds a new convenience hook to quickly obtain the current chat's status, and some information on what part type it's currently generating (and if that's a tool-invocation, which toolName it's generating for).

```tsx
import { useAiChatStatus } from "@liveblocks/react";

function ChatStatus() {
  const { status, partType, toolName } = useAiChatStatus("my-chat");
  console.log(status);          // "loading" | "idle" | "generating"
  console.log(status.partType); // "text" | "tool-invocation" | ...
  console.log(status.toolName); // string | undefined
}
```

Fixes LB-2213.


## TODO

- [x] Update changelog
- [x] Add documentation
