### PR TITLE
Fix CDPATH inheritance issue when run from a worktree group

### DIFF
--- a/scripts/for-all-e2e.sh
+++ b/scripts/for-all-e2e.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -eu
+CDPATH=''  # Don't let inherited CDPATHs hijack our relative cd's
 
 # Ensure this script can assume it's run from the repo's
 # root directory, even if the current working directory is

--- a/scripts/for-all-examples.sh
+++ b/scripts/for-all-examples.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -eu
+CDPATH=''  # Don't let inherited CDPATHs hijack our relative cd's
 
 # Ensure this script can assume it's run from the repo's
 # root directory, even if the current working directory is

--- a/scripts/for-all-packages.sh
+++ b/scripts/for-all-packages.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -eu
+CDPATH=''  # Don't let inherited CDPATHs hijack our relative cd's
 
 # Ensure this script can assume it's run from the repo's
 # root directory, even if the current working directory is


### PR DESCRIPTION
This is a common hardening strategy for shell scripts that run unexpectedly in an environment with CDPATH set.