### PR TITLE
Prep for new Proper Ack™

### DIFF
--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -271,7 +271,8 @@ export {
   patchNotificationSettings,
 } from "./protocol/NotificationSettings";
 export type {
-  AckOp,
+  AckOpV7,
+  AckOpV8,
   CreateListOp,
   CreateMapOp,
   CreateObjectOp,

--- a/packages/liveblocks-core/src/protocol/Op.ts
+++ b/packages/liveblocks-core/src/protocol/Op.ts
@@ -32,12 +32,13 @@ export namespace OpCode {
  * only.
  */
 export type Op =
-  | AckOp
   | CreateOp
   | UpdateObjectOp
   | DeleteCrdtOp
   | SetParentKeyOp // Only for lists!
-  | DeleteObjectKeyOp;
+  | DeleteObjectKeyOp
+  | AckOpV7 // Classic (H)Ack
+  | AckOpV8; // Proper Ack
 
 export type CreateOp =
   | CreateObjectOp
@@ -107,14 +108,23 @@ export type DeleteCrdtOp = {
 // way to trigger an acknowledgement for Ops that were seen by the server, but
 // deliberately ignored.
 //
-export type AckOp = {
+export type AckOpV7 = {
   readonly type: OpCode.DELETE_CRDT; // Not a typo!
   readonly id: "ACK";
   readonly opId: string;
 };
 
-export function isAckOp(op: Op): op is AckOp {
-  return op.type === OpCode.DELETE_CRDT && op.id === "ACK";
+// Proper Ack, this will be sent by V8+, instead of the hack above
+export type AckOpV8 = {
+  readonly type: OpCode.ACK;
+  readonly opId: string;
+};
+
+export function isAck(op: Op): op is AckOpV7 | AckOpV8 {
+  return (
+    op.type === OpCode.ACK || // >= v8
+    (op.type === OpCode.DELETE_CRDT && op.id === "ACK") // < v7
+  );
 }
 
 export type SetParentKeyOp = {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -69,7 +69,7 @@ import type {
 } from "./protocol/InboxNotifications";
 import type { MentionData } from "./protocol/MentionData";
 import type { Op } from "./protocol/Op";
-import { isAckOp, OpCode } from "./protocol/Op";
+import { isAck, OpCode } from "./protocol/Op";
 import type { RoomSubscriptionSettings } from "./protocol/RoomSubscriptionSettings";
 import type { IdTuple, SerializedCrdt } from "./protocol/SerializedCrdt";
 import type {
@@ -2020,7 +2020,7 @@ export function createRoom<
   function applyOp(op: Op, source: OpSource): ApplyResult {
     // Explicit case to handle incoming "AckOp"s, which are supposed to be
     // no-ops.
-    if (isAckOp(op)) {
+    if (isAck(op)) {
       return { modified: false };
     }
 


### PR DESCRIPTION
Replaces our (H)AckOp by a Proper Ack™ that will be used in the next internal V8 protocol. This future ack will correct the previous hack, and will also serve to reduce the size of our future acks, by no longer repeating back the entire Op anymore.