### PR TITLE
Trigger Vercel deploy on guides/tutorials/public changelog changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - docs/**
+      - guides/**
+      - tutorial/**
+      - CHANGELOG_PUBLIC.md
 
 jobs:
   deploy:


### PR DESCRIPTION
So that I don't have to click redeploy!