### PR TITLE
fix strikethrough tooltip typo

### DIFF
--- a/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
+++ b/packages/liveblocks-react-tiptap/src/toolbar/Toolbar.tsx
@@ -595,7 +595,7 @@ function ToolbarSectionInline() {
         <ToolbarToggle
           name="Strikethrough"
           icon={<StrikethroughIcon />}
-          shortcut="Mod-U"
+          shortcut="Mod-Shift-S"
           onClick={() =>
             (editor.chain().focus() as ExtendedChainedCommands<"toggleStrike">)
               .toggleStrike()


### PR DESCRIPTION
<!-- We appreciate your efforts in opening a PR! Your contribution means a lot.
In order to ensure a seamless handling of your PR, we kindly ask you to refer to the checklist sections provided below.
Please select the appropriate checklist that corresponds to the changes you are making:

## For Contributors

### Fixing a bug

- Provide helpful info for reviewer:
  - Steps to reproduce
  - A clear and concise description of the problem that the bug is causing.
  - Steps to reproduce the issue, if applicable.
  - An explanation of the changes made to fix the bug, including any relevant code snippets.
  - Any new or updated tests that were added to ensure that the bug is fully resolved.
  - A summary of any potential side effects that could result from the bug fix, if any.
  - A list of any other related issues or PRs that may be impacted by the bug fix.

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added
- Documentation added

## For Maintainers

### Description

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Add review comments if necessary to explain to the reviewer the logic behind a change

#### How to test it

- Provide recordings, Looms, or screenshots to help reviewers quickly identify the happy path and what they should test on their side.

#### Related issue(s)

- Add the related issue(s) here:
  - https://github.com/liveblocks/[REPOSITORY]/issues/[ISSUE_NUMBER]
  - ...
  
 -->

### Description

React Tiptap Toolbar shows incorrect shortcut in tooltip for Strikethrough (Mod-U).  Changed it to the correct shortcut (Mod-Shift-S).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix**
> 
> - Updates `Toolbar.tsx` Strikethrough button tooltip to display the correct shortcut `Mod-Shift-S` instead of `Mod-U`.
> 
> *No behavior or command logic changed; only the displayed shortcut string.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5889ad8e2d0761b03b30842715cf501632347b62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->