### PR TITLE
Don't run update on every package version bump

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -8,7 +8,7 @@ err () {
 }
 
 usage () {
-    err "usage: release.sh [-h] [-V <version>] [-p] [-m <message>] [-f] <pkgdir> [<pkgdir>...]"
+    err "usage: release.sh [-h] [-V <version>] [-p] [-m <message>] [-f] [-w] <pkgdir> [<pkgdir>...]"
     err
     err "Prepare a release by updating files in this repo."
     err "Run this prior to publishing to NPM (or elsewhere, e.g. DevTools)."
@@ -17,6 +17,7 @@ usage () {
     err "    -p   push the bump commit (no need if publish.sh is called afterwards)"
     err "    -m   improve the commit message by specifying what was bumped"
     err "    -f   force version update (use --force flag with npm version)"
+    err "    -w   disable workspace updates (use --workspaces-update false with npm version)"
     err ""
 }
 
@@ -24,12 +25,14 @@ VERSION=
 PUSH_COMMIT="false"
 COMMIT_MESSAGE="Bump to "
 FORCE_FLAG=""
-while getopts V:p:m:fh flag; do
+WORKSPACES_UPDATE_FLAG=""
+while getopts V:p:m:fwh flag; do
     case "$flag" in
         V) VERSION=$OPTARG;;
         p) PUSH_COMMIT="true";;
         m) COMMIT_MESSAGE=$OPTARG;;
         f) FORCE_FLAG="--force";;
+        w) WORKSPACES_UPDATE_FLAG="--workspaces-update false";;
         *) usage; exit 2;;
     esac
 done
@@ -80,7 +83,7 @@ update_package_version () {
     PKGNAME="$( get_package_name_from_dir "$PKGDIR" )"
 
     echo "==> Updating package.json version for $PKGNAME"
-    ( cd "$PKGDIR" && npm version "$VERSION" $FORCE_FLAG --no-git-tag-version --workspaces-update false && update_dependencies_to_new_package_versions "$2" )
+    ( cd "$PKGDIR" && npm version "$VERSION" $FORCE_FLAG --no-git-tag-version $WORKSPACES_UPDATE_FLAG && update_dependencies_to_new_package_versions "$2" )
 }
 
 commit_to_git () {

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -14,6 +14,13 @@ on:
         required: false
         default: false
         description: "Force version update (use --force flag with npm version)"
+      disable_workspaces_update:
+        type: boolean
+        required: false
+        default: false
+        description:
+          "Disable workspace updates (use --workspaces-update false with npm
+          version)"
 
 run-name: Publishing ${{ github.event.inputs.tag }} packages
 
@@ -83,15 +90,17 @@ jobs:
         env:
           VERSION: ${{steps.version.outputs.value}}
           FORCE_FLAG: ${{ inputs.force && '-f' || '' }}
+          WORKSPACES_UPDATE_FLAG:
+            ${{ inputs.disable_workspaces_update && '-w' || '' }}
         run:
           ./.github/scripts/release.sh -V "$VERSION" $FORCE_FLAG
-          "packages/liveblocks-core" "packages/liveblocks-client"
-          "packages/liveblocks-node" "packages/liveblocks-react"
-          "packages/liveblocks-redux" "packages/liveblocks-zustand"
-          "packages/liveblocks-yjs" "packages/liveblocks-react-ui"
-          "packages/liveblocks-react-lexical" "packages/liveblocks-node-lexical"
-          "packages/liveblocks-react-tiptap" "packages/liveblocks-emails"
-          "packages/liveblocks-node-prosemirror"
+          $WORKSPACES_UPDATE_FLAG "packages/liveblocks-core"
+          "packages/liveblocks-client" "packages/liveblocks-node"
+          "packages/liveblocks-react" "packages/liveblocks-redux"
+          "packages/liveblocks-zustand" "packages/liveblocks-yjs"
+          "packages/liveblocks-react-ui" "packages/liveblocks-react-lexical"
+          "packages/liveblocks-node-lexical" "packages/liveblocks-react-tiptap"
+          "packages/liveblocks-emails" "packages/liveblocks-node-prosemirror"
           "packages/liveblocks-react-blocknote"
 
       - name: Build all packages


### PR DESCRIPTION
currently release.sh runs `npm version`, which actually does an install on each package. This causes dependencies conflicts when doing upgrades that cause conflicts because some packages will be updated and some won't.

The script already does a final install at the end. By adding `--workspaces-update false` to the script, we avoid running the install until after all packages had their versions bumped. See the [npm docs](https://docs.npmjs.com/cli/v11/commands/npm-version#workspaces-update) for more info. 

## Before:

```
==> Updating package.json version for @liveblocks/react-ui
@liveblocks/react-ui
v3.9.1

added 11 packages in 4s
```

## After

```
==> Updating package.json version for @liveblocks/client
@liveblocks/react-ui
v3.9.1
```