### PR TITLE
Fix React Flow kitchen sink

### DIFF
--- a/e2e/next-react-flow-kitchen-sink/next.config.ts
+++ b/e2e/next-react-flow-kitchen-sink/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    resolveAlias: {
+      "@xyflow/react": "./node_modules/@xyflow/react",
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
The `Cursors` component in the React Flow kitchen broke when we switched to pnpm because the kitchen sink's and package's peer/dev dependencies were forcing two copies of `@xyflow/react`. To still use React 19 in the kitchen sink and 18 in the package, this PR resolves the issue at the bundler level.