### PR TITLE
CHANGELOG — WEEK 15

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -18,6 +18,10 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 -->
 
+# Week 15 (2026-04-10)
+
+## Contributors
+
 # Week 14 (2026-04-03)
 
 ## v3.17.0
@@ -88,6 +92,7 @@ list and feel free to give them credit at the end of a line, e.g.:
 - Support passing extra arguments to `--cmd` dynamically
 
 ## Website
+
 - [Liveblocks Unveil](https://liveblocks.io/unveil/april-2026): April 6–10, 5 days of launches.
 
 ## Documentation

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,7 +20,13 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 15 (2026-04-10)
 
+## Liveblocks dev server (v1.4.0)
+
+- Add support for `client.mutateStorage()` (from `@liveblocks/node`)
+
 ## Contributors
+
+nvie
 
 # Week 14 (2026-04-03)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -31,6 +31,7 @@ list and feel free to give them credit at the end of a line, e.g.:
 - New blog post: [Multiplayer SDK for React Flow: Realtime collaboration between humans and agents](https://liveblocks.io/blog/multiplayer-sdk-for-react-flow-realtime-collaboration-between-humans-and-agents).
 - New blog post: [Chat SDK adapter for Liveblocks](https://liveblocks.io/blog/chat-sdk-adapter-for-liveblocks).
 - New blog post: [Python SDK for Liveblocks](https://liveblocks.io/blog/python-sdk-for-liveblocks).
+- New blog post: [Agent skills for Liveblocks](https://liveblocks.io/blog/agent-skills-for-liveblocks).
 
 ## Contributors
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -24,9 +24,17 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 - Add support for `client.mutateStorage()` (from `@liveblocks/node`)
 
+## Website
+
+- New blog post: [AI agents are becoming native users of software](https://liveblocks.io/blog/ai-agents-are-becoming-native-users-of-software).
+- New blog post: [Introducing Feeds and APIs for Agent Workflows](https://liveblocks.io/blog/introducing-feeds-and-apis-for-agent-workflows).
+- New blog post: [Multiplayer SDK for React Flow: Realtime collaboration between humans and agents](https://liveblocks.io/blog/multiplayer-sdk-for-react-flow-realtime-collaboration-between-humans-and-agents).
+- New blog post: [Chat SDK adapter for Liveblocks](https://liveblocks.io/blog/chat-sdk-adapter-for-liveblocks).
+- New blog post: [Python SDK for Liveblocks](https://liveblocks.io/blog/python-sdk-for-liveblocks).
+
 ## Contributors
 
-nvie
+nvie, ctnicholas, stevenfabre
 
 # Week 14 (2026-04-03)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -33,6 +33,10 @@ list and feel free to give them credit at the end of a line, e.g.:
 - New blog post: [Python SDK for Liveblocks](https://liveblocks.io/blog/python-sdk-for-liveblocks).
 - New blog post: [Agent skills for Liveblocks](https://liveblocks.io/blog/agent-skills-for-liveblocks).
 
+## Documentation
+
+- Mention missing [`updatedAt`](https://liveblocks.io/docs/api-reference/liveblocks-node#patch-rooms-roomId-feeds-feedId-messages-messageId) field in `updateFeedMessage` reference.
+
 ## Contributors
 
 nvie, ctnicholas, stevenfabre

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,6 +20,41 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 15 (2026-04-10)
 
+## v3.18.0
+
+For full upgrade instructions, see the
+[3.18 upgrade guide](https://liveblocks.io/docs/platform/upgrading/3.18).
+
+### `@liveblocks/client`
+
+- **Breaking:** `useStorage` now returns plain objects for `LiveMap` values
+  instead of `Map` instances. Legacy APIs have been removed: `.toImmutable()`,
+  `.toObject()`, `.toArray()`.
+- New `.toJSON()` on all Live structures, returning a cached JSON-compatible
+  snapshot. `JSON.stringify(root)` now just works.
+- New `LiveObject.from(obj)` to create a LiveObject from plain JSON, recursively
+  converting nested objects/arrays to Live structures.
+- New `.reconcile(obj)` to efficiently reconcile a LiveObject tree to match a
+  JSON snapshot, only mutating what changed.
+- `initialStorage` accepts `LiveObject.from()` result directly.
+
+### `@liveblocks/react-flow/node`
+
+- New `mutateFlow()` API for reading and mutating React Flow data from a Node.js
+  backend. Install via `npm i @liveblocks/react-flow`, import from
+  `@liveblocks/react-flow/node`.
+
+### `@liveblocks/react-ui`
+
+- Add standalone `Avatar` component to complement `AvatarStack` for more
+  fine-grained customization.
+- Add `variant` prop to `AvatarStack` to support outlined avatars.
+
+### `@liveblocks/zustand` and `@liveblocks/redux`
+
+- Fix: Initial storage seeding no longer creates an undo frame.
+- Fix: Presence updates are now batched with storage updates.
+
 ## Liveblocks dev server (v1.4.0)
 
 - Add support for `client.mutateStorage()` (from `@liveblocks/node`)
@@ -39,7 +74,7 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 ## Contributors
 
-nvie, ctnicholas, stevenfabre
+nvie, ctnicholas, stevenfabre, marcbouchenoire
 
 # Week 14 (2026-04-03)
 


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-15-2026/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 10th of April.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching. Thank you [@random_dev](https://github.com/random_dev)!

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug.  Thank you [@random_dev](https://github.com/random_dev)!

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog file with no impact on runtime behavior.
> 
> **Overview**
> Prepares the public changelog for the next release cycle by adding a new `# Week 7 (2026-02-13)` section with an empty `## Contributors` placeholder at the top of `CHANGELOG_PUBLIC.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d43e482e0fdc14aa8869b2bb4a0843967af930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->