### PR TITLE
Add GitHub Action to setup examples on Vercel

### DIFF
--- a/.github/scripts/setup-vercel-example.sh
+++ b/.github/scripts/setup-vercel-example.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+set -euo pipefail
+
+vercel_api_url="https://api.vercel.com"
+examples_branch="examples"
+deploy_hook_name="Deploy example"
+temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/setup-vercel-example.XXXXXX")"
+
+cleanup() {
+  rm -rf "${temporary_directory}"
+}
+
+trap cleanup EXIT
+
+err() {
+  echo "$@" >&2
+}
+
+trim() {
+  local value="$1"
+
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+
+  printf "%s" "${value}"
+}
+
+vercel_url() {
+  printf "%s%s?teamId=%s" "${vercel_api_url}" "$1" "${VERCEL_TEAM_ID}"
+}
+
+create_response_file() {
+  mktemp "${temporary_directory}/response.XXXXXX"
+}
+
+curl_vercel() {
+  local method="$1"
+  local url="$2"
+  local response_file="$3"
+  local body="${4:-}"
+  local data_args=()
+
+  [[ -n "${body}" ]] && data_args=(--data "${body}")
+
+  curl --silent --show-error \
+    --request "${method}" \
+    --url "${url}" \
+    --header "Authorization: Bearer ${VERCEL_TOKEN}" \
+    --header "Content-Type: application/json" \
+    "${data_args[@]}" \
+    --output "${response_file}" \
+    --write-out "%{http_code}"
+}
+
+vercel_request() {
+  local description="$1"
+  local method="$2"
+  local url="$3"
+  local body="${4:-}"
+  local response_file
+  local status
+
+  response_file="$(create_response_file)"
+
+  echo >&2
+  echo "${description}" >&2
+
+  if ! status="$(curl_vercel "${method}" "${url}" "${response_file}" "${body}")"; then
+    err "${description} failed before receiving a Vercel response"
+    exit 1
+  fi
+
+  if [[ "${status}" -lt 200 || "${status}" -ge 300 ]]; then
+    err "${description} failed with HTTP ${status}"
+    cat "${response_file}" >&2
+    exit 1
+  fi
+
+  cat "${response_file}"
+}
+
+check_required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    err "Missing ${name}"
+    exit 1
+  fi
+}
+
+check_required_env "EXAMPLE_NAME"
+check_required_env "GITHUB_REPOSITORY"
+check_required_env "VERCEL_TEAM_ID"
+check_required_env "VERCEL_TOKEN"
+
+example_name="$(trim "${EXAMPLE_NAME}")"
+framework="$(trim "${FRAMEWORK:-}")"
+
+if [[ -z "${example_name}" ]]; then
+  err "Missing example name"
+  exit 1
+fi
+
+if [[ ! "${example_name}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+  err "Example name must be lowercase letters, numbers, and hyphens only"
+  exit 1
+fi
+
+if [[ ! -d "examples/${example_name}" ]]; then
+  err "Could not find examples/${example_name}"
+  exit 1
+fi
+
+project_name="examples-${example_name}"
+root_directory="examples/${example_name}"
+domain="${example_name}.liveblocks.app"
+
+echo "Setting up Vercel example project"
+echo "Example name: ${example_name}"
+echo "Project name: ${project_name}"
+echo "Root directory: ${root_directory}"
+echo "Custom domain: ${domain}"
+echo "GitHub repository: ${GITHUB_REPOSITORY}"
+echo "Production branch: ${examples_branch}"
+echo "Framework: ${framework:-"(none)"}"
+
+create_project_body="$(
+  jq -n \
+    --arg name "${project_name}" \
+    --arg root_directory "${root_directory}" \
+    --arg repository "${GITHUB_REPOSITORY}" \
+    '{
+      name: $name,
+      buildCommand: "npm run build",
+      installCommand: "npm install",
+      rootDirectory: $root_directory,
+      gitRepository: {
+        type: "github",
+        repo: $repository
+      }
+    }'
+)"
+
+if [[ -n "${framework}" ]]; then
+  # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project#framework
+  create_project_body="$(
+    jq --arg framework "${framework}" '.framework = $framework' <<<"${create_project_body}"
+  )"
+fi
+
+# Create a Vercel project for this GitHub repository.
+# Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
+existing_project_response_file="$(create_response_file)"
+if ! existing_project_status="$(
+  curl_vercel \
+    "GET" \
+    "$(vercel_url "/v10/projects/${project_name}")" \
+    "${existing_project_response_file}"
+)"; then
+  err "Looking up existing Vercel project failed before receiving a Vercel response"
+  exit 1
+fi
+
+if [[ "${existing_project_status}" == "200" ]]; then
+  echo
+  echo "Found existing Vercel project, updating it instead of creating a duplicate"
+  project_response="$(cat "${existing_project_response_file}")"
+elif [[ "${existing_project_status}" == "404" ]]; then
+  project_response="$(
+    vercel_request \
+      "Creating Vercel project" \
+      "POST" \
+      "$(vercel_url "/v11/projects")" \
+      "${create_project_body}"
+  )"
+else
+  err "Looking up existing Vercel project failed with HTTP ${existing_project_status}"
+  cat "${existing_project_response_file}" >&2
+  exit 1
+fi
+
+project_id="$(jq -r ".id // empty" <<<"${project_response}")"
+
+if [[ -z "${project_id}" ]]; then
+  err "Vercel project response did not include an ID"
+  echo "${project_response}" >&2
+  exit 1
+fi
+
+update_project_body="$(
+  jq -n \
+    --arg root_directory "${root_directory}" \
+    '{
+      buildCommand: "npm run build",
+      installCommand: "npm install",
+      rootDirectory: $root_directory,
+      gitComments: {
+        onCommit: false,
+        onPullRequest: false
+      }
+    }'
+)"
+
+if [[ -n "${framework}" ]]; then
+  update_project_body="$(
+    jq --arg framework "${framework}" '.framework = $framework' <<<"${update_project_body}"
+  )"
+fi
+
+# Keep the project settings in sync on first runs and reruns.
+# Also disable Vercel for GitHub PR and commit comments.
+# Source: https://vercel.com/docs/rest-api/projects/update-an-existing-project
+vercel_request \
+  "Updating Vercel project settings" \
+  "PATCH" \
+  "$(vercel_url "/v9/projects/${project_id}")" \
+  "${update_project_body}" \
+  >/dev/null
+
+# Set the production branch to the `examples` branch.
+# Source: https://raw.githubusercontent.com/vercel/terraform-provider-vercel/main/client/project.go
+vercel_request \
+  "Setting production branch" \
+  "PATCH" \
+  "$(vercel_url "/v9/projects/${project_id}/branch")" \
+  "$(jq -n --arg branch "${examples_branch}" '{ branch: $branch }')" \
+  >/dev/null
+
+# Read the latest project state so reruns can reuse existing deploy hooks.
+# Source: https://vercel.com/docs/rest-api/projects/find-a-project-by-id-or-name
+project_response="$(
+  vercel_request \
+    "Refreshing Vercel project" \
+    "GET" \
+    "$(vercel_url "/v10/projects/${project_id}")"
+)"
+deploy_hook_url="$(
+  jq -r \
+    --arg name "${deploy_hook_name}" \
+    --arg ref "${examples_branch}" \
+    '.link.deployHooks[]? | select(.name == $name and .ref == $ref) | .url' \
+    <<<"${project_response}" \
+    | head -n 1
+)"
+
+# Create a Vercel deploy hook for the `examples` branch.
+# Source: https://raw.githubusercontent.com/vercel/terraform-provider-vercel/fb57c95e/client/deploy_hooks.go
+deploy_hook_response=""
+if [[ -n "${deploy_hook_url}" ]]; then
+  echo
+  echo "Found existing Vercel Deploy Hook"
+else
+  deploy_hook_response="$(
+    vercel_request \
+      "Creating Vercel Deploy Hook" \
+      "POST" \
+      "$(vercel_url "/v2/projects/${project_id}/deploy-hooks")" \
+      "$(jq -n --arg name "${deploy_hook_name}" --arg ref "${examples_branch}" '{ name: $name, ref: $ref }')"
+  )"
+  deploy_hook_url="$(
+    jq -r \
+      --arg name "${deploy_hook_name}" \
+      --arg ref "${examples_branch}" \
+      '.url // (.link.deployHooks[]? | select(.name == $name and .ref == $ref) | .url) // empty' \
+      <<<"${deploy_hook_response}" \
+      | head -n 1
+  )"
+fi
+
+if [[ -z "${deploy_hook_url}" ]]; then
+  err "Deploy Hook response did not include a URL"
+  echo "${deploy_hook_response:-${project_response}}" >&2
+  exit 1
+fi
+
+# Check whether a custom domain already exists.
+# Source: https://github.com/vercel/sdk/blob/HEAD/docs/sdks/projects/README.md#getprojectdomains
+project_domains_response="$(
+  vercel_request \
+    "Checking custom domain" \
+    "GET" \
+    "$(vercel_url "/v9/projects/${project_id}/domains")"
+)"
+domain_exists="$(
+  jq -r --arg name "${domain}" '.domains[]? | select(.name == $name) | .name' \
+    <<<"${project_domains_response}" \
+    | head -n 1
+)"
+
+# Add a custom domain for this example.
+# Source: https://github.com/vercel/sdk/blob/HEAD/docs/sdks/projects/README.md#addprojectdomain
+if [[ -n "${domain_exists}" ]]; then
+  echo
+  echo "Found existing custom domain"
+else
+  vercel_request \
+    "Adding custom domain" \
+    "POST" \
+    "$(vercel_url "/v10/projects/${project_id}/domains")" \
+    "$(jq -n --arg name "${domain}" '{ name: $name, gitBranch: null }')" \
+    >/dev/null
+fi
+
+echo
+echo "Setup complete"
+echo "Project: ${project_name}"
+echo "Domain: https://${domain}"
+echo "Deploy Hook: ${deploy_hook_url}"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## ✅ Example deployed to Vercel"
+    echo
+    echo "\`${example_name}\` has been configured on Vercel and will deploy from the \`${examples_branch}\` branch."
+    echo
+    echo "🔗 Public URL: https://${domain}"
+    echo
+    echo "### Deploy Hook"
+    echo
+    echo '```text'
+    echo "${deploy_hook_url}"
+    echo '```'
+    echo
+    echo "Add this to \`.github/workflows/deploy-examples.yml\` on the \`${examples_branch}\` branch:"
+    echo
+    echo '```sh'
+    echo "echo \"Triggering deployment for ${example_name}\""
+    echo "curl -s -X POST ${deploy_hook_url}; echo"
+    echo '```'
+  } >>"${GITHUB_STEP_SUMMARY}"
+fi

