### PR TITLE
Promote `room.history.disable()` to an experimental API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## vNEXT (not yet released)
 
+## v3.18.2
+
+### `@liveblocks/client`
+
+- New experimental `room.history.disable(fn)` API that allows running storage
+  mutations without them appearing on the undo/redo stacks. Intended for
+  background/async writes (e.g. writing back AI generation results) that should
+  not be undoable.
+
 ## v3.18.1
 
 ### `@liveblocks/react-ui`

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -2771,6 +2771,42 @@ room.get("time");
 
 <PropertiesListEmpty title="Arguments">_None_</PropertiesListEmpty>
 
+### Room.history.disable [#Room.history.disable]
+
+<Banner title="Experimental API" type="warning">
+
+This API is experimental and may change or be removed in a future release
+without following semver guarantees.
+
+</Banner>
+
+Executes a callback with history tracking temporarily disabled. Any storage
+mutations made inside the callback will be applied normally but will not appear
+on the undo/redo stacks. This is useful for background or async writes that
+should not be undoable, such as writing back results from an AI generation task
+or reconciling state from an external source.
+
+If the callback throws, the undo/redo stacks are left unchanged (as if the
+callback never ran).
+
+```ts
+room.history.disable(() => {
+  root.set("generatedText", result);
+});
+```
+
+<PropertiesList title="Returns">
+  <PropertiesListItem name="return" type="T">
+    The return value of the callback.
+  </PropertiesListItem>
+</PropertiesList>
+
+<PropertiesList title="Arguments">
+  <PropertiesListItem name="fn" type="() => T" required>
+    The callback to execute while history is disabled.
+  </PropertiesListItem>
+</PropertiesList>
+
 ### Room.connect
 
 Connect the local room instance to the Liveblocks server. Does nothing if the

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -2782,9 +2782,9 @@ without following semver guarantees.
 
 Executes a callback with history tracking temporarily disabled. Any storage
 mutations made inside the callback will be applied normally but will not appear
-on the undo/redo stacks. This is useful for background or async writes that
-should not be undoable, such as writing back results from an AI generation task
-or reconciling state from an external source.
+on the undo/redo stacks. This is useful for background writes that should not be
+undoable, such as writing back results from agent updates or reconciling state
+from an external source.
 
 If the callback throws, the undo/redo stacks are left unchanged (as if the
 callback never ran).
@@ -2793,6 +2793,25 @@ callback never ran).
 room.history.disable(() => {
   root.set("generatedText", result);
 });
+```
+
+#### Async
+
+The history API is synchronous. For long-running async tasks, call
+`history.disable` at each synchronous step rather than wrapping the entire async
+function:
+
+```ts
+async function generateSummary() {
+  room.history.disable(() => root.set("status", "generating"));
+  const summary = await fetchSummaryFromAgent();
+  room.history.disable(() => {
+    room.batch(() => {
+      root.set("summary", summary);
+      root.set("status", "done");
+    });
+  });
+}
 ```
 
 <PropertiesList title="Returns">

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -2795,6 +2795,30 @@ room.history.disable(() => {
 });
 ```
 
