### PR TITLE
Fix AI slideshow PPTX export: webfonts and iframe load race

### DIFF
--- a/examples/nextjs-ai-slideshow/app/export-fonts.ts
+++ b/examples/nextjs-ai-slideshow/app/export-fonts.ts
@@ -1,0 +1,95 @@
+"use client";
+
+// Builds the CSS that html-to-image should inline into a slide snapshot so
+// webfonts (e.g. Google Fonts) survive the export. We can't rely on the
+// library's own font detection: it walks the target's children with the
+// parent window's `instanceof HTMLElement`, which is always false for
+// elements inside the slide iframe (a different JS realm), so it considers
+// every webfont "unused" and embeds nothing. Instead, collect every
+// @font-face rule from the slide document ourselves — inline <style> tags
+// and fetched <link> stylesheets — and inline their font files as data URLs.
+
+const FONT_FACE_PATTERN = /@font-face\s*{[^}]*}/g;
+const URL_PATTERN = /url\((['"]?)([^'")]+)\1\)/g;
+
+export async function collectFontEmbedCss(document: Document): Promise<string> {
+  const sources: { cssText: string; baseUrl: string | null }[] = [];
+
+  const links = Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]')
+  );
+  await Promise.all(
+    links.map(async (link) => {
+      if (!link.href) {
+        return;
+      }
+      try {
+        const response = await fetch(link.href);
+        if (response.ok) {
+          sources.push({ cssText: await response.text(), baseUrl: link.href });
+        }
+      } catch {
+        // Unreachable stylesheets simply contribute no fonts.
+      }
+    })
+  );
+
+  for (const style of Array.from(document.querySelectorAll("style"))) {
+    sources.push({ cssText: style.textContent ?? "", baseUrl: null });
+  }
+
+  const fontFaces: string[] = [];
+  for (const source of sources) {
+    for (const match of source.cssText.match(FONT_FACE_PATTERN) ?? []) {
+      fontFaces.push(await inlineFontUrls(match, source.baseUrl));
+    }
+  }
+
+  return fontFaces.join("\n");
+}
+
+async function inlineFontUrls(
+  fontFaceCss: string,
+  baseUrl: string | null
+): Promise<string> {
+  const replacements = new Map<string, string>();
+
+  await Promise.all(
+    Array.from(fontFaceCss.matchAll(URL_PATTERN)).map(async ([token, , url]) => {
+      if (url.startsWith("data:")) {
+        return;
+      }
+      try {
+        const absoluteUrl = new URL(url, baseUrl ?? undefined).href;
+        const response = await fetch(absoluteUrl);
+        if (response.ok) {
+          replacements.set(token, `url(${await blobToDataUrl(await response.blob())})`);
+        }
+      } catch {
+        // Leave the original URL in place; the font just won't embed.
+      }
+    })
+  );
+
+  let result = fontFaceCss;
+  for (const [token, replacement] of replacements) {
+    result = result.replaceAll(token, replacement);
+  }
+  return result;
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error("Expected a data URL from readAsDataURL"));
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}

--- a/examples/nextjs-ai-slideshow/app/page.tsx
+++ b/examples/nextjs-ai-slideshow/app/page.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useExampleRoomId } from "@/hooks/use-example-room-id";
 import { Chat } from "./chat";
