### PR TITLE
Release 3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
-
 ## vNEXT (not released yet)
+
+## v3.10.1
+
+### `@liveblocks/lexical`
+
+- Fix a bug where a fresh provider is required by Lexical in order to initialize
+  properly by always requieting a new provider in the factory function
+
+### `@liveblocks/yjs`
+
+- Add `forceNewProvider` option to `getYjsProviderForRoom` and destroy existing
+  provider when requested
 
 ## v3.10.0
 


### PR DESCRIPTION
Release 3.10.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds v3.10.1 changelog entries for a Lexical provider initialization fix and a new Yjs provider option.
> 
> - **Release notes: `v3.10.1`**
>   - `@liveblocks/lexical`: Ensure proper initialization by always creating a fresh provider in the factory.
>   - `@liveblocks/yjs`: Add `forceNewProvider` option to `getYjsProviderForRoom` and destroy existing provider when requested.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b2bf575e92df7bb8ee8d717111cbd3b0a2b47dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->