### PR TITLE
Fix `ToJson` failing to infer `Record<string, T>` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet released)
 
+### `@liveblocks/client`
+
+- Fix `ToJson` type losing specific value types for `Record<string, T>` fields
+  in Storage
+
 ## v3.18.1
 
 ### `@liveblocks/react-ui`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNEXT (not yet released)
 
+## v3.18.2
+
 ### `@liveblocks/client`
 
 - Fix `ToJson` type losing specific value types for `Record<string, T>` fields

--- a/packages/liveblocks-core/src/crdts/Lson.ts
+++ b/packages/liveblocks-core/src/crdts/Lson.ts
@@ -2,7 +2,7 @@ import type { LiveList } from "../crdts/LiveList";
 import type { LiveMap } from "../crdts/LiveMap";
 import type { LiveObject } from "../crdts/LiveObject";
 import type { LiveRegister } from "../crdts/LiveRegister";
-import type { Json, ReadonlyJsonObject } from "../lib/Json";
+import type { Json, ReadonlyJson, ReadonlyJsonObject } from "../lib/Json";
 
 export type LiveStructure =
   | LiveObject<LsonObject>
@@ -30,7 +30,7 @@ export type LiveNode =
  * A mapping of keys to Lson values. A Lson value is any valid JSON
  * value or a Live storage data structure (LiveMap, LiveList, etc.)
  */