+import { collectFontEmbedCss } from "./export-fonts";
 import {
   CollaborativeEditor,
   type EditorHistory,
@@ -49,9 +50,8 @@ function waitForPaint() {
 }
 
 function createOffscreenIframe(html: string) {
-  return new Promise<HTMLIFrameElement>((resolve) => {
+  return new Promise<HTMLIFrameElement>((resolve, reject) => {
     const iframe = document.createElement("iframe");
-    iframe.addEventListener("load", () => resolve(iframe), { once: true });
     iframe.setAttribute("sandbox", "allow-same-origin");
     iframe.width = String(SLIDE_WIDTH);
     iframe.height = String(SLIDE_HEIGHT);
@@ -61,9 +61,39 @@ function createOffscreenIframe(html: string) {
     iframe.style.width = `${SLIDE_WIDTH}px`;
     iframe.style.height = `${SLIDE_HEIGHT}px`;
     iframe.style.border = "0";
-    document.body.appendChild(iframe);
+    // srcDoc must be assigned before the iframe is inserted: an inserted
+    // iframe without a source fires a `load` event for its initial
+    // about:blank document, which would resolve this promise while the real
+    // document is still loading (a race that made exports flaky).
     iframe.srcdoc = html;
+    const timeout = window.setTimeout(() => {
+      iframe.remove();
+      reject(new Error("Timed out preparing a slide for export."));
+    }, 15_000);
+    iframe.addEventListener(
+      "load",
+      () => {
+        window.clearTimeout(timeout);
+        resolve(iframe);
+      },
+      { once: true }
+    );
+    document.body.appendChild(iframe);
   });
+}
+
+// Waits until the document's webfonts (e.g. Google Fonts) are downloaded, so
+// the snapshot isn't taken while text is still rendered with a fallback font.
+// The iframe `load` event guarantees stylesheets are parsed, so all
+// @font-face rules exist by the time this runs; rendering the text kicks off
+// the font loads that `fonts.ready` then awaits.
+async function waitForFonts(document: Document) {
+  try {
+    await document.fonts.ready;
+  } catch {
+    // Font loading failures shouldn't block the export; the slide will
+    // render with fallback fonts instead.
+  }
 }
 
 export default function Page() {
@@ -100,6 +130,7 @@ function SlideshowApp({ roomId }: { roomId: string }) {
   const [codeHistory, setCodeHistory] = useState<EditorHistory | null>(null);
   const [placingComment, setPlacingComment] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [exportFailed, setExportFailed] = useState(false);
   const [selectedSlideId, setSelectedSlideId] = useState<string | null>(null);
   const previousSelectedIndex = useRef(0);
   // The proposal currently shown in the Slide tab instead of the shared
@@ -321,18 +352,22 @@ function SlideshowApp({ roomId }: { roomId: string }) {
         const iframe = await createOffscreenIframe(html);
 
         try {
-          await waitForPaint();
           const document = iframe.contentDocument;
           const element = document?.body ?? document?.documentElement;
-          if (!element) {
+          if (!document || !element) {
             throw new Error("Slide preview is not ready yet.");
           }
+          await waitForFonts(document);
+          await waitForPaint();
 
           const dataUrl = await toPng(element, {
             width: SLIDE_WIDTH,
             height: SLIDE_HEIGHT,
             pixelRatio: 10,
             cacheBust: true,
+            // html-to-image's own webfont detection doesn't work across the
+            // iframe boundary (see export-fonts.ts), so hand it the fonts.
+            fontEmbedCSS: await collectFontEmbedCss(document),
             style: {
               width: `${SLIDE_WIDTH}px`,
               height: `${SLIDE_HEIGHT}px`,
@@ -348,6 +383,11 @@ function SlideshowApp({ roomId }: { roomId: string }) {
       }
 
       await pptx.writeFile({ fileName: "slides.pptx" });
+    } catch (error) {
+      // Surface export failures instead of silently stopping the spinner.
+      console.error("PPTX export failed", error);
+      setExportFailed(true);
+      window.setTimeout(() => setExportFailed(false), 4000);
     } finally {
       setExporting(false);
     }
@@ -448,13 +488,14 @@ function SlideshowApp({ roomId }: { roomId: string }) {
               size="sm"
               onClick={exportPptx}
               disabled={exporting}
+              className={exportFailed ? "text-destructive" : undefined}
             >
               {exporting ? (
                 <Loader2Icon className="size-4 animate-spin" />
               ) : (
                 <DownloadIcon className="size-4" />
               )}
-              Download .pptx
+              {exportFailed ? "Export failed" : "Download .pptx"}
             </Button>
           </div>
         </header>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two bugs in the `nextjs-ai-slideshow` PPTX export, matching user reports of "export not working" and "wrong font with Google Fonts".

### 1. Exports randomly failed (iframe load race)

`createOffscreenIframe` appended the iframe to the DOM **before** assigning `srcdoc`. An inserted iframe fires a `load` event for its initial `about:blank` document, so the promise could resolve while the real slide document was still loading — `contentDocument.body` was then missing/empty and the export threw "Slide preview is not ready yet" as an unhandled rejection (the spinner just stopped, nothing visible to the user). `srcdoc` is now assigned before insertion, with a timeout guard, and export failures now surface on the button ("Export failed" + `console.error`) instead of failing silently.

### 2. Webfonts (Google Fonts) rendered as fallback fonts in the exported deck

`html-to-image` decides which `@font-face` rules to embed by walking the target element's children and checking `child instanceof HTMLElement` — using the **parent window's** `HTMLElement`. Slide elements live inside an iframe (a different JS realm), so that check is always false, the "used fonts" set ends up containing only the root fallback (`Times New Roman`), and every webfont is skipped. The exported snapshot then rasterizes with fallback fonts — including the starter slide's Merriweather.

Fix: a new `app/export-fonts.ts` collects every `@font-face` rule from the slide document itself (inline `<style>` tags plus fetched `<link>` stylesheets, e.g. `fonts.googleapis.com`), inlines the font files as data URLs, and hands the result to `toPng` via its `fontEmbedCSS` option, bypassing the library's broken cross-realm detection. The export also awaits `document.fonts.ready` per slide so pixel output is consistent.

## Verification

Reproduced and verified with a Playwright harness against the local Liveblocks dev server, using the Monoton display font (visually unmistakable from any fallback): the exported PPTX's slide PNG was pixel-compared against reference renders of the same slide with the webfont vs. with the font link removed.

- Before: exported PNG diffed 0.6% from the **fallback** render and 6.1% from the webfont render (wrong font).
- After: 0.6% from the **webfont** render and 6.2% from the fallback render (correct font).
- Regression: a font-less multi-slide starter deck still exports both slides correctly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-149d1264-38d4-460e-82ee-bcc7fea7b791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-149d1264-38d4-460e-82ee-bcc7fea7b791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

