### PR TITLE
Add CLA enforcement for outside contributors

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    if: |
+      (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck')
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_TOKEN }}
+        with:
+          path-to-signatures: cla-signatures.json
+          path-to-cla-document: https://github.com/${{ github.repository }}/blob/main/CLA.md
+          branch: main
+          allowlist: bot*,dependabot*,dependabot[bot]
+          remote-organization-name: liveblocks

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,75 @@
+# Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Liveblocks. This Contributor
+License Agreement ("Agreement") documents the rights granted by contributors to
+this project. This is a legally binding document, so please read it carefully
+before agreeing to it.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by
+the copyright owner that is making this Agreement. For legal entities, the
+entity making a Contribution and all other entities that control, are controlled
+by, or are under common control with that entity are considered to be a single
+Contributor.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to this project for inclusion in, or documentation of, any of the
+products managed or maintained by the project (the "Work"). For the purposes of
+this definition, "submitted" means any form of electronic, verbal, or written
+communication sent to the project or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of, the
+project for the purpose of discussing and improving the Work.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+project maintainers and to recipients of software distributed by the project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+project maintainers and to recipients of software distributed by the project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution(s) alone or
+by combination of Your Contribution(s) with the Work to which such
+Contribution(s) was submitted.
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above license. If Your
+employer(s) has rights to intellectual property that You create that includes
+Your Contributions, You represent that You have received permission to make
+Contributions on behalf of that employer, that Your employer has waived such
+rights for Your Contributions to this project, or that Your employer has executed
+a separate Corporate Contributor License Agreement with the project.
+
+You represent that each of Your Contributions is Your original creation. You
+represent that Your Contribution submissions include complete details of any
+third-party license or other restriction (including, but not limited to, related
+patents and trademarks) of which You are personally aware and which are
+associated with any part of Your Contributions.
+
+## 5. Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without limitation,
+any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Signing
+
+To sign this CLA, you must post the following comment on the pull request:
+
+> I have read the CLA Document and I hereby sign the CLA

--- a/cla-signatures.json
+++ b/cla-signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
## Summary

- Adds a **CLA Assistant** GitHub Action workflow that requires outside contributors to sign a CLA before their PRs can be merged
- Contributors sign by commenting `I have read the CLA Document and I hereby sign the CLA` on their PR
- Signatures are stored in `cla-signatures.json` in the repo
- Members of the `liveblocks` GitHub org and bots are automatically exempted

## Setup

A `CLA_ASSISTANT_TOKEN` repo secret must be configured with a PAT that has `repo` and `read:org` scopes. This token is used to commit CLA signatures and check org membership.

## Test plan

- [ ] Open a test PR from a non-org-member fork and confirm the CLA check appears as pending
- [ ] Post the signature comment and confirm the check turns green
- [ ] Confirm org-member PRs pass the check automatically