-export type LsonObject = { [key: string]: Lson | undefined };
+export type LsonObject = Record<string, Lson | undefined>;
 
 /**
  * Helper type to convert any valid Lson type to the equivalent Json type.
@@ -50,15 +50,29 @@ export type LsonObject = { [key: string]: Lson | undefined };
 // prettier-ignore
 export type ToJson<L extends Lson | LsonObject> =
   // A LiveList serializes to an equivalent JSON array
-  L extends LiveList<infer I> ? readonly ToJson<I>[] :
+  // Short-circuit fully opaque LiveList<Lson> to avoid recursive expansion
+  L extends LiveList<infer I extends Lson> ?
+    Lson extends I ? readonly ReadonlyJson[] :
+    readonly ToJson<I>[] :
 
   // A LiveObject serializes to an equivalent JSON object
-  L extends LiveObject<infer O> ? ToJson<O> :
+  // Short-circuit fully opaque LiveObject<LsonObject> to avoid recursive expansion
+  // Otherwise, inline the mapped type here (instead of ToJson<O>) so that
+  // Record<string, LiveObject<...>> doesn't hit the LsonObject branch's guard.
+  L extends LiveObject<infer O extends LsonObject> ?
+    LsonObject extends O ? ReadonlyJsonObject :
+    { readonly [K in keyof O]: ToJson<Exclude<O[K], undefined>>
+                                 | (undefined extends O[K] ? undefined : never) } :
 
   // A LiveMap serializes to a JSON object with string-V pairs
-  L extends LiveMap<infer KS, infer V> ? { readonly [P in KS]: ToJson<V> } :
+  // Short-circuit fully opaque LiveMap<string, Lson> to avoid recursive expansion
+  L extends LiveMap<infer KS extends string, infer V extends Lson> ?
+    Lson extends V ? ReadonlyJsonObject :
+    { readonly [K in KS]: ToJson<V> } :
 
   // Any LsonObject recursively becomes a JsonObject
+  // Short-circuit generic string-keyed objects to ReadonlyJsonObject to avoid
+  // ugly recursive expansion (e.g. ToJson<LsonObject> or ToJson<JsonObject>)
   L extends LsonObject ?
     string extends keyof L ? ReadonlyJsonObject :
     { readonly [K in keyof L]: ToJson<Exclude<L[K], undefined>>

--- a/packages/liveblocks-core/test-d/ToJson.test-d.ts
+++ b/packages/liveblocks-core/test-d/ToJson.test-d.ts
@@ -1,0 +1,256 @@
+import type {
+  Lson,
+  LsonObject,
+  ReadonlyJsonObject,
+  ToJson,
+} from "@liveblocks/core";
+import { LiveList, LiveMap, LiveObject } from "@liveblocks/core";
+import { describe, expectTypeOf, test } from "vitest";
+
+declare const str: string;
+declare const num: number;
+declare const bool: boolean;
+
+declare function or<T, U>(a: T, b: U): T | U;
+declare function maybe<T>(a: T): T | undefined;
+
+declare function toJson<T extends Lson | LsonObject>(value: T): ToJson<T>;
+
+describe("ToJson", () => {
+  // ---------------------------------------------------------------------------
+  // Json scalars
+  // ---------------------------------------------------------------------------
+  test("number passthrough", () => {
+    expectTypeOf(toJson(num)).toEqualTypeOf<number>();
+  });
+
+  test("number literal", () => {
+    expectTypeOf(toJson(42)).toEqualTypeOf<42>();
+  });
+
+  test("string passthrough", () => {
+    expectTypeOf(toJson(str)).toEqualTypeOf<string>();
+  });
+
+  test("string literal", () => {
+    expectTypeOf(toJson("hi")).toEqualTypeOf<"hi">();
+  });
+
+  test("boolean passthrough", () => {
+    expectTypeOf(toJson(bool)).toEqualTypeOf<boolean>();
+  });
+
+  test("boolean literal", () => {
+    expectTypeOf(toJson(true)).toEqualTypeOf<true>();
+  });
+
+  test("null passthrough", () => {
+    expectTypeOf(toJson(null)).toEqualTypeOf<null>();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unions of Json scalars
+  // ---------------------------------------------------------------------------
+  test("string | number", () => {
+    expectTypeOf(toJson(or(str, num))).toEqualTypeOf<string | number>();
+  });
+
+  // ---------------------------------------------------------------------------
+  // LiveList
+  // ---------------------------------------------------------------------------
+  test("LiveList<number>", () => {
+    expectTypeOf(toJson(new LiveList([1, 2, 3]))).toEqualTypeOf<
+      readonly number[]
+    >();
+  });
+
+  test("LiveList<string>", () => {
+    expectTypeOf(toJson(new LiveList(["a", "b"]))).toEqualTypeOf<
+      readonly string[]
+    >();
+  });
+
+  test("nested LiveList<LiveList<number>>", () => {
+    expectTypeOf(toJson(new LiveList([new LiveList([1, 2])]))).toEqualTypeOf<
+      readonly (readonly number[])[]
+    >();
+  });
+
+  // ---------------------------------------------------------------------------
+  // LiveObject
+  // ---------------------------------------------------------------------------
+  test("LiveObject with scalar fields", () => {
+    expectTypeOf(toJson(new LiveObject({ a: 1, b: "" }))).toEqualTypeOf<{
+      readonly a: number;
+      readonly b: string;
+    }>();
+  });
+
+  test("LiveObject with optional field", () => {
+    expectTypeOf(
+      toJson(new LiveObject({ a: 1, b: maybe(str) }))
+    ).toEqualTypeOf<{
+      readonly a: number;
+      readonly b: string | undefined;
+    }>();
+
+    // XXX It would be nice if this would actually work
+    // expectTypeOf(
+    //   toJson(new LiveObject({ a: 1, b: maybe(str) }))
+    // ).toEqualTypeOf<{
+    //   readonly a: number;
+    //   readonly b?: string;                  // 👈 note the "?"
+    // }>();
+  });
+
+  test("LiveObject with mixed fields (docstring example)", () => {
+    expectTypeOf(
+      toJson(
+        new LiveObject({
+          a: 1,
+          b: new LiveList(["x"]),
+          c: maybe(num),
+        })
+      )
+    ).toEqualTypeOf<{
+      readonly a: number;
+      readonly b: readonly string[];
+      readonly c: number | undefined;
+    }>();
+
+    // XXX It would be nice if this would actually work
+    // expectTypeOf(
+    //   toJson(
+    //     new LiveObject({
+    //       a: 1,
+    //       b: new LiveList(["x"]),
+    //       c: 1 as number | undefined,
+    //     })
+    //   )
+    // ).toEqualTypeOf<{
+    //   readonly a: number;
+    //   readonly b: readonly string[];
+    //   readonly c?: number;                  // 👈 note the "?"
+    // }>();
+  });
+
+  test("nested LiveObject", () => {
+    expectTypeOf(
+      toJson(new LiveObject({ inner: new LiveObject({ x: 42 }) }))
+    ).toEqualTypeOf<{
+      readonly inner: { readonly x: number };
+    }>();
+    expectTypeOf(
+      toJson(new LiveObject({ inner: new LiveObject({ x: 42 as const }) }))
+    ).toEqualTypeOf<{
+      readonly inner: { readonly x: 42 };
+    }>();
+    expectTypeOf(
+      toJson(new LiveObject({ inner: new LiveObject({ x: 42 as 42 | "foo" }) }))
+    ).toEqualTypeOf<{
+      readonly inner: { readonly x: "foo" | 42 };
+    }>();
+  });
+
+  test("fully opaque LiveObject short-circuits to ReadonlyJsonObject", () => {
+    expectTypeOf(
+      toJson(new LiveObject<LsonObject>({}))
+    ).toEqualTypeOf<ReadonlyJsonObject>();
+  });
+
+  // ---------------------------------------------------------------------------
+  // LiveMap
+  // ---------------------------------------------------------------------------
+  test("LiveMap<string, number>", () => {
+    expectTypeOf(toJson(new LiveMap<string, number>())).toEqualTypeOf<{
+      readonly [key: string]: number;
+    }>();
+  });
+
+  test("LiveMap<string, LiveList<number>>", () => {
+    expectTypeOf(
+      toJson(new LiveMap<string, LiveList<number>>())
+    ).toEqualTypeOf<{
+      readonly [key: string]: readonly number[];
+    }>();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unions involving Live types
+  // ---------------------------------------------------------------------------
+  test("string | LiveList<number>", () => {
+    const value0 = or(str, new LiveList([]));
+    expectTypeOf(toJson(value0)).toEqualTypeOf<string | readonly never[]>();
+
+    const value1 = or(str, new LiveList([num]));
+    expectTypeOf(toJson(value1)).toEqualTypeOf<string | readonly number[]>();
+
+    const value2 = or(str, new LiveList([1, 2, 3]));
+    expectTypeOf(toJson(value2)).toEqualTypeOf<
+      string | readonly (1 | 2 | 3)[]
+    >();
+
+    const value3 = or(str, new LiveList([1, 2, 3] as const));
+    expectTypeOf(toJson(value3)).toEqualTypeOf<
+      string | readonly (1 | 2 | 3)[]
+    >();
+  });
+
+  // ---------------------------------------------------------------------------
+  // LsonObject (plain objects, not wrapped in LiveObject)
+  // ---------------------------------------------------------------------------
+  test("object with named keys", () => {
+    expectTypeOf(toJson({ x: 1, y: "a" })).toEqualTypeOf<{
+      readonly x: number;
+      readonly y: string;
+    }>();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Generic string-keyed objects (regression from #3348)
+  // ---------------------------------------------------------------------------
+  test("Record<string, specific type> through LiveObject", () => {
+    const liveObj = new LiveObject({} as Record<string, { prop: string }>);
+    expectTypeOf(liveObj).toEqualTypeOf<
+      LiveObject<Record<string, { prop: string }>>
+    >();
+
+    expectTypeOf(toJson(liveObj)).toEqualTypeOf<{
+      readonly [key: string]: { readonly prop: string };
+    }>();
+  });
+
+  test("Record<string, any> through LiveObject", () => {
+    const liveObj = new LiveObject({} as Record<string, any>);
+    // `any` takes both branches of the conditional, but the result is
+    // effectively `{ readonly [key: string]: any }`. Using toExtend
+    // because toEqualTypeOf doesn't handle `any` well.
+    expectTypeOf(toJson(liveObj)).toExtend<{
+      readonly [key: string]: any;
+    }>();
+  });
+
+  test("Record<string, never> through LiveObject", () => {
+    const liveObj = new LiveObject({} as Record<string, never>);
+    expectTypeOf(toJson(liveObj)).toEqualTypeOf<{
+      readonly [key: string]: never;
+    }>();
+  });
+
+  test("Record<string, unknown> through LiveObject", () => {
+    const liveObj = new LiveObject({} as Record<string, unknown> & LsonObject);
+    expectTypeOf(toJson(liveObj)).toEqualTypeOf<ReadonlyJsonObject>();
+  });
+
+  test("Record<string, specific type> through LiveList<LiveObject>", () => {
+    const liveObj = new LiveObject({} as Record<string, { prop: string }>);
+    const liveList = new LiveList([liveObj]);
+    expectTypeOf(liveList).toEqualTypeOf<
+      LiveList<LiveObject<Record<string, { prop: string }>>>
+    >();
+
+    expectTypeOf(toJson(liveList)).toEqualTypeOf<
+      readonly { readonly [key: string]: { readonly prop: string } }[]
+    >();
+  });
+});

--- a/packages/liveblocks-core/test-d/ToJson.test-d.ts
+++ b/packages/liveblocks-core/test-d/ToJson.test-d.ts
@@ -242,6 +242,19 @@ describe("ToJson", () => {
     expectTypeOf(toJson(liveObj)).toEqualTypeOf<ReadonlyJsonObject>();
   });
 
+  test("Record<string, LiveObject<specific type>>", () => {
+    const liveObj = new LiveObject(
+      {} as Record<string, LiveObject<{ prop: string }>>
+    );
+    expectTypeOf(liveObj).toEqualTypeOf<
+      LiveObject<Record<string, LiveObject<{ prop: string }>>>
+    >();
+
+    expectTypeOf(toJson(liveObj)).toEqualTypeOf<{
+      readonly [key: string]: { readonly prop: string };
+    }>();
+  });
+
   test("Record<string, specific type> through LiveList<LiveObject>", () => {
     const liveObj = new LiveObject({} as Record<string, { prop: string }>);
     const liveList = new LiveList([liveObj]);

--- a/packages/liveblocks-core/test-d/ToJson.test-d.ts
+++ b/packages/liveblocks-core/test-d/ToJson.test-d.ts
@@ -94,13 +94,6 @@ describe("ToJson", () => {
       readonly b: string | undefined;
     }>();
 
-    // XXX It would be nice if this would actually work
-    // expectTypeOf(
-    //   toJson(new LiveObject({ a: 1, b: maybe(str) }))
-    // ).toEqualTypeOf<{
-    //   readonly a: number;
-    //   readonly b?: string;                  // 👈 note the "?"
-    // }>();
   });
 
   test("LiveObject with mixed fields (docstring example)", () => {
@@ -117,21 +110,6 @@ describe("ToJson", () => {
       readonly b: readonly string[];
       readonly c: number | undefined;
     }>();
-
-    // XXX It would be nice if this would actually work
-    // expectTypeOf(
-    //   toJson(
-    //     new LiveObject({
-    //       a: 1,
-    //       b: new LiveList(["x"]),
-    //       c: 1 as number | undefined,
-    //     })
-    //   )
-    // ).toEqualTypeOf<{
-    //   readonly a: number;
-    //   readonly b: readonly string[];
-    //   readonly c?: number;                  // 👈 note the "?"
-    // }>();
   });
 
   test("nested LiveObject", () => {


### PR DESCRIPTION
This PR:

- Fixes #3348
- Short-circuit fully opaque types (`LiveObject<LsonObject>`, `LiveList<Lson>`, `LiveMap<string, Lson>`) at the Live type branches to prevent ugly recursive expansion in editor tooltips
- Add comprehensive type-level tests for `ToJson` (to ensure we don't regress again in the future on these edge cases)
