### PR TITLE
Document Liveblocks agent resources

### DIFF
--- a/docs/pages/integrations/claude-code.mdx
+++ b/docs/pages/integrations/claude-code.mdx
@@ -3,8 +3,8 @@ meta:
   title: "Claude Code + Liveblocks"
   parentTitle: "Integrations"
   description:
-    "Use Claude Code with the Liveblocks plugin to build
-    multiplayer apps with guided best practices."
+    "Use Claude Code with the Liveblocks plugin to build multiplayer apps with
+    guided best practices."
 ---
 
 Use [Claude Code](https://www.anthropic.com/claude-code) with Liveblocks to add
@@ -92,7 +92,9 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/liveblocks-plugin">Liveblocks plugin documentation</Button>
+<Button href="/docs/tools/liveblocks-plugin">
+  Liveblocks plugin documentation
+</Button>
 
 ### MCP server
 
@@ -107,7 +109,9 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
+<Button href="/docs/tools/mcp-server">
+  Liveblocks MCP server documentation
+</Button>
 
 ## Limitations and troubleshooting
 
@@ -121,15 +125,17 @@ Code session. If the plugin repository is not available, install the skills with
 ### MCP returns auth errors
 
 Use a secret key from the same [Liveblocks project](/dashboard) as your app.
-Confirm `LIVEBLOCKS_SECRET_KEY` is exported in the shell before starting Claude Code.
+Confirm `LIVEBLOCKS_SECRET_KEY` is exported in the shell before starting Claude
+Code.
 
 ### MCP returns incorrect data
 
 Check that you’re using the secret key for your current project. If you change
-the key, restart Claude Code from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
+the key, restart Claude Code from the shell where `LIVEBLOCKS_SECRET_KEY` is
+set.
 
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [MCP server](/docs/tools/mcp-server).
+- [Liveblocks MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/claude-code.mdx
+++ b/docs/pages/integrations/claude-code.mdx
@@ -41,7 +41,7 @@ such as rooms, Storage, Yjs, comments, and more.
       To allow AI to inspect and modify data in your project, set a Liveblocks
       secret key from [your dashboard](/dashboard) before starting Claude Code.
       The Liveblocks plugin uses this environment variable for its bundled
-      [Liveblocks MCP server](/docs/tools/mcp-server).
+      [MCP server](/docs/tools/mcp-server).
 
       ```bash
       export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
@@ -109,9 +109,7 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">
-  Liveblocks MCP server documentation
-</Button>
+<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
 
 ## Limitations and troubleshooting
 
@@ -120,7 +118,7 @@ allowing it to delete your production data.
 Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Claude
 Code session. If the plugin repository is not available, install the skills with
 `npx skills add liveblocks/skills` and configure the
-[Liveblocks MCP server](/docs/tools/mcp-server) separately.
+[MCP server](/docs/tools/mcp-server) separately.
 
 ### MCP returns auth errors
 
@@ -137,5 +135,5 @@ set.
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [Liveblocks MCP server](/docs/tools/mcp-server).
+- [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/claude-code.mdx
+++ b/docs/pages/integrations/claude-code.mdx
@@ -9,7 +9,7 @@ meta:
 
 Use [Claude Code](https://www.anthropic.com/claude-code) with Liveblocks to add
 collaborative features to your app. Install the
-[Liveblocks plugin](/docs/tools/agent-skills) so your assistant follows
+[Liveblocks plugin](/docs/tools/liveblocks-plugin) so your assistant follows
 Liveblocks and Yjs guidance, and can use MCP tools to inspect and modify data
 such as rooms, Storage, Yjs, comments, and more.
 
@@ -22,7 +22,7 @@ such as rooms, Storage, Yjs, comments, and more.
     <StepTitle>Install the Liveblocks plugin</StepTitle>
     <StepContent>
       To help AI follow best practices in your app, add the
-      [Liveblocks plugin](/docs/tools/agent-skills). It bundles Liveblocks agent
+      [Liveblocks plugin](/docs/tools/liveblocks-plugin). It bundles Liveblocks agent
       skills and MCP server configuration.
 
       ```bash
@@ -92,7 +92,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Liveblocks plugin documentation</Button>
+<Button href="/docs/tools/liveblocks-plugin">Liveblocks plugin documentation</Button>
 
 ### MCP server
 
@@ -114,7 +114,9 @@ allowing it to delete your production data.
 ### Skills do not load
 
 Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Claude
-Code session.
+Code session. If the plugin repository is not available, install the skills with
+`npx skills add liveblocks/skills` and configure the
+[Liveblocks MCP server](/docs/tools/mcp-server) separately.
 
 ### MCP returns auth errors
 
@@ -128,6 +130,6 @@ the key, restart Claude Code from the shell where `LIVEBLOCKS_SECRET_KEY` is set
 
 ## Related docs
 
-- [Liveblocks plugin](/docs/tools/agent-skills).
+- [Liveblocks plugin](/docs/tools/liveblocks-plugin).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/claude-code.mdx
+++ b/docs/pages/integrations/claude-code.mdx
@@ -3,16 +3,15 @@ meta:
   title: "Claude Code + Liveblocks"
   parentTitle: "Integrations"
   description:
-    "Use Claude Code with Liveblocks agent skills and the MCP server to build
+    "Use Claude Code with the Liveblocks plugin to build
     multiplayer apps with guided best practices."
 ---
 
 Use [Claude Code](https://www.anthropic.com/claude-code) with Liveblocks to add
-collaborative features to your app. Install
-[agent skills](/docs/tools/agent-skills) so your assistant follows Liveblocks
-and Yjs guidance, and use our [MCP server](/docs/tools/mcp-server) to allow AI
-to inspect and modify your data, such as rooms, Storage, Yjs, comments, and
-more.
+collaborative features to your app. Install the
+[Liveblocks plugin](/docs/tools/agent-skills) so your assistant follows
+Liveblocks and Yjs guidance, and can use MCP tools to inspect and modify data
+such as rooms, Storage, Yjs, comments, and more.
 
 <PromptCta />
 
@@ -20,29 +19,33 @@ more.
 
 <Steps>
   <Step>
-    <StepTitle>Install agent skills</StepTitle>
+    <StepTitle>Install the Liveblocks plugin</StepTitle>
     <StepContent>
-      To help AI follow best practices in your app, add [Liveblocks agent skills](/docs/tools/agent-skills)
-      to your system. Make sure to select Claude Code in the CLI. Global installation is easiest.
+      To help AI follow best practices in your app, add the
+      [Liveblocks plugin](/docs/tools/agent-skills). It bundles Liveblocks agent
+      skills and MCP server configuration.
 
       ```bash
-      npx skills add liveblocks/skills
+      npx plugins add liveblocks/liveblocks-plugin
       ```
+
+      Start a new Claude Code session after installation so the plugin is available.
 
     </StepContent>
 
   </Step>
 
   <Step>
-    <StepTitle>Install MCP server</StepTitle>
+    <StepTitle>Configure MCP server access</StepTitle>
     <StepContent>
-      To allow AI to inspect and modify data in your project, install the
-      [Liveblocks MCP server](/docs/tools/mcp-server). Run the following command
-      in the terminal, inserting your secret key from
-      [your dashboard](/dashboard):
+      To allow AI to inspect and modify data in your project, set a Liveblocks
+      secret key from [your dashboard](/dashboard) before starting Claude Code.
+      The Liveblocks plugin uses this environment variable for its bundled
+      [Liveblocks MCP server](/docs/tools/mcp-server).
 
       ```bash
-      claude mcp add liveblocks -e LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}" -- npx -y github:liveblocks/liveblocks-mcp-server
+      export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
+      claude
       ```
 
       <Banner type="warning" title="Only for development">
@@ -89,7 +92,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Agent skills documentation</Button>
+<Button href="/docs/tools/agent-skills">Liveblocks plugin documentation</Button>
 
 ### MCP server
 
@@ -110,21 +113,21 @@ allowing it to delete your production data.
 
 ### Skills do not load
 
-Re-run `npx skills add liveblocks/skills` from the repo root. Ensure Claude Code
-can see the generated plugin files.
+Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Claude
+Code session.
 
 ### MCP returns auth errors
 
 Use a secret key from the same [Liveblocks project](/dashboard) as your app.
-Confirm `LIVEBLOCKS_SECRET_KEY` in the MCP config matches that project.
+Confirm `LIVEBLOCKS_SECRET_KEY` is exported in the shell before starting Claude Code.
 
 ### MCP returns incorrect data
 
-Check that you’re using the correct secret key for your current project. Try
-uninstalling and reinstalling with the correct key.
+Check that you’re using the secret key for your current project. If you change
+the key, restart Claude Code from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 
 ## Related docs
 
-- [Agent skills](/docs/tools/agent-skills).
+- [Liveblocks plugin](/docs/tools/agent-skills).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/claude-desktop.mdx
+++ b/docs/pages/integrations/claude-desktop.mdx
@@ -9,10 +9,10 @@ meta:
 
 Use [Claude Desktop](https://claude.ai/download) with Liveblocks to add
 collaborative features to your app. Install
-[agent skills](/docs/tools/agent-skills) so your assistant follows Liveblocks
-and Yjs guidance, and use our [MCP server](/docs/tools/mcp-server) to allow AI
-to inspect and modify your data, such as rooms, Storage, Yjs, comments, and
-more.
+[Liveblocks skills](/docs/tools/agent-skills) so your assistant follows
+Liveblocks and Yjs guidance, and use our
+[Liveblocks MCP server](/docs/tools/mcp-server) to allow AI to inspect and
+modify your data, such as rooms, Storage, Yjs, comments, and more.
 
 <PromptCta />
 
@@ -102,7 +102,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Agent skills documentation</Button>
+<Button href="/docs/tools/agent-skills">Liveblocks skills documentation</Button>
 
 ### MCP server
 
@@ -117,7 +117,9 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
+<Button href="/docs/tools/mcp-server">
+  Liveblocks MCP server documentation
+</Button>
 
 ## Limitations and troubleshooting
 
@@ -139,6 +141,6 @@ uninstalling and reinstalling with the correct key.
 
 ## Related docs
 
-- [Agent skills](/docs/tools/agent-skills).
-- [MCP server](/docs/tools/mcp-server).
+- [Liveblocks skills](/docs/tools/agent-skills).
+- [Liveblocks MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/claude-desktop.mdx
+++ b/docs/pages/integrations/claude-desktop.mdx
@@ -9,10 +9,10 @@ meta:
 
 Use [Claude Desktop](https://claude.ai/download) with Liveblocks to add
 collaborative features to your app. Install
-[Liveblocks skills](/docs/tools/agent-skills) so your assistant follows
-Liveblocks and Yjs guidance, and use our
-[Liveblocks MCP server](/docs/tools/mcp-server) to allow AI to inspect and
-modify your data, such as rooms, Storage, Yjs, comments, and more.
+[Agent skills](/docs/tools/agent-skills) so your assistant follows Liveblocks
+and Yjs guidance, and use our [MCP server](/docs/tools/mcp-server) to allow AI
+to inspect and modify your data, such as rooms, Storage, Yjs, comments, and
+more.
 
 <PromptCta />
 
@@ -37,7 +37,7 @@ modify your data, such as rooms, Storage, Yjs, comments, and more.
     <StepTitle>Install MCP server</StepTitle>
     <StepContent>
       To allow AI to inspect and modify data in your project, install the
-      [Liveblocks MCP server](/docs/tools/mcp-server).
+      [MCP server](/docs/tools/mcp-server).
 
       1. In Claude Desktop, go to Settings → Developer → Edit Config.
       2. Open the JSON file, `claude_desktop_config.json`.
@@ -102,7 +102,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Liveblocks skills documentation</Button>
+<Button href="/docs/tools/agent-skills">Agent skills documentation</Button>
 
 ### MCP server
 
@@ -117,9 +117,7 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">
-  Liveblocks MCP server documentation
-</Button>
+<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
 
 ## Limitations and troubleshooting
 
@@ -141,6 +139,6 @@ uninstalling and reinstalling with the correct key.
 
 ## Related docs
 
-- [Liveblocks skills](/docs/tools/agent-skills).
-- [Liveblocks MCP server](/docs/tools/mcp-server).
+- [Agent skills](/docs/tools/agent-skills).
+- [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -3,16 +3,16 @@ meta:
   title: "OpenAI Codex + Liveblocks"
   parentTitle: "Integrations"
   description:
-    "Use OpenAI Codex with the Liveblocks plugin to build
-    collaborative apps with guided best practices."
+    "Use OpenAI Codex with the Liveblocks plugin to build collaborative apps
+    with guided best practices."
 ---
 
 Use [OpenAI Codex](https://openai.com/codex/) with Liveblocks to add
 collaborative features to your app. Install
-[Liveblocks plugin](/docs/tools/liveblocks-plugin) so your assistant follows Liveblocks
-and Yjs guidance, and use our [MCP server](/docs/tools/mcp-server) to allow AI
-to inspect and modify your data, such as rooms, Storage, Yjs, comments, and
-more.
+[Liveblocks plugin](/docs/tools/liveblocks-plugin) so your assistant follows
+Liveblocks and Yjs guidance, and use our
+[Liveblocks MCP server](/docs/tools/mcp-server) to allow AI to inspect and
+modify your data, such as rooms, Storage, Yjs, comments, and more.
 
 <PromptCta />
 
@@ -93,7 +93,9 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/liveblocks-plugin">Liveblocks plugin documentation</Button>
+<Button href="/docs/tools/liveblocks-plugin">
+  Liveblocks plugin documentation
+</Button>
 
 ### MCP server
 
@@ -108,7 +110,9 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
+<Button href="/docs/tools/mcp-server">
+  Liveblocks MCP server documentation
+</Button>
 
 ## Limitations and troubleshooting
 
@@ -132,6 +136,6 @@ the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [MCP server](/docs/tools/mcp-server).
+- [Liveblocks MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
 - [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -3,13 +3,13 @@ meta:
   title: "OpenAI Codex + Liveblocks"
   parentTitle: "Integrations"
   description:
-    "Use OpenAI Codex with Liveblocks agent skills and the MCP server to build
+    "Use OpenAI Codex with the Liveblocks plugin to build
     collaborative apps with guided best practices."
 ---
 
 Use [OpenAI Codex](https://openai.com/codex/) with Liveblocks to add
 collaborative features to your app. Install
-[agent skills](/docs/tools/agent-skills) so your assistant follows Liveblocks
+[Liveblocks plugin](/docs/tools/liveblocks-plugin) so your assistant follows Liveblocks
 and Yjs guidance, and use our [MCP server](/docs/tools/mcp-server) to allow AI
 to inspect and modify your data, such as rooms, Storage, Yjs, comments, and
 more.
@@ -23,7 +23,7 @@ more.
     <StepTitle>Install the Codex plugin</StepTitle>
     <StepContent>
       To help AI follow best practices in your app, add the Liveblocks Codex
-      plugin. It bundles [Liveblocks agent skills](/docs/tools/agent-skills)
+      plugin. It bundles Liveblocks agent skills
       and MCP server configuration.
 
       ```bash
@@ -93,7 +93,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Liveblocks plugin documentation</Button>
+<Button href="/docs/tools/liveblocks-plugin">Liveblocks plugin documentation</Button>
 
 ### MCP server
 
@@ -114,7 +114,10 @@ allowing it to delete your production data.
 
 ### Skills do not load
 
-Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Codex thread.
+Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Codex
+thread. If the plugin repository is not available, install the skills with
+`npx skills add liveblocks/skills` and configure the
+[Liveblocks MCP server](/docs/tools/mcp-server) separately.
 
 ### MCP returns auth errors
 
@@ -128,7 +131,7 @@ the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 
 ## Related docs
 
-- [Liveblocks plugin](/docs/tools/agent-skills).
+- [Liveblocks plugin](/docs/tools/liveblocks-plugin).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
 - [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -27,7 +27,7 @@ more.
       and MCP server configuration.
 
       ```bash
-      npx plugins add liveblocks/skills
+      npx plugins add liveblocks/liveblocks-plugin
       ```
 
       Start a new Codex thread after installation so the plugin is available.
@@ -114,7 +114,7 @@ allowing it to delete your production data.
 
 ### Skills do not load
 
-Re-run `npx plugins add liveblocks/skills`, then start a new Codex thread.
+Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Codex thread.
 
 ### MCP returns auth errors
 
@@ -131,4 +131,4 @@ the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 - [Agent skills](/docs/tools/agent-skills).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
-- [Liveblocks skills repository](https://github.com/liveblocks/skills).
+- [Liveblocks plugin repository](https://github.com/liveblocks/liveblocks-plugin).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -131,4 +131,4 @@ the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 - [Agent skills](/docs/tools/agent-skills).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
-- [Liveblocks plugin repository](https://github.com/liveblocks/liveblocks-plugin).
+- [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -10,9 +10,9 @@ meta:
 Use [OpenAI Codex](https://openai.com/codex/) with Liveblocks to add
 collaborative features to your app. Install
 [Liveblocks plugin](/docs/tools/liveblocks-plugin) so your assistant follows
-Liveblocks and Yjs guidance, and use our
-[Liveblocks MCP server](/docs/tools/mcp-server) to allow AI to inspect and
-modify your data, such as rooms, Storage, Yjs, comments, and more.
+Liveblocks and Yjs guidance, and use our [MCP server](/docs/tools/mcp-server) to
+allow AI to inspect and modify your data, such as rooms, Storage, Yjs, comments,
+and more.
 
 <PromptCta />
 
@@ -42,7 +42,7 @@ modify your data, such as rooms, Storage, Yjs, comments, and more.
       To allow AI to inspect and modify data in your project, set a Liveblocks
       secret key from [your dashboard](/dashboard) before starting Codex. The
       Liveblocks Codex plugin uses this environment variable for its bundled
-      [Liveblocks MCP server](/docs/tools/mcp-server).
+      [MCP server](/docs/tools/mcp-server).
 
       ```bash
       export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
@@ -110,9 +110,7 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">
-  Liveblocks MCP server documentation
-</Button>
+<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
 
 ## Limitations and troubleshooting
 
@@ -121,7 +119,7 @@ allowing it to delete your production data.
 Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Codex
 thread. If the plugin repository is not available, install the skills with
 `npx skills add liveblocks/skills` and configure the
-[Liveblocks MCP server](/docs/tools/mcp-server) separately.
+[MCP server](/docs/tools/mcp-server) separately.
 
 ### MCP returns auth errors
 
@@ -136,6 +134,6 @@ the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [Liveblocks MCP server](/docs/tools/mcp-server).
+- [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
 - [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -20,36 +20,33 @@ more.
 
 <Steps>
   <Step>
-    <StepTitle>Install agent skills</StepTitle>
+    <StepTitle>Install the Codex plugin</StepTitle>
     <StepContent>
-      To help AI follow best practices in your app, add [Liveblocks agent skills](/docs/tools/agent-skills)
-      to your system. Make sure to select Codex in the CLI. Global installation is easiest.
+      To help AI follow best practices in your app, add the Liveblocks Codex
+      plugin. It bundles [Liveblocks agent skills](/docs/tools/agent-skills)
+      and MCP server configuration.
 
       ```bash
-      npx skills add liveblocks/skills
+      npx plugins add liveblocks/skills
       ```
+
+      Start a new Codex thread after installation so the plugin is available.
 
     </StepContent>
 
   </Step>
 
   <Step>
-    <StepTitle>Install MCP server</StepTitle>
+    <StepTitle>Configure MCP server access</StepTitle>
     <StepContent>
-      To allow AI to inspect and modify data in your project, first ensure the Codex CLI is installed:
-      
-      ```bash
-      npm i -g @openai/codex
-      ```
-
-      Next, install the
-      [Liveblocks MCP server](/docs/tools/mcp-server), inserting your secret key
-      from [your dashboard](/dashboard):
+      To allow AI to inspect and modify data in your project, set a Liveblocks
+      secret key from [your dashboard](/dashboard) before starting Codex. The
+      Liveblocks Codex plugin uses this environment variable for its bundled
+      [Liveblocks MCP server](/docs/tools/mcp-server).
 
       ```bash
-      codex mcp add liveblocks \
-        --env LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}" \
-        -- npx -y github:liveblocks/liveblocks-mcp-server
+      export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
+      codex
       ```
 
       <Banner type="warning" title="Only for development">
@@ -117,21 +114,21 @@ allowing it to delete your production data.
 
 ### Skills do not load
 
-Re-run `npx skills add liveblocks/skills` from the repo root. Ensure Codex can
-see the generated plugin files.
+Re-run `npx plugins add liveblocks/skills`, then start a new Codex thread.
 
 ### MCP returns auth errors
 
 Use a secret key from the same [Liveblocks project](/dashboard) as your app.
-Confirm `LIVEBLOCKS_SECRET_KEY` in the MCP config matches that project.
+Confirm `LIVEBLOCKS_SECRET_KEY` is exported in the shell before starting Codex.
 
 ### MCP returns incorrect data
 
-Check that you’re using the correct secret key for your current project. Try
-uninstalling and reinstalling with the correct key.
+Check that you’re using the secret key for your current project. If you change
+the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 
 ## Related docs
 
 - [Agent skills](/docs/tools/agent-skills).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
+- [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/integrations/codex.mdx
+++ b/docs/pages/integrations/codex.mdx
@@ -93,7 +93,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Agent skills documentation</Button>
+<Button href="/docs/tools/agent-skills">Liveblocks plugin documentation</Button>
 
 ### MCP server
 
@@ -128,7 +128,7 @@ the key, restart Codex from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 
 ## Related docs
 
-- [Agent skills](/docs/tools/agent-skills).
+- [Liveblocks plugin](/docs/tools/agent-skills).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).
 - [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/integrations/cursor.mdx
+++ b/docs/pages/integrations/cursor.mdx
@@ -40,7 +40,7 @@ inspect and modify data such as rooms, Storage, Yjs, comments, and more.
       To allow AI to inspect and modify data in your project, set a Liveblocks
       secret key from [your dashboard](/dashboard) before starting Cursor. The
       Liveblocks plugin uses this environment variable for its bundled
-      [Liveblocks MCP server](/docs/tools/mcp-server).
+      [MCP server](/docs/tools/mcp-server).
 
       ```bash
       export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
@@ -108,9 +108,7 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">
-  Liveblocks MCP server documentation
-</Button>
+<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
 
 ## Limitations and troubleshooting
 
@@ -119,7 +117,7 @@ allowing it to delete your production data.
 Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Cursor
 session. If the plugin repository is not available, install the skills with
 `npx skills add liveblocks/skills` and configure the
-[Liveblocks MCP server](/docs/tools/mcp-server) separately.
+[MCP server](/docs/tools/mcp-server) separately.
 
 ### MCP returns auth errors
 
@@ -134,5 +132,5 @@ the key, restart Cursor from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [Liveblocks MCP server](/docs/tools/mcp-server).
+- [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/cursor.mdx
+++ b/docs/pages/integrations/cursor.mdx
@@ -3,14 +3,14 @@ meta:
   title: "Cursor + Liveblocks"
   parentTitle: "Integrations"
   description:
-    "Use Cursor with the Liveblocks plugin to build
-    multiplayer apps with guided best practices."
+    "Use Cursor with the Liveblocks plugin to build multiplayer apps with guided
+    best practices."
 ---
 
 Use [Cursor](https://cursor.com/) with Liveblocks to add collaborative features
-to your app. Install the [Liveblocks plugin](/docs/tools/liveblocks-plugin) so your
-assistant follows Liveblocks and Yjs guidance, and can use MCP tools to inspect
-and modify data such as rooms, Storage, Yjs, comments, and more.
+to your app. Install the [Liveblocks plugin](/docs/tools/liveblocks-plugin) so
+your assistant follows Liveblocks and Yjs guidance, and can use MCP tools to
+inspect and modify data such as rooms, Storage, Yjs, comments, and more.
 
 <PromptCta />
 
@@ -91,7 +91,9 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/liveblocks-plugin">Liveblocks plugin documentation</Button>
+<Button href="/docs/tools/liveblocks-plugin">
+  Liveblocks plugin documentation
+</Button>
 
 ### MCP server
 
@@ -106,7 +108,9 @@ the MCP server. Only data from this project can be inspected. Never use a secret
 key from a production project, as giving AI direct access would be dangerous,
 allowing it to delete your production data.
 
-<Button href="/docs/tools/mcp-server">MCP server documentation</Button>
+<Button href="/docs/tools/mcp-server">
+  Liveblocks MCP server documentation
+</Button>
 
 ## Limitations and troubleshooting
 
@@ -130,5 +134,5 @@ the key, restart Cursor from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [MCP server](/docs/tools/mcp-server).
+- [Liveblocks MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/cursor.mdx
+++ b/docs/pages/integrations/cursor.mdx
@@ -3,15 +3,14 @@ meta:
   title: "Cursor + Liveblocks"
   parentTitle: "Integrations"
   description:
-    "Use Cursor with Liveblocks agent skills and the MCP server to build
+    "Use Cursor with the Liveblocks plugin to build
     multiplayer apps with guided best practices."
 ---
 
 Use [Cursor](https://cursor.com/) with Liveblocks to add collaborative features
-to your app. Install [agent skills](/docs/tools/agent-skills) so your assistant
-follows Liveblocks and Yjs guidance, and use our
-[MCP server](/docs/tools/mcp-server) to allow AI to inspect and modify your
-data, such as rooms, Storage, Yjs, comments, and more.
+to your app. Install the [Liveblocks plugin](/docs/tools/agent-skills) so your
+assistant follows Liveblocks and Yjs guidance, and can use MCP tools to inspect
+and modify data such as rooms, Storage, Yjs, comments, and more.
 
 <PromptCta />
 
@@ -19,41 +18,33 @@ data, such as rooms, Storage, Yjs, comments, and more.
 
 <Steps>
   <Step>
-    <StepTitle>Install agent skills</StepTitle>
+    <StepTitle>Install the Liveblocks plugin</StepTitle>
     <StepContent>
-      To help AI follow best practices in your app, add [Liveblocks agent skills](/docs/tools/agent-skills)
-      to your system. Make sure to select Cursor in the CLI. Global installation is easiest.
+      To help AI follow best practices in your app, add the
+      [Liveblocks plugin](/docs/tools/agent-skills). It bundles Liveblocks agent
+      skills and MCP server configuration.
 
       ```bash
-      npx skills add liveblocks/skills
+      npx plugins add liveblocks/liveblocks-plugin
       ```
+
+      Start a new Cursor session after installation so the plugin is available.
 
     </StepContent>
 
   </Step>
 
   <Step>
-    <StepTitle>Install MCP server</StepTitle>
+    <StepTitle>Configure MCP server access</StepTitle>
     <StepContent>
-      To allow AI to inspect and modify data in your project, install the
+      To allow AI to inspect and modify data in your project, set a Liveblocks
+      secret key from [your dashboard](/dashboard) before starting Cursor. The
+      Liveblocks plugin uses this environment variable for its bundled
       [Liveblocks MCP server](/docs/tools/mcp-server).
 
-      1. Go to File → Cursor Settings → MCP → Add new server.
-      2. Add the following JSON, inserting your secret key from
-         [your dashboard](/dashboard):
-
-      ```json
-      {
-        "mcpServers": {
-          "liveblocks": {
-            "command": "npx",
-            "args": ["-y", "github:liveblocks/liveblocks-mcp-server"],
-            "env": {
-              "LIVEBLOCKS_SECRET_KEY": "{{SECRET_KEY}}"
-            }
-          }
-        }
-      }
+      ```bash
+      export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
+      cursor
       ```
 
       <Banner type="warning" title="Only for development">
@@ -100,7 +91,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Agent skills documentation</Button>
+<Button href="/docs/tools/agent-skills">Liveblocks plugin documentation</Button>
 
 ### MCP server
 
@@ -121,21 +112,21 @@ allowing it to delete your production data.
 
 ### Skills do not load
 
-Re-run `npx skills add liveblocks/skills` from the repo root. Ensure Cursor can
-see the generated plugin files.
+Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Cursor
+session.
 
 ### MCP returns auth errors
 
 Use a secret key from the same [Liveblocks project](/dashboard) as your app.
-Confirm `LIVEBLOCKS_SECRET_KEY` in the MCP config matches that project.
+Confirm `LIVEBLOCKS_SECRET_KEY` is exported in the shell before starting Cursor.
 
 ### MCP returns incorrect data
 
-Check that you’re using the correct secret key for your current project. Try
-uninstalling and reinstalling with the correct key.
+Check that you’re using the secret key for your current project. If you change
+the key, restart Cursor from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 
 ## Related docs
 
-- [Agent skills](/docs/tools/agent-skills).
+- [Liveblocks plugin](/docs/tools/agent-skills).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/integrations/cursor.mdx
+++ b/docs/pages/integrations/cursor.mdx
@@ -8,7 +8,7 @@ meta:
 ---
 
 Use [Cursor](https://cursor.com/) with Liveblocks to add collaborative features
-to your app. Install the [Liveblocks plugin](/docs/tools/agent-skills) so your
+to your app. Install the [Liveblocks plugin](/docs/tools/liveblocks-plugin) so your
 assistant follows Liveblocks and Yjs guidance, and can use MCP tools to inspect
 and modify data such as rooms, Storage, Yjs, comments, and more.
 
@@ -21,7 +21,7 @@ and modify data such as rooms, Storage, Yjs, comments, and more.
     <StepTitle>Install the Liveblocks plugin</StepTitle>
     <StepContent>
       To help AI follow best practices in your app, add the
-      [Liveblocks plugin](/docs/tools/agent-skills). It bundles Liveblocks agent
+      [Liveblocks plugin](/docs/tools/liveblocks-plugin). It bundles Liveblocks agent
       skills and MCP server configuration.
 
       ```bash
@@ -91,7 +91,7 @@ various best practices for using Liveblocks and Yjs. We always recommend using
 these skills when building, debugging, or answering questions about Liveblocks
 and Yjs.
 
-<Button href="/docs/tools/agent-skills">Liveblocks plugin documentation</Button>
+<Button href="/docs/tools/liveblocks-plugin">Liveblocks plugin documentation</Button>
 
 ### MCP server
 
@@ -113,7 +113,9 @@ allowing it to delete your production data.
 ### Skills do not load
 
 Re-run `npx plugins add liveblocks/liveblocks-plugin`, then start a new Cursor
-session.
+session. If the plugin repository is not available, install the skills with
+`npx skills add liveblocks/skills` and configure the
+[Liveblocks MCP server](/docs/tools/mcp-server) separately.
 
 ### MCP returns auth errors
 
@@ -127,6 +129,6 @@ the key, restart Cursor from the shell where `LIVEBLOCKS_SECRET_KEY` is set.
 
 ## Related docs
 
-- [Liveblocks plugin](/docs/tools/agent-skills).
+- [Liveblocks plugin](/docs/tools/liveblocks-plugin).
 - [MCP server](/docs/tools/mcp-server).
 - [REST API reference](/docs/api-reference/rest-api-endpoints).

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -71,6 +71,7 @@ Why is my Y.Map growing so large?
 ## Source code
 
 The source code is available in our
-[GitHub repository](https://github.com/liveblocks/liveblocks-plugin).
+[GitHub repository](https://github.com/liveblocks/skills).
 
-The repository also serves as the OpenAI Codex plugin marketplace source.
+The `liveblocks/liveblocks-plugin` repository is generated from this source so
+OpenAI Codex users can install from a plugin-named repository.

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -27,13 +27,13 @@ skills use the [Agent Skills](https://agentskills.io/home) format.
 For OpenAI Codex, install the Liveblocks plugin:
 
 ```bash
-npx plugins add liveblocks/skills
+npx plugins add liveblocks/liveblocks-plugin
 ```
 
 For other AI tools, install with the following command:
 
 ```bash
-npx skills add liveblocks/skills
+npx skills add liveblocks/liveblocks-plugin
 ```
 
 ## Skills
@@ -71,6 +71,6 @@ Why is my Y.Map growing so large?
 ## Source code
 
 The source code is available in our
-[GitHub repository](https://github.com/liveblocks/skills).
+[GitHub repository](https://github.com/liveblocks/liveblocks-plugin).
 
 The repository also serves as the OpenAI Codex plugin marketplace source.

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -1,83 +1,27 @@
 ---
 meta:
-  title: "Liveblocks plugin"
+  title: "Agent skills"
   parentTitle: "Tools"
   description:
-    "Install the Liveblocks plugin in your AI coding tool to build Liveblocks
-    and Yjs apps more easily."
+    "Use Liveblocks agent skills in tools that do not support plugins."
 ---
 
-Create your Liveblocks applications more easily with the Liveblocks plugin,
-designed to help AI coding assistants follow best practices for Liveblocks and
-Yjs. The plugin bundles Liveblocks agent skills and MCP server configuration.
-
-<PromptCta />
-
-<Figure>
-  <video autoPlay loop muted playsInline height={521} width={768}>
-    <source
-      src="/assets/agent-skills/agent-skills-claude.mp4"
-      type="video/mp4"
-    />
-  </video>
-</Figure>
-
-## Install
-
-Install the Liveblocks plugin:
+Liveblocks agent skills are now included in the
+[Liveblocks plugin](/docs/tools/liveblocks-plugin), which is the recommended
+installation path for supported AI coding tools.
 
 ```bash
 npx plugins add liveblocks/liveblocks-plugin
 ```
 
-## Supported tools
+If your AI tool does not support plugins, install the skills separately and then
+configure the [Liveblocks MCP server](/docs/tools/mcp-server).
 
-| Tool | Status |
-|---|---|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported |
-| [OpenAI Codex](https://openai.com/codex) | Supported |
-| [Cursor](https://www.cursor.com/) | Supported |
-
-The plugin uses the open plugin format and is distributed from
-`liveblocks/liveblocks-plugin`, a generated repository built from the
-[`liveblocks/skills`](https://github.com/liveblocks/skills) source repository.
-
-## Skills
-
-### liveblocks-best-practices
-
-Best practices for using Liveblocks. Contains 40+ comprehensive references
-related to each feature of Liveblocks. Use it when building, debugging, or
-answering questions about Liveblocks.
-
-### yjs-best-practices
-
-Best practices for using Yjs. Contains info on fixing common issues, structuring
-your data efficiently, and avoiding bugs. Use it when building, debugging, or
-answering questions about Yjs.
-
-## Usage
-
-After installation, skills are automatically available in your AI tool. Your
-agent will use them when it judges they are relevant. For example, the following
-questions will trigger skills:
-
-```
-How do I handle unstable Wi-Fi connections with Liveblocks?
+```bash
+npx skills add liveblocks/skills
 ```
 
-```
-How do I pass custom headers to my auth endpoint?
-```
+## Related docs
 
-```
-Why is my Y.Map growing so large?
-```
-
-## Source code
-
-The source code is available in our
-[GitHub repository](https://github.com/liveblocks/skills).
-
-The `liveblocks/liveblocks-plugin` repository is generated from this source so
-OpenAI Codex users can install from a plugin-named repository.
+- [Liveblocks plugin](/docs/tools/liveblocks-plugin).
+- [MCP server](/docs/tools/mcp-server).

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -1,27 +1,71 @@
 ---
 meta:
-  title: "Agent skills"
-  parentTitle: "Tools"
+  title: "Liveblocks skills"
+  parentTitle: "Build with AI"
   description:
-    "Use Liveblocks agent skills in tools that do not support plugins."
+    "Use Liveblocks skills to help AI agents write Liveblocks and Yjs code."
 ---
 
-Liveblocks agent skills are now included in the
-[Liveblocks plugin](/docs/tools/liveblocks-plugin), which is the recommended
-installation path for supported AI coding tools.
+Help AI agents build Liveblocks and Yjs apps with official guidance.
+
+Liveblocks skills teach agents how to handle auth, presence, Storage, comments,
+notifications, text editors, React patterns, and Yjs data modeling.
+
+## Installation
+
+Use the [Liveblocks plugin](/docs/tools/liveblocks-plugin) when your AI coding
+agent supports plugins. It includes the skills and MCP server configuration.
 
 ```bash
 npx plugins add liveblocks/liveblocks-plugin
 ```
 
-If your AI tool does not support plugins, install the skills separately and then
-configure the [Liveblocks MCP server](/docs/tools/mcp-server).
+If your AI tool does not support plugins, or you only want the skills, install
+them separately:
 
 ```bash
 npx skills add liveblocks/skills
 ```
 
-## Related docs
+Configure the [Liveblocks MCP server](/docs/tools/mcp-server) separately only if
+your agent needs access to Liveblocks project data.
+
+## Advantages
+
+Build with official Liveblocks and Yjs recommendations.
+
+- Liveblocks best practices: Get guidance for rooms, auth, presence, Storage,
+  comments, notifications, text editors, and React integration.
+- Yjs best practices: Model shared documents, handle providers and updates, and
+  avoid common performance issues.
+- Automatic activation: Skills-compatible agents can use the guidance when a
+  Liveblocks or Yjs task is detected.
+- Standalone install: Use the skills in tools that do not support plugins.
+- Optional MCP access: Pair the skills with the Liveblocks MCP server when your
+  agent needs to inspect or modify project data.
+
+## Included skills
+
+### liveblocks-best-practices
+
+Guidance for building, debugging, and reviewing Liveblocks code.
+
+### yjs-best-practices
+
+Guidance for Yjs data modeling, updates, providers, performance, and debugging.
+
+## Verify installation
+
+Start a new session in your AI tool and ask:
+
+```
+Use Liveblocks best practices to review my auth setup.
+```
+
+If the skills are loaded, your agent should use Liveblocks-specific guidance.
+
+## Learn more
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [MCP server](/docs/tools/mcp-server).
+- [Liveblocks MCP server](/docs/tools/mcp-server).
+- [Liveblocks skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -1,9 +1,9 @@
 ---
 meta:
-  title: "Liveblocks skills"
+  title: "Agent skills"
   parentTitle: "Build with AI"
   description:
-    "Use Liveblocks skills to help AI agents write Liveblocks and Yjs code."
+    "Use agent skills to help AI agents write Liveblocks and Yjs code."
 ---
 
 Help AI agents build Liveblocks and Yjs apps with official guidance.
@@ -27,8 +27,8 @@ them separately:
 npx skills add liveblocks/skills
 ```
 
-Configure the [Liveblocks MCP server](/docs/tools/mcp-server) separately only if
-your agent needs access to Liveblocks project data.
+Configure the [MCP server](/docs/tools/mcp-server) separately only if your agent
+needs access to Liveblocks project data.
 
 ## Advantages
 
@@ -41,8 +41,8 @@ Build with official Liveblocks and Yjs recommendations.
 - Automatic activation: Skills-compatible agents can use the guidance when a
   Liveblocks or Yjs task is detected.
 - Standalone install: Use the skills in tools that do not support plugins.
-- Optional MCP access: Pair the skills with the Liveblocks MCP server when your
-  agent needs to inspect or modify project data.
+- Optional MCP access: Pair the skills with the MCP server when your agent needs
+  to inspect or modify project data.
 
 ## Included skills
 
@@ -67,5 +67,5 @@ If the skills are loaded, your agent should use Liveblocks-specific guidance.
 ## Learn more
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [Liveblocks MCP server](/docs/tools/mcp-server).
-- [Liveblocks skills repository](https://github.com/liveblocks/skills).
+- [MCP server](/docs/tools/mcp-server).
+- [Agent skills repository](https://github.com/liveblocks/skills).

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -24,7 +24,13 @@ skills use the [Agent Skills](https://agentskills.io/home) format.
 
 ## Install
 
-Install with the following command:
+For OpenAI Codex, install the Liveblocks plugin:
+
+```bash
+npx plugins add liveblocks/skills
+```
+
+For other AI tools, install with the following command:
 
 ```bash
 npx skills add liveblocks/skills
@@ -66,3 +72,5 @@ Why is my Y.Map growing so large?
 
 The source code is available in our
 [GitHub repository](https://github.com/liveblocks/skills).
+
+The repository also serves as the OpenAI Codex plugin marketplace source.

--- a/docs/pages/tools/agent-skills.mdx
+++ b/docs/pages/tools/agent-skills.mdx
@@ -1,15 +1,15 @@
 ---
 meta:
-  title: "Agent skills"
+  title: "Liveblocks plugin"
   parentTitle: "Tools"
   description:
-    "Use Liveblocks agent skills to help develop your Liveblocks and Yjs apps
-    more easily."
+    "Install the Liveblocks plugin in your AI coding tool to build Liveblocks
+    and Yjs apps more easily."
 ---
 
-Create your Liveblocks applications more easily with our agent skills, designed
-to help AI coding assistants follow best practices for Liveblocks and Yjs. These
-skills use the [Agent Skills](https://agentskills.io/home) format.
+Create your Liveblocks applications more easily with the Liveblocks plugin,
+designed to help AI coding assistants follow best practices for Liveblocks and
+Yjs. The plugin bundles Liveblocks agent skills and MCP server configuration.
 
 <PromptCta />
 
@@ -24,17 +24,23 @@ skills use the [Agent Skills](https://agentskills.io/home) format.
 
 ## Install
 
-For OpenAI Codex, install the Liveblocks plugin:
+Install the Liveblocks plugin:
 
 ```bash
 npx plugins add liveblocks/liveblocks-plugin
 ```
 
-For other AI tools, install with the following command:
+## Supported tools
 
-```bash
-npx skills add liveblocks/liveblocks-plugin
-```
+| Tool | Status |
+|---|---|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported |
+| [OpenAI Codex](https://openai.com/codex) | Supported |
+| [Cursor](https://www.cursor.com/) | Supported |
+
+The plugin uses the open plugin format and is distributed from
+`liveblocks/liveblocks-plugin`, a generated repository built from the
+[`liveblocks/skills`](https://github.com/liveblocks/skills) source repository.
 
 ## Skills
 

--- a/docs/pages/tools/agent-skills.prompt.md
+++ b/docs/pages/tools/agent-skills.prompt.md
@@ -4,7 +4,8 @@
 
 **Do:**
 
-- Recommend installing with `npx plugins add liveblocks/liveblocks-plugin` when the plugin is missing.
+- Recommend installing with `npx plugins add liveblocks/liveblocks-plugin` when the plugin is missing and the user's tool supports plugins.
+- Recommend `npx skills add liveblocks/skills` plus MCP server setup when the user's tool does not support plugins.
 - Use `liveblocks-best-practices` for Liveblocks feature design/debugging questions.
 - Use `yjs-best-practices` for Yjs structure, performance, and bug-avoidance questions.
 - Encourage concrete prompts tied to the user's actual issue and stack.

--- a/docs/pages/tools/agent-skills.prompt.md
+++ b/docs/pages/tools/agent-skills.prompt.md
@@ -1,10 +1,10 @@
-# Liveblocks agent skills — context for your assistant
+# Liveblocks plugin — context for your assistant
 
-**Purpose:** Help users use Liveblocks and Yjs agent skills effectively in coding assistants.
+**Purpose:** Help users use the Liveblocks plugin and its Liveblocks/Yjs skills effectively in coding assistants.
 
 **Do:**
 
-- Recommend installing with `npx skills add liveblocks/skills` when skills are missing.
+- Recommend installing with `npx plugins add liveblocks/liveblocks-plugin` when the plugin is missing.
 - Use `liveblocks-best-practices` for Liveblocks feature design/debugging questions.
 - Use `yjs-best-practices` for Yjs structure, performance, and bug-avoidance questions.
 - Encourage concrete prompts tied to the user's actual issue and stack.

--- a/docs/pages/tools/liveblocks-plugin.mdx
+++ b/docs/pages/tools/liveblocks-plugin.mdx
@@ -1,0 +1,94 @@
+---
+meta:
+  title: "Liveblocks plugin"
+  parentTitle: "Tools"
+  description:
+    "Install the Liveblocks plugin in your AI coding tool to build Liveblocks
+    and Yjs apps more easily."
+---
+
+Create your Liveblocks applications more easily with the Liveblocks plugin,
+designed to help AI coding assistants follow best practices for Liveblocks and
+Yjs. The plugin bundles Liveblocks agent skills and MCP server configuration.
+
+<PromptCta />
+
+<Figure>
+  <video autoPlay loop muted playsInline height={521} width={768}>
+    <source
+      src="/assets/agent-skills/agent-skills-claude.mp4"
+      type="video/mp4"
+    />
+  </video>
+</Figure>
+
+## Install
+
+Install the Liveblocks plugin:
+
+```bash
+npx plugins add liveblocks/liveblocks-plugin
+```
+
+## Supported tools
+
+| Tool | Status |
+|---|---|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported |
+| [OpenAI Codex](https://openai.com/codex) | Supported |
+| [Cursor](https://www.cursor.com/) | Supported |
+
+The plugin uses the open plugin format and is distributed from
+`liveblocks/liveblocks-plugin`, a generated repository built from the
+[`liveblocks/skills`](https://github.com/liveblocks/skills) source repository.
+
+## Fallback install
+
+If your AI tool does not support plugins, or the plugin repository is not
+available, install the skills from the source repository:
+
+```bash
+npx skills add liveblocks/skills
+```
+
+Then configure the [Liveblocks MCP server](/docs/tools/mcp-server) separately.
+
+## Skills
+
+### liveblocks-best-practices
+
+Best practices for using Liveblocks. Contains 40+ comprehensive references
+related to each feature of Liveblocks. Use it when building, debugging, or
+answering questions about Liveblocks.
+
+### yjs-best-practices
+
+Best practices for using Yjs. Contains info on fixing common issues, structuring
+your data efficiently, and avoiding bugs. Use it when building, debugging, or
+answering questions about Yjs.
+
+## Usage
+
+After installation, skills are automatically available in your AI tool. Your
+agent will use them when it judges they are relevant. For example, the following
+questions will trigger skills:
+
+```
+How do I handle unstable Wi-Fi connections with Liveblocks?
+```
+
+```
+How do I pass custom headers to my auth endpoint?
+```
+
+```
+Why is my Y.Map growing so large?
+```
+
+## Source code
+
+The source code is available in our
+[GitHub repository](https://github.com/liveblocks/skills).
+
+The `liveblocks/liveblocks-plugin` repository is generated from this source so
+users can install from a plugin-named repository.

--- a/docs/pages/tools/liveblocks-plugin.mdx
+++ b/docs/pages/tools/liveblocks-plugin.mdx
@@ -12,9 +12,8 @@ also includes MCP server configuration for tools that can inspect and modify
 development project data.
 
 Use the plugin first if your AI coding tool supports plugins. Use the
-[Liveblocks MCP server](/docs/tools/mcp-server) directly if you only need data
-access. Use [Liveblocks skills](/docs/tools/agent-skills) only when plugins are
-not supported.
+[MCP server](/docs/tools/mcp-server) directly if you only need data access. Use
+[Agent skills](/docs/tools/agent-skills) only when plugins are not supported.
 
 <PromptCta />
 
@@ -64,7 +63,7 @@ connected to the key.
 </Banner>
 
 If you only want to configure MCP tools, or your AI tool does not support
-plugins, use the [Liveblocks MCP server](/docs/tools/mcp-server) directly.
+plugins, use the [MCP server](/docs/tools/mcp-server) directly.
 
 To verify MCP access, ask your agent:
 
@@ -100,7 +99,7 @@ skills, install them from the source repository:
 npx skills add liveblocks/skills
 ```
 
-Then configure the [Liveblocks MCP server](/docs/tools/mcp-server) separately.
+Then configure the [MCP server](/docs/tools/mcp-server) separately.
 
 ## Included skills
 

--- a/docs/pages/tools/liveblocks-plugin.mdx
+++ b/docs/pages/tools/liveblocks-plugin.mdx
@@ -49,9 +49,14 @@ data in the Liveblocks project connected to this key.
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported |
 | [OpenAI Codex](https://openai.com/codex)                      | Supported |
 | [Cursor](https://www.cursor.com/)                             | Supported |
+| [Grok Build](https://x.ai/news/grok-build-cli)                | Supported |
+| [GitHub Copilot](https://github.com/features/copilot)         | Supported |
 
 The plugin uses the open plugin format and is distributed from
 [`liveblocks/liveblocks-plugin`](https://github.com/liveblocks/liveblocks-plugin).
+The `plugins` CLI installs it automatically for Claude Code, Cursor, and OpenAI
+Codex. Grok Build and GitHub Copilot can use the plugin manifest, skills, MCP
+configuration, and instruction files from the repository.
 
 ## Fallback install
 

--- a/docs/pages/tools/liveblocks-plugin.mdx
+++ b/docs/pages/tools/liveblocks-plugin.mdx
@@ -1,15 +1,20 @@
 ---
 meta:
   title: "Liveblocks plugin"
-  parentTitle: "Tools"
+  parentTitle: "Build with AI"
   description:
     "Install the Liveblocks plugin in your AI coding tool to build Liveblocks
     and Yjs apps more easily."
 ---
 
-The Liveblocks plugin helps AI coding assistants follow Liveblocks and Yjs best
-practices. It also includes MCP server configuration so compatible tools can
-inspect and modify development project data.
+The Liveblocks plugin adds Liveblocks and Yjs guidance to AI coding agents. It
+also includes MCP server configuration for tools that can inspect and modify
+development project data.
+
+Use the plugin first if your AI coding tool supports plugins. Use the
+[Liveblocks MCP server](/docs/tools/mcp-server) directly if you only need data
+access. Use [Liveblocks skills](/docs/tools/agent-skills) only when plugins are
+not supported.
 
 <PromptCta />
 
@@ -22,46 +27,74 @@ inspect and modify development project data.
   </video>
 </Figure>
 
-## Install
+## Install the plugin
 
-Install the Liveblocks plugin, then start a new session in your AI coding tool.
+Use the plugin when your coding agent supports plugins. Install it, then start a
+new session in your AI coding tool.
 
 ```bash
 npx plugins add liveblocks/liveblocks-plugin
 ```
 
-## Enable MCP tools
+## Verify installation
 
-The skills work after installation. To let your AI tool inspect and modify
+Start a new session in your AI coding tool and ask:
+
+```
+Use Liveblocks best practices to review my auth setup.
+```
+
+If the plugin is loaded, your agent should use Liveblocks-specific guidance
+instead of generic realtime or Yjs advice.
+
+## Enable project access
+
+The skills work after installation. To also let your AI tool inspect and modify
 Liveblocks data, set a development project secret key before starting the tool:
 
 ```bash
 export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
 ```
 
-Do not use a production secret key. MCP tools can create, update, and delete
-data in the Liveblocks project connected to this key.
+<Banner type="warning" title="Do not use a production secret key">
+
+MCP tools can create, update, and delete data in the Liveblocks project
+connected to the key.
+
+</Banner>
+
+If you only want to configure MCP tools, or your AI tool does not support
+plugins, use the [Liveblocks MCP server](/docs/tools/mcp-server) directly.
+
+To verify MCP access, ask your agent:
+
+```
+List my Liveblocks rooms.
+```
+
+If the key is valid, your agent should be able to inspect rooms in the connected
+development project.
 
 ## Supported tools
 
-| Tool                                                          | Status    |
-| ------------------------------------------------------------- | --------- |
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported |
-| [OpenAI Codex](https://openai.com/codex)                      | Supported |
-| [Cursor](https://www.cursor.com/)                             | Supported |
-| [Grok Build](https://x.ai/news/grok-build-cli)                | Supported |
-| [GitHub Copilot](https://github.com/features/copilot)         | Supported |
+| Tool                                                          | Support                |
+| ------------------------------------------------------------- | ---------------------- |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Installed by `plugins` |
+| [OpenAI Codex](https://openai.com/codex)                      | Installed by `plugins` |
+| [Cursor](https://www.cursor.com/)                             | Installed by `plugins` |
+| [Grok Build](https://x.ai/news/grok-build-cli)                | Uses repository files  |
+| [GitHub Copilot](https://github.com/features/copilot)         | Uses repository files  |
 
 The plugin uses the open plugin format and is distributed from
 [`liveblocks/liveblocks-plugin`](https://github.com/liveblocks/liveblocks-plugin).
-The `plugins` CLI installs it automatically for Claude Code, Cursor, and OpenAI
-Codex. Grok Build and GitHub Copilot can use the plugin manifest, skills, MCP
-configuration, and instruction files from the repository.
+The `plugins` CLI installs the plugin automatically for Claude Code, Cursor, and
+OpenAI Codex. Grok Build and GitHub Copilot can use the plugin manifest, skills,
+MCP configuration, and instruction files from the repository.
 
-## Fallback install
+## Install only the skills
 
-If your AI tool does not support plugins, or the plugin repository is not
-available, install the skills from the source repository:
+If your AI tool does not support plugins, or you only want the standalone
+skills, install them from the source repository:
 
 ```bash
 npx skills add liveblocks/skills
@@ -69,21 +102,21 @@ npx skills add liveblocks/skills
 
 Then configure the [Liveblocks MCP server](/docs/tools/mcp-server) separately.
 
-## Skills
+## Included skills
 
 ### liveblocks-best-practices
 
-Best practices for using Liveblocks. Contains 40+ comprehensive references
-related to each feature of Liveblocks. Use it when building, debugging, or
+Guidance for Liveblocks rooms, auth, presence, Storage, comments, notifications,
+text editors, React patterns, and more. Use it when building, debugging, or
 answering questions about Liveblocks.
 
 ### yjs-best-practices
 
-Best practices for using Yjs. Contains info on fixing common issues, structuring
-your data efficiently, and avoiding bugs. Use it when building, debugging, or
-answering questions about Yjs.
+Guidance for Yjs data modeling, updates, providers, performance, subdocuments,
+and common debugging issues. Use it when building, debugging, or answering
+questions about Yjs.
 
-## Usage
+## Example prompts
 
 After installation, skills are automatically available in your AI tool. Your
 agent will use them when it judges they are relevant. For example, the following
@@ -100,6 +133,23 @@ How do I pass custom headers to my auth endpoint?
 ```
 Why is my Y.Map growing so large?
 ```
+
+## Troubleshooting
+
+### Plugin is not loaded
+
+Start a new session in your AI coding tool after installation. If it still is
+not available, run the install command again:
+
+```bash
+npx plugins add liveblocks/liveblocks-plugin
+```
+
+### MCP returns auth errors
+
+Check that `LIVEBLOCKS_SECRET_KEY` is set in the shell or app environment that
+starts your AI tool, then restart the tool. Use a secret key from a development
+project.
 
 ## Source code
 

--- a/docs/pages/tools/liveblocks-plugin.mdx
+++ b/docs/pages/tools/liveblocks-plugin.mdx
@@ -7,9 +7,9 @@ meta:
     and Yjs apps more easily."
 ---
 
-Create your Liveblocks applications more easily with the Liveblocks plugin,
-designed to help AI coding assistants follow best practices for Liveblocks and
-Yjs. The plugin bundles Liveblocks agent skills and MCP server configuration.
+The Liveblocks plugin helps AI coding assistants follow Liveblocks and Yjs best
+practices. It also includes MCP server configuration so compatible tools can
+inspect and modify development project data.
 
 <PromptCta />
 
@@ -24,11 +24,23 @@ Yjs. The plugin bundles Liveblocks agent skills and MCP server configuration.
 
 ## Install
 
-Install the Liveblocks plugin:
+Install the Liveblocks plugin, then start a new session in your AI coding tool.
 
 ```bash
 npx plugins add liveblocks/liveblocks-plugin
 ```
+
+## Enable MCP tools
+
+The skills work after installation. To let your AI tool inspect and modify
+Liveblocks data, set a development project secret key before starting the tool:
+
+```bash
+export LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
+```
+
+Do not use a production secret key. MCP tools can create, update, and delete
+data in the Liveblocks project connected to this key.
 
 ## Supported tools
 

--- a/docs/pages/tools/liveblocks-plugin.mdx
+++ b/docs/pages/tools/liveblocks-plugin.mdx
@@ -32,15 +32,14 @@ npx plugins add liveblocks/liveblocks-plugin
 
 ## Supported tools
 
-| Tool | Status |
-|---|---|
+| Tool                                                          | Status    |
+| ------------------------------------------------------------- | --------- |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Supported |
-| [OpenAI Codex](https://openai.com/codex) | Supported |
-| [Cursor](https://www.cursor.com/) | Supported |
+| [OpenAI Codex](https://openai.com/codex)                      | Supported |
+| [Cursor](https://www.cursor.com/)                             | Supported |
 
 The plugin uses the open plugin format and is distributed from
-`liveblocks/liveblocks-plugin`, a generated repository built from the
-[`liveblocks/skills`](https://github.com/liveblocks/skills) source repository.
+[`liveblocks/liveblocks-plugin`](https://github.com/liveblocks/liveblocks-plugin).
 
 ## Fallback install
 
@@ -87,8 +86,8 @@ Why is my Y.Map growing so large?
 
 ## Source code
 
-The source code is available in our
-[GitHub repository](https://github.com/liveblocks/skills).
+The plugin package is available in
+[`liveblocks/liveblocks-plugin`](https://github.com/liveblocks/liveblocks-plugin).
 
-The `liveblocks/liveblocks-plugin` repository is generated from this source so
-users can install from a plugin-named repository.
+Standalone skills are available in
+[`liveblocks/skills`](https://github.com/liveblocks/skills).

--- a/docs/pages/tools/markdown-access.mdx
+++ b/docs/pages/tools/markdown-access.mdx
@@ -148,5 +148,5 @@ listed docs URL with `.md` added.
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [Liveblocks MCP server](/docs/tools/mcp-server).
-- [Liveblocks skills](/docs/tools/agent-skills).
+- [MCP server](/docs/tools/mcp-server).
+- [Agent skills](/docs/tools/agent-skills).

--- a/docs/pages/tools/markdown-access.mdx
+++ b/docs/pages/tools/markdown-access.mdx
@@ -1,0 +1,152 @@
+---
+meta:
+  title: "Markdown access"
+  parentTitle: "Build with AI"
+  description:
+    "Access Liveblocks documentation as Markdown for LLMs and AI coding tools."
+---
+
+Liveblocks docs are available as Markdown for AI coding tools and agents.
+
+Use page-specific Markdown first. It gives agents current Liveblocks context
+without loading the whole documentation site.
+
+```txt
+https://liveblocks.io/docs/tools/mcp-server.md
+```
+
+## Available files
+
+### Page-specific Markdown
+
+Add `.md` to a docs URL:
+
+```txt
+https://liveblocks.io/docs/tools/liveblocks-plugin.md
+https://liveblocks.io/docs/tools/mcp-server.md
+https://liveblocks.io/docs/api-reference/liveblocks-react.md
+```
+
+Use this as the default option when an agent needs help with one feature, API,
+or setup flow.
+
+### Documentation index
+
+Use `llms.txt` when your agent needs to find the right Liveblocks docs page:
+
+```txt
+https://liveblocks.io/llms.txt
+```
+
+### Full documentation
+
+Use `llms-full.txt` only when your tool can handle a large context file:
+
+```txt
+https://liveblocks.io/llms-full.txt
+```
+
+### Accept header
+
+You can also request Markdown from a docs URL with the `Accept: text/markdown`
+header:
+
+```bash
+curl -H "Accept: text/markdown" https://liveblocks.io/docs/tools/mcp-server
+```
+
+## Copy from the docs
+
+Every documentation page includes a **Copy page** button in the page actions.
+Use it to copy the current page as Markdown, then paste it into your AI
+assistant.
+
+This is the fastest way to:
+
+- Copy documentation for a specific topic.
+- Add that page to an AI assistant's context.
+- Ask questions about that specific Liveblocks feature.
+
+Use the **View as Markdown** action when you want to open the Markdown page in a
+new tab instead.
+
+## Usage with AI tools
+
+Ask your AI tool to fetch the smallest relevant Markdown page first.
+
+### Install the Liveblocks plugin
+
+```txt
+Read https://liveblocks.io/docs/tools/liveblocks-plugin.md and help me install
+the Liveblocks plugin.
+```
+
+### Review Liveblocks React code
+
+```txt
+Read https://liveblocks.io/docs/api-reference/liveblocks-react.md and review my
+Liveblocks React hooks.
+```
+
+### Find the right page first
+
+```txt
+Read https://liveblocks.io/llms.txt, find the right Liveblocks docs page for Yjs
+auth, then use that page as context.
+```
+
+## Project rules
+
+In tools like [Cursor](https://cursor.com/docs/context/rules), add Liveblocks
+Markdown URLs to project rules so the agent knows which docs to use for
+Liveblocks tasks.
+
+For example, create `.cursor/rules/liveblocks.mdc`:
+
+```md
+---
+description: "Use Liveblocks docs when working with Liveblocks or Yjs."
+globs: ["**/*.{ts,tsx,js,jsx}"]
+alwaysApply: false
+---
+
+When working with Liveblocks:
+
+- Start with https://liveblocks.io/llms.txt to find the relevant docs page.
+- Prefer page-specific Markdown URLs over the full docs file.
+- Use https://liveblocks.io/docs/api-reference/liveblocks-react.md for
+  Liveblocks React hooks.
+- Use https://liveblocks.io/docs/tools/mcp-server.md when setting up MCP.
+```
+
+## Benefits
+
+- Markdown format: Easier for LLMs to parse than rendered HTML.
+- Current docs: Uses the same source as the Liveblocks documentation site.
+- Focused context: Fetch one page with `.md` instead of loading the full docs.
+- Direct access: Agents can fetch docs without browser scraping.
+- Token control: Start with page-specific Markdown, then use `llms.txt` or
+  `llms-full.txt` only when needed.
+
+## Limits and troubleshooting
+
+### Use the smallest file that works
+
+`llms-full.txt` can be large. Use a page-specific `.md` URL when you already
+know which page is relevant.
+
+### If you receive HTML
+
+Check that the URL ends in `.md`, or send an `Accept: text/markdown` header. The
+header must explicitly include `text/markdown`.
+
+### If a Markdown URL is unavailable
+
+Check `https://liveblocks.io/llms.txt` for supported docs pages, then use the
+listed docs URL with `.md` added.
+
+## Related docs
+
+- [Liveblocks plugin](/docs/tools/liveblocks-plugin).
+- [Liveblocks MCP server](/docs/tools/mcp-server).
+- [Liveblocks skills](/docs/tools/agent-skills).

--- a/docs/pages/tools/mcp-server.mdx
+++ b/docs/pages/tools/mcp-server.mdx
@@ -111,6 +111,9 @@ You can also add the configuration manually:
 }
 ```
 
+`${env:LIVEBLOCKS_SECRET_KEY}` tells Cursor to read the key from the environment
+instead of storing the secret directly in the config file.
+
 ### Claude Code
 
 To set up [Claude Code](https://claude.ai/code), run the following command in

--- a/docs/pages/tools/mcp-server.mdx
+++ b/docs/pages/tools/mcp-server.mdx
@@ -1,15 +1,22 @@
 ---
 meta:
-  title: "MCP server"
-  parentTitle: "Tools"
+  title: "Liveblocks MCP server"
+  parentTitle: "Build with AI"
   description:
     "Learn to use the official MCP server for Liveblocks, helpful for inspecting
     and modifying your project with AI in Cursor, VS Code, Claude Desktop, and
     more."
 ---
 
-The Liveblocks MCP server allows you to inspect and modify your project with AI
-in compatible apps such as Cursor, Claude, Codex, and more.
+The Liveblocks MCP server lets AI tools inspect and modify data in a Liveblocks
+project.
+
+Use the [Liveblocks plugin](/docs/tools/liveblocks-plugin) when your coding
+agent supports plugins. Use this page when you want to configure the MCP server
+manually or connect a tool that does not support plugins.
+
+Use [Liveblocks skills](/docs/tools/agent-skills) separately only when you also
+want Liveblocks and Yjs coding guidance in a tool that does not support plugins.
 
 <PromptCta />
 
@@ -21,38 +28,74 @@ in compatible apps such as Cursor, Claude, Codex, and more.
 
 ## Features
 
-Our MCP server features 39 different tools, enabling most features from our
-[REST API](/docs/api-reference/rest-api-endpoints). You can use it to:
+The MCP server exposes 39 tools for common Liveblocks operations. You can use it
+to:
 
-- Create and modify rooms, threads, comments, notifications, more.
+- Create and modify rooms, threads, comments, and notifications.
 - Read realtime Storage and Yjs values.
 - Broadcast custom events to connected clients.
 - Mark threads and notifications as read/unread.
 
-AI will often string tool calls together—for example, if you ask it to fetch a
-room that doesn’t exist, it will ask if you’d like to create the room first, and
-then fetch it after.
+The tools map to Liveblocks project data and many
+[REST API](/docs/api-reference/rest-api-endpoints) operations.
+
+## Supported clients
+
+The Liveblocks MCP server is a local stdio server. It works in clients that can
+run a local MCP command and pass environment variables:
+
+- Cursor
+- Claude Code
+- Claude Desktop
+- Codex
+- VS Code with GitHub Copilot
+
+Hosted MCP connectors such as ChatGPT connectors require a remote MCP URL. The
+Liveblocks MCP server does not provide a hosted remote endpoint today.
 
 ## Setup
 
-To install, you need to use your secret key from the correct project in
-[your dashboard](/dashboard). Below are instructions for [Cursor](#Cursor),
-[Claude Code](#Claude-Code), [Claude Desktop](#Claude-Desktop), and
-[Codex](#Codex).
+To install, use a secret key from the correct project in
+[your dashboard](/dashboard). Choose the setup instructions for your tool:
+[Cursor](#Cursor), [Claude Code](#Claude-Code),
+[Claude Desktop](#Claude-Desktop), [Codex](#Codex), or [VS Code](#VS-Code).
 
 <Banner type="warning" title="Only for development">
 
-Don’t insert a secret key from your production application, as AI will have
-direct access to modify it.
+Do not use a production secret key. The MCP server can modify data in the
+connected Liveblocks project.
 
 </Banner>
+
+### Install with add-mcp
+
+Use [`add-mcp`](https://www.npmjs.com/package/add-mcp) to install the Liveblocks
+MCP server for detected coding agents:
+
+```bash
+npx add-mcp -n liveblocks \
+  --env 'LIVEBLOCKS_SECRET_KEY=${env:LIVEBLOCKS_SECRET_KEY}' \
+  github:liveblocks/liveblocks-mcp-server
+```
+
+Add `--agent cursor`, `--agent codex`, or `--agent vscode` to install for one
+tool.
 
 ### Cursor
 
 To set up [Cursor](https://cursor.sh/):
 
-1. Go to File → Cursor Settings → MCP → Add new server.
-2. Add the following:
+<Button asChild>
+  <a href="https://cursor.com/en/install-mcp?name=liveblocks&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImdpdGh1YjpsaXZlYmxvY2tzL2xpdmVibG9ja3MtbWNwLXNlcnZlciJdLCJlbnYiOnsiTElWRUJMT0NLU19TRUNSRVRfS0VZIjoiJHtlbnY6TElWRUJMT0NLU19TRUNSRVRfS0VZfSJ9fQ%3D%3D">
+    <DocsCursorAiIcon className="mr-1.5 size-3.5 fill-current" />
+    Add to Cursor
+  </a>
+</Button>
+
+The button opens Cursor with the Liveblocks MCP configuration. It expects
+`LIVEBLOCKS_SECRET_KEY` to be set in the environment that starts Cursor.
+
+You can also add the configuration manually:
 
 ```json
 {
@@ -61,7 +104,7 @@ To set up [Cursor](https://cursor.sh/):
       "command": "npx",
       "args": ["-y", "github:liveblocks/liveblocks-mcp-server"],
       "env": {
-        "LIVEBLOCKS_SECRET_KEY": "{{SECRET_KEY}}"
+        "LIVEBLOCKS_SECRET_KEY": "${env:LIVEBLOCKS_SECRET_KEY}"
       }
     }
   }
@@ -117,7 +160,68 @@ codex mcp add liveblocks \
   -- npx -y github:liveblocks/liveblocks-mcp-server
 ```
 
+### VS Code
+
+To set up [VS Code](https://code.visualstudio.com/) with GitHub Copilot:
+
+<Button asChild>
+  <a href="vscode:mcp/install?%7B%22name%22%3A%22liveblocks%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22github%3Aliveblocks%2Fliveblocks-mcp-server%22%5D%2C%22env%22%3A%7B%22LIVEBLOCKS_SECRET_KEY%22%3A%22%24%7Benv%3ALIVEBLOCKS_SECRET_KEY%7D%22%7D%7D">
+    Add to VS Code
+  </a>
+</Button>
+
+The button opens VS Code with the Liveblocks MCP configuration. It expects
+`LIVEBLOCKS_SECRET_KEY` to be set in the environment that starts VS Code.
+
+You can also add it from the terminal:
+
+```bash
+code --add-mcp '{"name":"liveblocks","command":"npx","args":["-y","github:liveblocks/liveblocks-mcp-server"],"env":{"LIVEBLOCKS_SECRET_KEY":"${env:LIVEBLOCKS_SECRET_KEY}"}}'
+```
+
+## Verify setup
+
+After setup, restart your AI tool and ask:
+
+```
+List my Liveblocks rooms.
+```
+
+If the key is valid, your agent should be able to inspect rooms in the connected
+development project.
+
 ## Source code
 
 The source code is available in our
 [GitHub repository](https://github.com/liveblocks/liveblocks-mcp-server).
+
+## Related docs
+
+- [Liveblocks plugin](/docs/tools/liveblocks-plugin).
+- [Liveblocks skills](/docs/tools/agent-skills).
+
+## Troubleshooting
+
+### MCP returns auth errors
+
+Check that `LIVEBLOCKS_SECRET_KEY` uses a secret key from the correct Liveblocks
+project. If you changed the key, restart your AI tool from the shell or app
+environment where the key is set.
+
+### MCP returns unexpected data
+
+Check that the secret key belongs to the intended development project. The MCP
+server can only inspect and modify data in the project connected to that key.
+
+## Security best practices
+
+MCP servers run with the credentials you give them. Treat the Liveblocks MCP
+server like a trusted development integration.
+
+- Use a development project secret key, not a production key.
+- Use the smallest-scope project that still lets your agent complete the task.
+- Review MCP tool calls before approving changes that create, update, or delete
+  data.
+- Keep MCP configuration files out of commits when they contain real secrets.
+- Revoke and rotate the secret key if it was shared with the wrong tool or
+  committed by mistake.

--- a/docs/pages/tools/mcp-server.mdx
+++ b/docs/pages/tools/mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 meta:
-  title: "Liveblocks MCP server"
+  title: "MCP server"
   parentTitle: "Build with AI"
   description:
     "Learn to use the official MCP server for Liveblocks, helpful for inspecting
@@ -15,8 +15,8 @@ Use the [Liveblocks plugin](/docs/tools/liveblocks-plugin) when your coding
 agent supports plugins. Use this page when you want to configure the MCP server
 manually or connect a tool that does not support plugins.
 
-Use [Liveblocks skills](/docs/tools/agent-skills) separately only when you also
-want Liveblocks and Yjs coding guidance in a tool that does not support plugins.
+Use [Agent skills](/docs/tools/agent-skills) separately only when you also want
+Liveblocks and Yjs coding guidance in a tool that does not support plugins.
 
 <PromptCta />
 
@@ -198,7 +198,7 @@ The source code is available in our
 ## Related docs
 
 - [Liveblocks plugin](/docs/tools/liveblocks-plugin).
-- [Liveblocks skills](/docs/tools/agent-skills).
+- [Agent skills](/docs/tools/agent-skills).
 
 ## Troubleshooting
 

--- a/docs/pages/tools/mcp-server.mdx
+++ b/docs/pages/tools/mcp-server.mdx
@@ -73,7 +73,7 @@ Use [`add-mcp`](https://www.npmjs.com/package/add-mcp) to install the Liveblocks
 MCP server for detected coding agents:
 
 ```bash
-npx add-mcp -n liveblocks \
+npx add-mcp --yes -n liveblocks \
   --env 'LIVEBLOCKS_SECRET_KEY=${env:LIVEBLOCKS_SECRET_KEY}' \
   github:liveblocks/liveblocks-mcp-server
 ```

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -880,8 +880,8 @@
         "path": "/tools/nextjs-starter-kit"
       },
       {
-        "title": "Agent skills",
-        "path": "/tools/agent-skills"
+        "title": "Liveblocks plugin",
+        "path": "/tools/liveblocks-plugin"
       },
       {
         "title": "MCP server",

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -498,6 +498,27 @@
     ]
   },
   {
+    "title": "Build with AI",
+    "routes": [
+      {
+        "title": "Markdown access",
+        "path": "/tools/markdown-access"
+      },
+      {
+        "title": "Liveblocks plugin",
+        "path": "/tools/liveblocks-plugin"
+      },
+      {
+        "title": "Liveblocks MCP server",
+        "path": "/tools/mcp-server"
+      },
+      {
+        "title": "Liveblocks skills",
+        "path": "/tools/agent-skills"
+      }
+    ]
+  },
+  {
     "title": "Collaboration features",
     "routes": [
       {
@@ -878,14 +899,6 @@
       {
         "title": "Next.js Starter Kit",
         "path": "/tools/nextjs-starter-kit"
-      },
-      {
-        "title": "Liveblocks plugin",
-        "path": "/tools/liveblocks-plugin"
-      },
-      {
-        "title": "MCP server",
-        "path": "/tools/mcp-server"
       },
       {
         "title": "Frimousse",

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -509,11 +509,11 @@
         "path": "/tools/liveblocks-plugin"
       },
       {
-        "title": "Liveblocks MCP server",
+        "title": "MCP server",
         "path": "/tools/mcp-server"
       },
       {
-        "title": "Liveblocks skills",
+        "title": "Agent skills",
         "path": "/tools/agent-skills"
       }
     ]


### PR DESCRIPTION
This PR documents the Liveblocks agent resources work across the docs.

It adds a plugin-first path for AI coding tools, separates the MCP server and standalone skills docs, and groups the related pages under a new **Build with AI** section in the docs sidebar.

## What changed

- Added a new Liveblocks plugin docs page covering installation, verification, MCP access, supported tools, standalone skills fallback, example prompts, troubleshooting, and source links.
- Expanded the Liveblocks MCP server page with supported clients, `add-mcp`, Add to Cursor / VS Code buttons, manual setup for Cursor, Claude Code, Claude Desktop, Codex, and VS Code, verification, troubleshooting, and security guidance.
- Reworked the skills page into Liveblocks skills.
- Added a Markdown access page covering page-specific `.md` URLs, `llms.txt`, `llms-full.txt`, `Accept: text/markdown`, the docs Copy page action, and Cursor project rules.
- Updated Claude Code, Codex, Cursor, and Claude Desktop integration docs to use the new Liveblocks plugin / Liveblocks MCP server / Liveblocks skills naming and setup paths.
- Updated the agent-skills prompt context to recommend the plugin first, with skills plus MCP as the fallback.

## Callouts

- The existing `/docs/tools/agent-skills` URL is preserved, but the visible title is now Liveblocks skills.
- Grok Build and GitHub Copilot are documented on the plugin page as repository-file consumers rather than `plugins` CLI installs.
- The **Build with AI** sidebar group sits before **Collaboration features** so agent resources are easier to find.