### PR TITLE
fix(room): only seed initialStorage on first storage load

### DIFF
--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -56,6 +56,7 @@ import {
   createSerializedRoot,
   fakeSyncSource,
   FIRST_POSITION,
+  parseAsClientMsgs,
   prepareIsolatedStorageTest,
   prepareRoomWithStorage_loadWithDelay,
   prepareStorageTest,
@@ -1071,6 +1072,97 @@ describe("room", () => {
     room.connect();
     const storage = await room.getStorage();
     expect(storage.root.toJSON()).toEqual({ x: 0 });
+  });
+
+  /**
+   * Regression for https://github.com/liveblocks/liveblocks/issues/3535.
+   *
+   * A storage refresh that hits the merge branch of
+   * `createOrUpdateRootFromMessage` (everything but the very first load —
+   * reconnect after a 1009 "message too large" close, manual refresh, etc.)
+   * used to fall through into the `initialStorage` population loop. If a key
+   * looked momentarily missing in the local copy mid-merge, the loop would
+   * `root.set(key, initialStorage[key])` and clobber the authoritative server
+   * value with a default. The reporter saw this as a single >1MB
+   * `LiveObject.set` followed by the room being replaced with `initialStorage`
+   * on reconnect.
+   *
+   * `initialStorage` must only seed missing keys on the first load.
+   */
+  test("does not re-seed initialStorage on a refresh that finds the key missing (#3535)", async () => {
+    const initialStorage = { value: "default" };
+    const { room, wss } = createTestableRoom(
+      {},
+      undefined,
+      undefined,
+      undefined,
+      initialStorage
+    );
+
+    // The reporter's footgun: the local pool ends up with the `value` key
+    // missing post-merge (in their case because a >1MB `LiveObject.set` was
+    // rolled back on reconnect, leaving the slot momentarily empty). This
+    // test reproduces that "empty local state after merge" condition by
+    // having the reconnect-time server payload omit the `value` key — the
+    // merge then DELETEs it from the local copy, and the old behavior
+    // re-populated it from `initialStorage` and sent a tiny UPDATE_STORAGE
+    // op back that overwrote the real server document with `"default"`.
+    //
+    // After the fix, `initialStorage` only seeds on the *first* load, so the
+    // refresh leaves the key missing and the user can deal with it instead
+    // of silently losing data.
+
+    let connectionsSeen = 0;
+    const opsSentByClient: unknown[] = [];
+    wss.onConnection((conn) => {
+      connectionsSeen += 1;
+      const valueOnConnect = connectionsSeen === 1 ? "real" : undefined;
+      const rootData =
+        valueOnConnect !== undefined ? { value: valueOnConnect } : {};
+      conn.server.send(
+        serverMessage({
+          type: ServerMsgCode.STORAGE_CHUNK,
+          nodes: [["root", rootData]],
+        })
+      );
+      conn.server.send(
+        serverMessage({ type: ServerMsgCode.STORAGE_STREAM_END })
+      );
+    });
+    onTestFinished(
+      wss.onReceive.subscribe((data) => {
+        const msgs = parseAsClientMsgs(data);
+        for (const msg of msgs) {
+          if (msg.type === ClientMsgCode.UPDATE_STORAGE) {
+            opsSentByClient.push(...msg.ops);
+          }
+        }
+      })
+    );
+
+    room.connect();
+    const storage = await room.getStorage();
+    expect(storage.root.toJSON()).toEqual({ value: "real" });
+
+    // Simulate the 1009 "message too large" close that the reporter hit.
+    wss.last.close(
+      new CloseEvent("close", {
+        code: 1009,
+        wasClean: false,
+      })
+    );
+
+    await waitUntilStatus(room, "connected");
+    await vi.waitFor(() => expect(connectionsSeen).toBeGreaterThanOrEqual(2));
+    // Give the post-reconnect message loop a tick to flush any backfill the
+    // old code path would have queued.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The room data must not have been silently rewritten to the default,
+    // and no UPDATE_STORAGE op should have been emitted that sets `value`
+    // back to `"default"`.
+    expect(storage.root.toJSON()).toEqual({});
+    expect(opsSentByClient).toEqual([]);
   });
 
   test("undo redo with presence", async () => {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1915,7 +1915,9 @@ export function createRoom<
       throw new Error("Internal error: cannot load storage without items");
     }
 
-    if (context.root !== undefined) {
+    const isFirstLoad = context.root === undefined;
+
+    if (!isFirstLoad) {
       const currentItems: NodeMap = new Map();
       for (const [id, crdt] of context.pool.nodes) {
         currentItems.set(id, crdt._serialize());
@@ -1931,9 +1933,19 @@ export function createRoom<
       );
     }
 
-    const canWrite = self.get()?.canWrite ?? true;
+    // Populate missing top-level keys using `initialStorage` — only on the
+    // first load. Refreshes that hit the merge branch above already reconcile
+    // against authoritative server state, so re-running this here would
+    // overwrite real room data with `initialStorage` whenever a server-side
+    // reset (or an aborted local write that left local keys missing — see
+    // issue #3535: a >1MB `LiveObject.set` closes the socket with 1009 and the
+    // reconnect-driven refresh then ran this block and replaced the room with
+    // `initialStorage`) made a key briefly look missing in the local copy.
+    if (!isFirstLoad) {
+      return;
+    }
 
-    // Populate missing top-level keys using `initialStorage`
+    const canWrite = self.get()?.canWrite ?? true;
     const root = context.root;
     disableHistory(() => {
       for (const key in context.initialStorage) {


### PR DESCRIPTION
Fixes #3535.

### What

`createOrUpdateRootFromMessage` in `packages/liveblocks-core/src/room.ts` runs after both initial load and storage refresh (reconnect, manual `refreshStorage`, …). It had a single trailing `initialStorage` population loop:

```ts
disableHistory(() => {
  for (const key in context.initialStorage) {
    if (root.get(key) === undefined) {
      if (canWrite) {
        root.set(key, cloneLson(context.initialStorage[key]));
      } …
    }
  }
});
```

The loop was meant only to seed defaults on the *first* load. On a refresh, it still fired — and any top-level key that the merge left looking momentarily missing in the local copy would be `root.set(...)`-ed back to the `initialStorage` default and forwarded to the server as an `UPDATE_STORAGE` op. The reporter (@watemerald, reproduction repo [linked from the issue](https://github.com/watemerald/liveblocks-bug-repro)) caught this as: a `>1MB LiveObject.set` closes the socket with `1009 "Message is too large"`, the post-reconnect refresh runs this loop, and the live room document is silently replaced with the `initialStorage` default. Data loss at the lowest level a user would notice — the next polled `/v2/.../storage` read returns the default.

### Fix

`initialStorage` population now only runs on the first-load branch (`context.root === undefined`). The merge branch already reconciles against authoritative server state via `diffNodeMap` + `applyRemoteOps`; re-seeding on top of that is what produced the overwrite.

### Tests

Adds `does not re-seed initialStorage on a refresh that finds the key missing (#3535)` to `packages/liveblocks-core/src/__tests__/room.mockserver.test.ts`:

1. Sets up a room with `initialStorage = { value: "default" }` whose first server payload is `{ value: "real" }`.
2. Asserts the initial load reads `"real"` (initial-load branch correctly leaves the existing key alone).
3. Closes the socket with code `1009` to mirror the reporter's "message too large" trigger.
4. The reconnect-time storage payload omits `value`, forcing the merge to clear it from the local copy.
5. Asserts the local copy ends at `{}` (the merge faithfully reflects the server) and that no `UPDATE_STORAGE` op was sent.

Without the fix the assertion at step 5 fails with `{ value: "default" }` — exactly the failure the reporter is seeing. With the fix it passes. The full `room.mockserver.test.ts` suite (74 tests) stays green.

```
$ pnpm exec vitest run src/__tests__/room.mockserver.test.ts -t "#3535"
✓ does not re-seed initialStorage on a refresh that finds the key missing (#3535)

$ pnpm exec vitest run src/__tests__/room.mockserver.test.ts
Tests  74 passed (74)
```

### Behavior notes

- Behavior on **first load** is unchanged: missing top-level keys are still populated from `initialStorage`.
- Behavior on **refresh / reconnect** changes: previously these would also populate, now they don't. This is the entire point of the fix — a refresh should never silently rewrite room data with a client-supplied default; the authoritative server state already arrived in the same message.
- The `canWrite === false` warn path is gone for refreshes because the loop itself is gone there; first-load behavior preserves it.
- No public-API change; no migration needed for users on prior versions.

### Considered but not done

I considered narrower variants — e.g. only suppressing the loop when there are unacknowledged ops, or guarding per-key by tracking which keys we've ever seen from the server. Those would each leave a window where the bug still fires (e.g. manual `refreshStorage` after a long quiescent period, or any other code path where `diffNodeMap` deletes a key the local copy held). The clean read of `initialStorage`'s intent is "seed an empty room once" — moving the loop into the first-load branch is the smallest change that matches that intent. Happy to switch to either of the narrower shapes if you'd rather.