### PR TITLE
Prevent default `Composer` from collapsing on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## vNEXT (not yet released)
 
+### `@liveblocks/react-ui`
+
+- Prevent `Composer` from collapsing after focusing and blurring unless it was
+  explicitly meant to support a collapsed state.
+
 ## v3.21.0
 
 ...

--- a/packages/liveblocks-react-ui/src/__tests__/index.test.tsx
+++ b/packages/liveblocks-react-ui/src/__tests__/index.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { Comment } from "../components/Comment";
 import { Composer } from "../components/Composer";
 import { Thread } from "../components/Thread";
-import { render } from "./_utils"; // Basically re-exports from @testing-library/react
+import { fireEvent, render, screen } from "./_utils"; // Basically re-exports from @testing-library/react
 
 const comment: CommentData = {
   type: "comment",
@@ -139,5 +139,32 @@ describe("Composer", () => {
     const { container } = render(<Composer />);
 
     expect(container).not.toBeEmptyDOMElement();
+  });
+
+  test("should stay expanded after blurring when initially expanded", () => {
+    render(<Composer />);
+
+    fireEvent.focus(screen.getByLabelText("Composer editor"));
+    fireEvent.blur(screen.getByLabelText("Composer editor"), {
+      relatedTarget: document.body,
+    });
+
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
+
+  test("should collapse after blurring when initially collapsed", () => {
+    render(<Composer defaultCollapsed />);
+
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+
+    fireEvent.focus(screen.getByLabelText("Composer editor"));
+
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+
+    fireEvent.blur(screen.getByLabelText("Composer editor"), {
+      relatedTarget: document.body,
+    });
+
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
   });
 });

--- a/packages/liveblocks-react-ui/src/components/Composer.tsx
+++ b/packages/liveblocks-react-ui/src/components/Composer.tsx
@@ -753,6 +753,9 @@ export const Composer = forwardRef(
       controlledCollapsed,
       controlledOnCollapsedChange
     );
+    // Only auto-collapse composers that are explicitly meant to support a collapsed state.
+    const shouldCollapseWhenEmpty =
+      controlledCollapsed !== undefined || defaultCollapsed === true;
 
     const canComment = useHasPermissionAccess(roomId, "comments", "write");
 
@@ -791,11 +794,16 @@ export const Composer = forwardRef(
           event.relatedTarget ?? document.activeElement
         );
 
-        if (isOutside && isEmptyRef.current && !isEmojiPickerOpenRef.current) {
+        if (
+          shouldCollapseWhenEmpty &&
+          isOutside &&
+          isEmptyRef.current &&
+          !isEmojiPickerOpenRef.current
+        ) {
           onCollapsedChange?.(true);
         }
       },
-      [onBlur, onCollapsedChange]
+      [onBlur, onCollapsedChange, shouldCollapseWhenEmpty]
     );
 
     const handleEditorClick = useCallback(


### PR DESCRIPTION
This PR prevents `Composer` from auto-collapsing unless it's explicitly meant to support a collapsed state (by being controlled or by starting collapsed)

https://github.com/user-attachments/assets/ab6b2c19-e5dd-42b0-9a41-fb43d8d761b6