### PR TITLE
Fix `LiveList` push divergence after reconnect (client-side half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## vNEXT (not yet released)
 
-- Export internal utility
+### `@liveblocks/client`
+
+- Fix a `LiveList` divergence after reconnects: a pending `push` could under
+  specific timing conditions during a reconnect still cause a divergence between
+  clients, despite the fix from 3.19.4.
 
 ## v3.19.4
 

--- a/packages/liveblocks-core/e2e/README.md
+++ b/packages/liveblocks-core/e2e/README.md
@@ -44,6 +44,6 @@ Run a specific test file:
 npx turbo test:e2e -- e2e/list-insert.test.ts
 ```
 
-**Note**: Since these tests run against an actual production deployment, they
-require a `LIVEBLOCKS_PUBLIC_KEY` environment variable to connect to the
-Liveblocks service.
+**Note**: These tests run against a local Liveblocks dev server, which the
+`test:e2e` script starts automatically (`liveblocks dev`). No API key is
+needed; set `LIVEBLOCKS_DEV_SERVER_PORT` to override the default port (1154).

--- a/packages/liveblocks-core/e2e/list-consistency.test.ts
+++ b/packages/liveblocks-core/e2e/list-consistency.test.ts
@@ -91,7 +91,7 @@ test(
     // This test verifies that undo/redo operations maintain consistency across clients
     // when operations are performed on different clients in a distributed environment.
     async ({ root1, root2, room1, room2, control, assert }) => {
-      // Client A does a move operation: move C (index 2) to position 0
+      // Client A moves 🟢 (index 2) to position 0; Client B deletes it
       root1.get("list").move(2, 0);
       root2.get("list").delete(2);
       assert(

--- a/packages/liveblocks-core/e2e/list-push-reconnect-divergence.test.ts
+++ b/packages/liveblocks-core/e2e/list-push-reconnect-divergence.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
 
 import { LiveList } from "../src/crdts/LiveList";
-import { prepareTestsConflicts } from "./utils";
+import { withTimeout } from "../src/lib/utils";
+import { prepareTestsConflicts, waitUntilStatus } from "./utils";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -78,6 +79,74 @@ test(
       // Both clients must agree on the server's order, [P, Q].
       expect(list1.toJSON()).toEqual(list2.toJSON());
       expect(list2.toJSON()).toEqual(["P", "Q"]);
+    }
+  )
+);
+
+/**
+ * Same divergence, but reached *after* the snapshot reconcile, via a live op.
+ *
+ * After a reconnect, the snapshot reconcile itself adopts the server's
+ * positions, but the re-sent pending push stays unacknowledged until the
+ * server's ack lands. A remote sibling push arriving as a live op inside that
+ * window triggers the optimistic tail-bump, which moves the pending push past
+ * the sibling. The server already stored the push, so the re-send is acked
+ * without a repositioning op, and the bump is never undone.
+ *
+ * In the wild this window is widened by large list items (their re-send is
+ * slow to reach the server), which is why the bug shows up intermittently and
+ * mostly with big payloads. The test simulates that slowness by stalling A's
+ * uplink while the re-send sits on it.
+ */
+test(
+  "a sibling pushed while a re-sent pending push awaits its ack keeps its server position",
+  prepareTestsConflicts(
+    { list: new LiveList<string>([]) },
+    async ({ root1, root2, room1, control }) => {
+      const list1 = root1.get("list");
+      const list2 = root2.get("list");
+
+      // 1. Client A pushes P and flushes it to the server, but stalls its
+      //    downlink first, so the server's ack/echo never reaches A before the
+      //    connection drops: P is stored server-side (so B sees it) yet stays
+      //    *pending* on A.
+      list1.push("P");
+      control.pauseIncomingA();
+      await control.flushA(); // Ensure client B sees P
+
+      // 2. A reconnects, and we stall the fresh socket's uplink right after it
+      //    connects: at that point its FETCH_STORAGE request is already out
+      //    (sent synchronously on connect), but the snapshot needs a server
+      //    round trip, so the reconcile hasn't run yet. The reconcile then
+      //    puts the re-send of P on the stalled uplink instead of on the wire,
+      //    keeping P pending. The reconcile signals completion through the
+      //    storageDidLoad event.
+      const reconciled$ = room1.events.storageDidLoad.waitUntil();
+      room1.reconnect();
+      await waitUntilStatus(room1, "connecting");
+      await waitUntilStatus(room1, "connected");
+      control.pauseA();
+      await withTimeout(
+        reconciled$,
+        10_000,
+        "Client A did not reconcile after reconnect within 10s"
+      );
+
+      // 3. B pushes Q. It reaches A as a live op while P is still pending.
+      list2.push("Q");
+      await control.flushB();
+
+      // 4. Only now release P's re-send. P is already stored server-side, so
+      //    it must keep its server position (before Q) on both clients.
+      await control.flushA();
+
+      // Let any acks settle. (flushA's beacon is confirmed by Client B, so it
+      // says nothing about A having received its ack yet.)
+      await sleep(500);
+
+      // Both clients must agree on the server's order, [P, Q].
+      expect(list2.toJSON()).toEqual(["P", "Q"]);
+      expect(list1.toJSON()).toEqual(list2.toJSON());
     }
   )
 );

--- a/packages/liveblocks-core/e2e/list-push-reconnect-divergence.test.ts
+++ b/packages/liveblocks-core/e2e/list-push-reconnect-divergence.test.ts
@@ -21,16 +21,15 @@ async function waitUntil(
 }
 
 /**
- * Deterministic reproduction of the offline.test.ts "client synchronizes
- * offline changes" divergence.
+ * Deterministic version of the offline.test.ts "client synchronizes offline
+ * changes" scenario.
  *
- * The trigger is an item that the server has already stored but that the
+ * The tricky case is an item that the server has already stored but that the
  * pushing client still considers pending (unacknowledged), because the client
- * never received the ack. On reconnect, the client's optimistic tail-bump
- * moves that pending push past a sibling the other client added, re-sends it at
- * its original key, and the server bare-acks it (already stored, no
- * reposition), so the bump is never undone. The two clients then disagree on
- * the order.
+ * never received the ack. On reconnect, the snapshot also carries a sibling
+ * the other client appended in the meantime. The still-pending item must keep
+ * its server position (before the sibling) on both clients, rather than being
+ * optimistically bumped past it by its own re-sent push.
  */
 test(
   "a pending push the server already stored keeps its server position after reconnect",
@@ -40,9 +39,10 @@ test(
       const list1 = root1.get("list");
       const list2 = root2.get("list");
 
-      // 1. Client A pushes P and flushes it to the server, but drops every
-      //    incoming message first, so the server's ack/echo never reaches A: P
-      //    is stored server-side (so B sees it) yet stays *pending* on A.
+      // 1. Client A pushes P and flushes it to the server, but stalls its
+      //    downlink first, so the server's ack/echo never reaches A before the
+      //    connection drops: P is stored server-side (so B sees it) yet stays
+      //    *pending* on A.
       list1.push("P");
       control.dropIncomingA();
       control.flushSyncA();
@@ -62,9 +62,9 @@ test(
         "Client B sees [P, Q]"
       );
 
-      // 4. A reconnects. The snapshot carries both P and Q; A's tail-bump moves
-      //    its still-pending P past Q, then re-sends P at its original key. The
-      //    server bare-acks (P already there), so A's bump is never undone.
+      // 4. A reconnects. The snapshot carries both P and Q, and A re-sends its
+      //    still-pending P. P is already stored server-side, so it must keep
+      //    its server position (before Q) on both clients.
       room1.reconnect();
 
       await waitUntil(

--- a/packages/liveblocks-core/e2e/list-push-reconnect-divergence.test.ts
+++ b/packages/liveblocks-core/e2e/list-push-reconnect-divergence.test.ts
@@ -44,7 +44,7 @@ test(
       //    connection drops: P is stored server-side (so B sees it) yet stays
       //    *pending* on A.
       list1.push("P");
-      control.dropIncomingA();
+      control.pauseIncomingA();
       control.flushSyncA();
       await waitUntil(
         () => [...list2].includes("P"),
@@ -76,8 +76,8 @@ test(
       await sleep(500);
 
       // Both clients must agree on the server's order, [P, Q].
-      expect([...list1]).toEqual([...list2]);
-      expect([...list2]).toEqual(["P", "Q"]);
+      expect(list1.toJSON()).toEqual(list2.toJSON());
+      expect(list2.toJSON()).toEqual(["P", "Q"]);
     }
   )
 );

--- a/packages/liveblocks-core/e2e/list-push.test.ts
+++ b/packages/liveblocks-core/e2e/list-push.test.ts
@@ -4,11 +4,11 @@ import { LiveList } from "../src/crdts/LiveList";
 import { prepareTestsConflicts } from "./utils";
 
 // Two actors append to the same LiveList near-simultaneously: client A appends
-// a1 then a2; client B appends b1 without yet having seen a1/a2, so b1 guesses
-// the head position. By the time b1 reaches the server, a1 and a2 are already
-// stored, and the position conflict is resolved *between* them — so the list
-// settles as [a1, b1, a2] instead of append order [a1, a2, b1].
-// A server-authoritative append must place b1 at the true end.
+// a1 then a2; client B appends b1 without yet having seen a1/a2, so b1's
+// client-computed position is stale by the time it reaches the server (a1 and
+// a2 are already stored there). Because the op is tagged with intent: "push",
+// the server ignores that stale position and appends b1 at the true end, so
+// both clients settle in append order: [a1, a2, b1].
 test(
   "concurrent pushes settle in append order, never wedged",
   prepareTestsConflicts(

--- a/packages/liveblocks-core/e2e/list-set.test.ts
+++ b/packages/liveblocks-core/e2e/list-set.test.ts
@@ -215,7 +215,7 @@ test(
       list: new LiveList(["a"]),
     },
     async ({ root1, root2, control, assert }) => {
-      // Client A replaces "a" with "X"
+      // Client A replaces "a" with "🟢"
       root1.get("list").set(0, "🟢");
 
       // Client B simultaneously deletes "a"
@@ -245,8 +245,6 @@ test(
     },
     async ({ root1, root2, control, assert }) => {
       // Client A changes "a" to "🟢" and moves it after "b"
-      // This is done in a batch to ensure the default throttling won't
-      // send the second operation in the message queue
       root1.get("list").set(0, "🟢");
       root1.get("list").move(0, 1);
       assert(

--- a/packages/liveblocks-core/e2e/storage-notification-reconnect.test.ts
+++ b/packages/liveblocks-core/e2e/storage-notification-reconnect.test.ts
@@ -17,9 +17,10 @@
  *
  * NOTE ON CONTROL KEYS: several LiveObject tests carry an unchanged scalar key
  * (e.g. `keep`) that the mutation never touches. The reconnect path routes a
- * snapshot through `getTreesDiffOperations`, which re-sends the *full*
- * UPDATE_OBJECT data — so an unchanged key can be spuriously re-notified. The
- * control key is what makes that bug observable; do not remove it.
+ * snapshot through `getTreesDiffOperations`, whose UPDATE_OBJECT ops must
+ * carry only the keys that actually changed — a full-data re-send would
+ * spuriously re-notify the unchanged key. The control key is what makes that
+ * observable; do not remove it.
  */
 import { expect, onTestFinished, test } from "vitest";
 import WebSocket from "ws";
@@ -483,11 +484,10 @@ test("LiveObject: nested-object deletes fire equivalent notifications online and
   ).toEqual({ x: 1 });
 });
 
-// Baseline (passes today): when the transitioned key is the object's *only*
-// scalar, moving it into a child node empties the object's `data`, so the
-// snapshot diff produces an UPDATE_OBJECT with empty data — nothing left for
-// the full-data re-send to spuriously re-notify. Contrast with the next test,
-// which adds a surviving scalar sibling and exposes that exact leak.
+// Baseline: when the transitioned key is the object's *only* scalar, moving
+// it into a child node empties the object's `data`, so the snapshot diff has
+// no other scalar keys to consider. The next test adds a surviving scalar
+// sibling, which the diff must not spuriously re-notify.
 test("LiveObject: scalar→nested-object transition (sole key) fires equivalent notifications online and on reconnect", async () => {
   const { online, reconnect } = await bothPhases(
     () => ({
@@ -573,9 +573,8 @@ test("LiveObject: nested-object→scalar transition fires equivalent notificatio
 //   - the online path saw the intermediate churn while the reconnect path saw
 //     only the collapsed net result.
 //
-// Unlike the bug-spec tests above, these are expected to PASS on the current
-// path — they lock in the collapse semantics so the reconcile refactor can't
-// regress them.
+// These lock in the collapse semantics so the reconcile refactor can't regress
+// them.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const insertedItems = (deltas: ListUpdate["updates"]): unknown[] =>

--- a/packages/liveblocks-core/e2e/utils.ts
+++ b/packages/liveblocks-core/e2e/utils.ts
@@ -337,6 +337,10 @@ export function prepareTestsConflicts<S extends LsonObject>(
       resumeIncomingB: () => actor2.ws.resumeIncoming(),
     };
 
+    // TODO Maybe make this the default behavior of the ControlledWebSocket
+    // class, and clearly document this. _Send_ is paused by default, but
+    // _recv_ is not. I think that'd be a nice default?
+    // TODO Not super sure though how it related to the one-time sync below.
     actor1.ws.pause();
     actor2.ws.pause();
 

--- a/packages/liveblocks-core/e2e/utils.ts
+++ b/packages/liveblocks-core/e2e/utils.ts
@@ -24,12 +24,23 @@ async function initializeRoomForTest<
   TM extends BaseMetadata = BaseMetadata,
   CM extends BaseMetadata = BaseMetadata,
 >(roomId: string, initialPresence: NoInfr<P>, initialStorage: NoInfr<S>) {
-  let ws: PausableWebSocket | null = null;
+  let ws: ControlledWebSocket | null = null;
 
-  class PausableWebSocket extends WebSocket {
-    sendBuffer: string[] = [];
-    _isSendPaused = false;
-    _dropIncoming = false;
+  /**
+   * A WebSocket whose two directions can each be stalled, like a real
+   * network pipe. A stalled direction buffers frames FIFO; un-stalling
+   * delivers them in their original order, so the stream order can never be
+   * changed by these controls, only delayed.
+   *
+   * All state is per-socket. A reconnect creates a fresh, unstalled socket,
+   * and whatever was still buffered on the old socket is simply never
+   * delivered: those frames were in flight when the connection died.
+   */
+  class ControlledWebSocket extends WebSocket {
+    // When non-null, the direction is stalled and the array buffers its
+    // frames, in order. When null, frames flow through.
+    sendBuffer: string[] | null = null;
+    recvBuffer: unknown[][] | null = null;
 
     constructor(address: string | URL) {
       super(address);
@@ -38,50 +49,65 @@ async function initializeRoomForTest<
     }
 
     /**
-     * Stops sending messages through to the server. Effectively starts
-     * buffering messages in-memory until .resume() is called.
+     * Stalls the uplink: outgoing messages are buffered in-memory instead of
+     * sent, until .resume() is called. Models a slow upload or backpressure.
      */
     pause() {
-      this._isSendPaused = true;
+      this.sendBuffer ??= [];
     }
 
     /**
-     * Immediately sends all buffered messages to the server and stops
-     * buffering any new messages.
+     * Stalls the downlink: messages the server sends are buffered instead of
+     * delivered, until .resumeIncoming() is called. Models slow delivery.
+     *
+     * Stalling the downlink and then reconnecting simulates "the server
+     * received and processed our op, but its ack/echo never reached us": the
+     * buffered ack dies with the socket, and the op stays pending
+     * (unacknowledged) on this client across the reconnect.
+     */
+    pauseIncoming() {
+      this.recvBuffer ??= [];
+    }
+
+    /**
+     * Immediately sends all buffered messages to the server, in order, and
+     * stops buffering any new messages.
      */
     resume() {
-      this._isSendPaused = false;
-      for (const item of this.sendBuffer) {
+      const sendBuffer = this.sendBuffer;
+      this.sendBuffer = null;
+      for (const item of sendBuffer ?? []) {
         super.send(item);
       }
-      this.sendBuffer = [];
+    }
+
+    /**
+     * Immediately delivers all buffered incoming messages, in order, and
+     * stops buffering any new ones.
+     */
+    resumeIncoming() {
+      const recvBuffer = this.recvBuffer;
+      this.recvBuffer = null;
+      for (const args of recvBuffer ?? []) {
+        super.emit("message", ...args);
+      }
     }
 
     send(data: string) {
-      if (this._isSendPaused) {
+      if (this.sendBuffer !== null) {
         this.sendBuffer.push(data);
       } else {
         super.send(data);
       }
     }
 
-    /**
-     * Silently drops every message the server sends from now on, as if the
-     * network ate them. Used to keep an op "pending" on this client even
-     * though the server already received and processed it: the server's
-     * ack/echo never reaches the client, so it never clears from
-     * unacknowledgedOps.
-     */
-    dropIncoming() {
-      this._dropIncoming = true;
-    }
-
     // `ws` delivers incoming frames by emitting a "message" event (both
-    // addEventListener and .on() listeners run through this). Swallow those
-    // emissions while dropping, leaving every other event untouched.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches EventEmitter.emit's own signature
+    // addEventListener and .on() listeners run through this). Buffer those
+    // emissions while the downlink is stalled, leaving every other event
+    // untouched.
     emit(eventName: string | symbol, ...args: any[]): boolean {
-      if (this._dropIncoming && eventName === "message") {
+      if (this.recvBuffer !== null && eventName === "message") {
+        this.recvBuffer.push(args);
         return false;
       }
       return super.emit(eventName, ...args);
@@ -92,7 +118,7 @@ async function initializeRoomForTest<
     __DANGEROUSLY_disableThrottling: true,
     publicApiKey: "pk_localdev",
     polyfills: {
-      WebSocket: PausableWebSocket,
+      WebSocket: ControlledWebSocket,
     },
     baseUrl: BASE_URL,
   });
@@ -140,39 +166,55 @@ export function prepareTestsConflicts<S extends LsonObject>(
     /** Test utilities to exactly control message passing */
     control: {
       /**
-       * Sends all buffered messages from Client A to Client B, and waits
-       * until Client B has processed them.
+       * Flushes all messages from Client A and waits until Client B has
+       * received them.
+       * Note that this will hang if client B's downlink has been stalled, as
+       * it's unable to receive any messages until resumed.
        */
+      // TODO: Rename to flushAtoB() later
       flushA: () => Promise<void>;
       /**
-       * Sends all buffered messages from Client B to Client A, and waits
-       * until Client A has processed them.
+       * Flushes all messages from Client B and waits until Client A has
+       * received them.
+       * Note that this will hang if client A's downlink has been stalled, as
+       * it's unable to receive any messages until resumed.
        */
+      // TODO: Rename to flushBtoA() later
       flushB: () => Promise<void>;
       /**
-       * Flushes Client A's buffered sends to the server without waiting for a
-       * beacon round-trip. Use when Client A is dropping incoming messages (so
-       * a beacon would never return).
+       * Flushes Client A's buffered sends to the server (unlike flushA,
+       * without waiting for any confirmation).
        */
+      // TODO: Rename to flushToServerA() later
       flushSyncA: () => void;
       /**
-       * Flushes Client B's buffered sends to the server without waiting for a
-       * beacon round-trip. Use when Client B is dropping incoming messages (so
-       * a beacon would never return).
+       * Flushes Client B's buffered sends to the server (unlike flushB,
+       * without waiting for any confirmation).
        */
+      // TODO: Rename to flushToServerB() later
       flushSyncB: () => void;
       /**
-       * Makes client A silently drop every message the server sends from now
-       * on, keeping its in-flight ops "pending" even after the server has
-       * processed them.
+       * Stalls client A's uplink: outgoing messages buffer in order instead
+       * of being sent, until the next flush. Note that this stalls the
+       * *current* socket; a socket freshly created by a reconnect starts
+       * unstalled.
        */
-      dropIncomingA: () => void;
+      pauseA: () => void;
+      /** Same as pauseA, for client B. */
+      pauseB: () => void;
       /**
-       * Makes client B silently drop every message the server sends from now
-       * on, keeping its in-flight ops "pending" even after the server has
-       * processed them.
+       * Stalls client A's downlink: messages from the server buffer in order
+       * instead of being delivered, until resumeIncomingA(). Stalled messages
+       * die with the socket, so following this up with a reconnect simulates
+       * "the server processed our op, but its ack never reached us".
        */
-      dropIncomingB: () => void;
+      pauseIncomingA: () => void;
+      /** Same as pauseIncomingA, for client B. */
+      pauseIncomingB: () => void;
+      /** Delivers client A's stalled incoming messages, and stops stalling. */
+      resumeIncomingA: () => void;
+      /** Delivers client B's stalled incoming messages, and stops stalling. */
+      resumeIncomingB: () => void;
     };
   }) => Promise<void>
 ): () => Promise<void> {
@@ -287,13 +329,12 @@ export function prepareTestsConflicts<S extends LsonObject>(
         actor2.ws.pause();
       },
 
-      dropIncomingA: () => {
-        actor1.ws.dropIncoming();
-      },
-
-      dropIncomingB: () => {
-        actor2.ws.dropIncoming();
-      },
+      pauseA: () => actor1.ws.pause(),
+      pauseB: () => actor2.ws.pause(),
+      pauseIncomingA: () => actor1.ws.pauseIncoming(),
+      pauseIncomingB: () => actor2.ws.pauseIncoming(),
+      resumeIncomingA: () => actor1.ws.resumeIncoming(),
+      resumeIncomingB: () => actor2.ws.resumeIncoming(),
     };
 
     actor1.ws.pause();
@@ -355,7 +396,6 @@ export function prepareTestsConflicts<S extends LsonObject>(
       // Surface the full storage pool of both clients (every node, its parent,
       // its position key, and its value) so convergence failures are debuggable
       // from the test output alone.
-      // eslint-disable-next-line no-console
       console.error(
         `\n=== Storage pool dump on failure ===\n${actor1.room._dump()}\n\n${actor2.room._dump()}\n`
       );
@@ -422,7 +462,7 @@ export function prepareSingleClientTest<S extends LsonObject>(
  * asynchronously reached a particular status. Status must be reached within
  * a limited time window, or else this will fail, to avoid hanging.
  */
-async function waitUntilStatus(
+export async function waitUntilStatus(
   room: Room<JsonObject, LsonObject, BaseUserMeta, Json, BaseMetadata>,
   targetStatus: Status
 ): Promise<void> {

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -373,19 +373,8 @@ export abstract class AbstractCrdt {
     this.#pool = pool;
   }
 
-  /**
-   * @internal
-   * `fromSnapshot` is set when the op is part of a full-state snapshot
-   * reconstruction (the reconnect reconcile) rather than a live incremental op.
-   * Only LiveList uses it, to suppress its optimistic push tail-bump: the bump
-   * predicts where the server will place pending pushes, but a snapshot already
-   * holds the final positions, so there's nothing to predict.
-   */
-  abstract _attachChild(
-    op: CreateOp,
-    source: OpSource,
-    fromSnapshot?: boolean
-  ): ApplyResult;
+  /** @internal */
+  abstract _attachChild(op: CreateOp, source: OpSource): ApplyResult;
 
   /** @internal */
   _detach(): void {

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -429,7 +429,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return result.modified.updates[0];
   }
 
-  #applyRemoteInsert(op: CreateOp, fromSnapshot: boolean): ApplyResult {
+  #applyRemoteInsert(op: CreateOp): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -452,12 +452,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     // a view that excludes our still-unacked pushes, so they can't address a
     // position inside our pending tail block.
     //
-    // The bump is a purely-local, live-only anti-flicker prediction of where
-    // the server will place things. While reconstructing from a server snapshot
-    // (reconnect reconcile) we already have the answer, so we don't predict:
-    // bumping there would override the snapshot's positions with a guess, and
-    // the diff carries no corrective op to undo it.
-    const bumpDeltas = fromSnapshot ? [] : this.#bumpUnackedPushesAbove(key);
+    // The bump is a purely-local anti-flicker prediction of where the server
+    // will place things. It's sound because #unackedPushNodes only yields ops
+    // the server has provably not processed yet (ops whose fate became
+    // unknown in a disconnect are excluded at that source).
+    const bumpDeltas = this.#bumpUnackedPushesAbove(key);
 
     return {
       modified: makeUpdate(this, [
@@ -711,11 +710,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  _attachChild(
-    op: CreateOp,
-    source: OpSource,
-    fromSnapshot: boolean = false
-  ): ApplyResult {
+  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -732,7 +727,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       }
     } else {
       if (source === OpSource.THEIRS) {
-        result = this.#applyRemoteInsert(op, fromSnapshot);
+        result = this.#applyRemoteInsert(op);
       } else if (source === OpSource.OURS) {
         result = this.#applyInsertAck(op);
       } else {

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -474,6 +474,13 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * the single source of truth, so an item drops out the instant its op is
    * acked, with no per-instance membership to leak. Yielded in push order.
    *
+   * Excludes ops that may already be stored on the server (they were in
+   * flight when a connection died, so their fate is unknown): the bump
+   * prediction assumes the server has not processed the op yet, which is only
+   * guaranteed for ops sent on the current connection. For these excluded
+   * ops, the server's (re-)ack states the authoritative position; predicting
+   * locally could produce a wrong position that no ack would correct.
+   *
    * Restricted to items currently in `#items`: a pushed node whose op is still
    * pending may have been pulled out of the list (e.g. implicitly deleted by a
    * remote set, or removed by an undo) while still living in the pool, and such
@@ -486,6 +493,9 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
     for (const op of this._pool.unacknowledgedOps.getByParentId(this._id)) {
       if (op.intent !== "push") {
+        continue;
+      }
+      if (this._pool.unacknowledgedOps.isPossiblyStored(op.opId)) {
         continue;
       }
       const node = this._pool.getNode(op.id);

--- a/packages/liveblocks-core/src/crdts/UnacknowledgedOps.ts
+++ b/packages/liveblocks-core/src/crdts/UnacknowledgedOps.ts
@@ -25,6 +25,16 @@ export interface ReadonlyUnacknowledgedOps {
     parentId: string,
     parentKey: string
   ): Iterable<ClientWireCreateOp>;
+
+  /**
+   * Whether the given pending op may already have been processed by the
+   * server. True for ops that were in flight when a connection died: the
+   * server may have stored them with the ack getting lost in the disconnect,
+   * or may never have received them. Until the (re-sent) op's ack arrives,
+   * the client cannot know which, so optimistic predictions that assume the
+   * op has not been processed yet are unsound for these ops.
+   */
+  isPossiblyStored(opId: string): boolean;
 }
 
 /**
@@ -54,6 +64,9 @@ export class UnacknowledgedOps implements ReadonlyUnacknowledgedOps {
     new Map();
   // parentId -> (opId -> Create op)
   #createOpsByParent: Map<string, Map<string, ClientWireCreateOp>> = new Map();
+  // opIds of pending ops that were in flight when a connection died, so the
+  // server may already have processed them. See isPossiblyStored().
+  #possiblyStoredOpIds: Set<string> = new Set();
 
   #posKey(parentId: string, parentKey: string): PositionKey {
     return `${parentId}\n${parentKey}`;
@@ -99,6 +112,7 @@ export class UnacknowledgedOps implements ReadonlyUnacknowledgedOps {
     }
 
     this.#byOpId.delete(opId);
+    this.#possiblyStoredOpIds.delete(opId);
 
     if (isCreateOp(op)) {
       const posKey = this.#posKey(op.parentId, op.parentKey);
@@ -143,5 +157,20 @@ export class UnacknowledgedOps implements ReadonlyUnacknowledgedOps {
   /** All still-unacknowledged ops, in dispatch order. */
   values(): IterableIterator<ClientWireOp> {
     return this.#byOpId.values();
+  }
+
+  isPossiblyStored(opId: string): boolean {
+    return this.#possiblyStoredOpIds.has(opId);
+  }
+
+  /**
+   * Mark every currently pending op as possibly stored on the server. Called
+   * when the connection dies: all of these ops were in flight, and their
+   * (possibly lost) acks would have been the only way to know their fate.
+   */
+  markAllAsPossiblyStored(): void {
+    for (const opId of this.#byOpId.keys()) {
+      this.#possiblyStoredOpIds.add(opId);
+    }
   }
 }

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1715,6 +1715,14 @@ export function createRoom<
 
   function onDidDisconnect() {
     clearTimeout(context.buffer.flushTimerID);
+
+    // Every op still pending at this point was in flight on the connection
+    // that just died: the server may have processed it (with its ack lost in
+    // the disconnect), or never received it. Mark them, so that optimistic
+    // position predictions (like the LiveList tail-bump) stop applying to
+    // them: such predictions are only sound for ops the server has provably
+    // not processed yet.
+    context.unacknowledgedOps.markAllAsPossiblyStored();
   }
 
   // Register events handlers for events coming from the socket

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1902,17 +1902,17 @@ export function createRoom<
       // XXX_vincent Smell, needs a deeper refactor soon! A reconnect
       // snapshot is a stream of *nodes* (the full authoritative state), but
       // here we fabricate a diff of *ops* and replay it through the live
