### PR TITLE
Publishing CI changes

### DIFF
--- a/.github/workflows/publish-cli-tools.yml
+++ b/.github/workflows/publish-cli-tools.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_COMMIT_WRITE_TOKEN }}
 
       - name: Validate git tag
         run: ./.github/scripts/validate-version.sh "${{ inputs.tag }}"

--- a/.github/workflows/publish-devtools.yml
+++ b/.github/workflows/publish-devtools.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_COMMIT_WRITE_TOKEN }}
 
       - name: Validate version
         env:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_COMMIT_WRITE_TOKEN }}
 
       - name: Validate git tag
         run: ./.github/scripts/validate-version.sh "${{ inputs.tag }}"


### PR DESCRIPTION
- [x] Remove "force" and "disable workspace updates" options when triggering the action
  - [x] Workspace updates are disabled by default now
- [x] Use custom GitHub token again, reverting https://github.com/liveblocks/liveblocks/pull/2859