### PR TITLE
Make dev server Docker publish workflow manually triggered only

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,22 +1,8 @@
-name: Publish Docker images
+name: Publish Docker image for Liveblocks dev server
 
+# Builds and publishes the Liveblocks dev-server Docker image. Run manually after
+# the `liveblocks` CLI is published to npm, passing the published CLI version.
 on:
-  push:
-    tags:
-      - "v*"
-    branches:
-      - main
-    paths:
-      - "tools/liveblocks-cli/**"
-      - "packages/liveblocks-server/**"
-      - ".github/workflows/publish-docker-images.yml"
-      - ".github/workflows/docker-image.yml"
-  pull_request:
-    paths:
-      - "tools/liveblocks-cli/**"
-      - "packages/liveblocks-server/**"
-      - ".github/workflows/publish-docker-images.yml"
-      - ".github/workflows/docker-image.yml"
   workflow_dispatch:
     inputs:
       version:
@@ -25,49 +11,12 @@ on:
         description: "CLI package version to build Docker images for (e.g. 1.0.6, without v prefix). Images are tagged as a release with this version."
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-      is_release: ${{ steps.v.outputs.is_release }}
-      # Non-empty only for workflow_dispatch triggers. Passed to docker-image.yml
-      # so it can apply explicit version tags (type=raw) since there is no git tag
-      # for docker/metadata-action's type=semver to derive versions from.
-      release_version: ${{ steps.v.outputs.release_version }}
-    steps:
-      - name: Extract version
-        id: v
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            # External trigger with explicit version (e.g. from liveblocks-backend
-            # publish workflow). There is no git tag, so we pass the version
-            # explicitly for docker-image.yml to use as raw tags.
-            VERSION="${{ inputs.version }}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
-            # Tag push (e.g. v1.0.6). docker/metadata-action derives semver tags
-            # from the git tag automatically, so release_version is left empty.
-            VERSION="${GITHUB_REF_NAME#v}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "release_version=" >> "$GITHUB_OUTPUT"
-          else
-            # Non-release build (branch push, PR). No version tags applied.
-            VERSION=$(npm view liveblocks version)
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
-            echo "release_version=" >> "$GITHUB_OUTPUT"
-          fi
-
   publish:
-    needs: version
     uses: ./.github/workflows/docker-image.yml
     with:
       image: liveblocks/dev-server
-      is_release: ${{ needs.version.outputs.is_release }}
-      release_version: ${{ needs.version.outputs.release_version }}
+      is_release: "true"
+      release_version: ${{ inputs.version }}
       build-args: |
-        CLI_VERSION=${{ needs.version.outputs.version }}
-        VERSION=${{ needs.version.outputs.version }}
+        CLI_VERSION=${{ inputs.version }}
+        VERSION=${{ inputs.version }}


### PR DESCRIPTION
Fixes this incorrect auto-trigger, which would fail on `main` after every release of the public packages we do. This workflow should only get triggered manually after we publish the dev server from the backend repo.

<img width="1978" height="158" alt="Screen Shot 2026-06-02 at 10 41 26@2x" src="https://github.com/user-attachments/assets/be5373a2-915f-4860-b487-02367c9f23a1" />
