### PR TITLE
Keep the socket alive when there are pending Yjs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## vNEXT (not yet released)
 
+## v3.19.2
+
+### `@liveblocks/client`
+
+- Fix: clients that have `backgroundKeepAliveTimeout` enabled will no longer
+  disconnect before any pending Yjs updates have been synced to the server.
+
 ## v3.19.1
 
 ### `@liveblocks/node` and Python SDK

--- a/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.setup.ts
+++ b/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.setup.ts
@@ -88,10 +88,22 @@ export const THIRD_POSITION = makePosition(SECOND_POSITION);
 export const FOURTH_POSITION = makePosition(THIRD_POSITION);
 export const FIFTH_POSITION = makePosition(FOURTH_POSITION);
 
-export function makeSyncSource(): SyncSource {
+/**
+ * A `SyncSource` that throws on every accessor. Used as a placeholder in
+ * test fixtures: if a test ever exercises one of these methods, it fails
+ * loudly.
+ */
+export function fakeSyncSource(): SyncSource {
   return {
-    setSyncStatus: () => {},
-    destroy: () => {},
+    setSyncStatus: () => {
+      throw new Error("fakeSyncSource: setSyncStatus called");
+    },
+    getStatus: () => {
+      throw new Error("fakeSyncSource: getStatus called");
+    },
+    destroy: () => {
+      throw new Error("fakeSyncSource: destroy called");
+    },
   };
 }
 
@@ -118,7 +130,7 @@ function makeRoomConfig<TM extends BaseMetadata, CM extends BaseMetadata>(
       currentUserId: new Signal<string | undefined>(undefined),
     }),
     // Not used in unit tests (yet)
-    createSyncSource: makeSyncSource,
+    createSyncSource: fakeSyncSource,
   };
 }
 

--- a/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.setup.ts
+++ b/packages/liveblocks-core/src/__tests__/_MockWebSocketServer.setup.ts
@@ -96,13 +96,13 @@ export const FIFTH_POSITION = makePosition(FOURTH_POSITION);
 export function fakeSyncSource(): SyncSource {
   return {
     setSyncStatus: () => {
-      throw new Error("fakeSyncSource: setSyncStatus called");
+      // no-op
     },
     getStatus: () => {
-      throw new Error("fakeSyncSource: getStatus called");
+      throw new Error("fakeSyncSource: not implemented");
     },
     destroy: () => {
-      throw new Error("fakeSyncSource: destroy called");
+      // no-op
     },
   };
 }

--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -55,8 +55,8 @@ import {
   createSerializedList,
   createSerializedRegister,
   createSerializedRoot,
+  fakeSyncSource,
   FIRST_POSITION,
-  makeSyncSource,
   prepareIsolatedStorageTest,
   prepareRoomWithStorage_loadWithDelay,
   prepareStorageTest,
@@ -101,7 +101,7 @@ function createDefaultRoomConfig<
       currentUserId: new Signal<string | undefined>(undefined),
     }),
     // Not used in unit tests (yet)
-    createSyncSource: makeSyncSource,
+    createSyncSource: fakeSyncSource,
   };
 }
 

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -979,6 +979,10 @@ export function createClient<U extends BaseUserMeta = DU>(
       source.set(status);
     }
 
+    function getStatus(): InternalSyncStatus {
+      return source.get();
+    }
+
     function destroy() {
       unsub();
       const index = syncStatusSources.findIndex((item) => item === source);
@@ -993,7 +997,7 @@ export function createClient<U extends BaseUserMeta = DU>(
       }
     }
 
-    return { setSyncStatus, destroy };
+    return { setSyncStatus, getStatus, destroy };
   }
 
   // ----------------------------------------------------------------

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1198,6 +1198,7 @@ export interface IYjsProvider {
  */
 export interface SyncSource {
   setSyncStatus(status: InternalSyncStatus): void;
+  getStatus(): InternalSyncStatus;
   destroy(): void;
 }
 
@@ -1543,7 +1544,7 @@ export function createRoom<
     // - The `backgroundKeepAliveTimeout` client option is configured
     // - The browser window has been in the background for at least
     //   `backgroundKeepAliveTimeout` milliseconds
-    // - There are no pending changes
+    // - There are no pending changes scoped to this room (Storage, Yjs)
     //
     canZombie() {
       return (
@@ -1551,7 +1552,8 @@ export function createRoom<
         inBackgroundSince.current !== null &&
         Date.now() >
           inBackgroundSince.current + config.backgroundKeepAliveTimeout &&
-        getStorageStatus() !== "synchronizing"
+        syncSourceForStorage.getStatus() !== "synchronizing" &&
+        syncSourceForYjs.getStatus() !== "synchronizing"
       );
     },
   };


### PR DESCRIPTION
This PR fixes a bug where a backgrounded tab with pending Yjs updates could enter zombie state after `backgroundKeepAliveTimeout` had elapsed. The `canZombie` predicate, which decides whether a backgrounded client is allowed to disconnect the socket and auto-reconnect when the tab focuses again, only consulted Storage's sync status, so rooms that also have pending Yjs updates weren't protected.
