### PR TITLE
Silence some sourcemap warnings

### DIFF
--- a/shared/rollup-config/index.js
+++ b/shared/rollup-config/index.js
@@ -291,12 +291,23 @@ export function createConfig({ pkg, entries, styles: styleFiles, external }) {
         }),
       ],
       onwarn(warning, warn) {
+        // Ignore warnings about preserved "use client" directives.
         if (
           warning.code === "MODULE_LEVEL_DIRECTIVE" &&
           warning.message.includes("use client")
         ) {
           return;
         }
+
+        // Ignore warnings about sourcemap errors related to directives (first line of the file).
+        if (
+          warning.code === "SOURCEMAP_ERROR" &&
+          warning.message.includes("resolve original location of error") &&
+          warning.pos === 0
+        ) {
+          return;
+        }
+
         warn(warning);
       },
     };


### PR DESCRIPTION
Our Rollup-built packages started emitting warnings about sourcemap issues related to `"use client"` directives, although sourcemaps are still correctly generated. This PR silences the warnings.

<img width="697" height="547" alt="warnings" src="https://github.com/user-attachments/assets/ec3c470d-6252-479a-a945-d99639de4af1" />
