### PR TITLE
Fix: missing type in RoomPermission

### DIFF
--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -154,7 +154,8 @@ export type CreateThreadOptions<M extends BaseMetadata> = {
 export type RoomPermission =
   | []
   | ["room:write"]
-  | ["room:read", "room:presence:write"];
+  | ["room:read", "room:presence:write"]
+  | ["room:read", "room:presence:write", "comments:write"];
 export type RoomAccesses = Record<
   string,
   | ["room:write"]


### PR DESCRIPTION
Adds commenter role to `RoomPermission` with `["room:read", "room:presence:write", "comments:write"]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `["room:read", "room:presence:write", "comments:write"]` to `RoomPermission` to align with `RoomAccesses`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8ce729dbe6646e637b9b312303cf1640bd0b245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->