--- a/.github/scripts/setup-vercel-example.sh
+++ b/.github/scripts/setup-vercel-example.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+# This script sets up a Vercel example project and a Liveblocks project.
+# It's used by the `.github/workflows/setup-vercel-example.yml` GitHub Action.
+
 vercel_api_url="https://api.vercel.com"
+liveblocks_management_api_url="https://api.liveblocks.io/v2/management"
 examples_branch="examples"
-deploy_hook_name="Deploy example"
+vercel_deploy_hook_name="Deploy example"
 temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/setup-vercel-example.XXXXXX")"
 
 cleanup() {
@@ -26,7 +30,11 @@ trim() {
 }
 
 vercel_url() {
-  printf "%s%s?teamId=%s" "${vercel_api_url}" "$1" "${VERCEL_TEAM_ID}"
+  if [[ "$1" == *"?"* ]]; then
+    printf "%s%s&teamId=%s" "${vercel_api_url}" "$1" "${VERCEL_TEAM_ID}"
+  else
+    printf "%s%s?teamId=%s" "${vercel_api_url}" "$1" "${VERCEL_TEAM_ID}"
+  fi
 }
 
 create_response_file() {
@@ -45,7 +53,26 @@ curl_vercel() {
   curl --silent --show-error \
     --request "${method}" \
     --url "${url}" \
-    --header "Authorization: Bearer ${VERCEL_TOKEN}" \
+    --header "Authorization: Bearer ${VERCEL_API_TOKEN}" \
+    --header "Content-Type: application/json" \
+    "${data_args[@]}" \
+    --output "${response_file}" \
+    --write-out "%{http_code}"
+}
+
+curl_liveblocks() {
+  local method="$1"
+  local url="$2"
+  local response_file="$3"
+  local body="${4:-}"
+  local data_args=()
+
+  [[ -n "${body}" ]] && data_args=(--data "${body}")
+
+  curl --silent --show-error \
+    --request "${method}" \
+    --url "${url}" \
+    --header "Authorization: Bearer ${LIVEBLOCKS_MANAGEMENT_API_TOKEN}" \
     --header "Content-Type: application/json" \
     "${data_args[@]}" \
     --output "${response_file}" \
@@ -79,6 +106,33 @@ vercel_request() {
   cat "${response_file}"
 }
 
+liveblocks_request() {
+  local description="$1"
+  local method="$2"
+  local url="$3"
+  local body="${4:-}"
+  local response_file
+  local status
+
+  response_file="$(create_response_file)"
+
+  echo >&2
+  echo "${description}" >&2
+
+  if ! status="$(curl_liveblocks "${method}" "${url}" "${response_file}" "${body}")"; then
+    err "${description} failed before receiving a Liveblocks response"
+    exit 1
+  fi
+
+  if [[ "${status}" -lt 200 || "${status}" -ge 300 ]]; then
+    err "${description} failed with HTTP ${status}"
+    cat "${response_file}" >&2
+    exit 1
+  fi
+
+  cat "${response_file}"
+}
+
 check_required_env() {
   local name="$1"
 
@@ -90,8 +144,9 @@ check_required_env() {
 
 check_required_env "EXAMPLE_NAME"
 check_required_env "GITHUB_REPOSITORY"
+check_required_env "LIVEBLOCKS_MANAGEMENT_API_TOKEN"
 check_required_env "VERCEL_TEAM_ID"
-check_required_env "VERCEL_TOKEN"
+check_required_env "VERCEL_API_TOKEN"
 
 example_name="$(trim "${EXAMPLE_NAME}")"
 framework="$(trim "${FRAMEWORK:-}")"
@@ -111,7 +166,60 @@ if [[ ! -d "examples/${example_name}" ]]; then
   exit 1
 fi
 
-# Resolve the team URL segment for dashboard links (`https://vercel.com/<slug>/<project>`).
+vercel_project_name="examples-${example_name}"
+liveblocks_project_name="Example - ${example_name}"
+root_directory="examples/${example_name}"
+domain="${example_name}.liveblocks.app"
+env_example_path="${root_directory}/.env.example"
+liveblocks_key_env_name=""
+liveblocks_key_type=""
+manual_env_names=()
+
+if [[ -f "${env_example_path}" ]]; then
+  while IFS= read -r env_line || [[ -n "${env_line}" ]]; do
+    env_line="$(trim "${env_line}")"
+
+    [[ -z "${env_line}" || "${env_line}" == \#* || "${env_line}" != *=* ]] && continue
+
+    env_name="$(trim "${env_line%%=*}")"
+
+    [[ -z "${env_name}" ]] && continue
+
+    if [[ "${env_name}" == *LIVEBLOCKS* && "${env_name}" == *PUBLIC_KEY ]]; then
+      if [[ -n "${liveblocks_key_env_name}" ]]; then
+        err "Found multiple Liveblocks API key variables in ${env_example_path}: ${liveblocks_key_env_name} and ${env_name}"
+        exit 1
+      fi
+
+      liveblocks_key_env_name="${env_name}"
+      liveblocks_key_type="public"
+    elif [[ "${env_name}" == *LIVEBLOCKS* && "${env_name}" == *SECRET_KEY && "${env_name}" != *WEBHOOK* ]]; then
+      if [[ -n "${liveblocks_key_env_name}" ]]; then
+        err "Found multiple Liveblocks API key variables in ${env_example_path}: ${liveblocks_key_env_name} and ${env_name}"
+        exit 1
+      fi
+
+      liveblocks_key_env_name="${env_name}"
+      liveblocks_key_type="secret"
+    else
+      manual_env_names+=("${env_name}")
+    fi
+  done <"${env_example_path}"
+fi
+
+echo "Setting up Vercel and Liveblocks example projects"
+echo "Example name: ${example_name}"
+echo "Vercel project name: ${vercel_project_name}"
+echo "Liveblocks project name: ${liveblocks_project_name}"
+echo "Root directory: ${root_directory}"
+echo "Vercel custom domain: ${domain}"
+echo "GitHub repository: ${GITHUB_REPOSITORY}"
+echo "Production branch: ${examples_branch}"
+echo "Framework: ${framework:-"(none)"}"
+echo "Environment template: ${env_example_path}"
+echo "Liveblocks API key variable: ${liveblocks_key_env_name:-"(none found)"}"
+
+# Resolve the Vercel team URL segment for dashboard links.
 # Source: https://vercel.com/docs/rest-api/reference/endpoints/teams/get-a-team
 team_response="$(
   vercel_request \
@@ -121,29 +229,16 @@ team_response="$(
 )"
 team_slug="$(jq -r '.slug // empty' <<<"${team_response}")"
 
-project_name="examples-${example_name}"
-root_directory="examples/${example_name}"
-domain="${example_name}.liveblocks.app"
-
-echo "Setting up Vercel example project"
-echo "Example name: ${example_name}"
-echo "Project name: ${project_name}"
-echo "Root directory: ${root_directory}"
-echo "Custom domain: ${domain}"
-echo "GitHub repository: ${GITHUB_REPOSITORY}"
-echo "Production branch: ${examples_branch}"
-echo "Framework: ${framework:-"(none)"}"
-
-project_dashboard_url=""
+vercel_project_dashboard_url=""
 if [[ -n "${team_slug}" ]]; then
-  project_dashboard_url="https://vercel.com/${team_slug}/${project_name}"
+  vercel_project_dashboard_url="https://vercel.com/${team_slug}/${vercel_project_name}"
 else
   err "Warning: could not read team slug from GET /v2/teams/<team-id>; omitting Vercel dashboard project URL"
 fi
 
-create_project_body="$(
+create_vercel_project_body="$(
   jq -n \
-    --arg name "${project_name}" \
+    --arg name "${vercel_project_name}" \
     --arg root_directory "${root_directory}" \
     --arg repository "${GITHUB_REPOSITORY}" \
     --argjson framework "$(
@@ -167,44 +262,149 @@ create_project_body="$(
 
 # Create a Vercel project for this GitHub repository.
 # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
-existing_project_response_file="$(create_response_file)"
-if ! existing_project_status="$(
+existing_vercel_project_response_file="$(create_response_file)"
+if ! existing_vercel_project_status="$(
   curl_vercel \
     "GET" \
-    "$(vercel_url "/v10/projects/${project_name}")" \
-    "${existing_project_response_file}"
+    "$(vercel_url "/v10/projects/${vercel_project_name}")" \
+    "${existing_vercel_project_response_file}"
 )"; then
   err "Looking up existing Vercel project failed before receiving a Vercel response"
   exit 1
 fi
 
-if [[ "${existing_project_status}" == "200" ]]; then
+if [[ "${existing_vercel_project_status}" == "200" ]]; then
   echo
   echo "Found existing Vercel project, updating it instead of creating a duplicate"
-  project_response="$(cat "${existing_project_response_file}")"
-elif [[ "${existing_project_status}" == "404" ]]; then
-  project_response="$(
+  vercel_project_response="$(cat "${existing_vercel_project_response_file}")"
+elif [[ "${existing_vercel_project_status}" == "404" ]]; then
+  vercel_project_response="$(
     vercel_request \
       "Creating Vercel project" \
       "POST" \
       "$(vercel_url "/v11/projects")" \
-      "${create_project_body}"
+      "${create_vercel_project_body}"
   )"
 else
-  err "Looking up existing Vercel project failed with HTTP ${existing_project_status}"
-  cat "${existing_project_response_file}" >&2
+  err "Looking up existing Vercel project failed with HTTP ${existing_vercel_project_status}"
+  cat "${existing_vercel_project_response_file}" >&2
   exit 1
 fi
 
-project_id="$(jq -r ".id // empty" <<<"${project_response}")"
+vercel_project_id="$(jq -r ".id // empty" <<<"${vercel_project_response}")"
 
-if [[ -z "${project_id}" ]]; then
+if [[ -z "${vercel_project_id}" ]]; then
   err "Vercel project response did not include an ID"
-  echo "${project_response}" >&2
+  echo "${vercel_project_response}" >&2
   exit 1
 fi
 
-update_project_body="$(
+# Find or create the Liveblocks project backing this example.
+# Source: https://liveblocks.io/docs/api-reference/rest-api-endpoints#Management
+liveblocks_project=""
+liveblocks_cursor=""
+
+while true; do
+  liveblocks_projects_url="${liveblocks_management_api_url}/projects?limit=100"
+
+  if [[ -n "${liveblocks_cursor}" ]]; then
+    liveblocks_projects_url="${liveblocks_projects_url}&cursor=$(jq -rn --arg value "${liveblocks_cursor}" '$value | @uri')"
+  fi
+
+  liveblocks_projects_response="$(
+    liveblocks_request \
+      "Looking up Liveblocks project" \
+      "GET" \
+      "${liveblocks_projects_url}"
+  )"
+  liveblocks_project="$(
+    jq -c --arg name "${liveblocks_project_name}" \
+      '.projects[]? | select(.name == $name)' \
+      <<<"${liveblocks_projects_response}" \
+      | head -n 1
+  )"
+
+  if [[ -n "${liveblocks_project}" ]]; then
+    echo
+    echo "Found existing Liveblocks project"
+    break
+  fi
+
+  liveblocks_cursor="$(jq -r '.nextCursor // empty' <<<"${liveblocks_projects_response}")"
+
+  [[ -z "${liveblocks_cursor}" ]] && break
+done
+
+if [[ -z "${liveblocks_project}" ]]; then
+  liveblocks_project_response="$(
+    liveblocks_request \
+      "Creating Liveblocks production project" \
+      "POST" \
+      "${liveblocks_management_api_url}/projects" \
+      "$(jq -n --arg name "${liveblocks_project_name}" '{ name: $name, type: "prod", versionCreationTimeout: false }')"
+  )"
+  liveblocks_project="$(jq -c '.project' <<<"${liveblocks_project_response}")"
+fi
+
+liveblocks_project_id="$(jq -r '.id // empty' <<<"${liveblocks_project}")"
+
+if [[ -z "${liveblocks_project_id}" ]]; then
+  err "Liveblocks project response did not include an ID"
+  echo "${liveblocks_project}" >&2
+  exit 1
+fi
+
+vercel_liveblocks_env_name=""
+if [[ -n "${liveblocks_key_env_name}" ]]; then
+  if [[ "${liveblocks_key_type}" == "public" ]]; then
+    liveblocks_public_key_activated="$(jq -r '.publicKey.activated // false' <<<"${liveblocks_project}")"
+
+    if [[ "${liveblocks_public_key_activated}" != "true" ]]; then
+      liveblocks_request \
+        "Activating Liveblocks public key" \
+        "POST" \
+        "${liveblocks_management_api_url}/projects/${liveblocks_project_id}/api-keys/public/activate" \
+        >/dev/null
+
+      liveblocks_project_response="$(
+        liveblocks_request \
+          "Refreshing Liveblocks project" \
+          "GET" \
+          "${liveblocks_management_api_url}/projects/${liveblocks_project_id}"
+      )"
+      liveblocks_project="$(jq -c '.project' <<<"${liveblocks_project_response}")"
+    fi
+
+    liveblocks_key_value="$(jq -r '.publicKey.value // empty' <<<"${liveblocks_project}")"
+  else
+    liveblocks_key_value="$(jq -r '.secretKey.value // empty' <<<"${liveblocks_project}")"
+  fi
+
+  if [[ -z "${liveblocks_key_value}" ]]; then
+    err "Liveblocks project response did not include a ${liveblocks_key_type} key"
+    echo "${liveblocks_project}" >&2
+    exit 1
+  fi
+
+  vercel_request \
+    "Adding Liveblocks API key to Vercel environment variables" \
+    "POST" \
+    "$(vercel_url "/v10/projects/${vercel_project_id}/env?upsert=true")" \
+    "$(jq -n \
+      --arg key "${liveblocks_key_env_name}" \
+      --arg value "${liveblocks_key_value}" \
+      '{
+        key: $key,
+        value: $value,
+        type: "encrypted",
+        target: ["production"]
+      }')" \
+    >/dev/null
+
+  vercel_liveblocks_env_name="${liveblocks_key_env_name}"
+fi
+
+update_vercel_project_body="$(
   jq -n \
     --arg root_directory "${root_directory}" \
     --argjson framework "$(