-      // op-apply path. That path carries live-only optimistic semantics (the
-      // LiveList push tail-bump, "temporary position until the backend sends
-      // a fix" shifts, pending-conflict resolution) that are nonsensical
-      // when the stream we are applying already IS the fix. The
-      // `fromSnapshot` flag below patches only the one leak that bit us (the
-      // bump); it does not address the others. The proper fix is
-      // a node-stream reconcile that updates the tree in place, unified with
-      // the `_fromItems` path used on initial load, so a node stream never
-      // enters the op path at all. Until then `fromSnapshot` is a stopgap.
+      // op-apply path. That path carries live-only optimistic semantics
+      // ("temporary position until the backend sends a fix" shifts,
+      // pending-conflict resolution) that are nonsensical when the stream we
+      // are applying already IS the fix. (The LiveList push tail-bump is
+      // fine, though: it skips every op whose position the snapshot may
+      // already own, so replaying the diff cannot mispredict.) The proper
+      // fix is a node-stream reconcile that updates the tree in place,
+      // unified with the `_fromItems` path used on initial load, so a node
+      // stream never enters the op path at all.
       const ops = getTreesDiffOperations(currentItems, nodes);
-      const result = applyRemoteOps(ops, /* fromSnapshot */ true);
+      const result = applyRemoteOps(ops);
       notify(result.updates);
     } else {
       context.root = LiveObject._fromItems<S>(
@@ -2027,27 +2027,20 @@ export function createRoom<
     return { opsToEmit: opsWithOpIds, reverse, updates };
   }
 
-  function applyRemoteOps(
-    ops: readonly ServerWireOp[],
-    // True when `ops` reconstruct state from a server snapshot (the reconnect
-    // reconcile) rather than being live ops. Disables the live-only LiveList
-    // push tail-bump.
-    fromSnapshot: boolean = false
-  ): {
+  function applyRemoteOps(ops: readonly ServerWireOp[]): {
     // Updates to notify about afterwards
     updates: {
       storageUpdates: Map<string, StorageUpdate>;
       presence: boolean;
     };
   } {
-    return applyOps([], ops, /* isLocal */ false, fromSnapshot);
+    return applyOps([], ops, /* isLocal */ false);
   }
 
   function applyOps(
     pframes: readonly PresenceStackframe<P>[],
     ops: readonly Op[],
-    isLocal: boolean,
-    fromSnapshot: boolean = false
+    isLocal: boolean
   ): {
     reverse: Stackframe<P>[];
     updates: {
@@ -2102,7 +2095,7 @@ export function createRoom<
         source = OpSource.THEIRS;
       }
 
-      const applyOpResult = applyOp(op, source, fromSnapshot);
+      const applyOpResult = applyOp(op, source);
       if (applyOpResult.modified) {
         const nodeId = applyOpResult.modified.node._id;
 
@@ -2139,11 +2132,7 @@ export function createRoom<
     };
   }
 
-  function applyOp(
-    op: Op,
-    source: OpSource,
-    fromSnapshot: boolean = false
-  ): ApplyResult {
+  function applyOp(op: Op, source: OpSource): ApplyResult {
     // Explicit case to handle ignored Ops
     if (isIgnoredOp(op)) {
       return { modified: false };
@@ -2189,7 +2178,7 @@ export function createRoom<
           return { modified: false };
         }
 
-        return parentNode._attachChild(op, source, fromSnapshot);
+        return parentNode._attachChild(op, source);
       }
     }
   }


### PR DESCRIPTION
This PR is the client-side half of the `LiveList` post-reconnect divergence reported by Subframe (see @adam-subframe's deterministic repro in #3508). This PR reworked the test harness a bit, then re-expressed the scenario a bit cleaner.

## What changed

- We now mark every pending op as "possibly stored" the moment a connection dies.
- The tail-bump simply skips those ops: the prediction now only applies where it's sound (ops sent on the current connection). The excluded ops simply keep their authoritative position from the snapshot reconcile.
- This tackles the issue more elegantly and no longer required the `fromSnapshot` stopgap/hack introduced by #3490, which felt like a bit of a smell anyway.

Best reviewed commit-by-commit.

## The whole picture

The matching server-side fix is liveblocks/liveblocks-backend#1779. Either fix alone resolves the divergence; both together also eliminate the transient flicker. I've verified all four combinations against the e2e repro (running this suite against a locally-built dev server for the "fixed" server rows):

| Client                  | Server                                          | Test outcome                                    |
| ----------------------- | ----------------------------------------------- | ----------------------------------------------- |
| unfixed                 | unfixed                                         | ❌ diverges (`[Q,P]` vs `[P,Q]`)                |
| unfixed                 | **fixed** (by this [backend PR](https://github.com/liveblocks/liveblocks-backend/pull/1779))  | ✅ converges (corrective re-ack; brief flicker) |
| **fixed** (by **this PR**) | unfixed                                         | ✅ converges (no wrong prediction to correct)   |
| **fixed** | **fixed**  | ✅ converges, no flicker                        |
