### PR TITLE
fix(react-tiptap): restore Y.UndoManager unconditionally on view destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Fix keyboard shortcut in strikethrough tooltip. (Thanks @HellBoy-OP for the
   contribution!)
+- Fix Yjs undo/redo silently breaking after `editor.registerPlugin` /
+  `unregisterPlugin` is called (e.g. when Tiptap's `BubbleMenu`, `DragHandle`,
+  or `SlashCommand` mount). The reattach `restore()` is now installed
+  unconditionally on view destroy, matching upstream
+  `@tiptap/extension-collaboration`. (Thanks @lucasmotta for the contribution!)
 
 ## v3.18.5
 

--- a/packages/liveblocks-react-tiptap/src/collaboration/collaboration.ts
+++ b/packages/liveblocks-react-tiptap/src/collaboration/collaboration.ts
@@ -231,22 +231,24 @@ export const Collaboration = Extension.create<
           const hasUndoManSelf = undoManager.trackedOrigins.has(undoManager);
           const observers = undoManager._observers;
 
-          if (
-            "restore" in undoManager &&
-            typeof undoManager.restore === "function"
-          ) {
-            undoManager.restore = () => {
-              if (hasUndoManSelf) {
-                undoManager.trackedOrigins.add(undoManager);
-              }
+          // Always install the reattach `restore()`, regardless of whether
+          // one already exists on the UndoManager. The previous guarded
+          // version was a no-op for standard `Y.UndoManager` (which has no
+          // `restore` method), causing the UndoManager to be permanently
+          // orphaned after the first plugin reconfigure (e.g. BubbleMenu /
+          // DragHandle / SlashCommand mount). Matches upstream
+          // `@tiptap/extension-collaboration`.
+          undoManager.restore = () => {
+            if (hasUndoManSelf) {
+              undoManager.trackedOrigins.add(undoManager);
+            }
 
-              undoManager.doc.on(
-                "afterTransaction",
-                undoManager.afterTransactionHandler
-              );
-              undoManager._observers = observers;
-            };
-          }
+            undoManager.doc.on(
+              "afterTransaction",
+              undoManager.afterTransactionHandler
+            );
+            undoManager._observers = observers;
+          };
 
           if (viewRet?.destroy) {
             viewRet.destroy();


### PR DESCRIPTION
## Description

The Collaboration extension's wrapper around `yUndoPlugin.spec.view` only installs the reattach `restore()` if `undoManager.restore` is already a function. Standard `Y.UndoManager` doesn't expose a `restore()` method, so the guard short-circuits and the UndoManager is permanently orphaned the first time ProseMirror recreates plugin views.

Plugin views are recreated on every `editor.registerPlugin` / `unregisterPlugin`, which Tiptap's own `BubbleMenu`, `DragHandle`, and `SlashCommand` all call from their mount effects. The bug therefore fires before the user types a single character — edits stop being captured, `undoStack.length` stays at `0`, and `Cmd+Z` becomes a no-op (or worse, throws `RangeError: Applying a mismatched transaction`).

This change drops the guard and installs `undoManager.restore = () => { ... }` unconditionally, matching the current upstream `@tiptap/extension-collaboration@3.22.5` which removed the same guard for the same reason.

## How to test it

Standalone repro (no Liveblocks server needed): https://github.com/lucasmotta/liveblocks-tiptap-undo-repro

Side-by-side comparison of the buggy wrapper (LEFT) and the same wrapper with the proposed fix applied (RIGHT). Click **Run repro** and watch:

- LEFT after `editor.registerPlugin(...)`: `UndoManager: DEAD ✗`, second insert is not tracked (`undoStack` stuck at 1), `Cmd+Z` is a no-op.
- RIGHT: `UndoManager: ALIVE ✓`, second insert is tracked (`undoStack: 2`), `Cmd+Z` works.

In a real app, anyone using `useLiveblocksExtension` together with Tiptap's `BubbleMenu` / `DragHandle` / `SlashCommand` (or any code that calls `editor.registerPlugin`) reproduces this in the wild — undo is broken from the moment the editor mounts.

## Related issue(s)

- yjs/y-prosemirror#114 / yjs/y-prosemirror#102 — the underlying ProseMirror reconfigure tear-down that the wrapper exists to recover from. Closed upstream pending the new y-prosemirror binding.
- nperez0111/y-prosemirror@3c243e7 — community fix at the y-prosemirror layer (not merged or published).

The reattach machinery in this file is exactly what's needed to handle the bug today; the only change is removing a guard that prevented it from running.