### PR TITLE
Treat any inbound message as heartbeat liveness signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## vNEXT (not yet released)
 
+## v3.19.3
+
+### `@liveblocks/client`
+
+- Fix unexpected disconnects that could happen while receiving large or
+  long-running streaming responses from the server (e.g. when loading a large
+  initial storage state).
+
 ## v3.19.2
 
 ### `@liveblocks/client`

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -4,7 +4,7 @@ import type { Observable } from "./lib/EventSource";
 import { makeBufferableEventSource, makeEventSource } from "./lib/EventSource";
 import * as console from "./lib/fancy-console";
 import type { BuiltinEvent, Patchable, Target } from "./lib/fsm";
-import { FSM } from "./lib/fsm";
+import { FSM, IGNORE } from "./lib/fsm";
 import type { Json } from "./lib/Json";
 import { tryParseJson, withTimeout } from "./lib/utils";
 import { ServerMsgCode } from "./protocol/ServerMsg";
@@ -98,7 +98,7 @@ type Event =
   | { type: "NAVIGATOR_OFFLINE" } // e.g. browser goes offline
 
   // Events that the connection manager will internally deal with
-  | { type: "PONG" }
+  | { type: "ALIVE" } // Previously called "PONG", but widened to include any socket activity
   | { type: "EXPLICIT_SOCKET_ERROR"; event: IWebSocketEvent }
   | { type: "EXPLICIT_SOCKET_CLOSE"; event: IWebSocketCloseEvent }
 
@@ -171,8 +171,9 @@ const BACKOFF_DELAYS_SLOW = [2_000, 30_000, 60_000, 300_000] as const;
 
 /**
  * The client will send a PING to the server every 30 seconds, after which it
- * must receive a PONG back within the next 2 seconds. If that doesn't happen,
- * this is interpreted as an implicit connection loss event.
+ * must receive a PONG (or any other sign of activity) back within the next
+ * 2 seconds. If nothing arrives in that window, the connection is treated as
+ * implicitly lost.
  */
 const HEARTBEAT_INTERVAL = 30_000;
 const PONG_TIMEOUT = 2_000;
@@ -302,8 +303,8 @@ function enableTracing(machine: FSM<Context, Event, State>) {
     machine.events.didExitState.subscribe(({ state, durationMs }) =>
       log(`Exited ${state} after ${durationMs.toFixed(0)}ms`)
     ),
-    machine.events.didIgnoreEvent.subscribe((e) =>
-      log("Ignored event", e.type, e, "(current state won't handle it)")
+    machine.events.didIgnoreUnexpectedEvent.subscribe((e) =>
+      log("Ignored unexpected event", e.type, e, "(no transition declared)")
     ),
   ];
   return () => {
@@ -504,18 +505,9 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
     machine.send({ type: "EXPLICIT_SOCKET_CLOSE", event });
 
   const onSocketMessage = (event: IWebSocketMessageEvent) => {
-    // Any inbound message from the server proves the connection is alive,
-    // not just an explicit "pong". Without this, a long streaming response
-    // (e.g. a large initial storage state delivered as many frames) can
-    // delay pongs behind it on the same WebSocket and trip the heartbeat
-    // watchdog mid-stream.
-    //
-    // Only emit PONG when the machine is actually waiting for one, to
-    // avoid spamming didIgnoreEvent in the @ok.connected state (which has
-    // no handler for PONG).
-    if (machine.currentStateOrNull === "@ok.awaiting-pong") {
-      machine.send({ type: "PONG" });
-    }
+    // Every inbound message counts as activity, not just explicit PONGs
+    machine.send({ type: "ALIVE" });
+
     if (event.data !== "pong") {
       onMessage.notify(event);
     }
@@ -777,18 +769,25 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
           effect: [increaseBackoffDelay, logPrematureErrorOrCloseEvent(err)],
         };
       }
-    );
+    )
+    .addTransitions("@connecting.busy", {
+      // The socket message listener is attached during @connecting.busy (see
+      // onEnterAsync above), so server frames (most notably the actor-id
+      // handshake) can fire onSocketMessage and emit a ALIVE before we
+      // reach @ok.*. That's fine. Heartbeat only matters in @ok.*.
+      ALIVE: IGNORE,
+    });
 
   //
   // Configure the @ok.* states
   //
   // Keeps a heartbeat alive with the server whenever in the @ok.* state group.
   // 30 seconds after entering the "@ok.connected" state, it will emit
