### PR TITLE
Tweak `@liveblocks/node` docs introduction

### DIFF
--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -13,7 +13,7 @@ for use in your Node.js back end.
 
 ## Liveblocks client [#Liveblocks-client]
 
-The `Liveblocks` client is new in 1.2, and offers access to our REST API.
+The `Liveblocks` client offers access to our REST API.
 
 ```ts showLineNumbers={false}
 import { Liveblocks } from "@liveblocks/node";


### PR DESCRIPTION
The tiniest of all PRs, 1.2 and the `Liveblocks` client aren't so new anymore.