### PR TITLE
Re-export nanoid from client

### DIFF
--- a/packages/liveblocks-client/src/index.ts
+++ b/packages/liveblocks-client/src/index.ts
@@ -88,6 +88,7 @@ export {
   LiveList,
   LiveMap,
   LiveObject,
+  nanoid,
   shallow,
   stringifyCommentBody,
   toPlainLson,


### PR DESCRIPTION
...so examples relying on this don't have to rely on core (or a separate nanoid dependency).