-  // a heartbeat, and awaits a PONG back that should arrive within 2 seconds.
-  // If this happens, then it transitions back to normal "connected" state, and
-  // the cycle repeats. If the PONG is not received timely, then we interpret
-  // it as an implicit connection loss, and transition to reconnect (throw away
-  // this socket, and open a new one).
+  // a heartbeat, and awaits a PONG (or any other sign of activity) back that
+  // should arrive within 2 seconds. If this happens, it transitions back to
+  // "@ok.connected" and the cycle repeats. If nothing arrives in time, we
+  // interpret it as an implicit connection loss and transition to reconnect
+  // (throw away this socket, and open a new one).
   //
 
   const sendHeartbeat: Target<Context, Event | BuiltinEvent, State> = {
@@ -812,6 +811,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
     .addTransitions("@ok.connected", {
       NAVIGATOR_OFFLINE: maybeHeartbeat, // Don't take the browser's word for it when it says it's offline. Do a ping/pong to make sure.
       WINDOW_GOT_FOCUS: sendHeartbeat,
+      ALIVE: IGNORE,
     });
 
   machine.addTransitions("@idle.zombie", {
@@ -840,7 +840,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
       };
     })
 
-    .addTransitions("@ok.awaiting-pong", { PONG: "@ok.connected" })
+    .addTransitions("@ok.awaiting-pong", { ALIVE: "@ok.connected" })
     .addTimedTransition("@ok.awaiting-pong", PONG_TIMEOUT, {
       target: "@connecting.busy",
       // Log implicit connection loss and drop the current open socket
@@ -857,7 +857,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
       EXPLICIT_SOCKET_ERROR: (_, context) => {
         if (context.socket?.readyState === 1 /* WebSocket.OPEN */) {
           // TODO Do we need to forward this error to the client?
-          return null; /* Do not leave OK state, socket is still usable */
+          return IGNORE; /* Do not leave OK state, socket is still usable */
         }
 
         return {

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -513,7 +513,7 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
     // Only emit PONG when the machine is actually waiting for one, to
     // avoid spamming didIgnoreEvent in the @ok.connected state (which has
     // no handler for PONG).
-    if (machine.currentState === "@ok.awaiting-pong") {
+    if (machine.currentStateOrNull === "@ok.awaiting-pong") {
       machine.send({ type: "PONG" });
     }
     if (event.data !== "pong") {

--- a/packages/liveblocks-core/src/connection.ts
+++ b/packages/liveblocks-core/src/connection.ts
@@ -503,10 +503,23 @@ function createConnectionStateMachine<T extends BaseAuthResult>(
   const onSocketClose = (event: IWebSocketCloseEvent) =>
     machine.send({ type: "EXPLICIT_SOCKET_CLOSE", event });
 
-  const onSocketMessage = (event: IWebSocketMessageEvent) =>
-    event.data === "pong"
-      ? machine.send({ type: "PONG" })
-      : onMessage.notify(event);
+  const onSocketMessage = (event: IWebSocketMessageEvent) => {
+    // Any inbound message from the server proves the connection is alive,
+    // not just an explicit "pong". Without this, a long streaming response
+    // (e.g. a large initial storage state delivered as many frames) can
+    // delay pongs behind it on the same WebSocket and trip the heartbeat
+    // watchdog mid-stream.
+    //
+    // Only emit PONG when the machine is actually waiting for one, to
+    // avoid spamming didIgnoreEvent in the @ok.connected state (which has
+    // no handler for PONG).
+    if (machine.currentState === "@ok.awaiting-pong") {
+      machine.send({ type: "PONG" });
+    }
+    if (event.data !== "pong") {
+      onMessage.notify(event);
+    }
+  };
 
   function teardownSocket(socket: IWebSocketInstance | null) {
     if (socket) {

--- a/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
+++ b/packages/liveblocks-core/src/lib/__tests__/fsm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 
-import { distance, FSM, patterns } from "../fsm";
+import { distance, FSM, IGNORE, patterns } from "../fsm";
 import { wait } from "../utils";
 
 async function failAfter(ms: number): Promise<void> {
@@ -555,7 +555,7 @@ describe("finite state machine", () => {
         GO: () =>
           n++ % 2 === 0
             ? "one" // Transition if n is even
-            : null, // Otherwise, do nothing
+            : IGNORE, // Otherwise, do nothing
       })
       .start();
 
@@ -570,6 +570,136 @@ describe("finite state machine", () => {
     expect(fsm.currentState).toEqual("two"); // Did *not* transition!
     fsm.send({ type: "GO" });
     expect(fsm.currentState).toEqual("one");
+  });
+
+  describe("IGNORE sentinel", () => {
+    test("static IGNORE keeps state unchanged", () => {
+      const fsm = new FSM({})
+        .addState("foo")
+        .addTransitions("foo", { GO: IGNORE })
+        .start();
+
+      expect(fsm.currentState).toEqual("foo");
+      fsm.send({ type: "GO" });
+      expect(fsm.currentState).toEqual("foo");
+    });
+
+    test("static IGNORE fires no observable notifications", () => {
+      const didReceive = vi.fn();
+      const willTransition = vi.fn();
+      const didIgnoreUnexpected = vi.fn();
+
+      const fsm = new FSM({})
+        .addState("foo")
+        .addTransitions("foo", { GO: IGNORE })
+        .start();
+
+      fsm.events.didReceiveEvent.subscribe(didReceive);
+      fsm.events.willTransition.subscribe(willTransition);
+      fsm.events.didIgnoreUnexpectedEvent.subscribe(didIgnoreUnexpected);
+
+      fsm.send({ type: "GO" });
+
+      expect(didReceive).not.toHaveBeenCalled();
+      expect(willTransition).not.toHaveBeenCalled();
+      expect(didIgnoreUnexpected).not.toHaveBeenCalled();
+    });
+
+    test("missing transition still fires didIgnoreUnexpectedEvent (control)", () => {
+      const didIgnoreUnexpected = vi.fn();
+
+      // Declare GO somewhere so the FSM accepts it as a known event type,
+      // but not in state "foo" — so sending GO in "foo" goes unhandled.
+      const fsm = new FSM({})
+        .addState("foo")
+        .addState("bar")
+        .addTransitions("bar", { GO: "foo" })
+        .start();
+
+      fsm.events.didIgnoreUnexpectedEvent.subscribe(didIgnoreUnexpected);
+
+      expect(fsm.currentState).toEqual("foo");
+      fsm.send({ type: "GO" });
+      expect(didIgnoreUnexpected).toHaveBeenCalledTimes(1);
+    });
+
+    test("dynamic IGNORE (function returning IGNORE) is silent except for didReceiveEvent", () => {
+      const didReceive = vi.fn();
+      const willTransition = vi.fn();
+      const didIgnoreUnexpected = vi.fn();
+
+      const fsm = new FSM({})
+        .addState("foo")
+        .addTransitions("foo", { GO: () => IGNORE })
+        .start();
+
+      fsm.events.didReceiveEvent.subscribe(didReceive);
+      fsm.events.willTransition.subscribe(willTransition);
+      fsm.events.didIgnoreUnexpectedEvent.subscribe(didIgnoreUnexpected);
+
+      fsm.send({ type: "GO" });
+
+      // We had to invoke the function to learn it returns IGNORE.
+      expect(didReceive).toHaveBeenCalledTimes(1);
+      // But no transition happened, and the event is not "unexpected".
+      expect(willTransition).not.toHaveBeenCalled();
+      expect(didIgnoreUnexpected).not.toHaveBeenCalled();
+      expect(fsm.currentState).toEqual("foo");
+    });
+
+    test("mixing IGNORE with real transitions in the same mapping", () => {
+      const fsm = new FSM({})
+        .addState("foo")
+        .addState("bar")
+        .addTransitions("foo", { GO: "bar", PING: IGNORE })
+        .start();
+
+      fsm.send({ type: "PING" });
+      expect(fsm.currentState).toEqual("foo"); // silent no-op
+
+      fsm.send({ type: "GO" });
+      expect(fsm.currentState).toEqual("bar"); // normal transition
+    });
+
+    test("IGNORE works via wildcard pattern for a state group", () => {
+      const didIgnoreUnexpected = vi.fn();
+
+      const fsm = new FSM({})
+        .addState("group.one")
+        .addState("group.two")
+        .addState("other")
+        .addTransitions("group.*", { PING: IGNORE, GO: "other" })
+        .start();
+
+      fsm.events.didIgnoreUnexpectedEvent.subscribe(didIgnoreUnexpected);
+
+      expect(fsm.currentState).toEqual("group.one");
+      fsm.send({ type: "PING" });
+      expect(fsm.currentState).toEqual("group.one");
+      expect(didIgnoreUnexpected).not.toHaveBeenCalled();
+
+      // Switch to group.two by adding a transition path; reuse "GO".
+      // To exercise PING in group.two we need to be there first.
+      // Build a separate FSM for that leg to keep this test focused.
+      const fsm2 = new FSM({})
+        .addState("group.two")
+        .addTransitions("group.*", { PING: IGNORE })
+        .start();
+      const didIgnoreUnexpected2 = vi.fn();
+      fsm2.events.didIgnoreUnexpectedEvent.subscribe(didIgnoreUnexpected2);
+      fsm2.send({ type: "PING" });
+      expect(fsm2.currentState).toEqual("group.two");
+      expect(didIgnoreUnexpected2).not.toHaveBeenCalled();
+    });
+
+    test("declaring IGNORE for an already-declared event still throws", () => {
+      expect(() =>
+        new FSM({})
+          .addState("foo")
+          .addTransitions("foo", { GO: "foo" })
+          .addTransitions("foo", { GO: IGNORE })
+      ).toThrow(/transition already exists/);
+    });
   });
 
   describe("time-based transitions", () => {

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -294,6 +294,16 @@ export class FSM<
   }
 
   /**
+   * Like {@link currentState}, but returns `null` instead of throwing when
+   * the machine hasn't started yet or has already stopped. Useful for code
+   * that may run during teardown windows (e.g. a WebSocket message handler
+   * that can be invoked by a buffered event after the socket is closed).
+   */
+  public get currentStateOrNull(): TState | null {
+    return this.#currentStateOrNull;
+  }
+
+  /**
    * Starts the machine by entering the initial state.
    */
   public start(): this {

--- a/packages/liveblocks-core/src/lib/fsm.ts
+++ b/packages/liveblocks-core/src/lib/fsm.ts
@@ -28,6 +28,19 @@ export type AsyncErrorEvent = {
 export type BaseEvent = { readonly type: string };
 export type BuiltinEvent = TimerEvent | AsyncOKEvent<unknown> | AsyncErrorEvent;
 
+/**
+ * Sentinel target value declaring "this event is intentionally a silent
+ * no-op in this state". Use as a static mapping value
+ * (`{ EVENT: IGNORE }`) or as a return value from a target function.
+ *
+ * Unlike a missing transition (which fires `didIgnoreUnexpectedEvent`),
+ * an IGNORE'd event is fully silent: no state change, no effects, and
+ * no observable notifications. The static form is also cheap — the
+ * dispatcher short-circuits before invoking any transition machinery.
+ */
+export const IGNORE: unique symbol = Symbol("fsm.ignore");
+export type IGNORE = typeof IGNORE;
+
 export type Patchable<TContext> = Readonly<TContext> & {
   patch(patch: Partial<TContext>): void;
 };
@@ -44,7 +57,7 @@ export type TargetFn<
 > = (
   event: TEvent,
   context: Readonly<TContext>
-) => TState | TargetObject<TContext, TEvent, TState> | null;
+) => TState | TargetObject<TContext, TEvent, TState> | IGNORE;
 
 export type Effect<TContext, TEvent extends BaseEvent> = (
   context: Patchable<TContext>,
@@ -209,13 +222,13 @@ export class FSM<
 
   #allowedTransitions: Map<
     TState,
-    Map<TEvent["type"], TargetFn<TContext, TEvent, TState>>
+    Map<TEvent["type"], TargetFn<TContext, TEvent, TState> | IGNORE>
   >;
 
   readonly #eventHub: {
     readonly didReceiveEvent: EventSource<TEvent | BuiltinEvent>;
     readonly willTransition: EventSource<{ from: TState; to: TState }>;
-    readonly didIgnoreEvent: EventSource<TEvent | BuiltinEvent>;
+    readonly didIgnoreUnexpectedEvent: EventSource<TEvent | BuiltinEvent>;
     readonly willExitState: EventSource<TState>;
     readonly didEnterState: EventSource<TState>;
     readonly didExitState: EventSource<{
@@ -227,7 +240,13 @@ export class FSM<
   public readonly events: {
     readonly didReceiveEvent: Observable<TEvent | BuiltinEvent>;
     readonly willTransition: Observable<{ from: TState; to: TState }>;
-    readonly didIgnoreEvent: Observable<TEvent | BuiltinEvent>;
+    /**
+     * Fires when an event is sent to a state that has no transition
+     * declared for it. Use this to surface programmer-error or unexpected
+     * runtime conditions. Events deliberately declared as `IGNORE` (either
+     * statically or via a `TargetFn` returning `IGNORE`) are silent here.
+     */
+    readonly didIgnoreUnexpectedEvent: Observable<TEvent | BuiltinEvent>;
     readonly willExitState: Observable<TState>;
     readonly didEnterState: Observable<TState>;
     readonly didExitState: Observable<{
@@ -294,16 +313,6 @@ export class FSM<
   }
 
   /**
-   * Like {@link currentState}, but returns `null` instead of throwing when
-   * the machine hasn't started yet or has already stopped. Useful for code
-   * that may run during teardown windows (e.g. a WebSocket message handler
-   * that can be invoked by a buffered event after the socket is closed).
-   */
-  public get currentStateOrNull(): TState | null {
-    return this.#currentStateOrNull;
-  }
-
-  /**
    * Starts the machine by entering the initial state.
    */
   public start(): this {
@@ -344,7 +353,7 @@ export class FSM<
     this.#eventHub = {
       didReceiveEvent: makeEventSource(),
       willTransition: makeEventSource(),
-      didIgnoreEvent: makeEventSource(),
+      didIgnoreUnexpectedEvent: makeEventSource(),
       willExitState: makeEventSource(),
       didEnterState: makeEventSource(),
       didExitState: makeEventSource(),
@@ -352,7 +361,8 @@ export class FSM<
     this.events = {
       didReceiveEvent: this.#eventHub.didReceiveEvent.observable,
       willTransition: this.#eventHub.willTransition.observable,
-      didIgnoreEvent: this.#eventHub.didIgnoreEvent.observable,
+      didIgnoreUnexpectedEvent:
+        this.#eventHub.didIgnoreUnexpectedEvent.observable,
       willExitState: this.#eventHub.willExitState.observable,
       didEnterState: this.#eventHub.didEnterState.observable,
       didExitState: this.#eventHub.didExitState.observable,
@@ -503,14 +513,19 @@ export class FSM<
    * `context` params to conditionally decide which next state to transition
    * to.
    *
-   * If you set it to `null`, then the transition will be explicitly forbidden
-   * and throw an error. If you don't define a target for a transition, then
-   * such events will get ignored.
+   * If you don't define a target for a transition, the event is treated
+   * as unhandled in this state: `didIgnoreUnexpectedEvent` fires and the
+   * state does not change.
+   *
+   * To declare an event as an intentional silent no-op in this state, use
+   * the {@link IGNORE} sentinel — either statically (`{ EVENT: IGNORE }`)
+   * or as a return value from a target function. IGNORE'd events do not
+   * fire `didIgnoreUnexpectedEvent`.
    */
   public addTransitions(
     nameOrPattern: TState | Wildcard<TState>,
     mapping: {
-      [E in TEvent as E["type"]]?: Target<TContext, E, TState> | null;
+      [E in TEvent as E["type"]]?: Target<TContext, E, TState> | IGNORE;
     }
   ): this {
     if (this.#runningState !== RunningState.NOT_STARTED_YET) {
@@ -533,11 +548,19 @@ export class FSM<
 
         const target = target_ as
           | Target<TContext, TEvent, TState>
-          | null
+          | IGNORE
           | undefined;
         this.#knownEventTypes.add(type);
 
-        if (target !== undefined) {
+        if (target === undefined) {
+          continue;
+        }
+
+        if (target === IGNORE) {
+          // Store the sentinel as-is so the dispatcher can short-circuit
+          // before any transition machinery runs.
+          map.set(type, IGNORE);
+        } else {
           const targetFn = typeof target === "function" ? target : () => target;
           map.set(type, targetFn);
         }
@@ -578,7 +601,7 @@ export class FSM<
 
   #getTargetFn(
     eventName: TEvent["type"]
-  ): TargetFn<TContext, TEvent, TState> | undefined {
+  ): TargetFn<TContext, TEvent, TState> | IGNORE | undefined {
     return this.#allowedTransitions.get(this.currentState)?.get(eventName);
   }
 
@@ -680,13 +703,16 @@ export class FSM<
       return;
     }
 
-    const targetFn = this.#getTargetFn(event.type);
-    if (targetFn !== undefined) {
-      return this.#transition(event, targetFn);
-    } else {
-      // Ignore the event otherwise
-      this.#eventHub.didIgnoreEvent.notify(event);
+    const entry = this.#getTargetFn(event.type);
+    if (entry === IGNORE) {
+      // Explicit silent no-op: short-circuit before any notification fires.
+      return;
     }
+    if (entry !== undefined) {
+      return this.#transition(event, entry);
+    }
+    // No transition declared for this event in this state — surface it.
+    this.#eventHub.didIgnoreUnexpectedEvent.notify(event);
   }
 
   #transition<E extends TEvent | BuiltinEvent>(
@@ -701,9 +727,10 @@ export class FSM<
     const nextTarget = targetFn(event, this.#currentContext.current);
     let nextState: TState;
     let effects: Effect<TContext, E>[] | undefined = undefined;
-    if (nextTarget === null) {
-      // Do not transition
-      this.#eventHub.didIgnoreEvent.notify(event);
+    if (nextTarget === IGNORE) {
+      // Target function chose to ignore this event in this state — silent
+      // no-op. `didReceiveEvent` already fired above, since we had to
+      // invoke the function to find out.
       return;
     }
 


### PR DESCRIPTION
Updates the state machine so that not only PONG responses from the server are counted as still-alive, but basically any incoming message (PONGs included) is enough proof the connection is still alive.