+#### Batching
+
+When combining with [`room.batch`](#Room.batch), always place the batch _inside_
+the `disable` call. If `batch` wraps `disable`, the batched mutations will still
+end up on the undo stack.
+
+```ts
+// ✅ Disabling undo must happen around a batch
+room.history.disable(() => {
+  room.batch(() => {
+    root.set("x", 1);
+    root.set("y", 2);
+  });
+});
+
+// ❌ Batch wraps disable, mutations will still end up in the undo stack
+room.batch(() => {
+  room.history.disable(() => {
+    root.set("x", 1);
+    root.set("y", 2);
+  });
+});
+```
+
 #### Async
 
 The history API is synchronous. For long-running async tasks, call

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -3774,15 +3774,20 @@ Returns the room’s history. See [`Room.history`][] for more information.
 ```ts
 import { useHistory } from "@liveblocks/react/suspense";
 
-const { undo, redo, pause, resume } = useHistory();
+const { undo, redo, pause, resume, disable } = useHistory();
 ```
 
 <PropertiesListEmpty title="Arguments">_None_</PropertiesListEmpty>
 
 <PropertiesList title="Returns">
   <PropertiesListItem name="history" type="History">
-    The room's history object containing methods for undo, redo, pause, and
-    resume operations.
+    The room's history object containing methods for
+    [`undo`](/docs/api-reference/liveblocks-client#Room.history.undo),
+    [`redo`](/docs/api-reference/liveblocks-client#Room.history.redo),
+    [`pause`](/docs/api-reference/liveblocks-client#Room.history.pause),
+    [`resume`](/docs/api-reference/liveblocks-client#Room.history.resume), and
+    [`disable`](/docs/api-reference/liveblocks-client#Room.history.disable)
+    operations.
   </PropertiesListItem>
 </PropertiesList>
 

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -314,6 +314,99 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
+  test("background write via history.disable does not interfere with user's undo history", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{
+      userText: string;
+      generatedSummary: string;
+      status: string;
+    }>({
+      liveblocksType: "LiveObject",
+      data: { userText: "", generatedSummary: "", status: "idle" },
+    });
+
+    // User types something (undoable)
+    root.set("userText", "Hello world");
+
+    // A background task writes back a generation result (not undoable),
+    // using batch to group multiple mutations into a single message
+    room.history.disable(() => {
+      room.batch(() => {
+        root.set("generatedSummary", "AI-generated summary");
+        root.set("status", "done");
+      });
+    });
+
+    expect(root.get("userText")).toBe("Hello world");
+    expect(root.get("generatedSummary")).toBe("AI-generated summary");
+    expect(root.get("status")).toBe("done");
+
+    // Undo should only revert the user's typing, not the background write
+    room.history.undo();
+    expect(root.get("userText")).toBe("");
+    expect(root.get("generatedSummary")).toBe("AI-generated summary");
+    expect(root.get("status")).toBe("done");
+
+    // Nothing left to undo
+    expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("disable must wrap batch, not the other way around", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{
+      x: number;
+      y: number;
+    }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0, y: 0 },
+    });
+
+    // batch(disable(...)) does NOT work — batch pushes to the undo stack
+    // in its finally block, after disable has already restored the lengths
+    room.batch(() => {
+      room.history.disable(() => {
+        root.set("x", 1);
+        root.set("y", 1);
+      });
+    });
+
+    // The mutations leak onto the undo stack
+    expect(root.get("x")).toBe(1);
+    expect(room.history.canUndo()).toBe(true);
+
+    // disable(batch(...)) works correctly
+    room.history.undo();
+    room.history.disable(() => {
+      room.batch(() => {
+        root.set("x", 2);
+        root.set("y", 2);
+      });
+    });
+
+    expect(root.get("x")).toBe(2);
+    expect(root.get("y")).toBe(2);
+    expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("nested history.disable calls work correctly", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{
+      x: number;
+      y: number;
+    }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0, y: 0 },
+    });
+
+    room.history.disable(() => {
+      root.set("x", 1);
+      room.history.disable(() => {
+        root.set("y", 2);
+      });
+    });
+
+    expect(root.get("x")).toBe(1);
+    expect(root.get("y")).toBe(2);
+    expect(room.history.canUndo()).toBe(false);
+  });
+
   test("history.disable preserves the redo stack", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       x: number;

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -9,7 +9,6 @@ import { describe, expect, onTestFinished, test } from "vitest";
 
 import { LiveList } from "../crdts/LiveList";
 import { LiveObject } from "../crdts/LiveObject";
-import { kInternal } from "../internal";
 import { nn } from "../lib/assert";
 import { prepareIsolatedStorageTest } from "./_devserver";
 import type { JsonStorageUpdate } from "./_updatesUtils";
@@ -259,7 +258,7 @@ describe("room (dev server)", () => {
     });
   });
 
