### PR TITLE
Auto-insert missing CHANGELOG headings during release

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -124,7 +124,7 @@ inject_changelog_heading () {
     echo "==> Adding CHANGELOG heading for v$VERSION"
     tmp="$(mktemp)"
     if awk -v ver="$VERSION" '
-        !done && /^## vNEXT \(not yet released\)$/ {
+        !done && /^## vNEXT( .*)?$/ {
             print
             print ""
             print "## v" ver
@@ -137,7 +137,7 @@ inject_changelog_heading () {
         mv "$tmp" "$CHANGELOG"
     else
         rm -f "$tmp"
-        err "WARNING: Could not find a '## vNEXT (not yet released)' section in"
+        err "WARNING: Could not find a '## vNEXT' section in"
         err "$CHANGELOG; skipping CHANGELOG heading insertion."
     fi
 }

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -91,6 +91,57 @@ commit_to_git () {
     ) )
 }
 
+# A "final" release is X.Y.Z with no -prerelease suffix. Pre-releases like
+# 3.19.4-rc2 are intentionally excluded from CHANGELOG heading insertion.
+is_final_release () {
+    [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+# True if CHANGELOG.md already has a "## vX.Y.Z" heading for this version.
+changelog_has_heading () {
+    grep -qE "^## v${VERSION//./\\.}( .*)?\$" "$ROOT/CHANGELOG.md"
+}
+
+# Insert a "## vX.Y.Z" heading right below the "vNEXT (not yet released)"
+# section, claiming all accumulated entries for this release. No-op for
+# pre-releases and for versions that already have a heading.
+inject_changelog_heading () {
+    CHANGELOG="$ROOT/CHANGELOG.md"
+
+    if ! is_final_release; then
+        echo "==> Skipping CHANGELOG heading for pre-release $VERSION"
+        return
+    fi
+    if [ ! -f "$CHANGELOG" ]; then
+        err "WARNING: $CHANGELOG not found, skipping CHANGELOG heading"
+        return
+    fi
+    if changelog_has_heading; then
+        echo "==> CHANGELOG already has a heading for v$VERSION, leaving as-is"
+        return
+    fi
+
+    echo "==> Adding CHANGELOG heading for v$VERSION"
+    tmp="$(mktemp)"
+    if awk -v ver="$VERSION" '
+        !done && /^## vNEXT \(not yet released\)$/ {
+            print
+            print ""
+            print "## v" ver
+            done = 1
+            next
+        }
+        { print }
+        END { exit (done ? 0 : 3) }
+    ' "$CHANGELOG" > "$tmp"; then
+        mv "$tmp" "$CHANGELOG"
+    else
+        rm -f "$tmp"
+        err "WARNING: Could not find a '## vNEXT (not yet released)' section in"
+        err "$CHANGELOG; skipping CHANGELOG heading insertion."
+    fi
+}
+
 check_is_valid_version "$VERSION"
 
 # Run a fresh install to ensure the lock file isn't outdated before continuing
@@ -104,4 +155,7 @@ done
 # Update pnpm-lock.yaml with newly bumped versions
 pnpm install --no-frozen-lockfile
 
-commit_to_git "${COMMIT_MESSAGE}${VERSION}" "pnpm-lock.yaml" "packages/" "tools/"
+# Add a CHANGELOG heading for this release if one doesn't exist yet
+inject_changelog_heading
+
+commit_to_git "${COMMIT_MESSAGE}${VERSION}" "pnpm-lock.yaml" "packages/" "tools/" "CHANGELOG.md"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -97,26 +97,58 @@ is_final_release () {
     [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
-# True if CHANGELOG.md already has a "## vX.Y.Z" heading for this version.
+# True if the given CHANGELOG already has a "## vX.Y.Z" heading for this version.
 changelog_has_heading () {
-    grep -qE "^## v${VERSION//./\\.}( .*)?\$" "$ROOT/CHANGELOG.md"
+    grep -qE "^## v${VERSION//./\\.}( .*)?\$" "$1"
 }
 
-# Insert a "## vX.Y.Z" heading right below the "vNEXT (not yet released)"
-# section, claiming all accumulated entries for this release. No-op for
-# pre-releases and for versions that already have a heading.
+# True if a fresh "## vX.Y.Z" heading is due to be inserted into this CHANGELOG.
+changelog_needs_heading () {
+    is_final_release && [ -f "$1" ] && ! changelog_has_heading "$1"
+}
+
+# Classify the "## vNEXT" section of a CHANGELOG: prints "nonempty", "empty"
+# (immediately followed by another "## " heading or only blank lines), or
+# "missing" (no vNEXT section at all).
+vnext_state () {
+    awk '
+        /^## vNEXT( .*)?$/ { seen = 1; next }
+        seen && /^## /          { print "empty"; found = 1; exit }
+        seen && /[^[:space:]]/  { print "nonempty"; found = 1; exit }
+        END { if (!found) print (seen ? "empty" : "missing") }
+    ' "$1"
+}
+
+# Fail fast (before any version bump) if a heading is due for this release but
+# there are no entries to release under "## vNEXT". A skipped heading
+# (pre-release, or already present) needs no entries and is left alone.
+assert_changelog_ready () {
+    CHANGELOG="$1"
+    changelog_needs_heading "$CHANGELOG" || return 0
+    case "$( vnext_state "$CHANGELOG" )" in
+        nonempty) ;;
+        empty)
+            err "ERROR: No changelog entries under '## vNEXT' in $CHANGELOG."
+            err "Add release notes there before releasing v$VERSION."
+            exit 2 ;;
+        missing)
+            err "ERROR: No '## vNEXT' section found in $CHANGELOG."
+            err "Cannot insert a heading for v$VERSION."
+            exit 2 ;;
+    esac
+}
+
+# Insert a "## vX.Y.Z" heading right below the "vNEXT" section, claiming all
+# accumulated entries for this release. No-op for pre-releases and for versions
+# that already have a heading.
 inject_changelog_heading () {
-    CHANGELOG="$ROOT/CHANGELOG.md"
+    CHANGELOG="$1"
 
     if ! is_final_release; then
         echo "==> Skipping CHANGELOG heading for pre-release $VERSION"
         return
     fi
-    if [ ! -f "$CHANGELOG" ]; then
-        err "WARNING: $CHANGELOG not found, skipping CHANGELOG heading"
-        return
-    fi
-    if changelog_has_heading; then
+    if changelog_has_heading "$CHANGELOG"; then
         echo "==> CHANGELOG already has a heading for v$VERSION, leaving as-is"
         return
     fi
@@ -144,6 +176,9 @@ inject_changelog_heading () {
 
 check_is_valid_version "$VERSION"
 
+# Fail fast if a heading is due for this release but vNEXT has no entries
+assert_changelog_ready "$ROOT/CHANGELOG.md"
+
 # Run a fresh install to ensure the lock file isn't outdated before continuing
 pnpm install --no-frozen-lockfile
 git is-clean -v
@@ -156,6 +191,6 @@ done
 pnpm install --no-frozen-lockfile
 
 # Add a CHANGELOG heading for this release if one doesn't exist yet
-inject_changelog_heading
+inject_changelog_heading "$ROOT/CHANGELOG.md"
 
 commit_to_git "${COMMIT_MESSAGE}${VERSION}" "pnpm-lock.yaml" "packages/" "tools/" "CHANGELOG.md"


### PR DESCRIPTION
This PR makes `release.sh` auto-insert a `## vX.Y.Z` heading into `CHANGELOG.md` when one doesn't exist yet for the version being released, so I stop forgetting to do it by hand and triggering an extra PR roundtrip right before publishing. 😇

The heading is added directly below the permanent `## vNEXT` section. It piggy-backs on the existing `Bump to X.Y.Z` commit which already makes file changes during publishing.

It only fires for real releases that don't already have a heading:

| When asked to release...       | Behavior                                |
| --------------- | --------------------------------------- |
| `v3.19.4`        | ✅ inserts `## v3.19.4`                  |
| `v3.20.0`        | ✅ inserts `## v3.20.0`                  |
| `v3.19.4-rc2`    | ❌ skipped (pre-release)                 |
| `v3.18.0`        | ❌ skipped (heading already exists)      |

If the `vNEXT` section can't be found, it warns and leaves the file untouched rather than guessing.
