### PR TITLE
Fix ESLint configs in editors

### DIFF
--- a/packages/liveblocks-chat-sdk-adapter/eslint.config.mjs
+++ b/packages/liveblocks-chat-sdk-adapter/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-client/eslint.config.mjs
+++ b/packages/liveblocks-client/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-core/eslint.config.mjs
+++ b/packages/liveblocks-core/eslint.config.mjs
@@ -4,7 +4,7 @@ import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax"
 import consoleMustBeFancy from "./rules/console-must-be-fancy.cjs";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-emails/eslint.config.mjs
+++ b/packages/liveblocks-emails/eslint.config.mjs
@@ -3,7 +3,7 @@ import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax"
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-node-lexical/eslint.config.mjs
+++ b/packages/liveblocks-node-lexical/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-node-prosemirror/eslint.config.mjs
+++ b/packages/liveblocks-node-prosemirror/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-node/eslint.config.mjs
+++ b/packages/liveblocks-node/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-react-blocknote/eslint.config.mjs
+++ b/packages/liveblocks-react-blocknote/eslint.config.mjs
@@ -4,7 +4,7 @@ import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-react-flow/eslint.config.mjs
+++ b/packages/liveblocks-react-flow/eslint.config.mjs
@@ -3,7 +3,7 @@ import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax"
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-react-lexical/eslint.config.mjs
+++ b/packages/liveblocks-react-lexical/eslint.config.mjs
@@ -4,7 +4,7 @@ import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-react-tiptap/eslint.config.mjs
+++ b/packages/liveblocks-react-tiptap/eslint.config.mjs
@@ -4,7 +4,7 @@ import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-react-ui/eslint.config.mjs
+++ b/packages/liveblocks-react-ui/eslint.config.mjs
@@ -4,7 +4,7 @@ import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-react/eslint.config.mjs
+++ b/packages/liveblocks-react/eslint.config.mjs
@@ -3,7 +3,7 @@ import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax"
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-redux/eslint.config.mjs
+++ b/packages/liveblocks-redux/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-server/eslint.config.mjs
+++ b/packages/liveblocks-server/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import licenseHeader from "eslint-plugin-license-header";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/packages/liveblocks-yjs/eslint.config.mjs
+++ b/packages/liveblocks-yjs/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/packages/liveblocks-zustand/eslint.config.mjs
+++ b/packages/liveblocks-zustand/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import commonRestrictedSyntax from "@liveblocks/eslint-config/restricted-syntax";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     rules: {

--- a/shared/eslint-config/index.js
+++ b/shared/eslint-config/index.js
@@ -6,22 +6,27 @@ import tseslint from "typescript-eslint";
 /**
  * Creates the base ESLint flat config used by all packages in the monorepo.
  *
- * @param {string} tsconfigPath Path to the tsconfig.json (default: "./tsconfig.json")
- * @returns {import("eslint").Linter.Config[]}
+ * @param {string} tsconfigRootDir Path to the directory ESLint should use to resolve
+ *   `tsconfigPath`, pass `import.meta.dirname` from the package's
+ *   `eslint.config.mjs`.
+ * @param {string} tsconfigPath Path to the package's TypeScript config,
+ *   relative to `tsconfigRootDir`. Defaults to "./tsconfig.json".
+ * @returns {import("eslint").Linter.Config[]} The shared flat config entries.
  */
-export function makeConfig(tsconfigPath = "./tsconfig.json") {
+export function makeConfig(tsconfigRootDir, tsconfigPath = "./tsconfig.json") {
   return [
     js.configs.recommended,
     ...tseslint.configs.recommendedTypeChecked,
 
     {
       languageOptions: {
+        // Each project's individual/local tsconfig.json defines the behavior
+        // of the parser
         parserOptions: {
-          // Each project's individual/local tsconfig.json defines the behavior
-          // of the parser
           projectService: {
             defaultProject: tsconfigPath,
           },
+          tsconfigRootDir,
         },
       },
 

--- a/tools/liveblocks-cli/eslint.config.mjs
+++ b/tools/liveblocks-cli/eslint.config.mjs
@@ -19,7 +19,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import licenseHeader from "eslint-plugin-license-header";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {

--- a/tools/liveblocks-codemod/eslint.config.mjs
+++ b/tools/liveblocks-codemod/eslint.config.mjs
@@ -1,7 +1,7 @@
 import { makeConfig } from "@liveblocks/eslint-config";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     ignores: ["**/__tests__/**", "**/__testfixtures__/**"],

--- a/tools/liveblocks-devtools/eslint.config.mjs
+++ b/tools/liveblocks-devtools/eslint.config.mjs
@@ -2,7 +2,7 @@ import { makeConfig } from "@liveblocks/eslint-config";
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [
-  ...makeConfig(),
+  ...makeConfig(import.meta.dirname),
 
   {
     plugins: {


### PR DESCRIPTION
This PR sets `tsconfigRootDir` explicitly in ESLint configs to fix the following monorepo error in editors:

```
Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present:
 - /Users/marc/Developer/liveblocks/liveblocks/packages/liveblocks-core
 - /Users/marc/Developer/liveblocks/liveblocks/packages/liveblocks-react
 - /Users/marc/Developer/liveblocks/liveblocks/packages/liveblocks-react-ui
 - [...]
You'll need to explicitly set tsconfigRootDir in your parser options.
See: https://tseslint.com/parser-tsconfigrootdireslint
```