### PR TITLE
Improve Tenants docs and remove Enterprise messaging

### DIFF
--- a/docs/pages/authentication/tenants.mdx
+++ b/docs/pages/authentication/tenants.mdx
@@ -50,7 +50,7 @@ need to migrate the resource into a new room in the correct tenant.
 
 #### Resources using tenants
 
-A number of Liveblocksresources use tenants, such as rooms, comments, text
+A number of Liveblocks resources use tenants, such as rooms, comments, text
 editors, Yjs, Storage, inbox notifications, mention groups.
 
 ```ts


### PR DESCRIPTION
Make the Tenants page more clear, and remove "Enterprise-only" messaging.