### PR TITLE
Clean up deprecated options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v3.20.0
 
+- Deprecate `room.getStorageSnapshot()` in favor of `room.getStorageOrNull()`.
+
 ## v3.19.5
 
 ### `@liveblocks/client`

--- a/docs/pages/api-reference/liveblocks-client.mdx
+++ b/docs/pages/api-reference/liveblocks-client.mdx
@@ -223,17 +223,6 @@ const client = createClient({
     `"top-right"`, `"bottom-right"`, `"bottom-left"`, or `"top-left"`. [Learn
     more](#createClientBadgeLocation).
   </PropertiesListItem>
-  <PropertiesListItem
-    name="unstable_streamData"
-    type="boolean"
-    defaultValue="false"
-    deprecated
-  >
-    Deprecated. For new rooms, use [`engine: 2`](#Client.enterRoom) instead.
-    Engine 2 rooms have native support for streaming. This flag will be removed
-    in a future version, but will continue to work for existing engine 1 rooms
-    for now. [Learn more](/docs/guides/the-new-storage-engine-and-its-benefits).
-  </PropertiesListItem>
 </PropertiesList>
 
 ### createClient with public key [#createClientPublicKey]

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -427,17 +427,6 @@ function App() {
     `"top-right"`, `"bottom-right"`, `"bottom-left"`, or `"top-left"`. [Learn
     more](#Powered-by-Liveblocks-branding).
   </PropertiesListItem>
-  <PropertiesListItem
-    name="unstable_streamData"
-    type="boolean"
-    defaultValue="false"
-    deprecated
-  >
-    Deprecated. For new rooms, use [`engine: 2`](#RoomProvider) instead. Engine
-    2 rooms have native support for streaming. This flag will be removed in a
-    future version, but will continue to work for existing engine 1 rooms for
-    now. [Learn more](/docs/guides/the-new-storage-engine-and-its-benefits).
-  </PropertiesListItem>
 </PropertiesList>
 
 #### LiveblocksProvider with public key [#LiveblocksProviderPublicKey]

--- a/packages/liveblocks-core/e2e/storage-notification-reconnect.test.ts
+++ b/packages/liveblocks-core/e2e/storage-notification-reconnect.test.ts
@@ -17,7 +17,7 @@
  *
  * NOTE ON CONTROL KEYS: several LiveObject tests carry an unchanged scalar key
  * (e.g. `keep`) that the mutation never touches. The reconnect path routes a
- * snapshot through `getTreesDiffOperations`, whose UPDATE_OBJECT ops must
+ * snapshot through `diffNodeMap`, whose UPDATE_OBJECT ops must
  * carry only the keys that actually changed — a full-data re-send would
  * spuriously re-notify the unchanged key. The control key is what makes that
  * observable; do not remove it.

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -131,12 +131,6 @@ export type EnterOptions<P extends JsonObject = DP, S extends LsonObject = DS> =
      * the authentication endpoint or connect via WebSocket.
      */
     autoConnect?: boolean;
-
-    /**
-     * @deprecated This flag no longer has any effect and will be removed in
-     * a future version. All rooms now use the v2 storage engine by default.
-     */
-    engine?: 1 | 2;
   }
 
   // Initial presence is only mandatory if the custom type requires it to be

--- a/packages/liveblocks-core/src/client.ts
+++ b/packages/liveblocks-core/src/client.ts
@@ -537,12 +537,6 @@ export type ClientOptions<U extends BaseUserMeta = DU> = {
   backgroundKeepAliveTimeout?: number; // in milliseconds
   polyfills?: Polyfills;
   /**
-   * @deprecated All rooms will be migrated to the v2 storage engine in the
-   * future, which has native support for streaming. After that migration, this
-   * flag will no longer have any effect and will be removed in a future version.
-   */
-  unstable_streamData?: boolean;
-  /**
    * A function that returns a list of mention suggestions matching a string.
    */
   resolveMentionSuggestions?: (
@@ -820,7 +814,6 @@ export function createClient<U extends BaseUserMeta = DU>(
         enableDebugLogging: clientOptions.enableDebugLogging,
         baseUrl,
         errorEventSource: liveblocksErrorSource,
-        unstable_streamData: !!clientOptions.unstable_streamData,
         roomHttpClient: httpClient as LiveblocksHttpApi<TM, CM>,
         createSyncSource,
         badgeLocation: clientOptions.badgeLocation ?? "bottom-right",

--- a/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/liveblocks-helpers.test.ts
@@ -12,7 +12,7 @@ import { stableStringify } from "../../lib/stringify";
 import { OpCode } from "../../protocol/Op";
 import type { NodeMap } from "../../protocol/StorageNode";
 import { CrdtType } from "../../protocol/StorageNode";
-import { getTreesDiffOperations, isJsonEq } from "../liveblocks-helpers";
+import { diffNodeMap, isJsonEq } from "../liveblocks-helpers";
 import { LiveList } from "../LiveList";
 import { LiveMap } from "../LiveMap";
 import { LiveObject } from "../LiveObject";
@@ -26,7 +26,7 @@ test("Common first positions", () => {
   expect.soft(FIFTH_POSITION).toBe("!$");
 });
 
-describe("getTreesDiffOperations", () => {
+describe("diffNodeMap", () => {
   test("new liveList Register item", () => {
     const currentItems: NodeMap = new Map([
       ["root", { type: CrdtType.OBJECT, data: {} }],
@@ -50,7 +50,7 @@ describe("getTreesDiffOperations", () => {
       data: "B",
     });
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -90,7 +90,7 @@ describe("getTreesDiffOperations", () => {
     const newItems = new Map(currentItems);
     newItems.delete("0:2");
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -147,7 +147,7 @@ describe("getTreesDiffOperations", () => {
       ],
     ]);
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -235,7 +235,7 @@ describe("getTreesDiffOperations", () => {
       ],
     ]);
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -285,7 +285,7 @@ describe("getTreesDiffOperations", () => {
       ],
     ]);
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -308,7 +308,7 @@ describe("getTreesDiffOperations", () => {
       parentKey: "items",
     });
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -332,7 +332,7 @@ describe("getTreesDiffOperations", () => {
       parentKey: "map",
     });
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -357,7 +357,7 @@ describe("getTreesDiffOperations", () => {
       data: { a: 1 },
     });
 
-    const ops = getTreesDiffOperations(currentItems, newItems);
+    const ops = diffNodeMap(currentItems, newItems);
 
     expect(ops).toEqual([
       {
@@ -378,7 +378,7 @@ describe("getTreesDiffOperations", () => {
     const newItems = new Map(currentItems);
     newItems.set("0:1", { type: CrdtType.OBJECT, data: { a: 1 } });
 
-    expect(() => getTreesDiffOperations(currentItems, newItems)).toThrow(
+    expect(() => diffNodeMap(currentItems, newItems)).toThrow(
       "Internal error. Cannot serialize storage root into an operation"
     );
   });

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -262,21 +262,18 @@ export function isJsonEq(a: Json | undefined, b: Json | undefined): boolean {
  *  - UPDATE_OBJECT for "root" (data changed: a: 1 → 99)
  *  - CREATE_OBJECT for "node2" (added)
  */
-export function getTreesDiffOperations(
-  currentItems: NodeMap,
-  newItems: NodeMap
-): Op[] {
+export function diffNodeMap(prev: NodeMap, next: NodeMap): Op[] {
   const ops: Op[] = [];
 
-  currentItems.forEach((_, id) => {
-    if (!newItems.get(id)) {
+  prev.forEach((_, id) => {
+    if (!next.get(id)) {
       // Delete crdt
       ops.push({ type: OpCode.DELETE_CRDT, id });
     }
   });
 
-  newItems.forEach((crdt, id) => {
-    const currentCrdt = currentItems.get(id);
+  next.forEach((crdt, id) => {
+    const currentCrdt = prev.get(id);
     if (currentCrdt) {
       if (crdt.type === CrdtType.OBJECT) {
         if (currentCrdt.type !== CrdtType.OBJECT) {

--- a/packages/liveblocks-core/src/devtools/index.ts
+++ b/packages/liveblocks-core/src/devtools/index.ts
@@ -163,7 +163,7 @@ function partialSyncConnection(room: OpaqueRoom) {
 }
 
 function partialSyncStorage(room: OpaqueRoom) {
-  const root = room.getStorageSnapshot();
+  const root = room.getStorageOrNull();
   if (root) {
     sendToPanel({
       msg: "room::sync::partial",
@@ -197,7 +197,7 @@ function partialSyncOthers(room: OpaqueRoom) {
 }
 
 function fullSync(room: OpaqueRoom) {
-  const root = room.getStorageSnapshot();
+  const root = room.getStorageOrNull();
   const me = room[kInternal].getSelf_forDevTools();
   const others = room[kInternal].getOthers_forDevTools();
   // Because the room doesn't have access to the YJS doc, we must tell it to go get the full doc

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1703,7 +1703,7 @@ export function createRoom<
     // If a storage fetch has ever been initiated, we assume the client is
     // interested in storage, so we will refresh it after a reconnection.
     if (_getStorage$ !== null) {
-      refreshStorage({ flush: false }); // XXX VINCENT TO TAKE A LOOK SOON
+      refreshStorage();
     }
     flushNowOrSoon();
   }
@@ -2968,7 +2968,7 @@ export function createRoom<
     eventHub.storageDidLoad.notify();
   }
 
-  function refreshStorage(options: { flush: boolean }) {
+  function refreshStorage() {
     const messages = context.buffer.messages;
     if (!messages.some((msg) => msg.type === ClientMsgCode.FETCH_STORAGE)) {
       // Only add the fetch message to the outgoing message queue if it isn't
@@ -2977,15 +2977,12 @@ export function createRoom<
       nodeMapBuffer.take(); // Reset any partial state from previous fetch
       stopwatch?.start();
     }
-
-    if (options.flush) {
-      flushNowOrSoon();
-    }
   }
 
   function startLoadingStorage(): Promise<void> {
     if (_getStorage$ === null) {
-      refreshStorage({ flush: true });
+      refreshStorage();
+      flushNowOrSoon();
       _getStorage$ = new Promise((resolve) => {
         _resolveStoragePromise = resolve;
       });

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1905,18 +1905,6 @@ export function createRoom<
         currentItems.set(id, crdt._serialize());
       }
 
-      // XXX_vincent Smell, needs a deeper refactor soon! A reconnect
-      // snapshot is a stream of *nodes* (the full authoritative state), but
-      // here we fabricate a diff of *ops* and replay it through the live
-      // op-apply path. That path carries live-only optimistic semantics
-      // ("temporary position until the backend sends a fix" shifts,
-      // pending-conflict resolution) that are nonsensical when the stream we
-      // are applying already IS the fix. (The LiveList push tail-bump is
-      // fine, though: it skips every op whose position the snapshot may
-      // already own, so replaying the diff cannot mispredict.) The proper
-      // fix is a node-stream reconcile that updates the tree in place,
-      // unified with the `_fromItems` path used on initial load, so a node
-      // stream never enters the op path at all.
       const ops = diffNodeMap(currentItems, nodes);
       const result = applyRemoteOps(ops);
       notify(result.updates);

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -8,8 +8,8 @@ import type { ApplyResult, ManagedPool } from "./crdts/AbstractCrdt";
 import { createManagedPool, OpSource } from "./crdts/AbstractCrdt";
 import {
   cloneLson,
+  diffNodeMap,
   dumpPool,
-  getTreesDiffOperations,
   isLiveList,
   isLiveNode,
   isSameNodeOrChildOf,
@@ -1911,7 +1911,7 @@ export function createRoom<
       // fix is a node-stream reconcile that updates the tree in place,
       // unified with the `_fromItems` path used on initial load, so a node
       // stream never enters the op path at all.
-      const ops = getTreesDiffOperations(currentItems, nodes);
+      const ops = diffNodeMap(currentItems, nodes);
       const result = applyRemoteOps(ops);
       notify(result.updates);
     } else {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -772,10 +772,16 @@ export type Room<
 
   /**
    * Get the room's storage synchronously.
-   * The storage's root is a {@link LiveObject}.
+   * The storage's root is a LiveObject.
    *
    * @example
-   * const root = room.getStorageSnapshot();
+   * const root = room.getStorageOrNull();
+   */
+  getStorageOrNull(): LiveObject<S> | null;
+
+  /**
+   * @deprecated Renamed to `Room.getStorageOrNull`. This alias will be
+   * removed in the future.
    */
   getStorageSnapshot(): LiveObject<S> | null;
 
@@ -3033,7 +3039,7 @@ export function createRoom<
    * Once Storage is loaded, will return a stable reference to the storage
    * root.
    */
-  function getStorageSnapshot(): LiveObject<S> | null {
+  function getStorageOrNull(): LiveObject<S> | null {
     const root = context.root;
     if (root !== undefined) {
       // Done loading
@@ -3470,7 +3476,7 @@ export function createRoom<
   }
 
   function isStorageReady() {
-    return getStorageSnapshot() !== null;
+    return getStorageOrNull() !== null;
   }
 
   async function waitUntilStorageReady(): Promise<void> {
@@ -3872,7 +3878,8 @@ export function createRoom<
       updateFeedMessage,
       deleteFeedMessage,
       getStorage,
-      getStorageSnapshot,
+      getStorageOrNull,
+      getStorageSnapshot: getStorageOrNull, // Deprecated alias, will be removed in the future
       getStorageStatus,
 
       isPresenceReady,

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -113,11 +113,7 @@ import type {
   YDocUpdateServerMsg,
 } from "./protocol/ServerMsg";
 import { ServerMsgCode } from "./protocol/ServerMsg";
-import type {
-  NodeMap,
-  NodeStream,
-  SerializedCrdt,
-} from "./protocol/StorageNode";
+import type { NodeMap, NodeStream } from "./protocol/StorageNode";
 import { compactNodesToNodeStream } from "./protocol/StorageNode";
 import type {
   SubscriptionData,
@@ -1434,13 +1430,6 @@ export type RoomConfig<TM extends BaseMetadata, CM extends BaseMetadata> = {
   lostConnectionTimeout: number;
   backgroundKeepAliveTimeout?: number;
 
-  /**
-   * @deprecated All rooms will be migrated to the v2 storage engine in the
-   * future, which has native support for streaming. After that migration, this
-   * flag will no longer have any effect and will be removed in a future version.
-   */
-  unstable_streamData?: boolean;
-
   polyfills?: Polyfills;
 
   roomHttpClient: RoomHttpApi<TM, CM>;
@@ -1714,7 +1703,7 @@ export function createRoom<
     // If a storage fetch has ever been initiated, we assume the client is
     // interested in storage, so we will refresh it after a reconnection.
     if (_getStorage$ !== null) {
-      refreshStorage({ flush: false });
+      refreshStorage({ flush: false }); // XXX VINCENT TO TAKE A LOOK SOON
     }
     flushNowOrSoon();
   }
@@ -2979,23 +2968,9 @@ export function createRoom<
     eventHub.storageDidLoad.notify();
   }
 
-  async function streamStorage() {
-    // TODO: Handle potential race conditions where the room get disconnected while the request is pending
-    if (!managedSocket.authValue) return;
-    const nodes = new Map<string, SerializedCrdt>(
-      await httpClient.streamStorage({ roomId })
-    );
-    processInitialStorage(nodes);
-  }
-
   function refreshStorage(options: { flush: boolean }) {
     const messages = context.buffer.messages;
-    if (config.unstable_streamData) {
-      // instead of sending a fetch message over WS, stream over HTTP
-      void streamStorage();
-    } else if (
-      !messages.some((msg) => msg.type === ClientMsgCode.FETCH_STORAGE)
-    ) {
+    if (!messages.some((msg) => msg.type === ClientMsgCode.FETCH_STORAGE)) {
       // Only add the fetch message to the outgoing message queue if it isn't
       // already there
       messages.push({ type: ClientMsgCode.FETCH_STORAGE });

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -476,12 +476,6 @@ export type CreateRoomOptions = {
    */
   tenantId?: string;
   organizationId?: string;
-
-  /**
-   * @deprecated This flag no longer has any effect and will be removed in
-   * a future version. All rooms now use the v2 storage engine by default.
-   */
-  engine?: 1 | 2;
 };
 
 export type UpdateRoomOptions = {

--- a/packages/liveblocks-react/src/liveblocks.tsx
+++ b/packages/liveblocks-react/src/liveblocks.tsx
@@ -1817,7 +1817,6 @@ export function LiveblocksProvider<U extends BaseUserMeta = DU>(
     lostConnectionTimeout: useInitial(o.lostConnectionTimeout),
     backgroundKeepAliveTimeout: useInitial(o.backgroundKeepAliveTimeout),
     polyfills: useInitial(o.polyfills),
-    unstable_streamData: useInitial(o.unstable_streamData),
     preventUnsavedChanges: useInitial(o.preventUnsavedChanges),
     badgeLocation: useInitial(o.badgeLocation),
 

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -164,7 +164,7 @@ function makeMutationContext<
 
   return {
     get storage() {
-      const mutableRoot = room.getStorageSnapshot();
+      const mutableRoot = room.getStorageOrNull();
       if (mutableRoot === null) {
         throw new Error(needsStorage);
       }
@@ -1360,7 +1360,7 @@ function useMutableStorageRoot_withRoomContext<S extends LsonObject>(
     RoomContext
   );
   const subscribe = room.events.storageDidLoad.subscribeOnce;
-  const getSnapshot = room.getStorageSnapshot;
+  const getSnapshot = room.getStorageOrNull;
   const getServerSnapshot = alwaysNull;
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -473,7 +473,6 @@ function RoomProviderInner<
       initialPresence: props.initialPresence,
       initialStorage: props.initialStorage,
       autoConnect: props.autoConnect ?? typeof window !== "undefined",
-      engine: props.engine,
     },
     roomId
   ) as EnterOptions<P, S>;

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -390,12 +390,6 @@ export type RoomProviderProps<P extends JsonObject, S extends LsonObject> =
      * only on the client side.
      */
     autoConnect?: boolean;
-
-    /**
-     * @deprecated This flag no longer has any effect and will be removed in
-     * a future version. All rooms now use the v2 storage engine by default.
-     */
-    engine?: 1 | 2;
   }
 
   // Initial presence is only mandatory if the custom type requires it to be

--- a/packages/liveblocks-redux/src/index.ts
+++ b/packages/liveblocks-redux/src/index.ts
@@ -8,7 +8,7 @@ import type {
   Status,
   User,
 } from "@liveblocks/client";
-import type { EnterOptions, OpaqueClient, OpaqueRoom } from "@liveblocks/core";
+import type { OpaqueClient, OpaqueRoom } from "@liveblocks/core";
 import { detectDupes } from "@liveblocks/core";
 import type { StoreEnhancer } from "redux";
 
@@ -193,10 +193,7 @@ const internalEnhancer = <TState>(options: {
 
       const store = createStore(newReducer, initialState, enhancer);
 
-      function enterRoom(
-        newRoomId: string,
-        options?: Pick<EnterOptions, "engine">
-      ): void {
+      function enterRoom(newRoomId: string): void {
         if (lastRoomId === newRoomId) {
           return;
         }
@@ -210,7 +207,6 @@ const internalEnhancer = <TState>(options: {
         const initialPresence = pick(store.getState(), presenceKeys) as any;
 
         const { room, leave } = client.enterRoom(newRoomId, {
-          engine: options?.engine,
           initialPresence,
         });
         maybeRoom = room as OpaqueRoom;
@@ -306,7 +302,7 @@ const internalEnhancer = <TState>(options: {
 
       function newDispatch(action: any) {
         if (action.type === ACTION_TYPES.ENTER) {
-          enterRoom(action.roomId, action.options);
+          enterRoom(action.roomId);
         } else if (action.type === ACTION_TYPES.LEAVE) {
           leaveRoom();
         } else {
@@ -329,7 +325,6 @@ export const actions = {
   /**
    * Enters a room and starts sync it with Redux state
    * @param roomId The id of the room
-   * @param options Optional. Options to pass to the underlying client.enterRoom call (e.g. `engine`).
    */
   enterRoom,
   /**
@@ -338,18 +333,13 @@ export const actions = {
   leaveRoom,
 };
 
-function enterRoom(
-  roomId: string,
-  options?: Pick<EnterOptions, "engine">
-): {
+function enterRoom(roomId: string): {
   type: string;
   roomId: string;
-  options?: Pick<EnterOptions, "engine">;
 } {
   return {
     type: ACTION_TYPES.ENTER,
     roomId,
-    options,
   };
 }
 

--- a/packages/liveblocks-zustand/src/index.ts
+++ b/packages/liveblocks-zustand/src/index.ts
@@ -16,7 +16,6 @@ import type {
   DS,
   DTM,
   DU,
-  EnterOptions,
   OpaqueClient,
   OpaqueRoom,
 } from "@liveblocks/core";
@@ -46,12 +45,8 @@ export type LiveblocksContext<
   /**
    * Enters a room and starts sync it with zustand state
    * @param roomId The id of the room
-   * @param options Optional. Options to pass to the underlying client.enterRoom call (e.g. `engine`).
    */
-  readonly enterRoom: (
-    roomId: string,
-    options?: Pick<EnterOptions, "engine">
-  ) => () => void;
+  readonly enterRoom: (roomId: string) => () => void;
   /**
    * Leaves the currently entered room and stops sync it with zustand state, if
    * any. If enterRoom was not called before, this is a no-op.
@@ -167,10 +162,7 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
     let lastRoomId: string | null = null;
     let lastLeaveFn: (() => void) | null = null;
 
-    function enterRoom(
-      newRoomId: string,
-      options?: Pick<EnterOptions, "engine">
-    ): void {
+    function enterRoom(newRoomId: string): void {
       if (lastRoomId === newRoomId) {
         return;
       }
@@ -184,7 +176,6 @@ const middlewareImpl: InnerLiveblocksMiddleware = (config, options) => {
       const initialPresence = pick(get(), presenceKeys) as unknown as P;
 
       const { room, leave } = client.enterRoom(newRoomId, {
-        engine: options?.engine,
         initialPresence,
       }) as unknown as { room: TRoom; leave: () => void };
       maybeRoom = room;

--- a/tools/liveblocks-devtools/src/devtools/contexts/CurrentRoom.tsx
+++ b/tools/liveblocks-devtools/src/devtools/contexts/CurrentRoom.tsx
@@ -22,18 +22,6 @@ import type { FullBackgroundToPanelMessage } from "../protocol";
 import type { YDocNode } from "../tabs/yjs/to-y-node";
 import { toYNode } from "../tabs/yjs/to-y-node";
 
-// Old/legacy connection statuses sent by old clients, prior to Liveblocks 1.1.
-// These will be removed from a future version of Liveblocks, but DevTools will
-// have to support these status codes to remain backward compatible with old
-// clients.
-type OldConnectionStatus =
-  | "closed"
-  | "authenticating"
-  | "connecting"
-  | "open"
-  | "unavailable"
-  | "failed";
-
 export type YUpdate = {
   ds: DeleteSet;
   structs: (Y.Item | Y.GC | Skip)[];
@@ -41,7 +29,7 @@ export type YUpdate = {
 
 type Room = {
   readonly roomId: string;
-  status: Status | OldConnectionStatus | null;
+  status: Status | null;
   storage: readonly DevTools.LsonTreeNode[] | null;
   me: DevTools.UserTreeNode | null;
   others: readonly DevTools.UserTreeNode[];
@@ -391,7 +379,7 @@ export function useRoomIds(): string[] {
   return useSyncExternalStore(onRoomCountChanged.subscribe, () => allRoomIds);
 }
 
-export function useStatus(): Status | OldConnectionStatus | null {
+export function useStatus(): Status | null {
   const currentRoomId = useCurrentRoomId();
   return useSyncExternalStore(
     getSubscribe(currentRoomId, "onStatus") ?? nosub,


### PR DESCRIPTION
This PR is a batch of harmless internal cleanups ahead of v3.20.

This PR:
- Removes the `engine` option from all APIs that still had it. It already was a no-op.
- Remove the `unstable_streamData` option. Also a no-op.
- Rename `room.getStorageSnapshot()` (deprecated) → `room.getStorageOrNull()`. Pure name cleanup.
- Internal rename: `getTreesDiffOperations` → `diffNodeMap`.
- Drop the legacy `OldConnectionStatus` devtools type (connection statuses from pre-1.1 clients).
