### PR TITLE
CHANGELOG — WEEK 26

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,13 +20,20 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 26 (2026-06-26)
 
+## v3.20.1
+
+### `@liveblocks/client`
+
+- Fix a bug where sending a too large WebSocket message could sometimes overwrite a room's top-level storage key with `initialStorage`, causing data loss. (Thanks @watemerald for reporting!)
+
 ## Dashboard
 
 - Added support for manual and automatic re-ingestion of (web) knowledge sources at specified interval.
 - Streamlined display of knowledge sources and linking/unlinking of knowledge sources and copilots.
 
 ## Contributors
-@nimeshnayaju @pierrelevaillant
+
+nimeshnayaju, pierrelevaillant, nvie
 
 # Week 25 (2026-06-19)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,7 +20,13 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 26 (2026-06-26)
 
+## Dashboard
+
+- Added support for manual and automatic re-ingestion of (web) knowledge sources at specified interval.
+- Streamlined display of knowledge sources and linking/unlinking of knowledge sources and copilots.
+
 ## Contributors
+@nimeshnayaju @pierrelevaillant
 
 # Week 25 (2026-06-19)
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -24,7 +24,7 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 ### `@liveblocks/client`
 
-- Fix a bug where sending a too large WebSocket message could sometimes overwrite a room's top-level storage key with `initialStorage`, causing data loss. (Thanks @watemerald for reporting!)
+- Fix a bug where sending a too large WebSocket message could sometimes overwrite a room's top-level storage key with `initialStorage`, causing data loss. Thanks for reporting [@watemerald](https://github.com/watemerald)!
 
 ## Dashboard
 

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -18,6 +18,10 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 -->
 
+# Week 26 (2026-06-26)
+
+## Contributors
+
 # Week 25 (2026-06-19)
 
 ## v3.20.0


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-26-2026/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 26th of June.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching. Thank you [@random_dev](https://github.com/random_dev)!

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug.  Thank you [@random_dev](https://github.com/random_dev)!

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog file with no impact on runtime behavior.
> 
> **Overview**
> Prepares the public changelog for the next release cycle by adding a new `# Week 7 (2026-02-13)` section with an empty `## Contributors` placeholder at the top of `CHANGELOG_PUBLIC.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d43e482e0fdc14aa8869b2bb4a0843967af930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->