@@ -224,14 +424,14 @@ update_project_body="$(
     }'
 )"
 
-# Keep the project settings in sync on first runs and reruns.
+# Keep the Vercel project settings in sync on first runs and reruns.
 # Also disable Vercel for GitHub PR and commit comments.
 # Source: https://vercel.com/docs/rest-api/projects/update-an-existing-project
 vercel_request \
   "Updating Vercel project settings" \
   "PATCH" \
-  "$(vercel_url "/v9/projects/${project_id}")" \
-  "${update_project_body}" \
+  "$(vercel_url "/v9/projects/${vercel_project_id}")" \
+  "${update_vercel_project_body}" \
   >/dev/null
 
 # Set the production branch to the `examples` branch.
@@ -239,93 +439,97 @@ vercel_request \
 vercel_request \
   "Setting production branch" \
   "PATCH" \
-  "$(vercel_url "/v9/projects/${project_id}/branch")" \
+  "$(vercel_url "/v9/projects/${vercel_project_id}/branch")" \
   "$(jq -n --arg branch "${examples_branch}" '{ branch: $branch }')" \
   >/dev/null
 
-# Read the latest project state so reruns can reuse existing deploy hooks.
+# Read the latest Vercel project state so reruns can reuse existing deploy hooks.
 # Source: https://vercel.com/docs/rest-api/projects/find-a-project-by-id-or-name
-project_response="$(
+vercel_project_response="$(
   vercel_request \
     "Refreshing Vercel project" \
     "GET" \
-    "$(vercel_url "/v10/projects/${project_id}")"
+    "$(vercel_url "/v10/projects/${vercel_project_id}")"
 )"
-deploy_hook_url="$(
+vercel_deploy_hook_url="$(
   jq -r \
-    --arg name "${deploy_hook_name}" \
+    --arg name "${vercel_deploy_hook_name}" \
     --arg ref "${examples_branch}" \
     '.link.deployHooks[]? | select(.name == $name and .ref == $ref) | .url' \
-    <<<"${project_response}" \
+    <<<"${vercel_project_response}" \
     | head -n 1
 )"
 
 # Create a Vercel deploy hook for the `examples` branch.
 # Source: https://raw.githubusercontent.com/vercel/terraform-provider-vercel/fb57c95e/client/deploy_hooks.go
-deploy_hook_response=""
-if [[ -n "${deploy_hook_url}" ]]; then
+vercel_deploy_hook_response=""
+if [[ -n "${vercel_deploy_hook_url}" ]]; then
   echo
   echo "Found existing Vercel Deploy Hook"
 else
-  deploy_hook_response="$(
+  vercel_deploy_hook_response="$(
     vercel_request \
       "Creating Vercel Deploy Hook" \
       "POST" \
-      "$(vercel_url "/v2/projects/${project_id}/deploy-hooks")" \
-      "$(jq -n --arg name "${deploy_hook_name}" --arg ref "${examples_branch}" '{ name: $name, ref: $ref }')"
+      "$(vercel_url "/v2/projects/${vercel_project_id}/deploy-hooks")" \
+      "$(jq -n --arg name "${vercel_deploy_hook_name}" --arg ref "${examples_branch}" '{ name: $name, ref: $ref }')"
   )"
-  deploy_hook_url="$(
+  vercel_deploy_hook_url="$(
     jq -r \
-      --arg name "${deploy_hook_name}" \
+      --arg name "${vercel_deploy_hook_name}" \
       --arg ref "${examples_branch}" \
       '.url // (.link.deployHooks[]? | select(.name == $name and .ref == $ref) | .url) // empty' \
-      <<<"${deploy_hook_response}" \
+      <<<"${vercel_deploy_hook_response}" \
       | head -n 1
   )"
 fi
 
-if [[ -z "${deploy_hook_url}" ]]; then
-  err "Deploy Hook response did not include a URL"
-  echo "${deploy_hook_response:-${project_response}}" >&2
+if [[ -z "${vercel_deploy_hook_url}" ]]; then
+  err "Vercel Deploy Hook response did not include a URL"
+  echo "${vercel_deploy_hook_response:-${vercel_project_response}}" >&2
   exit 1
 fi
 
-# Check whether a custom domain already exists.
+# Check whether the Vercel custom domain already exists.
 # Source: https://github.com/vercel/sdk/blob/HEAD/docs/sdks/projects/README.md#getprojectdomains
-project_domains_response="$(
+vercel_project_domains_response="$(
   vercel_request \
-    "Checking custom domain" \
+    "Checking Vercel custom domain" \
     "GET" \
-    "$(vercel_url "/v9/projects/${project_id}/domains")"
+    "$(vercel_url "/v9/projects/${vercel_project_id}/domains")"
 )"
-domain_exists="$(
+vercel_domain_exists="$(
   jq -r --arg name "${domain}" '.domains[]? | select(.name == $name) | .name' \
-    <<<"${project_domains_response}" \
+    <<<"${vercel_project_domains_response}" \
     | head -n 1
 )"
 
-# Add a custom domain for this example.
+# Add a Vercel custom domain for this example.
 # Source: https://github.com/vercel/sdk/blob/HEAD/docs/sdks/projects/README.md#addprojectdomain
-if [[ -n "${domain_exists}" ]]; then
+if [[ -n "${vercel_domain_exists}" ]]; then
   echo
-  echo "Found existing custom domain"
+  echo "Found existing Vercel custom domain"
 else
   vercel_request \
-    "Adding custom domain" \
+    "Adding Vercel custom domain" \
     "POST" \