-  test("withoutHistory prevents mutations from appearing in undo stack", async () => {
+  test("history.disable prevents mutations from appearing in undo stack", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       x: number;
     }>({
@@ -267,7 +266,7 @@ describe("room (dev server)", () => {
       data: { x: 0 },
     });
 
-    room.history[kInternal].withoutHistory(() => {
+    room.history.disable(() => {
       root.set("x", 1);
     });
 
@@ -275,7 +274,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("withoutHistory returns the callback's return value", async () => {
+  test("history.disable returns the callback's return value", async () => {
     const { room } = await prepareIsolatedStorageTest<{
       x: number;
     }>({
@@ -283,12 +282,12 @@ describe("room (dev server)", () => {
       data: { x: 0 },
     });
 
-    const result = room.history[kInternal].withoutHistory(() => 42);
+    const result = room.history.disable(() => 42);
 
     expect(result).toBe(42);
   });
 
-  test("withoutHistory restores undo stack even if callback throws", async () => {
+  test("history.disable restores undo stack even if callback throws", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       x: number;
     }>({
@@ -301,13 +300,13 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(true);
 
     expect(() => {
-      room.history[kInternal].withoutHistory(() => {
+      room.history.disable(() => {
         root.set("x", 2);
         throw new Error("boom");
       });
     }).toThrow("boom");
 
-    // The mutation inside withoutHistory should not have added to the stack,
+    // The mutation inside history.disable should not have added to the stack,
     // but the pre-existing undo entry should still be there
     expect(room.history.canUndo()).toBe(true);
     room.history.undo();
@@ -315,7 +314,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("withoutHistory preserves the redo stack", async () => {
+  test("history.disable preserves the redo stack", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       x: number;
     }>({
@@ -329,8 +328,8 @@ describe("room (dev server)", () => {
     expect(root.get("x")).toBe(0);
     expect(room.history.canRedo()).toBe(true);
 
-    // Mutation inside withoutHistory should not wipe the redo stack
-    room.history[kInternal].withoutHistory(() => {
+    // Mutation inside history.disable should not wipe the redo stack
+    room.history.disable(() => {
       root.set("x", 99);
     });
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -306,9 +306,27 @@ export interface History {
    */
   resume: () => void;
 
-  readonly [kInternal]: {
-    withoutHistory: <T>(fn: () => T) => T;
-  };
+  /**
+   * Executes a callback with history tracking temporarily disabled. Any
+   * storage mutations made inside the callback will be applied normally
+   * but will not appear on the undo/redo stacks.
+   *
+   * This is useful for background or async writes that should not be
+   * undoable, such as writing back results from an AI generation task
+   * or reconciling state from an external source.
+   *
+   * Returns the callback's return value. If the callback throws, the
+   * undo/redo stacks are left unchanged (as if the callback never ran).
+   *
+   * @example
+   * room.history.disable(() => {
+   *   root.set("generatedText", result);
+   * });
+   *
+   * @experimental This API is experimental and may change or be removed
+   * in a future release without following semver guarantees.
+   */
+  disable: <T>(fn: () => T) => T;
 }
 
 export type HistoryEvent = {
@@ -3787,9 +3805,7 @@ export function createRoom<
         clear,
         pause: pauseHistory,
         resume: resumeHistory,
-        [kInternal]: {
-          withoutHistory,
-        },
+        disable: withoutHistory,
       },
 
       fetchYDoc,

--- a/packages/liveblocks-react-flow/src/lib/flow.ts
+++ b/packages/liveblocks-react-flow/src/lib/flow.ts
@@ -5,7 +5,7 @@ import type {
   Resolve,
   ToJson,
 } from "@liveblocks/core";
-import { kInternal, LiveMap, LiveObject } from "@liveblocks/core";
+import { LiveMap, LiveObject } from "@liveblocks/core";
 import { useHistory, useMutation, useStorage } from "@liveblocks/react";
 import {
   useInitial,
@@ -537,7 +537,7 @@ export function useLiveblocksFlow<
 
   useEffect(() => {
     if (isStorageLoaded) {
-      history[kInternal].withoutHistory(() => {
+      history.disable(() => {
         setInitialStorage();
       });
     }

--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -28,6 +28,7 @@ export const {
   RoomProvider,
   useCanRedo,
   useCanUndo,
+  useHistory,
   useIsInsideRoom,
   useMutation,
   useMyPresence,

--- a/packages/liveblocks-react/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import { createRoomContext, useRoom as useRoomGlobal } from "../room";
 import {
   useCanRedo,
   useCanUndo,
+  useHistory,
   useIsInsideRoom,
   useMutation,
   useMyPresence,
@@ -456,5 +457,37 @@ describe("useCanUndo / useCanRedo", () => {
 
     expect(canUndo.result.current).toEqual(false);
     expect(canRedo.result.current).toEqual(true);
+  });
+});
+
+describe("useHistory", () => {
+  test("history.disable prevents mutations from being undoable", async () => {
+    const history = renderHook(() => useHistory());
+    const canUndo = renderHook(() => useCanUndo());
+    const mutation = renderHook(() =>
+      useMutation(
+        ({ storage }) => storage.get("obj").set("a", Math.random()),
+        []
+      )
+    );
+
+    const sim = await websocketSimulator();
+    act(() => sim.simulateExistingStorageLoaded());
+
+    // A normal mutation is undoable
+    act(() => mutation.result.current());
+    expect(canUndo.result.current).toEqual(true);
+
+    // Undo it to get back to clean state
+    act(() => history.result.current.undo());
+    expect(canUndo.result.current).toEqual(false);
+
+    // A mutation inside history.disable is not undoable
+    act(() => {
+      history.result.current.disable(() => {
+        mutation.result.current();
+      });
+    });
+    expect(canUndo.result.current).toEqual(false);
   });
 });

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -9,7 +9,7 @@ import type {
   User,
 } from "@liveblocks/client";
 import type { EnterOptions, OpaqueClient, OpaqueRoom } from "@liveblocks/core";
-import { detectDupes, kInternal } from "@liveblocks/core";
+import { detectDupes } from "@liveblocks/core";
 import type { StoreEnhancer } from "redux";
 
 import {
@@ -260,7 +260,7 @@ const internalEnhancer = <TState>(options: {
             }
           }
 
-          room.history[kInternal].withoutHistory(() => {
+          room.history.disable(() => {
             maybeRoom!.batch(() => {
               root.reconcilePartially(missing);
             });

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -20,7 +20,7 @@ import type {
   OpaqueClient,
   OpaqueRoom,
 } from "@liveblocks/core";
-import { detectDupes, errorIf, kInternal } from "@liveblocks/core";
+import { detectDupes, errorIf } from "@liveblocks/core";
 import type { StateCreator, StoreMutatorIdentifier } from "zustand";
 
 import { PKG_FORMAT, PKG_NAME, PKG_VERSION } from "./version";
@@ -225,7 +225,7 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
           }
         }
 
-        room.history[kInternal].withoutHistory(() => {
+        room.history.disable(() => {
           room.batch(() => {
             root.reconcilePartially(missing);
           });


### PR DESCRIPTION
This implementation already existed as a fully hidden/private API used internally, but it may actually be useful for generated content (e.g. AI generated updates) that should not be undo-able.

I've kept the API marked experimental, because I'm not 100% convinced yet this is the stable/final form factor.

```ts
// Using the room client directly
room.history.disable(() => {
  room.batch(() => {
    root.set("summary", generatedSummary);
    root.set("status", "done");
  });
});

// Or via React hook
const { disable } = useHistory();

disable(() => {
  // These mutations won't appear on the undo/redo stack
  root.set("summary", generatedSummary);
});
```
