### PR TITLE
Fix double-encoded attachment names

### DIFF
--- a/packages/liveblocks-core/src/api-client.ts
+++ b/packages/liveblocks-core/src/api-client.ts
@@ -1078,7 +1078,7 @@ export function createApiClient<
       return autoRetry(
         async () =>
           httpClient.putBlob<CommentAttachment>(
-            url`/v2/c/rooms/${roomId}/attachments/${attachment.id}/upload/${encodeURIComponent(attachment.name)}`,
+            url`/v2/c/rooms/${roomId}/attachments/${attachment.id}/upload/${attachment.name}`,
             await authManager.getAuthValue({
               roomId,
               resource: "comments",
@@ -1107,7 +1107,7 @@ export function createApiClient<
             uploadId: string;
             key: string;
           }>(
-            url`/v2/c/rooms/${roomId}/attachments/${attachment.id}/multipart/${encodeURIComponent(attachment.name)}`,
+            url`/v2/c/rooms/${roomId}/attachments/${attachment.id}/multipart/${attachment.name}`,
             await authManager.getAuthValue({
               roomId,
               resource: "comments",

--- a/packages/liveblocks-react/src/__tests__/_restMocks.ts
+++ b/packages/liveblocks-react/src/__tests__/_restMocks.ts
@@ -1,5 +1,6 @@
 import type {
   BaseMetadata,
+  CommentAttachment,
   CommentBody,
   CommentData,
   GroupData,
@@ -97,6 +98,63 @@ export function mockCreateComment<CM extends BaseMetadata>(
 ) {
   return http.post(
     `https://api.liveblocks.io/v2/c/rooms/:roomId/threads/${params.threadId}/comments`,
+    resolver
+  );
+}
+
+export function mockUploadAttachment(
+  resolver: HttpResponseResolver<
+    { roomId: string; attachmentId: string; name: string },
+    never,
+    CommentAttachment
+  >
+) {
+  return http.put(
+    "https://api.liveblocks.io/v2/c/rooms/:roomId/attachments/:attachmentId/upload/:name",
+    resolver
+  );
+}
+
+export function mockCreateMultipartAttachmentUpload(
+  resolver: HttpResponseResolver<
+    { roomId: string; attachmentId: string; name: string },
+    never,
+    { uploadId: string; key: string }
+  >
+) {
+  return http.post(
+    "https://api.liveblocks.io/v2/c/rooms/:roomId/attachments/:attachmentId/multipart/:name",
+    resolver
+  );
+}
+
+export function mockUploadMultipartAttachmentPart(
+  resolver: HttpResponseResolver<
+    {
+      roomId: string;
+      attachmentId: string;
+      uploadId: string;
+      partNumber: string;
+    },
+    never,
+    { partNumber: number; etag: string }
+  >
+) {
+  return http.put(
+    "https://api.liveblocks.io/v2/c/rooms/:roomId/attachments/:attachmentId/multipart/:uploadId/:partNumber",
+    resolver
+  );
+}
+
+export function mockCompleteMultipartAttachmentUpload(
+  resolver: HttpResponseResolver<
+    { roomId: string; attachmentId: string; uploadId: string },
+    { parts: { partNumber: number; etag: string }[] },
+    CommentAttachment
+  >
+) {
+  return http.post(
+    "https://api.liveblocks.io/v2/c/rooms/:roomId/attachments/:attachmentId/multipart/:uploadId/complete",
     resolver
   );
 }

--- a/packages/liveblocks-react/src/__tests__/useCreateComment.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useCreateComment.test.tsx
@@ -21,7 +21,14 @@ import {
   dummyThreadInboxNotificationData,
 } from "./_dummies";
 import MockWebSocket from "./_MockWebSocket";
-import { mockCreateComment, mockGetThreads } from "./_restMocks";
+import {
+  mockCompleteMultipartAttachmentUpload,
+  mockCreateComment,
+  mockCreateMultipartAttachmentUpload,
+  mockGetThreads,
+  mockUploadAttachment,
+  mockUploadMultipartAttachmentPart,
+} from "./_restMocks";
 import { createContextsForTest } from "./_utils";
 
 const server = setupServer();
@@ -38,6 +45,10 @@ afterEach(() => {
 });
 
 afterAll(() => server.close());
+
+function createAttachmentFile(name: string, size: number) {
+  return new File([new Uint8Array(size)], name, { type: "image/png" });
+}
 
 describe("useCreateComment", () => {
   test("should create a comment optimistically and override with thread coming from server", async () => {
@@ -357,6 +368,118 @@ describe("useCreateComment", () => {
       expect(serverComment?.createdAt).toEqual(fakeCreatedAt);
       expect(serverComment?.metadata).toEqual(metadata);
     });
+
+    unmount();
+  });
+});
+
+describe("useRoom attachments", () => {
+  test.each([
+    {
+      name: "my file.png",
+      encodedPath: "my%20file.png",
+    },
+    {
+      name: "literal%20name.png",
+      encodedPath: "literal%2520name.png",
+    },
+  ])(
+    "should upload $name without double-encoding the attachment path segment",
+    async ({ name, encodedPath }) => {
+      const roomId = "room 1";
+      const requests: Request[] = [];
+
+      const {
+        room: { RoomProvider, useRoom },
+      } = createContextsForTest();
+
+      const { result, unmount } = renderHook(() => useRoom(), {
+        wrapper: ({ children }) => (
+          <RoomProvider id={roomId}>{children}</RoomProvider>
+        ),
+      });
+
+      const attachment = result.current.prepareAttachment(
+        createAttachmentFile(name, 5)
+      );
+
+      server.use(
+        mockUploadAttachment(({ request }) => {
+          requests.push(request);
+
+          return HttpResponse.json({
+            type: "attachment",
+            id: attachment.id,
+            name,
+            mimeType: "image/png",
+            size: 5,
+          });
+        })
+      );
+
+      await act(async () => {
+        await result.current.uploadAttachment(attachment);
+      });
+
+      const request = requests[0];
+      expect(
+        request?.url.endsWith(
+          `/v2/c/rooms/room%201/attachments/${attachment.id}/upload/${encodedPath}?fileSize=5`
+        )
+      ).toBeTruthy();
+
+      unmount();
+    }
+  );
+
+  test("should upload multipart attachments without double-encoding the attachment path segment", async () => {
+    const roomId = "room 1";
+    const requests: Request[] = [];
+
+    const {
+      room: { RoomProvider, useRoom },
+    } = createContextsForTest();
+
+    const { result, unmount } = renderHook(() => useRoom(), {
+      wrapper: ({ children }) => (
+        <RoomProvider id={roomId}>{children}</RoomProvider>
+      ),
+    });
+
+    const attachment = result.current.prepareAttachment(
+      createAttachmentFile("my file.png", 5 * 1024 * 1024 + 1)
+    );
+
+    server.use(
+      mockCreateMultipartAttachmentUpload(({ request }) => {
+        requests.push(request);
+        return HttpResponse.json({ uploadId: "upload_123", key: "unused" });
+      }),
+      mockUploadMultipartAttachmentPart(({ params }) => {
+        const partNumber = Number(params.partNumber);
+        return HttpResponse.json({ partNumber, etag: `etag_${partNumber}` });
+      }),
+      mockCompleteMultipartAttachmentUpload(() =>
+        HttpResponse.json({
+          type: "attachment",
+          id: attachment.id,
+          name: "my file.png",
+          mimeType: "image/png",
+          size: 5 * 1024 * 1024 + 1,
+        })
+      )
+    );
+
+    await act(async () => {
+      await result.current.uploadAttachment(attachment);
+    });
+
+    const createMultipartRequest = requests[0];
+    expect(
+      createMultipartRequest?.url.endsWith(
+        `/v2/c/rooms/room%201/attachments/${attachment.id}/multipart/my%20file.png?fileSize=5242881`
+      )
+    ).toBeTruthy();
 
     unmount();
   });

--- a/shared/eslint-config/restricted-syntax.js
+++ b/shared/eslint-config/restricted-syntax.js
@@ -20,4 +20,10 @@ export default [
       "ImportDeclaration[source.value='vitest'] ImportSpecifier[imported.name='it']",
     message: "Import 'test' instead of 'it' from vitest.",
   },
+  {
+    selector:
+      "TaggedTemplateExpression[tag.name='url'] CallExpression[callee.name='encodeURIComponent']",
+    message:
+      "`url` template holes are already encoded. Pass the value directly instead of calling `encodeURIComponent()`.",
+  },
 ];


### PR DESCRIPTION
This fixes double-encoded attachment names (`url` already encodes its template holes but we were also using `encodeURIComponent`), see the [backend PR](https://github.com/liveblocks/liveblocks-backend/pull/1806) for more details.

While I was there I also added an ESLint check to avoid this in the future.