-    "$(vercel_url "/v10/projects/${project_id}/domains")" \
+    "$(vercel_url "/v10/projects/${vercel_project_id}/domains")" \
     "$(jq -n --arg name "${domain}" '{ name: $name, gitBranch: null }')" \
     >/dev/null
 fi
 
 echo
 echo "Setup complete"
-echo "Project: ${project_name}"
-echo "Deployment URL: https://${domain}"
-if [[ -n "${project_dashboard_url}" ]]; then
-  echo "Vercel project URL: ${project_dashboard_url}"
+echo "Vercel project: ${vercel_project_name}"
+echo "Liveblocks project: ${liveblocks_project_name}"
+echo "Vercel deployment URL: https://${domain}"
+if [[ -n "${vercel_project_dashboard_url}" ]]; then
+  echo "Vercel project URL: ${vercel_project_dashboard_url}"
 fi
-echo "Deploy Hook: ${deploy_hook_url}"
+if [[ -n "${vercel_liveblocks_env_name}" ]]; then
+  echo "Vercel Liveblocks env var: ${vercel_liveblocks_env_name}"
+fi
+echo "Vercel Deploy Hook: ${vercel_deploy_hook_url}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {
@@ -333,22 +537,43 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo
     echo "\`${example_name}\` has been configured on Vercel and will deploy from the \`${examples_branch}\` branch."
     echo
-    echo "🔗 Deployment URL: https://${domain}"
-    if [[ -n "${project_dashboard_url}" ]]; then
-      echo "🗂️ Vercel URL: ${project_dashboard_url}"
+    echo "🔗 Vercel deployment URL: https://${domain}"
+    if [[ -n "${vercel_project_dashboard_url}" ]]; then
+      echo "🗂️ Vercel URL: ${vercel_project_dashboard_url}"
+    fi
+    echo "🧱 Liveblocks project: \`${liveblocks_project_name}\`"
+    echo
+    echo "### Environment variables"
+    echo
+    if [[ -n "${vercel_liveblocks_env_name}" ]]; then
+      echo "Added to Vercel for production:"
+      echo
+      echo "| Variable | Source |"
+      echo "| --- | --- |"
+      echo "| \`${vercel_liveblocks_env_name}\` | Liveblocks ${liveblocks_key_type} key |"
+    else
+      echo "No Liveblocks API key variable was found in \`${env_example_path}\`, so no Liveblocks key was added to Vercel."
     fi
     echo
