### PR TITLE
Add explicit error handling for network errors in `streamStorage`

### DIFF
--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -1605,17 +1605,14 @@ export function createApiClient<
   }
 
   async function streamStorage(options: { roomId: string }) {
-    const result = await httpClient.rawGet(
+    const result = await httpClient.get(
       url`/v2/c/rooms/${options.roomId}/storage`,
       await authManager.getAuthValue({
         requestedScope: "room:read",
         roomId: options.roomId,
       })
     );
-    if (!result.ok) {
-      throw await HttpError.fromResponse(result);
-    }
-    return (await result.json()) as StorageNode[];
+    return result as unknown as StorageNode[];
   }
 
   /* -------------------------------------------------------------------------------------------------

--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -1612,6 +1612,9 @@ export function createApiClient<
         roomId: options.roomId,
       })
     );
+    if (!result.ok) {
+      throw await HttpError.fromResponse(result);
+    }
     return (await result.json()) as StorageNode[];
   }
 


### PR DESCRIPTION
<!-- We appreciate your efforts in opening a PR! Your contribution means a lot.
In order to ensure a seamless handling of your PR, we kindly ask you to refer to the checklist sections provided below.
Please select the appropriate checklist that corresponds to the changes you are making:

## For Contributors

### Fixing a bug

- Provide helpful info for reviewer:
  - Steps to reproduce
  - A clear and concise description of the problem that the bug is causing.
  - Steps to reproduce the issue, if applicable.
  - An explanation of the changes made to fix the bug, including any relevant code snippets.
  - Any new or updated tests that were added to ensure that the bug is fully resolved.
  - A summary of any potential side effects that could result from the bug fix, if any.
  - A list of any other related issues or PRs that may be impacted by the bug fix.

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added
- Documentation added

## For Maintainers

### Description

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Add review comments if necessary to explain to the reviewer the logic behind a change

#### How to test it

- Provide recordings, Looms, or screenshots to help reviewers quickly identify the happy path and what they should test on their side.

#### Related issue(s)

- Add the related issue(s) here:
  - https://github.com/liveblocks/[REPOSITORY]/issues/[ISSUE_NUMBER]
  - ...
  
 -->

We've observed the following error after a client receives a 500 response from `/storage`:
```
TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
    at new Map (<anonymous>)
    at Ee (../../../../node_modules/@liveblocks/core/dist/index.js:9902:27)
```
That `new Map` is this one: https://github.com/liveblocks/liveblocks/blob/446f419534d8437ff881cdb8fbe4a96e795219e7/packages/liveblocks-core/src/room.ts#L2956-L2958

This PR doesn't attempt to get to the root cause of that 500. It's just meant to help the client handle the error a bit more gracefully.