### PR TITLE
Improve mentions in composers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## vNEXT (not yet released)
 
+## v3.18.1 (not yet released)
+
+### `@liveblocks/react-ui`
+
+- Mentions suggestions now appear in more cases after typing `@`:
+  - After punctuation like `!`, `.`, `(`, etc. (e.g. `Hello!@`,
+    `cc: the other team (@`)
+  - After emojis (e.g. `Hello 👋@`)
+
 ## v3.18.0
 
 For full upgrade instructions, see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## vNEXT (not yet released)
 
-## v3.18.1 (not yet released)
+## v3.18.1
 
 ### `@liveblocks/react-ui`
 

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -520,6 +520,17 @@ test.describe("Composer", () => {
       ]);
     });
 
+    test("should not support mentions preceded by non-whitespace characters", async () => {
+      const { editor } = getComposer(page);
+
+      await editor.pressSequentially("Hello stacy@example");
+      await sleep(100);
+
+      await expect(
+        page.locator(".lb-composer-mention-suggestions-list")
+      ).not.toBeVisible();
+    });
+
     test("should support non-alphanumeric characters in mentions but not leading or consecutive whitespace", async () => {
       const { editor } = getComposer(page);
 
@@ -560,6 +571,16 @@ test.describe("Composer", () => {
       await expect(
         page.locator(".lb-composer-mention-suggestions-list")
       ).not.toBeVisible();
+    });
+
+    test("should support mentions preceded by emojis", async () => {
+      const { editor } = getComposer(page);
+
+      await editor.pressSequentially("Hello 👋@");
+
+      await expect(
+        page.locator(".lb-composer-suggestions-list-item").first()
+      ).toBeVisible();
     });
 
     test("should support user and group mentions", async () => {

--- a/e2e/next-sandbox/test/comments/composer.test.ts
+++ b/e2e/next-sandbox/test/comments/composer.test.ts
@@ -583,6 +583,25 @@ test.describe("Composer", () => {
       ).toBeVisible();
     });
 
+    test("should support mentions preceded by some specific punctuations", async () => {
+      const { editor } = getComposer(page);
+
+      await editor.pressSequentially("Hello!@");
+      await expect(
+        page.locator(".lb-composer-suggestions-list-item").first()
+      ).toBeVisible();
+
+      await editor.pressSequentially("Hello.@");
+      await expect(
+        page.locator(".lb-composer-suggestions-list-item").first()
+      ).toBeVisible();
+
+      await editor.pressSequentially("Hello (@");
+      await expect(
+        page.locator(".lb-composer-suggestions-list-item").first()
+      ).toBeVisible();
+    });
+
     test("should support user and group mentions", async () => {
       const { editor } = getComposer(page);
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/slate/plugins/mentions.ts
@@ -18,6 +18,9 @@ import { isWhitespaceCharacter } from "../../../slate/utils/is-whitespace-charac
 
 const EMOJI_REGEX =
   /\p{Extended_Pictographic}|\p{Emoji_Modifier}|\uFE0F|\u200D/u;
+
+// A few punctuation characters that aren't common (or even forbidden) as the
+// last character in email addresses' local part so we allow them before "@" mentions.
 const SUPPORTED_PRECEDING_PUNCTUATION = new Set<string>([
   '"',
   "'",
@@ -27,9 +30,11 @@ const SUPPORTED_PRECEDING_PUNCTUATION = new Set<string>([
   ",",
   ";",
   "(",
+  ")",
   "[",
-  "{",
+  "]",
   "<",
+  ">",
 ]);
 
 export type MentionDraft = {

--- a/packages/liveblocks-react-ui/src/primitives/Composer/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/slate/plugins/mentions.ts
@@ -18,6 +18,19 @@ import { isWhitespaceCharacter } from "../../../slate/utils/is-whitespace-charac
 
 const EMOJI_REGEX =
   /\p{Extended_Pictographic}|\p{Emoji_Modifier}|\uFE0F|\u200D/u;
+const SUPPORTED_PRECEDING_PUNCTUATION = new Set<string>([
+  '"',
+  "'",
+  ".",
+  "!",
+  "?",
+  ",",
+  ";",
+  "(",
+  "[",
+  "{",
+  "<",
+]);
 
 export type MentionDraft = {
   range: SlateRange;
@@ -38,6 +51,9 @@ export function getMentionDraftAtSelection(
   // - `Hello @stacy` → `"stacy"` mention draft (because "@" is preceded by a whitespace character)
   // - `Hello pierre@example.com` → no mention draft (because "@" is preceded by a non-whitespace character)
   // - `Hello @alicia@example.com` → `"alicia@example.com"` mention draft (because the first "@" is preceded by a whitespace character)
+  // - `Hello!@chris` → `"chris"` mention draft (because "!" is a supported preceding punctuation)
+  // - `Hello.@vincent` → `"vincent"` mention draft (because "." is a supported preceding punctuation)
+  // - `Hello (@olivier` → `"olivier"` mention draft (because "(" is a supported preceding punctuation)
   // - `Hello 👋@nimesh` → `"nimesh"` mention draft (because the first "@" is preceded by an emoji)
   const match = getMatchRange(editor, selection, ["@"], {
     include: true,
@@ -47,6 +63,11 @@ export function getMentionDraftAtSelection(
 
       // If "@" is the first character of the block, this "@" is immediately accepted ✅
       if (!characterBefore) {
+        return false;
+      }
+
+      // If the character before "@" is a supported preceding punctuation, this "@" is accepted ✅
+      if (SUPPORTED_PRECEDING_PUNCTUATION.has(characterBefore.text)) {
         return false;
       }
 

--- a/packages/liveblocks-react-ui/src/primitives/Composer/slate/plugins/mentions.ts
+++ b/packages/liveblocks-react-ui/src/primitives/Composer/slate/plugins/mentions.ts
@@ -16,6 +16,9 @@ import { getMatchRange } from "../../../slate/utils/get-match-range";
 import { isEmptyString } from "../../../slate/utils/is-empty-string";
 import { isWhitespaceCharacter } from "../../../slate/utils/is-whitespace-character";
 
+const EMOJI_REGEX =
+  /\p{Extended_Pictographic}|\p{Emoji_Modifier}|\uFE0F|\u200D/u;
+
 export type MentionDraft = {
   range: SlateRange;
   text: string;
@@ -30,20 +33,30 @@ export function getMentionDraftAtSelection(
     return;
   }
 
-  // Walk backwards from the selection until "@" is found, unless the character
-  // before isn't whitespace (or "@" is the block's first character)
+  // Walk backwards from the selection until "@" is found (with a few rules):
+  // - `@` → `""` mention draft
+  // - `Hello @stacy` → `"stacy"` mention draft (because "@" is preceded by a whitespace character)
+  // - `Hello pierre@example.com` → no mention draft (because "@" is preceded by a non-whitespace character)
+  // - `Hello @alicia@example.com` → `"alicia@example.com"` mention draft (because the first "@" is preceded by a whitespace character)
+  // - `Hello 👋@nimesh` → `"nimesh"` mention draft (because the first "@" is preceded by an emoji)
   const match = getMatchRange(editor, selection, ["@"], {
     include: true,
     allowConsecutiveWhitespace: false,
     ignoreTerminator: (_, point) => {
       const characterBefore = getCharacterBefore(editor, point);
 
-      // Ignore "@" if it's preceded by a non-whitespace character
-      if (characterBefore && !isWhitespaceCharacter(characterBefore.text)) {
-        return true;
+      // If "@" is the first character of the block, this "@" is immediately accepted ✅
+      if (!characterBefore) {
+        return false;
       }
 
-      return false;
+      // If the character before "@" is an emoji, this "@" is accepted ✅
+      if (EMOJI_REGEX.test(characterBefore.text)) {
+        return false;
+      }
+
+      // If the character before "@" is still a non-whitespace character, this "@" is ignored ❌
+      return !isWhitespaceCharacter(characterBefore.text);
     },
   });
 


### PR DESCRIPTION
This PR improves how mentions suggestions appear after typing `@`. We were really strict about it to support email addresses but this PR relaxes the rules a bit while keeping this behavior.