### PR TITLE
Fix bug where sending too large message could cause data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet released)
 
+### `@liveblocks/client`
+
+- Fix a bug where sending a too large WebSocket message could sometimes
+  overwrite a room's top-level storage key with `initialStorage`, causing data
+  loss. (Thanks @watemerald for reporting!)
+
 ## v3.20.0
 
 ### All packages

--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -28,6 +28,7 @@ import { kInternal } from "../internal";
 import { makeEventSource } from "../lib/EventSource";
 import * as console from "../lib/fancy-console";
 import type { Json, JsonObject } from "../lib/Json";
+import { isJsonArray, isJsonObject } from "../lib/Json";
 import type { BaseUserMeta } from "../protocol/BaseUserMeta";
 import { ClientMsgCode } from "../protocol/ClientMsg";
 import type { BaseMetadata } from "../protocol/Comments";
@@ -52,6 +53,7 @@ import {
 } from "./_MockWebSocketServer.behaviors";
 import {
   createSerializedList,
+  createSerializedObject,
   createSerializedRegister,
   createSerializedRoot,
   fakeSyncSource,
@@ -1745,6 +1747,71 @@ describe("room", () => {
       expectStorage({
         items2: ["B"],
       });
+    });
+
+    // Regression test for https://github.com/liveblocks/liveblocks/issues/3535
+    test("initialStorage must not overwrite an existing key whose pending write never gets acked", async () => {
+      const { root, room, wss, expectStorage } =
+        await prepareIsolatedStorageTest<{
+          doc: LiveObject<{ title: string }>;
+        }>(
+          // A room that already has data under the top-level key `doc`.
+          [
+            createSerializedRoot(),
+            createSerializedObject(
+              "0:0",
+              { title: "DO NOT LOSE ME" },
+              "root",
+              "doc"
+            ),
+          ],
+          1,
+          // initialStorage defines `doc` too -- but as an empty default. The footgun.
+          { doc: new LiveObject({ title: "" }) }
+        );
+
+      // The client loads the real server data, not the empty default.
+      expectStorage({ doc: { title: "DO NOT LOSE ME" } });
+
+      // Drop the connection, then replace `doc` while offline. The op can never
+      // be acked -- in the wild this is a write too large for the WS frame,
+      // tripping a 1009 -- so it stays pending across the reconnect.
+      wss.last.close(
+        new CloseEvent("close", {
+          code: WebsocketCloseCodes.CLOSE_ABNORMAL,
+          wasClean: false,
+        })
+      );
+      root.set("doc", new LiveObject({ title: "rewritten" }));
+
+      // The reconnect refetches storage; the server (which never got the write)
+      // resends the original `doc`.
+      await waitUntilStorageUpdate(room);
+
+      // On reconnect, conflict resolution keeps our pending write and suppresses
+      // the server's `doc`, so the local root briefly reads `doc` as missing. The
+      // backfill must NOT mistake that for an unset key and write the empty
+      // default: that op is exactly what overwrites the real server document.
+      const sentOps = wss.receivedMessages
+        .flat()
+        .flatMap((msg) =>
+          isJsonObject(msg) &&
+          msg.type === ClientMsgCode.UPDATE_STORAGE &&
+          msg.ops !== undefined &&
+          isJsonArray(msg.ops)
+            ? msg.ops
+            : []
+        );
+      const wroteEmptyDefaultDoc = sentOps.some(
+        (op) =>
+          isJsonObject(op) &&
+          op.type === OpCode.CREATE_OBJECT &&
+          op.parentKey === "doc" &&
+          op.data !== undefined &&
+          isJsonObject(op.data) &&
+          op.data.title === ""
+      );
+      expect(wroteEmptyDefaultDoc).toBe(false);
     });
 
     test("disconnect and reconnect should keep user current presence", async () => {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1,4 +1,5 @@
-import { getBearerTokenFromAuthValue, type RoomHttpApi } from "./api-client";
+import type { RoomHttpApi } from "./api-client";
+import { getBearerTokenFromAuthValue } from "./api-client";
 import type { AuthManager, AuthValue } from "./auth-manager";
 import { injectBrandBadge } from "./brand";
 import type { InternalSyncStatus } from "./client";
@@ -117,7 +118,11 @@ import type {
   YDocUpdateServerMsg,
 } from "./protocol/ServerMsg";
 import { ServerMsgCode } from "./protocol/ServerMsg";
-import type { NodeMap, NodeStream } from "./protocol/StorageNode";
+import type {
+  NodeMap,
+  NodeStream,
+  SerializedRootObject,
+} from "./protocol/StorageNode";
 import { compactNodesToNodeStream } from "./protocol/StorageNode";
 import type {
   SubscriptionData,
@@ -1530,6 +1535,25 @@ function makeNodeMapBuffer() {
   };
 }
 
+function topLevelKeysOf(nodes: NodeMap): Set<string> {
+  const keys = new Set<string>();
+
+  // The root's primitive (non-Live) keys are stored inline in its `data`.
+  const root = nodes.get("root") as SerializedRootObject | undefined;
+  for (const key in root?.data) {
+    keys.add(key);
+  }
+
+  // Live children of the root are separate nodes pointing back at it.
+  for (const node of nodes.values()) {
+    if (node.parentId === "root") {
+      keys.add(node.parentKey);
+    }
+  }
+
+  return keys;
+}
+
 /**
  * @internal
  * Initializes a new Room, and returns its public API.
@@ -1933,11 +1957,12 @@ export function createRoom<
 
     const canWrite = self.get()?.canWrite ?? true;
 
-    // Populate missing top-level keys using `initialStorage`
+    // Populate only top-level keys that storage doesn't have yet, using `initialStorage`
+    const serverTopLevelKeys = topLevelKeysOf(nodes);
     const root = context.root;
     disableHistory(() => {
       for (const key in context.initialStorage) {
-        if (root.get(key) === undefined) {
+        if (!serverTopLevelKeys.has(key)) {
           if (canWrite) {
             root.set(key, cloneLson(context.initialStorage[key]));
           } else {


### PR DESCRIPTION
When a client enters a room with `initialStorage` for a top-level key that **already exists on the server**, a single storage write too large to fit in one WebSocket message (`1009` "message too large") could, on the forced reconnect, overwrite the real server value with the empty `initialStorage` default.

Fixes #3535. (Thanks @watemerald for the excellent repro!)