-    echo "### Deploy Hook"
+    if ((${#manual_env_names[@]} > 0)); then
+      echo "Still needs to be added manually on Vercel:"
+      echo
+      for manual_env_name in "${manual_env_names[@]}"; do
+        echo "- \`${manual_env_name}\`"
+      done
+      echo
+    fi
+    echo "### Vercel Deploy Hook"
     echo
     echo '```text'
-    echo "${deploy_hook_url}"
+    echo "${vercel_deploy_hook_url}"
     echo '```'
     echo
-    echo "Add this to \`.github/workflows/deploy-examples.yml\` on the \`${examples_branch}\` branch:"
+    echo "⚠️ Add this to \`.github/workflows/deploy-examples.yml\` on the \`${examples_branch}\` branch:"
     echo
     echo '```sh'
     echo "echo \"Triggering deployment for ${example_name}\""
-    echo "curl -s -X POST ${deploy_hook_url}; echo"
+    echo "curl -s -X POST ${vercel_deploy_hook_url}; echo"
     echo '```'
   } >>"${GITHUB_STEP_SUMMARY}"
 fi

--- a/.github/scripts/setup-vercel-example.sh
+++ b/.github/scripts/setup-vercel-example.sh
@@ -1,14 +1,32 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script sets up a Vercel example project and a Liveblocks project.
+# This script sets up an example on Vercel and Liveblocks.
 # It's used by the `.github/workflows/setup-vercel-example.yml` GitHub Action.
+# It's only meant for new examples so it will abort if an example is already set up.
 
 vercel_api_url="https://api.vercel.com"
 liveblocks_management_api_url="https://api.liveblocks.io/v2/management"
 examples_branch="examples"
 vercel_deploy_hook_name="Deploy example"
 temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/setup-vercel-example.XXXXXX")"
+
+example_name=""
+framework=""
+vercel_project_name=""
+vercel_project_id=""
+vercel_project_dashboard_url=""
+liveblocks_project_name=""
+liveblocks_project=""
+liveblocks_project_id=""
+root_directory=""
+domain=""
+env_example_path=""
+liveblocks_key_env_name=""
+liveblocks_key_type=""
+vercel_liveblocks_env_name=""
+vercel_deploy_hook_url=""
+manual_env_names=()
 
 cleanup() {
   rm -rf "${temporary_directory}"
@@ -29,16 +47,42 @@ trim() {
   printf "%s" "${value}"
 }
 
+create_response_file() {
+  mktemp "${temporary_directory}/response.XXXXXX"
+}
+
+check_required_env() {
+  local name="$1"
+
+  if [[ -z "${!name:-}" ]]; then
+    err "Missing ${name}"
+    exit 1
+  fi
+}
+
+duplicate_setup_error() {
+  local reason="$1"
+
+  err "${reason}"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## ❌ Example already exists"
+      echo
+      echo "${reason}"
+      echo
+    } >>"${GITHUB_STEP_SUMMARY}"
+  fi
+
+  exit 1
+}
+
 vercel_url() {
   if [[ "$1" == *"?"* ]]; then
     printf "%s%s&teamId=%s" "${vercel_api_url}" "$1" "${VERCEL_TEAM_ID}"
   else
     printf "%s%s?teamId=%s" "${vercel_api_url}" "$1" "${VERCEL_TEAM_ID}"
   fi
-}
-
-create_response_file() {
-  mktemp "${temporary_directory}/response.XXXXXX"
 }
 
 curl_vercel() {
@@ -79,11 +123,12 @@ curl_liveblocks() {
     --write-out "%{http_code}"
 }
 
-vercel_request() {
-  local description="$1"
-  local method="$2"
-  local url="$3"
-  local body="${4:-}"
+api_request() {
+  local service_name="$1"
+  local description="$2"
+  local method="$3"
+  local url="$4"
+  local body="${5:-}"
   local response_file
   local status
 
@@ -92,9 +137,16 @@ vercel_request() {
   echo >&2
   echo "${description}" >&2
 
-  if ! status="$(curl_vercel "${method}" "${url}" "${response_file}" "${body}")"; then
-    err "${description} failed before receiving a Vercel response"
-    exit 1
+  if [[ "${service_name}" == "Vercel" ]]; then
+    status="$(curl_vercel "${method}" "${url}" "${response_file}" "${body}")" || {
+      err "${description} failed before receiving a Vercel response"
+      exit 1
+    }
+  else
+    status="$(curl_liveblocks "${method}" "${url}" "${response_file}" "${body}")" || {
+      err "${description} failed before receiving a Liveblocks response"
+      exit 1
+    }
   fi
 
   if [[ "${status}" -lt 200 || "${status}" -ge 300 ]]; then
@@ -104,78 +156,58 @@ vercel_request() {
   fi
 
   cat "${response_file}"
+}
+
+vercel_request() {
+  api_request "Vercel" "$@"
 }
 
 liveblocks_request() {
-  local description="$1"
-  local method="$2"
-  local url="$3"
-  local body="${4:-}"
-  local response_file
-  local status
-
-  response_file="$(create_response_file)"
-
-  echo >&2
-  echo "${description}" >&2
-
-  if ! status="$(curl_liveblocks "${method}" "${url}" "${response_file}" "${body}")"; then
-    err "${description} failed before receiving a Liveblocks response"
-    exit 1
-  fi
-
-  if [[ "${status}" -lt 200 || "${status}" -ge 300 ]]; then
-    err "${description} failed with HTTP ${status}"
-    cat "${response_file}" >&2
-    exit 1
-  fi
-
-  cat "${response_file}"
+  api_request "Liveblocks" "$@"
 }
 
-check_required_env() {
-  local name="$1"
-
-  if [[ -z "${!name:-}" ]]; then
-    err "Missing ${name}"
-    exit 1
-  fi
+require_inputs() {
+  check_required_env "EXAMPLE_NAME"
+  check_required_env "GITHUB_REPOSITORY"
+  check_required_env "LIVEBLOCKS_MANAGEMENT_API_TOKEN"
+  check_required_env "VERCEL_TEAM_ID"
+  check_required_env "VERCEL_API_TOKEN"
 }
 
-check_required_env "EXAMPLE_NAME"
-check_required_env "GITHUB_REPOSITORY"
-check_required_env "LIVEBLOCKS_MANAGEMENT_API_TOKEN"
-check_required_env "VERCEL_TEAM_ID"
-check_required_env "VERCEL_API_TOKEN"
+read_example_inputs() {
+  example_name="$(trim "${EXAMPLE_NAME}")"
+  framework="$(trim "${FRAMEWORK:-}")"
 
-example_name="$(trim "${EXAMPLE_NAME}")"
-framework="$(trim "${FRAMEWORK:-}")"
+  if [[ -z "${example_name}" ]]; then
+    err "Missing example name"
+    exit 1
+  fi
 
-if [[ -z "${example_name}" ]]; then
-  err "Missing example name"
-  exit 1
-fi
+  if [[ ! "${example_name}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+    err "Example name must be lowercase letters, numbers, and hyphens only"
+    exit 1
+  fi
 
-if [[ ! "${example_name}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
-  err "Example name must be lowercase letters, numbers, and hyphens only"
-  exit 1
-fi
+  root_directory="examples/${example_name}"
 
-if [[ ! -d "examples/${example_name}" ]]; then
-  err "Could not find examples/${example_name}"
-  exit 1
-fi
+  if [[ ! -d "${root_directory}" ]]; then
+    err "Could not find ${root_directory}"
+    exit 1
+  fi
 
-vercel_project_name="examples-${example_name}"
-liveblocks_project_name="Example - ${example_name}"
-root_directory="examples/${example_name}"
-domain="${example_name}.liveblocks.app"
-env_example_path="${root_directory}/.env.example"
-liveblocks_key_env_name=""
-liveblocks_key_type=""
-manual_env_names=()
+  vercel_project_name="examples-${example_name}"
+  liveblocks_project_name="Example - ${example_name}"
+  domain="${example_name}.liveblocks.app"
+  env_example_path="${root_directory}/.env.example"
+}
 
-if [[ -f "${env_example_path}" ]]; then
+read_env_example() {
+  local env_line
+  local env_name
+
+  [[ ! -f "${env_example_path}" ]] && return
+
+  # `.env.example` files in examples tell us which Liveblocks key Vercel needs.
   while IFS= read -r env_line || [[ -n "${env_line}" ]]; do
     env_line="$(trim "${env_line}")"
 
@@ -185,157 +217,172 @@ if [[ -f "${env_example_path}" ]]; then
 
     [[ -z "${env_name}" ]] && continue
 
+    # Look for variables like `LIVEBLOCKS_SECRET_KEY`, `NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY`, etc.
     if [[ "${env_name}" == *LIVEBLOCKS* && "${env_name}" == *PUBLIC_KEY ]]; then
-      if [[ -n "${liveblocks_key_env_name}" ]]; then
-        err "Found multiple Liveblocks API key variables in ${env_example_path}: ${liveblocks_key_env_name} and ${env_name}"
-        exit 1
-      fi
-
-      liveblocks_key_env_name="${env_name}"
-      liveblocks_key_type="public"
+      set_liveblocks_key_env_name "${env_name}" "public"
     elif [[ "${env_name}" == *LIVEBLOCKS* && "${env_name}" == *SECRET_KEY && "${env_name}" != *WEBHOOK* ]]; then
-      if [[ -n "${liveblocks_key_env_name}" ]]; then
-        err "Found multiple Liveblocks API key variables in ${env_example_path}: ${liveblocks_key_env_name} and ${env_name}"
-        exit 1
-      fi
-
-      liveblocks_key_env_name="${env_name}"
-      liveblocks_key_type="secret"
+      set_liveblocks_key_env_name "${env_name}" "secret"
     else
       manual_env_names+=("${env_name}")
     fi
   done <"${env_example_path}"
-fi
+}
 
-echo "Setting up Vercel and Liveblocks example projects"
-echo "Example name: ${example_name}"
-echo "Vercel project name: ${vercel_project_name}"
-echo "Liveblocks project name: ${liveblocks_project_name}"
-echo "Root directory: ${root_directory}"
-echo "Vercel custom domain: ${domain}"
-echo "GitHub repository: ${GITHUB_REPOSITORY}"
-echo "Production branch: ${examples_branch}"
-echo "Framework: ${framework:-"(none)"}"
-echo "Environment template: ${env_example_path}"
-echo "Liveblocks API key variable: ${liveblocks_key_env_name:-"(none found)"}"
+set_liveblocks_key_env_name() {
+  local env_name="$1"
+  local key_type="$2"
 
-# Resolve the Vercel team URL segment for dashboard links.
-# Source: https://vercel.com/docs/rest-api/reference/endpoints/teams/get-a-team
-team_response="$(
-  vercel_request \
-    "Fetching Vercel team metadata" \
-    "GET" \
-    "${vercel_api_url}/v2/teams/${VERCEL_TEAM_ID}"
-)"
-team_slug="$(jq -r '.slug // empty' <<<"${team_response}")"
+  if [[ -n "${liveblocks_key_env_name}" ]]; then
+    err "Found multiple Liveblocks API key variables in ${env_example_path}: ${liveblocks_key_env_name} and ${env_name}"
+    exit 1
+  fi
 
-vercel_project_dashboard_url=""
-if [[ -n "${team_slug}" ]]; then
-  vercel_project_dashboard_url="https://vercel.com/${team_slug}/${vercel_project_name}"
-else
-  err "Warning: could not read team slug from GET /v2/teams/<team-id>; omitting Vercel dashboard project URL"
-fi
+  liveblocks_key_env_name="${env_name}"
+  liveblocks_key_type="${key_type}"
+}
 
-create_vercel_project_body="$(
-  jq -n \
-    --arg name "${vercel_project_name}" \
-    --arg root_directory "${root_directory}" \
-    --arg repository "${GITHUB_REPOSITORY}" \
-    --argjson framework "$(
-      # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project#framework
-      [[ -n "${framework}" ]] \
-        && jq -n --arg f "${framework}" '$f' \
-        || echo "null"
-    )" \
-    '{
-      name: $name,
-      buildCommand: "npm run build",
-      installCommand: "npm install",
-      rootDirectory: $root_directory,
-      framework: $framework,
-      gitRepository: {
-        type: "github",
-        repo: $repository
-      }
-    }'
-)"
 
-# Create a Vercel project for this GitHub repository.
-# Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
-existing_vercel_project_response_file="$(create_response_file)"
-if ! existing_vercel_project_status="$(
-  curl_vercel \
-    "GET" \
-    "$(vercel_url "/v10/projects/${vercel_project_name}")" \
-    "${existing_vercel_project_response_file}"
-)"; then
-  err "Looking up existing Vercel project failed before receiving a Vercel response"
-  exit 1
-fi
+print_setup_overview() {
+  echo "Setting up Vercel and Liveblocks example projects"
+  echo "Example name: ${example_name}"
+  echo "Vercel project name: ${vercel_project_name}"
+  echo "Liveblocks project name: ${liveblocks_project_name}"
+  echo "Root directory: ${root_directory}"
+  echo "Vercel custom domain: ${domain}"
+  echo "GitHub repository: ${GITHUB_REPOSITORY}"
+  echo "Production branch: ${examples_branch}"
+  echo "Framework: ${framework:-"(none)"}"
+  echo "Environment template: ${env_example_path}"
+  echo "Liveblocks API key variable: ${liveblocks_key_env_name:-"(none found)"}"
+}
 
-if [[ "${existing_vercel_project_status}" == "200" ]]; then
-  echo
-  echo "Found existing Vercel project, updating it instead of creating a duplicate"
-  vercel_project_response="$(cat "${existing_vercel_project_response_file}")"
-elif [[ "${existing_vercel_project_status}" == "404" ]]; then
-  vercel_project_response="$(
+resolve_vercel_project_dashboard_url() {
+  local team_response
+  local team_slug
+
+  # Source: https://vercel.com/docs/rest-api/reference/endpoints/teams/get-a-team
+  team_response="$(
     vercel_request \
-      "Creating Vercel project" \
-      "POST" \
-      "$(vercel_url "/v11/projects")" \
-      "${create_vercel_project_body}"
-  )"
-else
-  err "Looking up existing Vercel project failed with HTTP ${existing_vercel_project_status}"
-  cat "${existing_vercel_project_response_file}" >&2
-  exit 1
-fi
-
-vercel_project_id="$(jq -r ".id // empty" <<<"${vercel_project_response}")"
-
-if [[ -z "${vercel_project_id}" ]]; then
-  err "Vercel project response did not include an ID"
-  echo "${vercel_project_response}" >&2
-  exit 1
-fi
-
-# Find or create the Liveblocks project backing this example.
-# Source: https://liveblocks.io/docs/api-reference/rest-api-endpoints#Management
-liveblocks_project=""
-liveblocks_cursor=""
-
-while true; do
-  liveblocks_projects_url="${liveblocks_management_api_url}/projects?limit=100"
-
-  if [[ -n "${liveblocks_cursor}" ]]; then
-    liveblocks_projects_url="${liveblocks_projects_url}&cursor=$(jq -rn --arg value "${liveblocks_cursor}" '$value | @uri')"
-  fi
-
-  liveblocks_projects_response="$(
-    liveblocks_request \
-      "Looking up Liveblocks project" \
+      "Fetching Vercel team metadata" \
       "GET" \
-      "${liveblocks_projects_url}"
+      "${vercel_api_url}/v2/teams/${VERCEL_TEAM_ID}"
   )"
-  liveblocks_project="$(
-    jq -c --arg name "${liveblocks_project_name}" \
-      '.projects[]? | select(.name == $name)' \
-      <<<"${liveblocks_projects_response}" \
-      | head -n 1
-  )"
+  team_slug="$(jq -r '.slug // empty' <<<"${team_response}")"
 
-  if [[ -n "${liveblocks_project}" ]]; then
-    echo
-    echo "Found existing Liveblocks project"
-    break
+  if [[ -n "${team_slug}" ]]; then
+    vercel_project_dashboard_url="https://vercel.com/${team_slug}/${vercel_project_name}"
+  else
+    err "Warning: could not read team slug from GET /v2/teams/<team-id>; omitting Vercel dashboard project URL"
+  fi
+}
+
+create_vercel_project() {
+  local create_vercel_project_body
+  local existing_vercel_project_response_file
+  local existing_vercel_project_status
+  local framework_json
+  local vercel_project_response
+
+  if [[ -n "${framework}" ]]; then
+    framework_json="$(jq -n --arg framework "${framework}" '$framework')"
+  else
+    framework_json="null"
   fi
 
-  liveblocks_cursor="$(jq -r '.nextCursor // empty' <<<"${liveblocks_projects_response}")"
+  create_vercel_project_body="$(
+    jq -n \
+      --arg name "${vercel_project_name}" \
+      --arg root_directory "${root_directory}" \
+      --arg repository "${GITHUB_REPOSITORY}" \
+      --argjson framework "${framework_json}" \
+      '{
+        name: $name,
+        buildCommand: "npm run build",
+        installCommand: "npm install",
+        rootDirectory: $root_directory,
+        framework: $framework,
+        gitRepository: {
+          type: "github",
+          repo: $repository
+        }
+      }'
+  )"
 
-  [[ -z "${liveblocks_cursor}" ]] && break
-done
+  # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
+  existing_vercel_project_response_file="$(create_response_file)"
+  if ! existing_vercel_project_status="$(
+    curl_vercel \
+      "GET" \
+      "$(vercel_url "/v10/projects/${vercel_project_name}")" \
+      "${existing_vercel_project_response_file}"
+  )"; then
+    err "Looking up existing Vercel project failed before receiving a Vercel response"
+    exit 1
+  fi
 
-if [[ -z "${liveblocks_project}" ]]; then
+  if [[ "${existing_vercel_project_status}" == "200" ]]; then
+    duplicate_setup_error "Example '${example_name}' already exists: Vercel project '${vercel_project_name}' is already present."
+  elif [[ "${existing_vercel_project_status}" == "404" ]]; then
+    vercel_project_response="$(
+      vercel_request \
+        "Creating Vercel project" \
+        "POST" \
+        "$(vercel_url "/v11/projects")" \
+        "${create_vercel_project_body}"
+    )"
+  else
+    err "Looking up existing Vercel project failed with HTTP ${existing_vercel_project_status}"
+    cat "${existing_vercel_project_response_file}" >&2
+    exit 1
+  fi
+
+  vercel_project_id="$(jq -r ".id // empty" <<<"${vercel_project_response}")"
+
+  if [[ -z "${vercel_project_id}" ]]; then
+    err "Vercel project response did not include an ID"
+    echo "${vercel_project_response}" >&2
+    exit 1
+  fi
+}
+
+create_liveblocks_project() {
+  local liveblocks_cursor=""
+  local liveblocks_projects_response
+  local liveblocks_projects_url
+  local liveblocks_project_response
+
+  # Source: https://liveblocks.io/docs/api-reference/rest-api-endpoints#Management
+  while true; do
+    liveblocks_projects_url="${liveblocks_management_api_url}/projects?limit=100"
+
+    if [[ -n "${liveblocks_cursor}" ]]; then
+      liveblocks_projects_url="${liveblocks_projects_url}&cursor=$(jq -rn --arg value "${liveblocks_cursor}" '$value | @uri')"
+    fi
+
+    liveblocks_projects_response="$(
+      liveblocks_request \
+        "Looking up Liveblocks project" \
+        "GET" \
+        "${liveblocks_projects_url}"
+    )"
+    liveblocks_project="$(
+      jq -c --arg name "${liveblocks_project_name}" \
+        '.projects[]? | select(.name == $name)' \
+        <<<"${liveblocks_projects_response}" \
+        | head -n 1
+    )"
+
+    if [[ -n "${liveblocks_project}" ]]; then
+      duplicate_setup_error "Example '${example_name}' already exists: Liveblocks project '${liveblocks_project_name}' is already present."
+    fi
+
+    liveblocks_cursor="$(jq -r '.nextCursor // empty' <<<"${liveblocks_projects_response}")"
+
+    [[ -z "${liveblocks_cursor}" ]] && break
+  done
+
+  # Examples are public deployments, so we create a Liveblocks production project.
+  # Production secret keys are only accessible once at creation time.
   liveblocks_project_response="$(
     liveblocks_request \
       "Creating Liveblocks production project" \
