### PR TITLE
Update .envrc file to support upcoming worktree groups

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,7 @@
+# Inherit from a parent .envrc when this repo is checked out as a worktree
+# group (see https://github.com/nvie/worktrees). No-op in a normal checkout.
+source_up_if_exists
+
 layout node
 
 # Automatically put scripts/ in your $PATH, as long as you


### PR DESCRIPTION
I'm working on a new tool to more easily make coordinated changes to multiple repos at once using Git worktrees, and I need to be able to control the environment from a parent directory for it. That's exactly what this update allows.