### PR TITLE
Fix `history.disable()` edge cases by defining weirdness out of existence

### DIFF
--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -5,7 +5,7 @@
  * For connection state machine, auth, reconnection, and wire protocol tests,
  * see room.mockserver.test.ts.
  */
-import { describe, expect, onTestFinished, test } from "vitest";
+import { describe, expect, onTestFinished, test, vi } from "vitest";
 
 import { LiveList } from "../crdts/LiveList";
 import { LiveObject } from "../crdts/LiveObject";
@@ -618,5 +618,26 @@ describe("room (dev server)", () => {
       expect(root.get("x")).toBe(i - 1);
     }
     expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("history.disable() never fires history subscription events", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up undo state so canUndo is true
+    root.set("x", 1);
+
+    const callback = vi.fn();
+    onTestFinished(room.events.history.subscribe(callback));
+
+    // Mutations inside disable should not produce any history notifications
+    room.history.disable(() => {
+      root.set("x", 2);
+      root.set("x", 3);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -101,9 +101,7 @@ describe("room (dev server)", () => {
   });
 
   test("canUndo / canRedo", async () => {
-    const { room, root } = await prepareIsolatedStorageTest<{
-      a: number;
-    }>({
+    const { room, root } = await prepareIsolatedStorageTest<{ a: number }>({
       liveblocksType: "LiveObject",
       data: { a: 1 },
     });
@@ -121,9 +119,7 @@ describe("room (dev server)", () => {
   });
 
   test("clearing undo/redo stack", async () => {
-    const { room, root } = await prepareIsolatedStorageTest<{
-      a: number;
-    }>({
+    const { room, root } = await prepareIsolatedStorageTest<{ a: number }>({
       liveblocksType: "LiveObject",
       data: { a: 1 },
     });
@@ -259,9 +255,7 @@ describe("room (dev server)", () => {
   });
 
   test("history.disable prevents mutations from appearing in undo stack", async () => {
-    const { room, root } = await prepareIsolatedStorageTest<{
-      x: number;
-    }>({
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
     });
@@ -275,9 +269,7 @@ describe("room (dev server)", () => {
   });
 
   test("history.disable returns the callback's return value", async () => {
-    const { room } = await prepareIsolatedStorageTest<{
-      x: number;
-    }>({
+    const { room } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
     });
@@ -288,9 +280,7 @@ describe("room (dev server)", () => {
   });
 
   test("history.disable restores undo stack even if callback throws", async () => {
-    const { room, root } = await prepareIsolatedStorageTest<{
-      x: number;
-    }>({
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
     });
@@ -408,9 +398,7 @@ describe("room (dev server)", () => {
   });
 
   test("history.disable preserves the redo stack", async () => {
-    const { room, root } = await prepareIsolatedStorageTest<{
-      x: number;
-    }>({
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
     });

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -254,7 +254,7 @@ describe("room (dev server)", () => {
     });
   });
 
-  test("history.disable prevents mutations from appearing in undo stack", async () => {
+  test("history.disable() prevents mutations from appearing in undo stack", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
@@ -268,7 +268,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("history.disable returns the callback's return value", async () => {
+  test("history.disable() returns the callback's return value", async () => {
     const { room } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
@@ -279,7 +279,7 @@ describe("room (dev server)", () => {
     expect(result).toBe(42);
   });
 
-  test("history.disable restores undo stack even if callback throws", async () => {
+  test("history.disable() restores undo stack even if callback throws", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
@@ -304,7 +304,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("background write via history.disable does not interfere with user's undo history", async () => {
+  test("background write via history.disable() does not interfere with user's undo history", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       userText: string;
       generatedSummary: string;
@@ -340,7 +340,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("disable must wrap batch, not the other way around", async () => {
+  test("disable() must wrap batch(), not the other way around", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       x: number;
       y: number;
@@ -376,7 +376,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("nested history.disable calls work correctly", async () => {
+  test("nested history.disable() calls work correctly", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{
       x: number;
       y: number;
@@ -397,7 +397,7 @@ describe("room (dev server)", () => {
     expect(room.history.canUndo()).toBe(false);
   });
 
-  test("history.disable preserves the redo stack", async () => {
+  test("history.disable() preserves the redo stack", async () => {
     const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
       liveblocksType: "LiveObject",
       data: { x: 0 },
@@ -416,5 +416,207 @@ describe("room (dev server)", () => {
 
     expect(root.get("x")).toBe(99);
     expect(room.history.canRedo()).toBe(true);
+  });
+
+  test("history.clear() inside history.disable() preserves original history", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up some undo/redo state
+    root.set("x", 1);
+    root.set("x", 2);
+    room.history.undo();
+    expect(root.get("x")).toBe(1);
+    expect(room.history.canUndo()).toBe(true);
+    expect(room.history.canRedo()).toBe(true);
+
+    // Clear inside disable only affects the temporary stacks, not the real ones
+    room.history.disable(() => {
+      // Inside disable, the real stacks are swapped out — starts empty
+      expect(room.history.canUndo()).toBe(false);
+      expect(room.history.canRedo()).toBe(false);
+
+      // Adding an entry makes canUndo true within the block
+      root.set("x", 99);
+      expect(room.history.canUndo()).toBe(true);
+
+      // Clear wipes the temporary stacks
+      room.history.clear();
+      expect(room.history.canUndo()).toBe(false);
+      expect(room.history.canRedo()).toBe(false);
+    });
+
+    // The mutation inside disable() still applies to storage
+    expect(root.get("x")).toBe(99);
+    // Original history is preserved — clear() only wiped the temporary stacks
+    expect(room.history.canUndo()).toBe(true);
+    expect(room.history.canRedo()).toBe(true);
+  });
+
+  test("undo() inside history.disable() does not affect original undo stack", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up 3 undo entries
+    root.set("x", 1);
+    root.set("x", 2);
+    root.set("x", 3);
+
+    // Calling undo() inside disable operates on the empty temp stack — no-ops
+    room.history.disable(() => {
+      room.history.undo();
+      room.history.undo();
+    });
+
+    // All 3 original entries should still be intact
+    expect(root.get("x")).toBe(3);
+    for (let i = 3; i >= 1; i--) {
+      expect(room.history.canUndo()).toBe(true);
+      room.history.undo();
+      expect(root.get("x")).toBe(i - 1);
+    }
+    expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("undo() within history.disable() can revert block-local mutations", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up 3 undo entries
+    root.set("x", 1);
+    root.set("x", 2);
+    root.set("x", 3);
+
+    room.history.disable(() => {
+      root.set("x", 4); // Add 4th item (on temp stack)
+      room.history.undo(); // Undoes 4th item, back at 3
+      root.set("x", 5); // Add new item
+      root.set("x", 6); // Add another
+    });
+
+    // Mutations applied, but undo stack restored to original 3 entries
+    expect(root.get("x")).toBe(6);
+    room.history.undo();
+    expect(root.get("x")).toBe(2);
+    room.history.undo();
+    expect(root.get("x")).toBe(1);
+    room.history.undo();
+    expect(root.get("x")).toBe(0);
+    expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("undo() after history.disable() undoes the last pre-disable mutation", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up 3 undo entries
+    root.set("x", 1);
+    root.set("x", 2);
+    root.set("x", 3);
+
+    room.history.disable(() => {
+      root.set("x", 99); // Add another
+    });
+
+    // Mutations applied, but undo stack restored to original 3 entries
+    expect(root.get("x")).toBe(99);
+    room.history.undo();
+    expect(root.get("x")).toBe(2);
+    room.history.redo();
+    expect(root.get("x")).toBe(99);
+  });
+
+  test("undo() inside history.disable() cannot go beyond the block start", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up 3 undo entries
+    root.set("x", 1);
+    root.set("x", 2);
+    root.set("x", 3);
+
+    room.history.disable(() => {
+      root.set("x", 4); // Add 4th item (on temp stack)
+      room.history.undo(); // Undoes 4th item, back at 3
+      room.history.undo(); // No-op — temp stack is empty
+    });
+
+    // Original 3 entries intact — the second undo was a no-op
+    expect(root.get("x")).toBe(3);
+    room.history.undo();
+    expect(root.get("x")).toBe(2);
+    room.history.undo();
+    expect(root.get("x")).toBe(1);
+    room.history.undo();
+    expect(root.get("x")).toBe(0);
+    expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("undo() beyond block start and back again inside history.disable()", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Build up 3 undo entries
+    root.set("x", 1);
+    root.set("x", 2);
+    root.set("x", 3);
+
+    room.history.disable(() => {
+      root.set("x", 4); // Add 4th item (on temp stack)
+      room.history.undo(); // Undoes 4th item, back at 3
+      room.history.undo(); // No-op — temp stack empty
+      room.history.undo(); // No-op — temp stack empty
+      root.set("x", 5); // Add new item
+    });
+
+    // Mutation applied, original 3 entries intact
+    expect(root.get("x")).toBe(5);
+    room.history.undo();
+    expect(root.get("x")).toBe(2);
+    room.history.undo();
+    expect(root.get("x")).toBe(1);
+    room.history.undo();
+    expect(root.get("x")).toBe(0);
+    expect(room.history.canUndo()).toBe(false);
+  });
+
+  test("history.disable() at undo stack cap (50) does not evict oldest entry", async () => {
+    const { room, root } = await prepareIsolatedStorageTest<{ x: number }>({
+      liveblocksType: "LiveObject",
+      data: { x: 0 },
+    });
+
+    // Fill the undo stack to the cap (50 entries)
+    for (let i = 1; i <= 50; i++) {
+      root.set("x", i);
+    }
+    expect(root.get("x")).toBe(50);
+
+    // Mutate inside disable — should not shift the real undo stack
+    room.history.disable(() => {
+      root.set("x", 999);
+    });
+
+    expect(root.get("x")).toBe(999);
+
+    // All 50 original undo entries should still be intact
+    for (let i = 50; i >= 1; i--) {
+      expect(room.history.canUndo()).toBe(true);
+      room.history.undo();
+      expect(root.get("x")).toBe(i - 1);
+    }
+    expect(room.history.canUndo()).toBe(false);
   });
 });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
@@ -481,9 +481,7 @@ describe("LiveList edge cases", () => {
   describe("reconnect with remote changes and subscribe", () => {
     test("register added to list", async () => {
       const { expectStorage, room, root, wss } =
-        await prepareIsolatedStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedRoot(),
             createSerializedList("0:1", "root", "items"),
@@ -563,9 +561,7 @@ describe("LiveList edge cases", () => {
 
     test("register moved in list", async () => {
       const { expectStorage, room, root, wss } =
-        await prepareIsolatedStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedRoot(),
             createSerializedList("0:1", "root", "items"),
@@ -634,9 +630,7 @@ describe("LiveList edge cases", () => {
 
     test("register deleted from list", async () => {
       const { expectStorage, room, root, wss } =
-        await prepareIsolatedStorageTest<{
-          items: LiveList<string>;
-        }>(
+        await prepareIsolatedStorageTest<{ items: LiveList<string> }>(
           [
             createSerializedRoot(),
             createSerializedList("0:1", "root", "items"),

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
@@ -101,9 +101,7 @@ describe("LiveObject", () => {
   });
 
   test("set with same value is a no-op", async () => {
-    const { root, room } = await prepareIsolatedStorageTest<{
-      a: number;
-    }>({
+    const { root, room } = await prepareIsolatedStorageTest<{ a: number }>({
       liveblocksType: "LiveObject",
       data: { a: 1 },
     });
@@ -118,9 +116,7 @@ describe("LiveObject", () => {
   });
 
   test("set with different value creates an undo entry", async () => {
-    const { root, room } = await prepareIsolatedStorageTest<{
-      a: number;
-    }>({
+    const { root, room } = await prepareIsolatedStorageTest<{ a: number }>({
       liveblocksType: "LiveObject",
       data: { a: 1 },
     });
@@ -651,9 +647,7 @@ describe("LiveObject", () => {
     });
 
     test("should not notify if property does not exist", async () => {
-      const { room, root } = await prepareIsolatedStorageTest<{
-        a?: number;
-      }>();
+      const { room, root } = await prepareIsolatedStorageTest<{ a?: number }>();
 
       const callback = vi.fn();
       room.subscribe(root, callback);
@@ -664,9 +658,7 @@ describe("LiveObject", () => {
     });
 
     test("should notify if property has been deleted", async () => {
-      const { room, root } = await prepareIsolatedStorageTest<{
-        a?: number;
-      }>({
+      const { room, root } = await prepareIsolatedStorageTest<{ a?: number }>({
         liveblocksType: "LiveObject",
         data: { a: 1 },
       });

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1336,8 +1336,8 @@ type RoomState<
   pool: ManagedPool;
   root: LiveObject<S> | undefined;
 
-  readonly undoStack: Stackframe<P>[][];
-  readonly redoStack: Stackframe<P>[][];
+  undoStack: Stackframe<P>[][];
+  redoStack: Stackframe<P>[][];
 
   /**
    * When history is paused, all operations will get queued up here. When
@@ -3362,13 +3362,20 @@ export function createRoom<
   }
 
   function disableHistory<T>(fn: () => T): T {
-    const undoBefore = context.undoStack.length;
-    const redoBefore = context.redoStack.length;
+    const origUndo = context.undoStack;
+    const origRedo = context.redoStack;
+    const tempUndo: Stackframe<P>[][] = [];
+    const tempRedo: Stackframe<P>[][] = [];
+    context.undoStack = tempUndo;
+    context.redoStack = tempRedo;
     try {
       return fn();
     } finally {
-      context.undoStack.length = undoBefore;
-      context.redoStack.length = redoBefore;
+      if (context.undoStack !== tempUndo || context.redoStack !== tempRedo) {
+        throw new Error("unexpected stack swap during history.disable()"); // eslint-disable-line no-unsafe-finally
+      }
+      context.undoStack = origUndo;
+      context.redoStack = origRedo;
     }
   }
 

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1891,7 +1891,7 @@ export function createRoom<
 
     // Populate missing top-level keys using `initialStorage`
     const root = context.root;
-    withoutHistory(() => {
+    disableHistory(() => {
       for (const key in context.initialStorage) {
         if (root.get(key) === undefined) {
           if (canWrite) {
@@ -3361,7 +3361,7 @@ export function createRoom<
     commitPausedHistoryToUndoStack();
   }
 
-  function withoutHistory<T>(fn: () => T): T {
+  function disableHistory<T>(fn: () => T): T {
     const undoBefore = context.undoStack.length;
     const redoBefore = context.redoStack.length;
     try {
@@ -3805,7 +3805,7 @@ export function createRoom<
         clear,
         pause: pauseHistory,
         resume: resumeHistory,
-        disable: withoutHistory,
+        disable: disableHistory,
       },
 
       fetchYDoc,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2287,7 +2287,9 @@ export function createRoom<
 
   function canUndo() { return context.undoStack.length > 0; } // prettier-ignore
   function canRedo() { return context.redoStack.length > 0; } // prettier-ignore
+
   function onHistoryChange() {
+    if (_historyDisabled > 0) return;
     eventHub.history.notify({ canUndo: canUndo(), canRedo: canRedo() });
   }
 
@@ -3361,6 +3363,9 @@ export function createRoom<
     commitPausedHistoryToUndoStack();
   }
 
+  // Depth counter for nested history.disable() calls, 0 means history is not disabled
+  let _historyDisabled = 0;
+
   function disableHistory<T>(fn: () => T): T {
     const origUndo = context.undoStack;
     const origRedo = context.redoStack;
@@ -3368,9 +3373,11 @@ export function createRoom<
     const tempRedo: Stackframe<P>[][] = [];
     context.undoStack = tempUndo;
     context.redoStack = tempRedo;
+    _historyDisabled++;
     try {
       return fn();
     } finally {
+      _historyDisabled--;
       if (context.undoStack !== tempUndo || context.redoStack !== tempRedo) {
         throw new Error("unexpected stack swap during history.disable()"); // eslint-disable-line no-unsafe-finally
       }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2289,7 +2289,7 @@ export function createRoom<
   function canRedo() { return context.redoStack.length > 0; } // prettier-ignore
 
   function onHistoryChange() {
-    if (_historyDisabled > 0) return;
+    if (historyDisabled > 0) return;
     eventHub.history.notify({ canUndo: canUndo(), canRedo: canRedo() });
   }
 
@@ -3364,7 +3364,7 @@ export function createRoom<
   }
 
   // Depth counter for nested history.disable() calls, 0 means history is not disabled
-  let _historyDisabled = 0;
+  let historyDisabled = 0;
 
   function disableHistory<T>(fn: () => T): T {
     const origUndo = context.undoStack;
@@ -3373,11 +3373,11 @@ export function createRoom<
     const tempRedo: Stackframe<P>[][] = [];
     context.undoStack = tempUndo;
     context.redoStack = tempRedo;
-    _historyDisabled++;
+    historyDisabled++;
     try {
       return fn();
     } finally {
-      _historyDisabled--;
+      historyDisabled--;
       if (context.undoStack !== tempUndo || context.redoStack !== tempRedo) {
         throw new Error("unexpected stack swap during history.disable()"); // eslint-disable-line no-unsafe-finally
       }

--- a/packages/liveblocks-core/test-d/ToJson.test-d.ts
+++ b/packages/liveblocks-core/test-d/ToJson.test-d.ts
@@ -93,7 +93,6 @@ describe("ToJson", () => {
       readonly a: number;
       readonly b: string | undefined;
     }>();
-
   });
 
   test("LiveObject with mixed fields (docstring example)", () => {


### PR DESCRIPTION
This fixes edge cases in `history.disable()` by replacing the length-based save/restore approach with physically swapping the undo/redo stack arrays for fresh empty ones during the callback. This defines some of the discovered weirdnesses out of existence: all history operations naturally work on the temporary stacks, so edge cases like `clear()` inside `disable()`, cap eviction at 50 items, and `undo()`/`redo()` within the block—while rare!—still just work correctly without any special guards.

This PR:
- Swaps undo/redo stacks with fresh arrays during the `disable()` callback, restores originals in `finally`
- Suppresses `room.events.history` notifications during `disable()` since changes are discarded anyway
- Renames internal `withoutHistory` to `disableHistory`
