### PR TITLE
release for 3.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT
 
+## v3.11.1
+
 ### `@liveblocks/core`
 
 - Log full error details when WebSocket connections to Liveblocks are getting


### PR DESCRIPTION
Release branch for 3.11.1

### `@liveblocks/core`

- Log full error details when WebSocket connections to Liveblocks are getting
  blocked

### `@liveblocks/yjs`

- Fix an issue where a document incorrectly reported its sync state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds v3.11.1 release notes to the changelog, covering WebSocket error detail logging in core and a Yjs sync state fix.
> 
> - **Docs** (`CHANGELOG.md`):
>   - Add `v3.11.1` section
>     - `@liveblocks/core`: Log full error details when WebSocket connections are blocked.
>     - `@liveblocks/yjs`: Fix incorrect sync state reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a91fa2d33357e85dbcc8f46335c07b01368d326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->