@@ -344,43 +391,55 @@ if [[ -z "${liveblocks_project}" ]]; then
       "$(jq -n --arg name "${liveblocks_project_name}" '{ name: $name, type: "prod", versionCreationTimeout: false }')"
   )"
   liveblocks_project="$(jq -c '.project' <<<"${liveblocks_project_response}")"
-fi
+  liveblocks_project_id="$(jq -r '.id // empty' <<<"${liveblocks_project}")"
 
-liveblocks_project_id="$(jq -r '.id // empty' <<<"${liveblocks_project}")"
-
-if [[ -z "${liveblocks_project_id}" ]]; then
-  err "Liveblocks project response did not include an ID"
-  echo "${liveblocks_project}" >&2
-  exit 1
-fi
-
-vercel_liveblocks_env_name=""
-if [[ -n "${liveblocks_key_env_name}" ]]; then
-  if [[ "${liveblocks_key_type}" == "public" ]]; then
-    liveblocks_public_key_activated="$(jq -r '.publicKey.activated // false' <<<"${liveblocks_project}")"
-
-    if [[ "${liveblocks_public_key_activated}" != "true" ]]; then
-      liveblocks_request \
-        "Activating Liveblocks public key" \
-        "POST" \
-        "${liveblocks_management_api_url}/projects/${liveblocks_project_id}/api-keys/public/activate" \
-        >/dev/null
-
-      liveblocks_project_response="$(
-        liveblocks_request \
-          "Refreshing Liveblocks project" \
-          "GET" \
-          "${liveblocks_management_api_url}/projects/${liveblocks_project_id}"
-      )"
-      liveblocks_project="$(jq -c '.project' <<<"${liveblocks_project_response}")"
-    fi
-
-    liveblocks_key_value="$(jq -r '.publicKey.value // empty' <<<"${liveblocks_project}")"
-  else
-    liveblocks_key_value="$(jq -r '.secretKey.value // empty' <<<"${liveblocks_project}")"
+  if [[ -z "${liveblocks_project_id}" ]]; then
+    err "Liveblocks project response did not include an ID"
+    echo "${liveblocks_project}" >&2
+    exit 1
   fi
+}
 
-  if [[ -z "${liveblocks_key_value}" ]]; then
+liveblocks_key_value() {
+  if [[ "${liveblocks_key_type}" == "public" ]]; then
+    ensure_liveblocks_public_key
+    jq -r '.publicKey.value // empty' <<<"${liveblocks_project}"
+  else
+    jq -r '.secretKey.value // empty' <<<"${liveblocks_project}"
+  fi
+}
+
+ensure_liveblocks_public_key() {
+  local liveblocks_project_response
+  local liveblocks_public_key_activated
+
+  liveblocks_public_key_activated="$(jq -r '.publicKey.activated // false' <<<"${liveblocks_project}")"
+
+  [[ "${liveblocks_public_key_activated}" == "true" ]] && return
+
+  liveblocks_request \
+    "Activating Liveblocks public key" \
+    "POST" \
+    "${liveblocks_management_api_url}/projects/${liveblocks_project_id}/api-keys/public/activate" \
+    >/dev/null
+
+  liveblocks_project_response="$(
+    liveblocks_request \
+      "Refreshing Liveblocks project" \
+      "GET" \
+      "${liveblocks_management_api_url}/projects/${liveblocks_project_id}"
+  )"
+  liveblocks_project="$(jq -c '.project' <<<"${liveblocks_project_response}")"
+}
+
+add_liveblocks_key_to_vercel() {
+  local key_value
+
+  [[ -z "${liveblocks_key_env_name}" ]] && return
+
+  key_value="$(liveblocks_key_value)"
+
+  if [[ -z "${key_value}" ]]; then
     err "Liveblocks project response did not include a ${liveblocks_key_type} key"
     echo "${liveblocks_project}" >&2
     exit 1
@@ -389,10 +448,10 @@ if [[ -n "${liveblocks_key_env_name}" ]]; then
   vercel_request \
     "Adding Liveblocks API key to Vercel environment variables" \
     "POST" \
-    "$(vercel_url "/v10/projects/${vercel_project_id}/env?upsert=true")" \
+    "$(vercel_url "/v10/projects/${vercel_project_id}/env")" \
     "$(jq -n \
       --arg key "${liveblocks_key_env_name}" \
-      --arg value "${liveblocks_key_value}" \
+      --arg value "${key_value}" \
       '{
         key: $key,
         value: $value,
@@ -402,71 +461,78 @@ if [[ -n "${liveblocks_key_env_name}" ]]; then
     >/dev/null
 
   vercel_liveblocks_env_name="${liveblocks_key_env_name}"
-fi
+}
 
-update_vercel_project_body="$(
-  jq -n \
-    --arg root_directory "${root_directory}" \
-    --argjson framework "$(
-      [[ -n "${framework}" ]] \
-        && jq -n --arg f "${framework}" '$f' \
-        || echo "null"
-    )" \
-    '{
-      buildCommand: "npm run build",
-      installCommand: "npm install",
-      rootDirectory: $root_directory,
-      framework: $framework,
-      gitComments: {
-        onCommit: false,
-        onPullRequest: false
-      }
-    }'
-)"
+configure_vercel_project() {
+  local framework_json
+  local update_vercel_project_body
 
-# Keep the Vercel project settings in sync on first runs and reruns.
-# Also disable Vercel for GitHub PR and commit comments.
-# Source: https://vercel.com/docs/rest-api/projects/update-an-existing-project
-vercel_request \
-  "Updating Vercel project settings" \
-  "PATCH" \
-  "$(vercel_url "/v9/projects/${vercel_project_id}")" \
-  "${update_vercel_project_body}" \
-  >/dev/null
+  if [[ -n "${framework}" ]]; then
+    framework_json="$(jq -n --arg framework "${framework}" '$framework')"
+  else
+    framework_json="null"
+  fi
 
-# Set the production branch to the `examples` branch.
-# Source: https://raw.githubusercontent.com/vercel/terraform-provider-vercel/main/client/project.go
-vercel_request \
-  "Setting production branch" \
-  "PATCH" \
-  "$(vercel_url "/v9/projects/${vercel_project_id}/branch")" \
-  "$(jq -n --arg branch "${examples_branch}" '{ branch: $branch }')" \
-  >/dev/null
+  update_vercel_project_body="$(
+    jq -n \
+      --arg root_directory "${root_directory}" \
+      --argjson framework "${framework_json}" \
+      '{
+        buildCommand: "npm run build",
+        installCommand: "npm install",
+        rootDirectory: $root_directory,
+        framework: $framework,
+        gitComments: {
+          onCommit: false,
+          onPullRequest: false
+        }
+      }'
+  )"
 
-# Read the latest Vercel project state so reruns can reuse existing deploy hooks.
-# Source: https://vercel.com/docs/rest-api/projects/find-a-project-by-id-or-name
-vercel_project_response="$(
+  # Source: https://vercel.com/docs/rest-api/projects/update-an-existing-project
   vercel_request \
-    "Refreshing Vercel project" \
-    "GET" \
-    "$(vercel_url "/v10/projects/${vercel_project_id}")"
-)"
-vercel_deploy_hook_url="$(
-  jq -r \
-    --arg name "${vercel_deploy_hook_name}" \
-    --arg ref "${examples_branch}" \
-    '.link.deployHooks[]? | select(.name == $name and .ref == $ref) | .url' \
-    <<<"${vercel_project_response}" \
-    | head -n 1
-)"
+    "Updating Vercel project settings" \
+    "PATCH" \
+    "$(vercel_url "/v9/projects/${vercel_project_id}")" \
+    "${update_vercel_project_body}" \
+    >/dev/null
 
