### PR TITLE
Add Dependabot config and only use patch updates for examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
 version: 2
 updates:
+  # Only patch lockfile bumps for examples, starter kits, interactive tutorial
+  - package-ecosystem: "npm"
+    directories:
+      - "/examples/**"
+      - "/starter-kits/**"
+      - "/tutorial/**"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    versioning-strategy: lockfile-only
+
+  # Default behavior elsewhere
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    exclude-paths:
-      - "docs/**"
-      - "examples/**"
-      - "guides/**"
-      - "tutorial/**"
+      interval: "weekly"


### PR DESCRIPTION
Dependabot currently triggers for examples and tutorials. This will disable it in these directories, [learn more](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#exclude-paths-).

I think this will override the GitHub settings we've set for timing, but I don't have access to settings and can't see the current value we have.