### PR TITLE
Clarify collaboration minutes in pricing docs

### DIFF
--- a/docs/pages/pricing/faqs.mdx
+++ b/docs/pages/pricing/faqs.mdx
@@ -19,9 +19,31 @@ For full per-metric rates and worked examples, see our
 
 ## What counts as a realtime collaboration minute?
 
-Realtime collaboration minutes count when multiple users are active in a room.
-Two users in a room for 5 minutes is 10 collaboration minutes, billed at $0.002
-each. You can see exactly what's being counted on your
+Realtime collaboration minutes count when two or more people or agents are
+connected to the same room at the same time. Each connected user-minute counts
+toward the total. For example, two users in a room for 5 minutes is 10
+collaboration minutes, billed at $0.002 each.
+
+If only one person or agent is in a room, it costs $0.
+
+**What counts as active in a room?** A user or agent is active when they have an
+open connection to a room—for example, when they've joined with
+[`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider) or
+[`enterRoom`](/docs/api-reference/liveblocks-client#Client.enterRoom). Each
+browser tab counts as one connection.
+
+**Do idle tabs count?** By default, Liveblocks keeps WebSocket connections open
+even in background tabs, so users who are reading without editing still count as
+connected. You can optionally disconnect inactive background tabs with
+[`backgroundKeepAliveTimeout`](/docs/api-reference/liveblocks-client#createClientBackgroundKeepAliveTimeout).
+
+**Can I see collaboration minutes by user or by room?** Your
+[dashboard usage page](/dashboard/usage) shows collaboration minutes at the
+workspace level. On each project's overview page, you can see collaboration
+minutes over time for that project. Per-user and per-room breakdowns aren't
+available in the dashboard today.
+
+You can see exactly what's being counted on your
 [dashboard usage page](/dashboard/usage).
 
 ## Which Liveblocks plan should I choose?

--- a/docs/pages/pricing/faqs.mdx
+++ b/docs/pages/pricing/faqs.mdx
@@ -19,32 +19,41 @@ For full per-metric rates and worked examples, see our
 
 ## What counts as a realtime collaboration minute?
 
-Realtime collaboration minutes count when two or more people or agents are
-connected to the same room at the same time. Each connected user-minute counts
-toward the total. For example, two users in a room for 5 minutes is 10
-collaboration minutes, billed at $0.002 each.
+Realtime collaboration minutes measure time when two or more people or agents
+are in the same room together. Each connected user-minute counts. Two users in a
+room for 5 minutes is 10 collaboration minutes, billed at $0.002 each.
 
-If only one person or agent is in a room, it costs $0.
+Solo sessions cost $0. If only one person or agent is in a room, it is not
+billed.
 
-**What counts as active in a room?** A user or agent is active when they have an
-open connection to a room—for example, when they've joined with
+### What counts as connected?
+
+A user counts as connected when they have an open connection to a room—for
+example, after joining with
 [`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider) or
 [`enterRoom`](/docs/api-reference/liveblocks-client#Client.enterRoom). Each
-browser tab counts as one connection.
+browser tab is one connection.
 
-**Do idle tabs count?** By default, Liveblocks keeps WebSocket connections open
-even in background tabs, so users who are reading without editing still count as
-connected. You can optionally disconnect inactive background tabs with
-[`backgroundKeepAliveTimeout`](/docs/api-reference/liveblocks-client#createClientBackgroundKeepAliveTimeout).
+### When does billing pause?
 
-**Can I see collaboration minutes by user or by room?** Your
-[dashboard usage page](/dashboard/usage) shows collaboration minutes at the
-workspace level. On each project's overview page, you can see collaboration
-minutes over time for that project. Per-user and per-room breakdowns aren't
-available in the dashboard today.
+If no one is using the room (no presence updates, cursor movement, or other
+activity), the room becomes inactive after 10 seconds. Collaboration minutes
+stop accumulating until someone interacts again.
 
-You can see exactly what's being counted on your
-[dashboard usage page](/dashboard/usage).
+### Do background tabs count?
+
+By default, Liveblocks keeps connections open in background tabs, so those users
+still count as connected. To disconnect inactive background tabs automatically,
+set
+[`backgroundKeepAliveTimeout`](/docs/api-reference/liveblocks-client#createClientBackgroundKeepAliveTimeout)
+on your client.
+
+### Where can I see collaboration minutes?
+
+Your [dashboard usage page](/dashboard/usage) shows collaboration minutes at the
+workspace level. Each project overview page shows collaboration minutes over
+time for that project. Per-user and per-room breakdowns are not available in the
+dashboard today.
 
 ## Which Liveblocks plan should I choose?
 

--- a/docs/pages/pricing/overview.mdx
+++ b/docs/pages/pricing/overview.mdx
@@ -36,14 +36,14 @@ See [Plans](/docs/pricing/plans) for full details on each plan.
 Liveblocks charges for what your app uses, applied against your monthly credits
 first. The main metered units:
 
-| Unit                                                                    | Description                                                     | Rate              |
-| ----------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
-| [Realtime collaboration minutes](/docs/pricing/plans/pro#Metered-usage) | Minutes when 2+ people or agents are connected to the same room | $0.002 per minute |
-| [Comments created](/docs/pricing/plans/pro#Metered-usage)               | Each comment posted in your app                                 | $0.01 per comment |
-| [Realtime data storage updates](/docs/pricing/plans/pro#Metered-usage)  | Each change written to stored data                              | $1 per 1M updates |
-| [Realtime data stored](/docs/pricing/plans/pro#Metered-usage)           | Total data kept in storage                                      | $0.15 per GB      |
-| [Monthly custom notifications](/docs/pricing/plans/pro#Metered-usage)   | Notifications you trigger from your own code                    | $0.01 per event   |
-| [File storage](/docs/pricing/plans/pro#Metered-usage)                   | Total files stored                                              | $0.15 per GB      |
+| Unit                                                                    | Description                                                  | Rate              |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------ | ----------------- |
+| [Realtime collaboration minutes](/docs/pricing/plans/pro#Metered-usage) | When 2+ people are in the same room, each user-minute counts | $0.002 per minute |
+| [Comments created](/docs/pricing/plans/pro#Metered-usage)               | Each comment posted in your app                              | $0.01 per comment |
+| [Realtime data storage updates](/docs/pricing/plans/pro#Metered-usage)  | Each change written to stored data                           | $1 per 1M updates |
+| [Realtime data stored](/docs/pricing/plans/pro#Metered-usage)           | Total data kept in storage                                   | $0.15 per GB      |
+| [Monthly custom notifications](/docs/pricing/plans/pro#Metered-usage)   | Notifications you trigger from your own code                 | $0.01 per event   |
+| [File storage](/docs/pricing/plans/pro#Metered-usage)                   | Total files stored                                           | $0.15 per GB      |
 
 Rates shown here are indicative. See
 [Pro](/docs/pricing/plans/pro#Metered-usage) and

--- a/docs/pages/pricing/overview.mdx
+++ b/docs/pages/pricing/overview.mdx
@@ -36,14 +36,14 @@ See [Plans](/docs/pricing/plans) for full details on each plan.
 Liveblocks charges for what your app uses, applied against your monthly credits
 first. The main metered units:
 
-| Unit                                                                    | Description                                           | Rate              |
-| ----------------------------------------------------------------------- | ----------------------------------------------------- | ----------------- |
-| [Realtime collaboration minutes](/docs/pricing/plans/pro#Metered-usage) | Active time people and agents spend together in rooms | $0.002 per minute |
-| [Comments created](/docs/pricing/plans/pro#Metered-usage)               | Each comment posted in your app                       | $0.01 per comment |
-| [Realtime data storage updates](/docs/pricing/plans/pro#Metered-usage)  | Each change written to stored data                    | $1 per 1M updates |
-| [Realtime data stored](/docs/pricing/plans/pro#Metered-usage)           | Total data kept in storage                            | $0.15 per GB      |
-| [Monthly custom notifications](/docs/pricing/plans/pro#Metered-usage)   | Notifications you trigger from your own code          | $0.01 per event   |
-| [File storage](/docs/pricing/plans/pro#Metered-usage)                   | Total files stored                                    | $0.15 per GB      |
+| Unit                                                                    | Description                                                     | Rate              |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| [Realtime collaboration minutes](/docs/pricing/plans/pro#Metered-usage) | Minutes when 2+ people or agents are connected to the same room | $0.002 per minute |
+| [Comments created](/docs/pricing/plans/pro#Metered-usage)               | Each comment posted in your app                                 | $0.01 per comment |
+| [Realtime data storage updates](/docs/pricing/plans/pro#Metered-usage)  | Each change written to stored data                              | $1 per 1M updates |
+| [Realtime data stored](/docs/pricing/plans/pro#Metered-usage)           | Total data kept in storage                                      | $0.15 per GB      |
+| [Monthly custom notifications](/docs/pricing/plans/pro#Metered-usage)   | Notifications you trigger from your own code                    | $0.01 per event   |
+| [File storage](/docs/pricing/plans/pro#Metered-usage)                   | Total files stored                                              | $0.15 per GB      |
 
 Rates shown here are indicative. See
 [Pro](/docs/pricing/plans/pro#Metered-usage) and

--- a/docs/pages/pricing/plans/free.mdx
+++ b/docs/pages/pricing/plans/free.mdx
@@ -16,15 +16,15 @@ reach a limit, the affected feature pauses until the next billing cycle. Upgrade
 to [Pro](/docs/pricing/plans/pro) or [Team](/docs/pricing/plans/team) for
 monthly credits and overage billing.
 
-| Item                                                                                                                                                                                         | Free included usage                                          |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| <LimitLabel tooltip="Minutes when 2+ people or agents are connected to the same room. Each connected user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel> | <Limits.FreeRealtimeCollaborationMinutesIncluded /> included |
-| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                                      | <Limits.FreeCommentsCreatedIncluded /> included              |
-| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                             | <Limits.FreeRealtimeDataStorageUpdatesIncluded /> included   |
-| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                           | <Limits.FreeRealtimeDataStoredIncluded /> included           |
-| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel>         | <Limits.FreeMaxCollaborationNotifications />                 |
-| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                                | <Limits.FreeCustomNotificationsCompareIncluded /> included   |
-| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                                   | <Limits.FreeMaxFileStorage /> included                       |
+| Item                                                                                                                                                                                 | Free included usage                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| <LimitLabel tooltip="When 2+ people or agents are in the same room, each user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel>                     | <Limits.FreeRealtimeCollaborationMinutesIncluded /> included |
+| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                              | <Limits.FreeCommentsCreatedIncluded /> included              |
+| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                     | <Limits.FreeRealtimeDataStorageUpdatesIncluded /> included   |
+| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                   | <Limits.FreeRealtimeDataStoredIncluded /> included           |
+| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel> | <Limits.FreeMaxCollaborationNotifications />                 |
+| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                        | <Limits.FreeCustomNotificationsCompareIncluded /> included   |
+| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                           | <Limits.FreeMaxFileStorage /> included                       |
 
 ## Other limits
 

--- a/docs/pages/pricing/plans/free.mdx
+++ b/docs/pages/pricing/plans/free.mdx
@@ -16,15 +16,15 @@ reach a limit, the affected feature pauses until the next billing cycle. Upgrade
 to [Pro](/docs/pricing/plans/pro) or [Team](/docs/pricing/plans/team) for
 monthly credits and overage billing.
 
-| Item                                                                                                                                                                                 | Free included usage                                          |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| <LimitLabel tooltip="The total active time people and agents spend together inside rooms.">Realtime collaboration minutes</LimitLabel>                                               | <Limits.FreeRealtimeCollaborationMinutesIncluded /> included |
-| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                              | <Limits.FreeCommentsCreatedIncluded /> included              |
-| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                     | <Limits.FreeRealtimeDataStorageUpdatesIncluded /> included   |
-| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                   | <Limits.FreeRealtimeDataStoredIncluded /> included           |
-| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel> | <Limits.FreeMaxCollaborationNotifications />                 |
-| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                        | <Limits.FreeCustomNotificationsCompareIncluded /> included   |
-| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                           | <Limits.FreeMaxFileStorage /> included                       |
+| Item                                                                                                                                                                                         | Free included usage                                          |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| <LimitLabel tooltip="Minutes when 2+ people or agents are connected to the same room. Each connected user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel> | <Limits.FreeRealtimeCollaborationMinutesIncluded /> included |
+| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                                      | <Limits.FreeCommentsCreatedIncluded /> included              |
+| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                             | <Limits.FreeRealtimeDataStorageUpdatesIncluded /> included   |
+| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                           | <Limits.FreeRealtimeDataStoredIncluded /> included           |
+| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel>         | <Limits.FreeMaxCollaborationNotifications />                 |
+| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                                | <Limits.FreeCustomNotificationsCompareIncluded /> included   |
+| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                                   | <Limits.FreeMaxFileStorage /> included                       |
 
 ## Other limits
 

--- a/docs/pages/pricing/plans/pro.mdx
+++ b/docs/pages/pricing/plans/pro.mdx
@@ -23,15 +23,15 @@ Metered usage is billed per unit, only for what you actually use. Each plan
 includes monthly credits that cover this usage first, so you only pay for
 anything above them.
 
-| Item                                                                                                                                                                                 | Pro pricing                                  |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| <LimitLabel tooltip="The total active time people and agents spend together inside rooms.">Realtime collaboration minutes</LimitLabel>                                               | <Limits.RealtimeCollaborationMinutesPrice /> |
-| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                              | <Limits.CommentsCreatedPrice />              |
-| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                     | <Limits.RealtimeDataStorageUpdatesPrice />   |
-| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                   | <Limits.RealtimeDataStoredPrice />           |
-| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel> | <Limits.ProMaxCollaborationNotifications />  |
-| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                        | <Limits.CustomNotificationsPrice />          |
-| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                           | <Limits.FileStoragePrice />                  |
+| Item                                                                                                                                                                                         | Pro pricing                                  |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| <LimitLabel tooltip="Minutes when 2+ people or agents are connected to the same room. Each connected user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel> | <Limits.RealtimeCollaborationMinutesPrice /> |
+| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                                      | <Limits.CommentsCreatedPrice />              |
+| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                             | <Limits.RealtimeDataStorageUpdatesPrice />   |
+| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                           | <Limits.RealtimeDataStoredPrice />           |
+| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel>         | <Limits.ProMaxCollaborationNotifications />  |
+| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                                | <Limits.CustomNotificationsPrice />          |
+| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                                   | <Limits.FileStoragePrice />                  |
 
 ## Other limits
 

--- a/docs/pages/pricing/plans/pro.mdx
+++ b/docs/pages/pricing/plans/pro.mdx
@@ -23,15 +23,15 @@ Metered usage is billed per unit, only for what you actually use. Each plan
 includes monthly credits that cover this usage first, so you only pay for
 anything above them.
 
-| Item                                                                                                                                                                                         | Pro pricing                                  |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| <LimitLabel tooltip="Minutes when 2+ people or agents are connected to the same room. Each connected user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel> | <Limits.RealtimeCollaborationMinutesPrice /> |
-| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                                      | <Limits.CommentsCreatedPrice />              |
-| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                             | <Limits.RealtimeDataStorageUpdatesPrice />   |
-| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                           | <Limits.RealtimeDataStoredPrice />           |
-| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel>         | <Limits.ProMaxCollaborationNotifications />  |
-| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                                | <Limits.CustomNotificationsPrice />          |
-| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                                   | <Limits.FileStoragePrice />                  |
+| Item                                                                                                                                                                                 | Pro pricing                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
+| <LimitLabel tooltip="When 2+ people or agents are in the same room, each user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel>                     | <Limits.RealtimeCollaborationMinutesPrice /> |
+| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                              | <Limits.CommentsCreatedPrice />              |
+| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                     | <Limits.RealtimeDataStorageUpdatesPrice />   |
+| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                   | <Limits.RealtimeDataStoredPrice />           |
+| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel> | <Limits.ProMaxCollaborationNotifications />  |
+| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                        | <Limits.CustomNotificationsPrice />          |
+| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                           | <Limits.FileStoragePrice />                  |
 
 ## Other limits
 

--- a/docs/pages/pricing/plans/team.mdx
+++ b/docs/pages/pricing/plans/team.mdx
@@ -28,15 +28,15 @@ Metered usage is billed per unit, only for what you actually use. Each plan
 includes monthly credits that cover this usage first, so you only pay for
 anything above them.
 
-| Item                                                                                                                                                                                         | Team pricing                                 |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| <LimitLabel tooltip="Minutes when 2+ people or agents are connected to the same room. Each connected user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel> | <Limits.RealtimeCollaborationMinutesPrice /> |
-| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                                      | <Limits.CommentsCreatedPrice />              |
-| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                             | <Limits.RealtimeDataStorageUpdatesPrice />   |
-| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                           | <Limits.RealtimeDataStoredPrice />           |
-| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel>         | <Limits.TeamMaxCollaborationNotifications /> |
-| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                                | <Limits.CustomNotificationsPrice />          |
-| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                                   | <Limits.FileStoragePrice />                  |
+| Item                                                                                                                                                                                 | Team pricing                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
+| <LimitLabel tooltip="When 2+ people or agents are in the same room, each user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel>                     | <Limits.RealtimeCollaborationMinutesPrice /> |
+| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                              | <Limits.CommentsCreatedPrice />              |
+| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                     | <Limits.RealtimeDataStorageUpdatesPrice />   |
+| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                   | <Limits.RealtimeDataStoredPrice />           |
+| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel> | <Limits.TeamMaxCollaborationNotifications /> |
+| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                        | <Limits.CustomNotificationsPrice />          |
+| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                           | <Limits.FileStoragePrice />                  |
 
 ## Other limits
 

--- a/docs/pages/pricing/plans/team.mdx
+++ b/docs/pages/pricing/plans/team.mdx
@@ -28,15 +28,15 @@ Metered usage is billed per unit, only for what you actually use. Each plan
 includes monthly credits that cover this usage first, so you only pay for
 anything above them.
 
-| Item                                                                                                                                                                                 | Team pricing                                 |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| <LimitLabel tooltip="The total active time people and agents spend together inside rooms.">Realtime collaboration minutes</LimitLabel>                                               | <Limits.RealtimeCollaborationMinutesPrice /> |
-| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                              | <Limits.CommentsCreatedPrice />              |
-| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                     | <Limits.RealtimeDataStorageUpdatesPrice />   |
-| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                   | <Limits.RealtimeDataStoredPrice />           |
-| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel> | <Limits.TeamMaxCollaborationNotifications /> |
-| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                        | <Limits.CustomNotificationsPrice />          |
-| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                           | <Limits.FileStoragePrice />                  |
+| Item                                                                                                                                                                                         | Team pricing                                 |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| <LimitLabel tooltip="Minutes when 2+ people or agents are connected to the same room. Each connected user-minute counts. Solo sessions cost $0.">Realtime collaboration minutes</LimitLabel> | <Limits.RealtimeCollaborationMinutesPrice /> |
+| <LimitLabel tooltip="Number of net new comments created.">Comments created</LimitLabel>                                                                                                      | <Limits.CommentsCreatedPrice />              |
+| <LimitLabel tooltip="Each change written to stored data, billed per million updates.">Realtime data storage updates</LimitLabel>                                                             | <Limits.RealtimeDataStorageUpdatesPrice />   |
+| <LimitLabel tooltip="Total data kept in storage, billed per GB.">Realtime data stored</LimitLabel>                                                                                           | <Limits.RealtimeDataStoredPrice />           |
+| <LimitLabel tooltip="Notifications automatically triggered from collaborative features like comment thread updates and @ mentions.">Monthly collaboration notifications</LimitLabel>         | <Limits.TeamMaxCollaborationNotifications /> |
+| <LimitLabel tooltip="Notifications you trigger from your own code.">Monthly custom notifications</LimitLabel>                                                                                | <Limits.CustomNotificationsPrice />          |
+| <LimitLabel tooltip="Total amount of files stored, such as comment attachments.">File storage</LimitLabel>                                                                                   | <Limits.FileStoragePrice />                  |
 
 ## Other limits
 


### PR DESCRIPTION
Expands the pricing FAQ and syncs plan-page tooltips with the sharper collaboration-minutes definition.

The FAQ now clarifies:
- Solo sessions cost $0
- What counts as active in a room (open connection; each tab = one connection)
- Idle tabs (connections stay open by default; optional `backgroundKeepAliveTimeout`)
- Available dashboard breakdowns (workspace + per-project; no per-user/per-room today)

Also updated the pricing overview table and Free/Pro/Team metered-usage tooltips.

## Next steps
- [x] Land the companion liveblocks.io PR
- [x] Add server hibernation copy once @ofoucherot confirms how it affects billing