-# Create a Vercel deploy hook for the `examples` branch.
-# Source: https://raw.githubusercontent.com/vercel/terraform-provider-vercel/fb57c95e/client/deploy_hooks.go
-vercel_deploy_hook_response=""
-if [[ -n "${vercel_deploy_hook_url}" ]]; then
-  echo
-  echo "Found existing Vercel Deploy Hook"
-else
+  # Source: https://github.com/vercel/terraform-provider-vercel/blob/main/client/project.go
+  # It's an undocumented endpoint, more info: https://community.vercel.com/t/rest-api-docs-for-updating-production-git-branch/820
+  vercel_request \
+    "Setting Vercel production branch" \
+    "PATCH" \
+    "$(vercel_url "/v9/projects/${vercel_project_id}/branch")" \
+    "$(jq -n --arg branch "${examples_branch}" '{ branch: $branch }')" \
+    >/dev/null
+}
+
+create_vercel_deploy_hook() {
+  local vercel_deploy_hook_response
+  local vercel_project_response
+
+  # Source: https://vercel.com/docs/rest-api/projects/find-a-project-by-id-or-name
+  vercel_project_response="$(
+    vercel_request \
+      "Refreshing Vercel project" \
+      "GET" \
+      "$(vercel_url "/v10/projects/${vercel_project_id}")"
+  )"
+  vercel_deploy_hook_url="$(
+    jq -r \
+      --arg name "${vercel_deploy_hook_name}" \
+      --arg ref "${examples_branch}" \
+      '.link.deployHooks[]? | select(.name == $name and .ref == $ref) | .url' \
+      <<<"${vercel_project_response}" \
+      | head -n 1
+  )"
+
+  if [[ -n "${vercel_deploy_hook_url}" ]]; then
+    duplicate_setup_error "Example '${example_name}' already exists: deploy hook '${vercel_deploy_hook_name}' already exists for '${vercel_project_name}'."
+  fi
+
+  # Source: https://github.com/vercel/terraform-provider-vercel/blob/main/client/deploy_hooks.go
+  # It's an undocumented endpoint, more info: https://community.vercel.com/t/rest-api-docs-for-updating-production-git-branch/820
   vercel_deploy_hook_response="$(
     vercel_request \
       "Creating Vercel Deploy Hook" \
@@ -482,56 +548,62 @@ else
       <<<"${vercel_deploy_hook_response}" \
       | head -n 1
   )"
-fi
 
-if [[ -z "${vercel_deploy_hook_url}" ]]; then
-  err "Vercel Deploy Hook response did not include a URL"
-  echo "${vercel_deploy_hook_response:-${vercel_project_response}}" >&2
-  exit 1
-fi
+  if [[ -z "${vercel_deploy_hook_url}" ]]; then
+    err "Vercel Deploy Hook response did not include a URL"
+    echo "${vercel_deploy_hook_response:-${vercel_project_response}}" >&2
+    exit 1
+  fi
+}
 
-# Check whether the Vercel custom domain already exists.
-# Source: https://github.com/vercel/sdk/blob/HEAD/docs/sdks/projects/README.md#getprojectdomains
-vercel_project_domains_response="$(
-  vercel_request \
-    "Checking Vercel custom domain" \
-    "GET" \
-    "$(vercel_url "/v9/projects/${vercel_project_id}/domains")"
-)"
-vercel_domain_exists="$(
-  jq -r --arg name "${domain}" '.domains[]? | select(.name == $name) | .name' \
-    <<<"${vercel_project_domains_response}" \
-    | head -n 1
-)"
+add_vercel_custom_domain() {
+  local vercel_domain_exists
+  local vercel_project_domains_response
 
-# Add a Vercel custom domain for this example.
-# Source: https://github.com/vercel/sdk/blob/HEAD/docs/sdks/projects/README.md#addprojectdomain
-if [[ -n "${vercel_domain_exists}" ]]; then
-  echo
-  echo "Found existing Vercel custom domain"
-else
+  # Source: https://vercel.com/docs/rest-api/projects/retrieve-project-domains-by-project-by-id-or-name
+  vercel_project_domains_response="$(
+    vercel_request \
+      "Checking Vercel custom domain" \
+      "GET" \
+      "$(vercel_url "/v9/projects/${vercel_project_id}/domains")"
+  )"
+  vercel_domain_exists="$(
+    jq -r --arg name "${domain}" '.domains[]? | select(.name == $name) | .name' \
+      <<<"${vercel_project_domains_response}" \
+      | head -n 1
+  )"
+
+  if [[ -n "${vercel_domain_exists}" ]]; then
+    duplicate_setup_error "Example '${example_name}' already exists: custom domain '${domain}' is already attached."
+  fi
+
+  # Source: https://vercel.com/docs/rest-api/projects/add-a-domain-to-a-project
   vercel_request \
     "Adding Vercel custom domain" \
     "POST" \
     "$(vercel_url "/v10/projects/${vercel_project_id}/domains")" \
     "$(jq -n --arg name "${domain}" '{ name: $name, gitBranch: null }')" \
     >/dev/null
-fi
+}
 
-echo
-echo "Setup complete"
-echo "Vercel project: ${vercel_project_name}"
-echo "Liveblocks project: ${liveblocks_project_name}"
-echo "Vercel deployment URL: https://${domain}"
-if [[ -n "${vercel_project_dashboard_url}" ]]; then
-  echo "Vercel project URL: ${vercel_project_dashboard_url}"
-fi
-if [[ -n "${vercel_liveblocks_env_name}" ]]; then
-  echo "Vercel Liveblocks env var: ${vercel_liveblocks_env_name}"
-fi
-echo "Vercel Deploy Hook: ${vercel_deploy_hook_url}"
+print_success_log() {
+  echo
+  echo "Setup complete"
+  echo "Vercel project: ${vercel_project_name}"
+  echo "Liveblocks project: ${liveblocks_project_name}"
+  echo "Vercel deployment URL: https://${domain}"
+  if [[ -n "${vercel_project_dashboard_url}" ]]; then
+    echo "Vercel project URL: ${vercel_project_dashboard_url}"
+  fi
+  if [[ -n "${vercel_liveblocks_env_name}" ]]; then
+    echo "Vercel Liveblocks env var: ${vercel_liveblocks_env_name}"
+  fi
+  echo "Vercel Deploy Hook: ${vercel_deploy_hook_url}"
+}
 
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+write_success_summary() {
+  [[ -z "${GITHUB_STEP_SUMMARY:-}" ]] && return
+
   {
     echo "## ✅ Example deployed to Vercel"
     echo
@@ -565,6 +637,7 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     fi
     echo "### Vercel Deploy Hook"
     echo
+    # We store deploy hooks publicly so we can also display them here.
     echo '```text'
     echo "${vercel_deploy_hook_url}"
     echo '```'
@@ -576,4 +649,24 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "curl -s -X POST ${vercel_deploy_hook_url}; echo"
     echo '```'
   } >>"${GITHUB_STEP_SUMMARY}"
-fi
+}
+
+main() {
+  require_inputs
+  read_example_inputs
+  read_env_example
+  print_setup_overview
+
+  resolve_vercel_project_dashboard_url
+  create_vercel_project
+  create_liveblocks_project
+  add_liveblocks_key_to_vercel
+  configure_vercel_project
+  create_vercel_deploy_hook
+  add_vercel_custom_domain
+
+  print_success_log
+  write_success_summary
+}
+
+main "$@"

--- a/.github/scripts/setup-vercel-example.sh
+++ b/.github/scripts/setup-vercel-example.sh
@@ -129,24 +129,24 @@ create_project_body="$(
     --arg name "${project_name}" \
     --arg root_directory "${root_directory}" \
     --arg repository "${GITHUB_REPOSITORY}" \
+    --argjson framework "$(
+      # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project#framework
+      [[ -n "${framework}" ]] \
+        && jq -n --arg f "${framework}" '$f' \
+        || echo "null"
+    )" \
     '{
       name: $name,
       buildCommand: "npm run build",
       installCommand: "npm install",
       rootDirectory: $root_directory,
+      framework: $framework,
       gitRepository: {
         type: "github",
         repo: $repository
       }
     }'
 )"
-
-if [[ -n "${framework}" ]]; then
-  # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project#framework
-  create_project_body="$(
-    jq --arg framework "${framework}" '.framework = $framework' <<<"${create_project_body}"
-  )"
-fi
 
 # Create a Vercel project for this GitHub repository.
 # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
@@ -190,22 +190,22 @@ fi
 update_project_body="$(
   jq -n \
     --arg root_directory "${root_directory}" \
+    --argjson framework "$(
+      [[ -n "${framework}" ]] \
+        && jq -n --arg f "${framework}" '$f' \
+        || echo "null"
+    )" \
     '{
       buildCommand: "npm run build",
       installCommand: "npm install",
       rootDirectory: $root_directory,
+      framework: $framework,
       gitComments: {
         onCommit: false,
         onPullRequest: false
       }
     }'
 )"
-
-if [[ -n "${framework}" ]]; then
-  update_project_body="$(
-    jq --arg framework "${framework}" '.framework = $framework' <<<"${update_project_body}"
-  )"
-fi
 
 # Keep the project settings in sync on first runs and reruns.
 # Also disable Vercel for GitHub PR and commit comments.

--- a/.github/scripts/setup-vercel-example.sh
+++ b/.github/scripts/setup-vercel-example.sh
@@ -111,6 +111,16 @@ if [[ ! -d "examples/${example_name}" ]]; then
   exit 1
 fi
 
+# Resolve the team URL segment for dashboard links (`https://vercel.com/<slug>/<project>`).
+# Source: https://vercel.com/docs/rest-api/reference/endpoints/teams/get-a-team
+team_response="$(
+  vercel_request \
+    "Fetching Vercel team metadata" \
+    "GET" \
+    "${vercel_api_url}/v2/teams/${VERCEL_TEAM_ID}"
+)"
+team_slug="$(jq -r '.slug // empty' <<<"${team_response}")"
+
 project_name="examples-${example_name}"
 root_directory="examples/${example_name}"
 domain="${example_name}.liveblocks.app"
