### PR TITLE
Ai chat expose timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
   that offers a convenient way to get the current generation status for an AI
   chat, indicating whether the chat is idle, currently generating contents, and,
   if so, what type of content is currently generating.
-
 - Fixes an issue where `useUnreadInboxNotificationsCount` wasn't returning the
   proper count if there were more than a page of unread notifications.
 
@@ -30,8 +29,8 @@
 
 ### `@liveblocks/react-ui`
 
-- Add `timeout` property to `<AiChat>` to allow customization of the default 30
-  second timeout.
+- Add `responseTimeout` property to `AiChat` to allow customization of the
+  default 30 seconds timeout.
 
 ## v3.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet published)
 
+### `@liveblocks/react-ui`
+
+- Add `timeout` property to `<AiChat>` to allow customization of the default 30
+  second timeout.
+
 ## v3.7.1
 
 ### `@liveblocks/react`
@@ -1395,7 +1400,9 @@ for more information about this change please read our
 
 ### Version History
 
-This release adds some new hooks for Version History in text documents. If you're interested in getting access, please [contact us](https://liveblocks.io/contact/sales).
+This release adds some new hooks for Version History in text documents. If
+you're interested in getting access, please
+[contact us](https://liveblocks.io/contact/sales).
 
 - Add `useHistoryVersion` hook to retrieve version history (in
   `@liveblocks/react`)

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -487,9 +487,9 @@ the `components` prop. A full list is [available here](#AiChat-components).
     Inline styles to apply to the chat container. Useful for setting CSS custom
     properties.
   </PropertiesListItem>
-  <PropertiesListItem name="timeout" type="number">
-    The time, in milliseconds, before an AI response will timeout. Defaults
-    to 30_000.
+  <PropertiesListItem name="responseTimeout" type="number">
+    The time, in milliseconds, before an AI response will timeout. Defaults to
+    30_000.
   </PropertiesListItem>
 </PropertiesList>
 

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -488,7 +488,7 @@ the `components` prop. A full list is [available here](#AiChat-components).
     properties.
   </PropertiesListItem>
   <PropertiesListItem name="timeout" type="number">
-    The timeout, in milliseconds, before an AI response will timeout. Defaults
+    The time, in milliseconds, before an AI response will timeout. Defaults
     to 30_000.
   </PropertiesListItem>
 </PropertiesList>

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -487,6 +487,10 @@ the `components` prop. A full list is [available here](#AiChat-components).
     Inline styles to apply to the chat container. Useful for setting CSS custom
     properties.
   </PropertiesListItem>
+  <PropertiesListItem name="timeout" type="number">
+    The timeout, in milliseconds, before an AI response will timeout. Defaults
+    to 30_000.
+  </PropertiesListItem>
 </PropertiesList>
 
 ###### components [#AiChat-components]
@@ -3094,7 +3098,9 @@ All hooks for Notifications are in
 
 <Banner title="Contact support for access">
 
-Version History is an add-on feature, available by contacting support. Please [contact us](https://liveblocks.io/contact/sales) and we'd love to help you get started.
+Version History is an add-on feature, available by contacting support. Please
+[contact us](https://liveblocks.io/contact/sales) and we'd love to help you get
+started.
 
 </Banner>
 

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -111,13 +111,18 @@ export interface AiChatProps extends ComponentProps<"div"> {
   layout?: "inset" | "compact";
 
   /**
+   * The timeout for the AI response.
+   */
+  timeout?: number;
+
+  /**
    * Override the component's strings.
    */
   overrides?: Partial<
     GlobalOverrides &
-      AiComposerOverrides &
-      AiChatMessageOverrides &
-      AiChatOverrides
+    AiComposerOverrides &
+    AiChatMessageOverrides &
+    AiChatOverrides
   >;
 
   /**
@@ -425,6 +430,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
       layout = "inset",
       components,
       className,
+      timeout,
       ...props
     },
     forwardedRef
@@ -562,6 +568,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
             overrides={overrides}
             autoFocus={autoFocus}
             knowledge={localKnowledge}
+            timeout={timeout}
             onComposerSubmit={onComposerSubmit}
             onComposerSubmitted={({ id }) => setLastSentMessageId(id)}
             className={cn(

--- a/packages/liveblocks-react-ui/src/components/AiChat.tsx
+++ b/packages/liveblocks-react-ui/src/components/AiChat.tsx
@@ -111,18 +111,18 @@ export interface AiChatProps extends ComponentProps<"div"> {
   layout?: "inset" | "compact";
 
   /**
-   * The timeout for the AI response.
+   * The time, in milliseconds, before an AI response will timeout.
    */
-  timeout?: number;
+  responseTimeout?: number;
 
   /**
    * Override the component's strings.
    */
   overrides?: Partial<
     GlobalOverrides &
-    AiComposerOverrides &
-    AiChatMessageOverrides &
-    AiChatOverrides
+      AiComposerOverrides &
+      AiChatMessageOverrides &
+      AiChatOverrides
   >;
 
   /**
@@ -454,7 +454,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
       layout = "inset",
       components,
       className,
-      timeout,
+      responseTimeout,
       ...props
     },
     forwardedRef
@@ -593,7 +593,7 @@ export const AiChat = forwardRef<HTMLDivElement, AiChatProps>(
             overrides={overrides}
             autoFocus={autoFocus}
             knowledge={localKnowledge}
-            timeout={timeout}
+            responseTimeout={responseTimeout}
             onComposerSubmit={onComposerSubmit}
             onComposerSubmitted={({ id }) => setLastSentMessageId(id)}
             className={cn(

--- a/packages/liveblocks-react-ui/src/components/internal/AiComposer.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiComposer.tsx
@@ -98,6 +98,11 @@ export interface AiComposerProps
    * @internal
    */
   stream?: boolean;
+
+  /**
+   * The timeout for the AI response
+   */
+  timeout?: number;
 }
 
 function AiComposerAction({
@@ -158,6 +163,7 @@ export const AiComposer = forwardRef<HTMLFormElement, AiComposerProps>(
       knowledge: localKnowledge,
       branchId,
       copilotId,
+      timeout,
       stream = true,
       onComposerSubmitted,
       ...props
@@ -168,7 +174,7 @@ export const AiComposer = forwardRef<HTMLFormElement, AiComposerProps>(
     const sendAiMessage = useSendAiMessage(chatId, {
       stream,
       copilotId,
-
+      timeout,
       // TODO: We shouldn't need to pass knowledge from AiChat to AiComposer
       //       to useSendAiMessage, ideally it would be attached to a chat ID
       //       behind the scenes inside AiChat.

--- a/packages/liveblocks-react-ui/src/components/internal/AiComposer.tsx
+++ b/packages/liveblocks-react-ui/src/components/internal/AiComposer.tsx
@@ -85,6 +85,11 @@ export interface AiComposerProps
   copilotId?: CopilotId;
 
   /**
+   * The time, in milliseconds, before an AI response will timeout.
+   */
+  responseTimeout?: number;
+
+  /**
    * @internal
    */
   knowledge?: AiKnowledgeSource[];
@@ -98,11 +103,6 @@ export interface AiComposerProps
    * @internal
    */
   stream?: boolean;
-
-  /**
-   * The timeout for the AI response
-   */
-  timeout?: number;
 }
 
 function AiComposerAction({
@@ -163,7 +163,7 @@ export const AiComposer = forwardRef<HTMLFormElement, AiComposerProps>(
       knowledge: localKnowledge,
       branchId,
       copilotId,
-      timeout,
+      responseTimeout,
       stream = true,
       onComposerSubmitted,
       ...props
@@ -174,7 +174,7 @@ export const AiComposer = forwardRef<HTMLFormElement, AiComposerProps>(
     const sendAiMessage = useSendAiMessage(chatId, {
       stream,
       copilotId,
-      timeout,
+      timeout: responseTimeout,
       // TODO: We shouldn't need to pass knowledge from AiChat to AiComposer
       //       to useSendAiMessage, ideally it would be attached to a chat ID
       //       behind the scenes inside AiChat.


### PR DESCRIPTION
Adds timeout property to AiChat

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make AiChat response timeout configurable via a new responseTimeout prop wired through to useSendAiMessage and document it.
> 
> - **@liveblocks/react-ui**:
>   - **AiChat/AiComposer**: Add `responseTimeout` prop; `AiChat` forwards it to `AiComposer`, which passes it as `timeout` to `useSendAiMessage`.
> - **Docs**:
>   - Document `AiChat`’s new `responseTimeout` prop in `docs/pages/api-reference/liveblocks-react-ui.mdx`.
> - **Changelog**:
>   - Note configurable `AiChat` response timeout (defaults to 30s).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 678543b365cd21f6a60212a5d4df74c5920395ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->