### PR TITLE
Add build to link script

### DIFF
--- a/scripts/link-example-locally.sh
+++ b/scripts/link-example-locally.sh
@@ -66,7 +66,10 @@ done
 
 # Step 4: Build all @liveblocks packages to ensure they're up-to-date
 err "Building @liveblocks packages..."
-( cd ../../ && npm run build > /dev/null )
+if ! ( cd ../../ && npm run build > /dev/null 2>&1 ); then
+    err "Warning: Some packages failed to build. This may cause version mismatch issues."
+    err "You can manually build packages with: npm run build"
+fi
 
 # Step 5: Add this example to the top-level package.json to officially make it
 # a workspace.


### PR DESCRIPTION
Adds a build step to the link script, in case you forget to run `npm run build` at the root, some packages could be different versions. just one less thing to go wrong.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Builds all @liveblocks packages during the link process to avoid version mismatch, and updates subsequent step numbering.
> 
> - **Scripts**:
>   - `scripts/link-example-locally.sh`:
>     - Add build step to compile all `@liveblocks/*` packages before adding the example as a workspace; logs a warning if the build fails.
>     - Renumber subsequent steps accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77312ece13499b343b51dcf903e3e1e47ef92d53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->