@@ -123,6 +133,13 @@ echo "Custom domain: ${domain}"
 echo "GitHub repository: ${GITHUB_REPOSITORY}"
 echo "Production branch: ${examples_branch}"
 echo "Framework: ${framework:-"(none)"}"
+
+project_dashboard_url=""
+if [[ -n "${team_slug}" ]]; then
+  project_dashboard_url="https://vercel.com/${team_slug}/${project_name}"
+else
+  err "Warning: could not read team slug from GET /v2/teams/<team-id>; omitting Vercel dashboard project URL"
+fi
 
 create_project_body="$(
   jq -n \
@@ -304,7 +321,10 @@ fi
 echo
 echo "Setup complete"
 echo "Project: ${project_name}"
-echo "Domain: https://${domain}"
+echo "Deployment URL: https://${domain}"
+if [[ -n "${project_dashboard_url}" ]]; then
+  echo "Vercel project URL: ${project_dashboard_url}"
+fi
 echo "Deploy Hook: ${deploy_hook_url}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
@@ -313,7 +333,10 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo
     echo "\`${example_name}\` has been configured on Vercel and will deploy from the \`${examples_branch}\` branch."
     echo
-    echo "🔗 Public URL: https://${domain}"
+    echo "🔗 Deployment URL: https://${domain}"
+    if [[ -n "${project_dashboard_url}" ]]; then
+      echo "🗂️ Vercel URL: ${project_dashboard_url}"
+    fi
     echo
     echo "### Deploy Hook"
     echo

--- a/.github/scripts/setup-vercel-example.sh
+++ b/.github/scripts/setup-vercel-example.sh
@@ -276,39 +276,11 @@ resolve_vercel_project_dashboard_url() {
   fi
 }
 
-create_vercel_project() {
-  local create_vercel_project_body
+assert_no_existing_vercel_project() {
   local existing_vercel_project_response_file
   local existing_vercel_project_status
-  local framework_json
-  local vercel_project_response
 
-  if [[ -n "${framework}" ]]; then
-    framework_json="$(jq -n --arg framework "${framework}" '$framework')"
-  else
-    framework_json="null"
-  fi
-
-  create_vercel_project_body="$(
-    jq -n \
-      --arg name "${vercel_project_name}" \
-      --arg root_directory "${root_directory}" \
-      --arg repository "${GITHUB_REPOSITORY}" \
-      --argjson framework "${framework_json}" \
-      '{
-        name: $name,
-        buildCommand: "npm run build",
-        installCommand: "npm install",
-        rootDirectory: $root_directory,
-        framework: $framework,
-        gitRepository: {
-          type: "github",
-          repo: $repository
-        }
-      }'
-  )"
-
-  # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
+  # Source: https://vercel.com/docs/rest-api/projects/find-a-project-by-id-or-name
   existing_vercel_project_response_file="$(create_response_file)"
   if ! existing_vercel_project_status="$(
     curl_vercel \
@@ -322,34 +294,19 @@ create_vercel_project() {
 
   if [[ "${existing_vercel_project_status}" == "200" ]]; then
     duplicate_setup_error "Example '${example_name}' already exists: Vercel project '${vercel_project_name}' is already present."
-  elif [[ "${existing_vercel_project_status}" == "404" ]]; then
-    vercel_project_response="$(
-      vercel_request \
-        "Creating Vercel project" \
-        "POST" \
-        "$(vercel_url "/v11/projects")" \
-        "${create_vercel_project_body}"
-    )"
-  else
+  fi
+
+  if [[ "${existing_vercel_project_status}" != "404" ]]; then
     err "Looking up existing Vercel project failed with HTTP ${existing_vercel_project_status}"
     cat "${existing_vercel_project_response_file}" >&2
     exit 1
   fi
-
-  vercel_project_id="$(jq -r ".id // empty" <<<"${vercel_project_response}")"
-
-  if [[ -z "${vercel_project_id}" ]]; then
-    err "Vercel project response did not include an ID"
-    echo "${vercel_project_response}" >&2
-    exit 1
-  fi
 }
 
-create_liveblocks_project() {
+assert_no_existing_liveblocks_project() {
   local liveblocks_cursor=""
   local liveblocks_projects_response
   local liveblocks_projects_url
-  local liveblocks_project_response
 
   # Source: https://liveblocks.io/docs/api-reference/rest-api-endpoints#Management
   while true; do
@@ -380,6 +337,67 @@ create_liveblocks_project() {
 
     [[ -z "${liveblocks_cursor}" ]] && break
   done
+}
+
+preflight_setup() {
+  assert_no_existing_vercel_project
+  assert_no_existing_liveblocks_project
+}
+
+create_vercel_project() {
+  local create_vercel_project_body
+  local framework_json
+  local vercel_project_response
+
+  if [[ -n "${framework}" ]]; then
+    framework_json="$(jq -n --arg framework "${framework}" '$framework')"
+  else
+    framework_json="null"
+  fi
+
+  create_vercel_project_body="$(
+    jq -n \
+      --arg name "${vercel_project_name}" \
+      --arg root_directory "${root_directory}" \
+      --arg repository "${GITHUB_REPOSITORY}" \
+      --argjson framework "${framework_json}" \
+      '{
+        name: $name,
+        buildCommand: "npm run build",
+        installCommand: "npm install",
+        rootDirectory: $root_directory,
+        framework: $framework,
+        gitRepository: {
+          type: "github",
+          repo: $repository
+        }
+      }'
+  )"
+
+  assert_no_existing_vercel_project
+
+  # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project
+  vercel_project_response="$(
+    vercel_request \
+      "Creating Vercel project" \
+      "POST" \
+      "$(vercel_url "/v11/projects")" \
+      "${create_vercel_project_body}"
+  )"
+
+  vercel_project_id="$(jq -r ".id // empty" <<<"${vercel_project_response}")"
+
+  if [[ -z "${vercel_project_id}" ]]; then
+    err "Vercel project response did not include an ID"
+    echo "${vercel_project_response}" >&2
+    exit 1
+  fi
+}
+
+create_liveblocks_project() {
+  local liveblocks_project_response
+
+  assert_no_existing_liveblocks_project
 
   # Examples are public deployments, so we create a Liveblocks production project.
   # Production secret keys are only accessible once at creation time.
@@ -658,6 +676,7 @@ main() {
   print_setup_overview
 
   resolve_vercel_project_dashboard_url
+  preflight_setup
   create_vercel_project
   create_liveblocks_project
   add_liveblocks_key_to_vercel

--- a/.github/workflows/setup-vercel-example.yml
+++ b/.github/workflows/setup-vercel-example.yml
@@ -1,0 +1,40 @@
+name: Set up Vercel example
+
+on:
+  workflow_dispatch:
+    inputs:
+      example_name:
+        description:
+          "Name of the example's folder in the `examples/` directory (e.g.
+          `nextjs-comments`)"
+        required: true
+        type: string
+      framework:
+        description: "Framework preset (e.g. `nextjs`)"
+        required: false
+        type: choice
+        # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project#framework
+        options:
+          - nextjs
+          - nuxtjs
+          - svelte
+          - sveltekit
+          - vite
+          - vue
+
+jobs:
+  setup-vercel-example:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create and configure Vercel project
+        env:
+          EXAMPLE_NAME: ${{ inputs.example_name }}
+          FRAMEWORK: ${{ inputs.framework }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: bash ./.github/scripts/setup-vercel-example.sh

--- a/.github/workflows/setup-vercel-example.yml
+++ b/.github/workflows/setup-vercel-example.yml
@@ -37,6 +37,8 @@ jobs:
           EXAMPLE_NAME: ${{ inputs.example_name }}
           FRAMEWORK: ${{ inputs.framework }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          LIVEBLOCKS_MANAGEMENT_API_TOKEN:
+            ${{ secrets.LIVEBLOCKS_MANAGEMENT_API_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
         run: bash ./.github/scripts/setup-vercel-example.sh

--- a/.github/workflows/setup-vercel-example.yml
+++ b/.github/workflows/setup-vercel-example.yml
@@ -15,6 +15,8 @@ on:
         type: choice
         # Source: https://vercel.com/docs/rest-api/projects/create-a-new-project#framework
         options:
+          # `choice` inputs can't be optional, so `""` acts as `null`.
+          - ""
           - nextjs
           - nuxtjs
           - svelte

--- a/docs/pages/platform/management-api.mdx
+++ b/docs/pages/platform/management-api.mdx
@@ -18,8 +18,9 @@ delete projects, webhooks, and more.
 The Liveblocks Management API is organized around REST. The API has predictable
 resource-oriented URLs, accepts form-encoded request bodies, returns
 JSON-encoded responses, and uses standard HTTP response codes, authentication,
-and verbs. See the [API reference](api-reference/rest-api-endpoints#Management)
-for more information.
+and verbs. See the
+[API reference](/docs/api-reference/rest-api-endpoints#Management) for more
+information.
 
 ```
 https://api.liveblocks.io/v2/management
@@ -221,5 +222,6 @@ for your use case, please contact
 
 ## API reference
 
-See the [API reference](api-reference/rest-api-endpoints#Management) for more
+See the
+[API reference](/docs/api-reference/rest-api-endpoints#Management) for more
 information.

--- a/docs/pages/platform/rest-api.mdx
+++ b/docs/pages/platform/rest-api.mdx
@@ -17,8 +17,8 @@ and more.
 The Liveblocks API is organized around REST. The API has predictable
 resource-oriented URLs, accepts form-encoded request bodies, returns
 JSON-encoded responses, and uses standard HTTP response codes, authentication,
-and verbs. See the [API reference](api-reference/rest-api-endpoints) for more
-information.
+and verbs. See the
+[API reference](/docs/api-reference/rest-api-endpoints) for more information.
 
 ```
 https://api.liveblocks.io/v2


### PR DESCRIPTION
This PR adds a manual GitHub Action that sets up new examples to be deployed on Vercel automatically.

It creates a Vercel project for the example, sets all our common settings on it (`examples` branch, custom domain, deploy hook, etc.), creates a Liveblocks project as well to get a new API key and adds it on Vercel.