### PR TITLE
Make yjs and y-prosemirror required peer deps of @liveblocks/emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet released)
 
+## v3.18.4
+
+### `@liveblocks/emails`
+
+- Mark `yjs` and `y-prosemirror` as required peer dependencies.
+
 ## v3.18.3
 
 ### `@liveblocks/*`

--- a/packages/liveblocks-emails/package.json
+++ b/packages/liveblocks-emails/package.json
@@ -44,14 +44,6 @@
     "y-prosemirror": "^1",
     "yjs": "^13"
   },
-  "peerDependenciesMeta": {
-    "y-prosemirror": {
-      "optional": true
-    },
-    "yjs": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@liveblocks/eslint-config": "workspace:*",
     "@liveblocks/vitest-config": "workspace:*",


### PR DESCRIPTION
These were marked as optional before, but in practice consumers could not actually use the package without these peers installed.

Bundlers typically statically resolve all imports at build time, which then fails with "Module not found" for any consumer missing them, regardless of whether that consumer's code path ever uses the yjs or y-prosemirror functionality.