### PR TITLE
docs: rooms guidance, attachments/reactions page, notification settings & flow, token lifetime, and two new guides

### DIFF
--- a/docs/pages/authentication.mdx
+++ b/docs/pages/authentication.mdx
@@ -391,6 +391,40 @@ const room = await liveblocks.getRoom("a32wQXid4A9");
 console.log(room.data.usersAccesses);
 ```
 
+## Token lifetime [#token-lifetime]
+
+Both ID tokens and access tokens are short-lived
+[JSON Web Tokens](https://en.wikipedia.org/wiki/JSON_Web_Token) that are
+currently valid for one hour after being issued. You don’t need to manage this
+yourself—the Liveblocks client caches tokens in memory, and automatically calls
+your authentication endpoint again when a token is about to expire.
+
+<Banner title="Don't cache tokens" type="warning">
+
+Never cache tokens yourself, or add caching to your authentication endpoint, as
+your client will not function correctly. The Liveblocks client handles caching
+for you, only requesting a new token when necessary.
+
+</Banner>
+
+### Revoking access [#revoking-access]
+
+How quickly a permission change takes effect depends on the token type you use:
+
+- **ID tokens**: permissions live on the room, and are checked “at the door”
+  every time a token is used to enter a room. Removing a user’s access with
+  [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomId)
+  means they’ll be denied entry the next time they try to connect.
+- **Access tokens**: permissions are baked into the token itself when it’s
+  created. Removing a user’s access in your own system doesn’t invalidate tokens
+  that were already issued—those remain valid until they expire. If you need
+  access changes to apply promptly, we recommend [ID tokens](#id-token).
+
+To force a signed-out user to reauthenticate, for example after they log out of
+your app, call
+[`client.logout()`](/docs/api-reference/liveblocks-client#Client.logout), which
+purges cached tokens from the client’s memory.
+
 ## Select your framework [#select-your-framework]
 
 Select your framework for specific instructions on setting up ID token

--- a/docs/pages/authentication/access-token.mdx
+++ b/docs/pages/authentication/access-token.mdx
@@ -311,13 +311,26 @@ the naming pattern doesn’t apply. This isn’t ideal, and it also doesn’t sc
 as the token will need to be refreshed whenever access is granted to new rooms
 for this to work correctly.
 
+#### Revoking access
+
+Because permissions are baked into each access token when it’s created, removing
+a user’s access in your own system doesn’t invalidate tokens that were already
+issued—those remain valid until they expire. Tokens are short-lived and
+currently valid for one hour, so there can be a delay between revoking access in
+your system and the user losing access. With
+[ID tokens](/docs/authentication#id-token), permissions are checked on the room
+each time a user connects, so access changes apply on the next connection. Learn
+more about [token lifetime](/docs/authentication#token-lifetime).
+
 #### Building complex permissions
 
 For this reason,
 **[we recommend using ID tokens for complex permissions](/docs/authentication#id-token-room-permissions)**.
 ID token authentication allows you to attach permissions to each room when it’s
 created or modified, which means you don’t need to check permissions yourself,
-and no naming pattern is required.
+and no naming pattern is required. If you’re already using access tokens, read
+our
+[guide on migrating from access tokens to ID tokens](/docs/guides/how-to-migrate-from-access-tokens-to-id-tokens).
 
 ### Migrating your current rooms IDs
 

--- a/docs/pages/collaboration-features/comments.mdx
+++ b/docs/pages/collaboration-features/comments.mdx
@@ -55,6 +55,13 @@ annotations, video annotations, and more.
   />
   <DocsCard
     type="technology"
+    title="Attachments and reactions"
+    href="/docs/collaboration-features/comments/attachments-and-reactions"
+    description="Add files and emoji reactions to comments"
+    visual={<DocsFeaturesIcon className="fill-product-icon-brand h-auto w-6" />}
+  />
+  <DocsCard
+    type="technology"
     title="Primitives"
     href="/docs/collaboration-features/comments/primitives"
     description="Construct fully custom components"

--- a/docs/pages/collaboration-features/comments/attachments-and-reactions.mdx
+++ b/docs/pages/collaboration-features/comments/attachments-and-reactions.mdx
@@ -1,0 +1,161 @@
+---
+meta:
+  title: "Attachments and reactions"
+  parentTitle: "Comments"
+  description: "Add files and emoji reactions to comments"
+---
+
+Comments supports file attachments and emoji reactions out-of-the-box. Both are
+enabled by default in the
+[default components](/docs/collaboration-features/comments/default-components),
+and both can be turned off with a single prop, or rebuilt from scratch with
+[primitives](/docs/collaboration-features/comments/primitives) and hooks.
+
+## Attachments
+
+Users can attach files to their comments, for example screenshots, documents, or
+videos. Files are uploaded to Liveblocks file storage, and image and video
+attachments display an inline preview, while other file types show the file’s
+name and size.
+
+In the default [`Composer`][] component, users can add attachments with the
+attach button, by dragging and dropping files, or by pasting them. No setup is
+required—attachments work by default.
+
+### Enabling attachments in custom behavior [#enabling-attachments]
+
+If you’ve added
+[custom behavior](/docs/api-reference/liveblocks-react-ui#Custom-behavior) to
+your composer with `onComposerSubmit` and mutation hooks such as
+[`useCreateThread`](/docs/api-reference/liveblocks-react#useCreateThread),
+[`useCreateComment`](/docs/api-reference/liveblocks-react#useCreateComment), or
+[`useEditComment`](/docs/api-reference/liveblocks-react#useEditComment), make
+sure to pass the `attachments` array through to your mutation, otherwise
+attachments will be silently dropped.
+
+```tsx
+const createThread = useCreateThread();
+
+// +++
+<Composer
+  onComposerSubmit={({ body, attachments }, event) => {
+    event.preventDefault();
+    createThread({ body, attachments, metadata: {} });
+  }}
+/>;
+// +++
+```
+
+### Disabling attachments [#disabling-attachments]
+
+To turn off attachments, set the `showAttachments` prop to `false` on each of
+the following components: [`Composer`][], [`Comment`][], [`Thread`][], and
+[`InboxNotification`](/docs/api-reference/liveblocks-react-ui#InboxNotification).
+
+```tsx
+<Composer showAttachments={false} />
+<Comment showAttachments={false} comment={comment} />
+<Thread showAttachments={false} thread={thread} />
+<InboxNotification showAttachments={false} inboxNotification={inboxNotification} />
+```
+
+### Attachment limits [#attachment-limits]
+
+- Each comment can contain up to **10 attachments**.
+- Any file type can be attached.
+- The maximum size of a single file depends on your plan—see
+  [limits](/docs/pricing/limits) for the values on each plan.
+
+If a user tries to attach a file that’s too large, the default components
+display an error message, which can be customized with the
+`ATTACHMENT_TOO_LARGE`
+[override](/docs/api-reference/liveblocks-react-ui#Overrides).
+
+### Downloading attachments [#downloading-attachments]
+
+Attachments are stored privately, and are accessed through short-lived presigned
+URLs. In React, use
+[`useAttachmentUrl`](/docs/api-reference/liveblocks-react#useAttachmentUrl) to
+get a URL for displaying or downloading an attachment. On the server, use
+[`liveblocks.getAttachment`](/docs/api-reference/liveblocks-node#get-rooms-roomId-attachments-attachmentId),
+which is helpful when including attachments in emails or syncing them elsewhere.
+
+### Attachments in custom components [#custom-attachments]
+
+If you’re building a fully custom composer with primitives, use
+[`Composer.AttachFiles`](/docs/api-reference/liveblocks-react-ui#primitives-Composer.AttachFiles)
+to render an attach button and
+[`Composer.AttachmentsDropArea`](/docs/api-reference/liveblocks-react-ui#primitives-Composer.AttachmentsDropArea)
+to create a drop area for files. Learn more under
+[handle attachments](/docs/api-reference/liveblocks-react-ui#Handle-attachments),
+and use the
+[`FileSize`](/docs/api-reference/liveblocks-react-ui#primitives-FileSize)
+primitive to display file sizes.
+
+## Emoji reactions
+
+Users can react to any comment with emojis. The default [`Comment`][] and
+[`Thread`][] components render a reaction button which opens an emoji picker,
+and display each comment’s reactions with counts. Like attachments, reactions
+are enabled by default and require no setup.
+
+<Figure>
+  <Image
+    src="/assets/comments/thread.png"
+    alt="Thread with comments"
+    width={768}
+    height={446}
+  />
+</Figure>
+
+### Disabling reactions [#disabling-reactions]
+
+To turn off reactions, set the `showReactions` prop to `false` on [`Thread`][],
+[`Comment`][], and
+[`InboxNotification`](/docs/api-reference/liveblocks-react-ui#InboxNotification).
+
+```tsx
+<Thread showReactions={false} thread={thread} />
+<Comment showReactions={false} comment={comment} />
+<InboxNotification showReactions={false} inboxNotification={inboxNotification} />
+```
+
+### Custom reactions [#custom-reactions]
+
+If you’re building custom components, add and remove reactions with the
+[`useAddReaction`](/docs/api-reference/liveblocks-react#useAddReaction) and
+[`useRemoveReaction`](/docs/api-reference/liveblocks-react#useRemoveReaction)
+hooks. Each comment exposes its reactions on `comment.reactions`.
+
+```tsx
+import { CommentData } from "@liveblocks/client";
+import { useAddReaction } from "@liveblocks/react/suspense";
+
+function CustomReactionButton({ comment }: { comment: CommentData }) {
+  const addReaction = useAddReaction();
+
+  return (
+    <button
+      onClick={() =>
+        addReaction({
+          threadId: comment.threadId,
+          commentId: comment.id,
+          emoji: "⭐",
+        })
+      }
+    >
+      ⭐
+    </button>
+  );
+}
+```
+
+To render an emoji picker in your custom components, we recommend
+[Frimousse](https://frimousse.liveblocks.io), the lightweight emoji picker used
+by our default components. Learn more under
+[emoji picker](/docs/api-reference/liveblocks-react-ui#emoji-picker) and
+[emoji reactions](/docs/api-reference/liveblocks-react-ui#emoji-reactions).
+
+[`Composer`]: /docs/api-reference/liveblocks-react-ui#Composer
+[`Comment`]: /docs/api-reference/liveblocks-react-ui#Comment
+[`Thread`]: /docs/api-reference/liveblocks-react-ui#Thread

--- a/docs/pages/collaboration-features/comments/concepts.mdx
+++ b/docs/pages/collaboration-features/comments/concepts.mdx
@@ -125,6 +125,10 @@ Similarly to threads, comments can also store
 [custom metadata](/docs/ready-made-features/comments/metadata), which is helpful
 for integrating them into your product.
 
+Comments can also include file attachments and emoji reactions, both of which
+are enabled by default in the default components. Learn more under
+[attachments and reactions](/docs/collaboration-features/comments/attachments-and-reactions).
+
 ### Deleted comments
 
 Deleting a comment doesn’t remove the comment object from the thread, instead

--- a/docs/pages/collaboration-features/comments/default-components.mdx
+++ b/docs/pages/collaboration-features/comments/default-components.mdx
@@ -142,3 +142,7 @@ It’s possible to style and localize the default components:
 
 Learn more under
 [styling and customization](/docs/ready-made-features/comments/styling-and-customization).
+
+File attachments and emoji reactions are enabled by default in these components,
+and each can be disabled with a prop. Learn more under
+[attachments and reactions](/docs/collaboration-features/comments/attachments-and-reactions).

--- a/docs/pages/collaboration-features/comments/styling-and-customization.mdx
+++ b/docs/pages/collaboration-features/comments/styling-and-customization.mdx
@@ -12,7 +12,9 @@ range of means, such as CSS variables, class names, and more. It’s also possib
 to use
 [overrides](/docs/ready-made-features/comments/styling-and-customization#Overrides-and-localization)
 to modify any strings used in the default components, which is especially
-helpful for localization.
+helpful for localization. For an overview of every customization level, and when
+to use each one, read
+[what can you customize in Liveblocks](/docs/guides/what-can-you-customize-in-liveblocks).
 
 ## Default components
 

--- a/docs/pages/collaboration-features/notifications/concepts.mdx
+++ b/docs/pages/collaboration-features/notifications/concepts.mdx
@@ -186,12 +186,11 @@ use them differently. Learn more about notification channels in our
 [email notifications](/docs/ready-made-features/notifications/email-notifications)
 page.
 
-## Data flow
+## Notification flow [#notification-flow]
 
-An unread inbox notification will trigger a notification based on the project
-notification settings and the user notification settings. Liveblocks evaluates
-both the project-level configuration and user preferences to determine whether
-to send a channel notification.
+Every notification, whether it ends up in the in-app inbox, an email, or a Slack
+message, starts life as an inbox notification, and follows the same path to
+reach the user.
 
 <Figure>
   <Image
@@ -201,6 +200,32 @@ to send a channel notification.
     height={990}
   />
 </Figure>
+
+1. **An inbox notification is created or updated.** This happens automatically
+   when Liveblocks features are used—for example a mention in a comment or a
+   text editor—or manually, when your server calls
+   [`liveblocks.triggerInboxNotification`](/docs/api-reference/liveblocks-node#post-inbox-notifications-trigger)
+   for a custom notification.
+2. **The notification appears in the user’s in-app inbox** immediately, in
+   realtime, if you’ve built a notification tray with our
+   [default components](/docs/ready-made-features/notifications/default-components)
+   or [hooks](/docs/ready-made-features/notifications/hooks).
+3. **Liveblocks checks whether the notification is still unread** after the
+   webhook interval, which defaults to 30 minutes and can be customized in the
+   webhooks dashboard. Notifications the user has already read never trigger
+   channel notifications.
+4. **Settings are evaluated for each channel.** For each channel—`email`,
+   `slack`, `teams`, `webPush`—Liveblocks combines the project-level settings
+   from your dashboard with the user’s own
+   [notification settings](/docs/ready-made-features/notifications/email-notifications#Notification-settings)
+   to decide whether this notification kind should be delivered there.
+5. **A `"notification"` webhook event is sent to your endpoint** for each
+   channel that passes the check. Your endpoint then delivers the actual email,
+   Slack message, Teams message, or web push notification.
+
+This is why a single system powers every destination: you trigger one inbox
+notification, and the project settings, user settings, and your webhook endpoint
+together determine where it surfaces.
 
 ## Permissions
 
@@ -216,10 +241,9 @@ For greater control over notification permissions, we recommend utilizing
 
 ### ID token
 
-When using
-[ID token authentication](/docs/authentication#id-token),
-Liveblocks reads the permissions set on the room, and uses these to deliver
-notifications that the user is authorized to view.
+When using [ID token authentication](/docs/authentication#id-token), Liveblocks
+reads the permissions set on the room, and uses these to deliver notifications
+that the user is authorized to view.
 
 ## Email notifications
 

--- a/docs/pages/collaboration-features/notifications/email-notifications.mdx
+++ b/docs/pages/collaboration-features/notifications/email-notifications.mdx
@@ -59,14 +59,27 @@ user, though this can be customized in the webhooks dashboard.
 
 `"notification"` webhooks can be enabled and disabled on certain channels in the
 notifications dashboard page. Channels are used to represent different places
-your users may receive notifications, such as on `email`, `slack`, `teams`, and
-`webPush`.
+your users may receive notifications, and there are four of them: `email`,
+`slack`, `teams`, and `webPush`.
 
 <Figure>
   <video width={1512} height={982} autoPlay loop muted playsInline>
     <source src="/assets/webhooks/notification-settings.mp4" type="video/mp4" />
   </video>
 </Figure>
+
+Every channel works the same way—Liveblocks sends a `"notification"` webhook
+event for each enabled channel, and your endpoint delivers the message to the
+matching destination. This means everything on this page applies to all
+channels, not just email. If you’re setting up another channel, follow one of
+our get started guides:
+
+- [Slack notifications](/docs/get-started/nextjs-notifications-slack)
+- [Microsoft Teams notifications](/docs/get-started/nextjs-notifications-microsoft-teams)
+- [Web push notifications](/docs/get-started/nextjs-notifications-web-push)
+
+Each channel has its own settings, so users can, for example, choose to receive
+thread notifications by email but not on Slack.
 
 ### Event object
 
@@ -223,8 +236,50 @@ this feature, please feel free to reach out to us.
 
 ## Notification settings
 
+Notification settings exist at two levels, and both are evaluated before a
+`"notification"` webhook event is sent. This means you can set company-wide
+defaults in the dashboard, while still letting each user fine-tune their own
+preferences in your app. Learn more about how the two levels are combined under
+[notification flow](/docs/ready-made-features/notifications/concepts#notification-flow).
+
+<dl>
+  <dt>Project-level settings</dt>
+  <dd>
+    Configured in the dashboard by you. Enable channels, choose which
+    notification kinds are sent on each channel, and set the default values that
+    apply to every user.
+  </dd>
+  <dt>User-level settings</dt>
+  <dd>
+    Configured in your app by each user. Users can override the project defaults
+    for themselves, for example disabling Slack notifications while keeping
+    email enabled.
+  </dd>
+</dl>
+
+### Project-level settings [#project-notification-settings]
+
+On the “Notifications” page in your project’s
+[dashboard](https://liveblocks.io/dashboard), you can enable each channel, and
+choose which notification kinds (e.g. `thread`, `textMention`, or custom kinds
+such as `$myCustomNotification`) should be sent on it. The values you set here
+act as the defaults for every user that hasn’t chosen their own settings yet.
+
+<Figure>
+  <video width={1512} height={982} autoPlay loop muted playsInline>
+    <source src="/assets/webhooks/notification-settings.mp4" type="video/mp4" />
+  </video>
+</Figure>
+
+A kind must be enabled on a channel in the dashboard before any webhook events
+for it are sent—user settings alone are not enough. Before enabling a new kind
+on an existing project, read
+[what to check before enabling a new notification kind](/docs/guides/what-to-check-before-enabling-a-new-notification-kind).
+
+### User-level settings [#user-notification-settings]
+
 It’s possible to allow users to choose their own notification settings for each
-channel in your application.
+channel in your application, overriding the project defaults.
 
 <Figure>
   <Image
@@ -263,6 +318,14 @@ function NotificationSettings() {
   );
 }
 ```
+
+For a full walkthrough of building a settings panel, including custom
+notification kinds, read
+[how to create a notification settings panel](/docs/guides/how-to-create-a-notification-settings-panel).
+User settings can also be read and modified from the server with
+[`liveblocks.getNotificationSettings`](/docs/api-reference/liveblocks-node#get-users-userId-notification-settings)
+and
+[`liveblocks.updateNotificationSettings`](/docs/api-reference/liveblocks-node#post-users-userId-notification-settings).
 
 ## Retrieving and modifying Comments data
 

--- a/docs/pages/collaboration-features/notifications/styling-and-customization.mdx
+++ b/docs/pages/collaboration-features/notifications/styling-and-customization.mdx
@@ -8,7 +8,9 @@ meta:
 Styling Notifications
 [default components](/docs/ready-made-features/notifications/default-components)
 is enabled through a range of means, such as CSS variables, class names, and
-more.
+more. For an overview of every customization level, and when to use each one,
+read
+[what can you customize in Liveblocks](/docs/guides/what-can-you-customize-in-liveblocks).
 
 ## Default components
 

--- a/docs/pages/concepts.mdx
+++ b/docs/pages/concepts.mdx
@@ -112,6 +112,51 @@ Rooms typically map to artifacts people and AI agents can create inside your
 product, such as text documents, workflow diagrams, spreadsheets, whiteboards,
 forms, 3D files, video editors, design files, presentations, and more.
 
+### What should be a room? [#what-should-be-a-room]
+
+A good rule of thumb is that each shareable artifact in your product should be
+its own room. If two people open the same page and expect to see each other’s
+activity, they should be connected to the same room.
+
+| Your product                   | What a room maps to                     |
+| ------------------------------ | --------------------------------------- |
+| Canvas or whiteboard product   | Each canvas is a room                   |
+| Dashboard or analytics product | Each dashboard is a room                |
+| Text editor                    | Each document is a room                 |
+| Spreadsheet product            | Each spreadsheet is a room              |
+| Video or design review tool    | Each file under review is a room        |
+| Form builder                   | Each form is a room                     |
+| Project management tool        | Each project, board, or issue is a room |
+
+Rooms are inexpensive to create and connect to, so it’s normal for a product to
+have thousands or millions of rooms—one for every document your users have ever
+created. A room can be created explicitly from your back end with
+[`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms), or
+automatically the first time a user enters it, for example with
+[`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider) in React.
+
+### Best practices [#room-best-practices]
+
+- **Create one room per artifact, not one per team or per app.** Smaller rooms
+  keep documents fast, make permissions easier to reason about, and mean users
+  only receive updates for the document they’re looking at.
+- **Reuse your existing document IDs as room IDs.** A room ID is any unique
+  string, so the simplest approach is to use the same ID your database already
+  uses for the document. Using a naming pattern such as
+  `organization-id:document-id` also makes it easier to
+  [grant access to groups of rooms](/docs/authentication/access-token#room-permissions).
+- **Rooms don’t need to be multiplayer from day one.** A room with a single user
+  inside behaves exactly like any other document—you can start every document as
+  a room, and collaboration features such as multiplayer editing, comments, and
+  notifications become available the moment a second person (or AI agent) joins.
+- **Set permissions on the room.** When using
+  [ID token authentication](/docs/authentication#id-token), the room is the
+  source of truth for who can enter it, at the default, group, and user levels.
+- **Know which features are room-based and which aren’t.** Presence, Storage,
+  Yjs documents, and comment threads all live inside a room. Inbox notifications
+  are project-based, so users receive them across all rooms they have access to,
+  without needing to be connected to those rooms.
+
 ## Primitives
 
 Primitives are the building blocks available inside rooms that make multiplayer

--- a/docs/pages/concepts.mdx
+++ b/docs/pages/concepts.mdx
@@ -112,50 +112,13 @@ Rooms typically map to artifacts people and AI agents can create inside your
 product, such as text documents, workflow diagrams, spreadsheets, whiteboards,
 forms, 3D files, video editors, design files, presentations, and more.
 
-### What should be a room? [#what-should-be-a-room]
-
-A good rule of thumb is that each shareable artifact in your product should be
-its own room. If two people open the same page and expect to see each other’s
-activity, they should be connected to the same room.
-
-| Your product                   | What a room maps to                     |
-| ------------------------------ | --------------------------------------- |
-| Canvas or whiteboard product   | Each canvas is a room                   |
-| Dashboard or analytics product | Each dashboard is a room                |
-| Text editor                    | Each document is a room                 |
-| Spreadsheet product            | Each spreadsheet is a room              |
-| Video or design review tool    | Each file under review is a room        |
-| Form builder                   | Each form is a room                     |
-| Project management tool        | Each project, board, or issue is a room |
-
-Rooms are inexpensive to create and connect to, so it’s normal for a product to
-have thousands or millions of rooms—one for every document your users have ever
-created. A room can be created explicitly from your back end with
-[`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms), or
-automatically the first time a user enters it, for example with
-[`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider) in React.
-
-### Best practices [#room-best-practices]
-
-- **Create one room per artifact, not one per team or per app.** Smaller rooms
-  keep documents fast, make permissions easier to reason about, and mean users
-  only receive updates for the document they’re looking at.
-- **Reuse your existing document IDs as room IDs.** A room ID is any unique
-  string, so the simplest approach is to use the same ID your database already
-  uses for the document. Using a naming pattern such as
-  `organization-id:document-id` also makes it easier to
-  [grant access to groups of rooms](/docs/authentication/access-token#room-permissions).
-- **Rooms don’t need to be multiplayer from day one.** A room with a single user
-  inside behaves exactly like any other document—you can start every document as
-  a room, and collaboration features such as multiplayer editing, comments, and
-  notifications become available the moment a second person (or AI agent) joins.
-- **Set permissions on the room.** When using
-  [ID token authentication](/docs/authentication#id-token), the room is the
-  source of truth for who can enter it, at the default, group, and user levels.
-- **Know which features are room-based and which aren’t.** Presence, Storage,
-  Yjs documents, and comment threads all live inside a room. Inbox notifications
-  are project-based, so users receive them across all rooms they have access to,
-  without needing to be connected to those rooms.
+A good rule of thumb is that each shareable artifact should be its own room—each
+canvas in a canvas product, each dashboard in an analytics product, each
+document in a text editor. Rooms are inexpensive to create, so it’s normal for a
+product to have thousands or millions of them. For a full breakdown of how to
+map your product to rooms, including best practices for room IDs, granularity,
+and permissions, read
+[what should be a room?](/docs/guides/what-should-be-a-room)
 
 ## Primitives
 

--- a/docs/routes.json
+++ b/docs/routes.json
@@ -563,6 +563,10 @@
             "path": "/collaboration-features/comments/metadata"
           },
           {
+            "title": "Attachments and reactions",
+            "path": "/collaboration-features/comments/attachments-and-reactions"
+          },
+          {
             "title": "Primitives",
             "path": "/collaboration-features/comments/primitives"
           },

--- a/guides/categories.json
+++ b/guides/categories.json
@@ -21,6 +21,10 @@
       "name": "Authentication"
     },
     {
+      "id": "rooms",
+      "name": "Rooms"
+    },
+    {
       "id": "frameworks",
       "name": "Frameworks"
     },

--- a/guides/guides.json
+++ b/guides/guides.json
@@ -1,5 +1,12 @@
 [
   {
+    "title": "What should be a room?",
+    "path": "/what-should-be-a-room",
+    "topics": ["rooms"],
+    "technologies": ["react", "nodejs"],
+    "date": "2026-07-10"
+  },
+  {
     "title": "How to migrate from access tokens to ID tokens",
     "path": "/how-to-migrate-from-access-tokens-to-id-tokens",
     "topics": ["authentication"],

--- a/guides/guides.json
+++ b/guides/guides.json
@@ -1,5 +1,19 @@
 [
   {
+    "title": "How to migrate from access tokens to ID tokens",
+    "path": "/how-to-migrate-from-access-tokens-to-id-tokens",
+    "topics": ["authentication"],
+    "technologies": ["nodejs"],
+    "date": "2026-07-10"
+  },
+  {
+    "title": "What can you customize in Liveblocks?",
+    "path": "/what-can-you-customize-in-liveblocks",
+    "topics": ["comments", "notifications"],
+    "technologies": ["react", "react-ui"],
+    "date": "2026-07-10"
+  },
+  {
     "title": "Adding Liveblocks to existing useState hooks",
     "path": "/adding-liveblocks-to-existing-usestate-hooks",
     "topics": ["state"],

--- a/guides/pages/how-to-migrate-from-access-tokens-to-id-tokens.mdx
+++ b/guides/pages/how-to-migrate-from-access-tokens-to-id-tokens.mdx
@@ -1,0 +1,176 @@
+---
+meta:
+  title: "How to migrate from access tokens to ID tokens"
+  description:
+    "Learn how to move your authentication from access tokens to ID tokens,
+    making rooms the source of truth for permissions."
+---
+
+[ID token authentication](/docs/authentication#id-token) lets Liveblocks handle
+permissions for you—permissions are set on each room, and checked “at the door”
+every time a user connects. This avoids the
+[limitations of access tokens](/docs/authentication/access-token#limitations)
+around nested permissions, makes revoking access take effect on the next
+connection, and allows Liveblocks to filter
+[notifications](/docs/ready-made-features/notifications) by room access. This
+guide takes you through migrating an existing application from access tokens to
+ID tokens.
+
+The migration has two parts, and they can be done separately:
+
+1. Set permissions on your existing rooms.
+2. Switch your authentication endpoint from
+   [`liveblocks.prepareSession`](/docs/api-reference/liveblocks-node#access-tokens)
+   to
+   [`liveblocks.identifyUser`](/docs/api-reference/liveblocks-node#id-tokens).
+
+Setting permissions on rooms has no effect while you’re still issuing access
+tokens, so you can safely complete step 1 first, verify it, and only then switch
+your endpoint. If anything goes wrong, rolling back is as simple as reverting
+your endpoint change.
+
+## Map your permission logic to rooms
+
+With access tokens, your endpoint decides which rooms a user can enter, often
+using
+[wildcard naming patterns](/docs/authentication/access-token#room-permissions):
+
+```ts
+// Access token authentication
+const session = liveblocks.prepareSession("olivier@example.com");
+
+// Every user in the "engineering" team can edit "engineering" rooms
+session.allow("engineering:*", session.FULL_ACCESS);
+
+const { body, status } = await session.authorize();
+```
+
+With ID tokens, the same logic is expressed as permissions on the room itself,
+at three levels: `defaultAccesses` for everyone, `groupsAccesses` for groups of
+users, and `usersAccesses` for individual users. The example above becomes a
+group permission on each `engineering` room:
+
+```ts
+// ID token authentication: permission lives on the room
+await liveblocks.updateRoom("engineering:xxYY12", {
+  groupsAccesses: {
+    engineering: ["*:write"],
+  },
+});
+```
+
+Go through each `session.allow` call in your endpoint and decide how it maps:
+
+| Access token pattern                            | ID token equivalent                           |
+| ----------------------------------------------- | --------------------------------------------- |
+| Every user can enter the room                   | `defaultAccesses: ["*:write"]`                |
+| A team or organization can enter matching rooms | `groupsAccesses: { "my-group": ["*:write"] }` |
+| A specific user was invited to a room           | `usersAccesses: { "user-id": ["*:write"] }`   |
+
+You can find every permission value, such as `*:read` and `comments:write`, on
+the [permissions page](/docs/authentication/permissions).
+
+## Update your existing rooms
+
+Next, write a one-off script that applies these permissions to every existing
+room, using
+[`liveblocks.getRooms`](/docs/api-reference/liveblocks-node#get-rooms) to
+paginate through them and
+[`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomId)
+to set the accesses.
+
+```ts
+import { Liveblocks } from "@liveblocks/node";
+
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
+
+let cursor: string | undefined = undefined;
+
+do {
+  // Get a page of rooms
+  const { data: rooms, nextCursor } = await liveblocks.getRooms({
+    startingAfter: cursor,
+  });
+
+  for (const room of rooms) {
+    // Decide which accesses this room should have, e.g. from your database
+    // or from your room ID naming pattern
+    const groupId = room.id.split(":")[0];
+
+    await liveblocks.updateRoom(room.id, {
+      defaultAccesses: [],
+      groupsAccesses: {
+        [groupId]: ["*:write"],
+      },
+    });
+  }
+
+  cursor = nextCursor ?? undefined;
+} while (cursor);
+```
+
+Remember to also set permissions when _new_ rooms are created, by passing the
+same options to
+[`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms).
+
+## Switch your authentication endpoint
+
+Once your rooms have permissions, replace `prepareSession` with `identifyUser`
+in your authentication endpoint. Instead of listing allowed rooms, you now pass
+the user’s ID and their group IDs.
+
+```ts
+import { Liveblocks } from "@liveblocks/node";
+
+const liveblocks = new Liveblocks({
+  secret: "{{SECRET_KEY}}",
+});
+
+export async function POST(request: Request) {
+  // Get the current user from your database
+  const user = __getUserFromDB__(request);
+
+  // ❌ Before: access token authentication
+  // const session = liveblocks.prepareSession(user.id, {
+  //   userInfo: user.metadata,
+  // });
+  // session.allow(`${user.organization}:*`, session.FULL_ACCESS);
+  // const { status, body } = await session.authorize();
+
+  // ✅ After: ID token authentication
+  const { status, body } = await liveblocks.identifyUser(
+    {
+      userId: user.id,
+
+      // The user's groups, matching the `groupsAccesses` set on your rooms
+      groupIds: [user.organization],
+    },
+    { userInfo: user.metadata }
+  );
+
+  return new Response(body, { status });
+}
+```
+
+The front end doesn’t need any changes—the client calls the same authentication
+endpoint, and accepts both token types.
+
+## Verify the migration
+
+After switching, check the following:
+
+- Users can still enter the rooms they could before. If a user is denied access,
+  the room is missing the matching `defaultAccesses`, `groupsAccesses`, or
+  `usersAccesses` entry.
+- Invite flows and share dialogs now update room permissions with
+  [`liveblocks.updateRoom`](/docs/api-reference/liveblocks-node#post-rooms-roomId)
+  instead of your own permissions table.
+- Users receive [notifications](/docs/ready-made-features/notifications) only
+  for rooms they can access. With ID tokens, Liveblocks reads room permissions
+  to filter notifications, which wasn’t possible with access tokens.
+
+Note that tokens are short-lived, so users may keep their previous access until
+their current token expires and the client automatically fetches a new one.
+Learn more about [token lifetime](/docs/authentication#token-lifetime).

--- a/guides/pages/what-can-you-customize-in-liveblocks.mdx
+++ b/guides/pages/what-can-you-customize-in-liveblocks.mdx
@@ -1,0 +1,187 @@
+---
+meta:
+  title: "What can you customize in Liveblocks?"
+  description:
+    "Learn which parts of Liveblocks you can customize, from styling the default
+    components to building fully custom UI with primitives and hooks."
+---
+
+Almost everything in Liveblocks is customizable, but different features expose
+different levels of customization, and it’s not always obvious which one you
+need. This guide explains each level, from small styling tweaks to fully custom
+UI, and which levels are available for each feature.
+
+## The customization ladder
+
+Liveblocks UI is customizable at five levels. Each level requires more work than
+the previous one, but gives you more control—start at the top, and only move
+down when you hit something you can’t change.
+
+1. [**Component props**](#component-props): toggle built-in behavior, such as
+   disabling attachments.
+2. [**CSS variables and class names**](#styling): restyle the default components
+   to match your brand.
+3. [**Overrides**](#overrides): replace any text in the components, and localize
+   them.
+4. [**Primitives**](#primitives): keep Liveblocks behavior, but build the UI
+   yourself.
+5. [**Hooks**](#hooks): raw data in, your components out—everything is custom.
+
+## Component props [#component-props]
+
+The default components in
+[`@liveblocks/react-ui`](/docs/api-reference/liveblocks-react-ui) accept props
+that toggle built-in features, with no other changes needed. For example, you
+can disable attachments or emoji reactions in Comments:
+
+```tsx
+<Thread
+  thread={thread}
+  showAttachments={false}
+  showReactions={false}
+  showComposerFormattingControls={false}
+/>
+```
+
+Check each component’s props in the
+[API reference](/docs/api-reference/liveblocks-react-ui) before reaching for a
+deeper level of customization—the option you need may already exist.
+
+## CSS variables and class names [#styling]
+
+Every default component is styled through a shared set of CSS variables, and
+predictable `lb-` prefixed class names. This means you can change colors,
+spacing, and radii globally with a few lines of CSS, or target any specific
+element in the components.
+
+```css
+/* Restyle every Liveblocks component */
+.lb-root {
+  --lb-accent: purple;
+  --lb-spacing: 1em;
+  --lb-radius: 0;
+}
+
+/* Target a specific element */
+.lb-thread {
+  border: 1px solid gray;
+}
+```
+
+Dark mode is included, either via media queries or via HTML attributes if you
+have a theme switcher. Learn more under styling and customization for
+[Comments](/docs/ready-made-features/comments/styling-and-customization),
+[Notifications](/docs/ready-made-features/notifications/styling-and-customization),
+and
+[AI Copilots](/docs/collaboration-features/ai-copilots/styling-and-customization).
+
+## Overrides [#overrides]
+
+Every piece of text inside the default components can be replaced with
+[overrides](/docs/api-reference/liveblocks-react-ui#Overrides), either globally
+or per-component. This is also how you localize components into other languages.
+
+```tsx
+<LiveblocksUiConfig
+  overrides={{
+    locale: "fr",
+    COMPOSER_PLACEHOLDER: "Écrivez un commentaire…",
+  }}
+>
+  <App />
+</LiveblocksUiConfig>
+```
+
+## Primitives [#primitives]
+
+If the default components don’t fit your design, Comments provides
+[primitives](/docs/ready-made-features/comments/primitives)—headless, unstyled,
+composable components in the style of Radix UI or Headless UI. They handle
+behavior such as rich-text editing, mention suggestions, and file attachments,
+while you supply every element and style yourself, including with Tailwind or
+your existing design system components.
+
+```tsx
+import { Composer } from "@liveblocks/react-ui/primitives";
+
+// A custom composer, styled entirely by you
+function MyComposer() {
+  return (
+    <Composer.Form onComposerSubmit={/* ... */}>
+      <Composer.Editor className="my-editor" />
+      <Composer.Submit asChild>
+        <MyDesignSystemButton>Send</MyDesignSystemButton>
+      </Composer.Submit>
+    </Composer.Form>
+  );
+}
+```
+
+Primitives and default components can be mixed freely—for example, a custom
+composer built with primitives can sit below default `Thread` components.
+
+## Hooks [#hooks]
+
+Every feature exposes its data through hooks, so you can always skip Liveblocks
+components entirely and render your own. For example,
+[`useThreads`](/docs/api-reference/liveblocks-react#useThreads) returns raw
+thread data, and
+[`useInboxNotifications`](/docs/api-reference/liveblocks-react#useInboxNotifications)
+returns raw inbox notifications, which you can render however you like, with
+mutations such as
+[`useCreateComment`](/docs/api-reference/liveblocks-react#useCreateComment) and
+[`useMarkInboxNotificationAsRead`](/docs/api-reference/liveblocks-react#useMarkInboxNotificationAsRead)
+handling the writes.
+
+## What’s available for each feature
+
+| Feature       | Props | CSS variables & class names | Overrides | Primitives | Hooks |
+| ------------- | ----- | --------------------------- | --------- | ---------- | ----- |
+| Comments      | ✔     | ✔                           | ✔         | ✔          | ✔     |
+| Notifications | ✔     | ✔                           | ✔         | —          | ✔     |
+| Text editor   | ✔     | ✔                           | ✔         | —          | ✔     |
+| AI Copilots   | ✔     | ✔                           | ✔         | —          | ✔     |
+
+### Can I customize notifications? [#customizing-notifications]
+
+Yes—this is a common question because Notifications has no primitives, but it’s
+still deeply customizable:
+
+- The default
+  [`InboxNotification`](/docs/api-reference/liveblocks-react-ui#InboxNotification)
+  component is styled with the same CSS variables and class names as every other
+  component.
+- Its `kinds` prop lets you completely change how each notification kind is
+  rendered—including your own
+  [custom notification kinds](/docs/ready-made-features/notifications/concepts#Custom-notifications)—while
+  keeping read/unread handling for free.
+- For a fully custom notification tray, use
+  [`useInboxNotifications`](/docs/api-reference/liveblocks-react#useInboxNotifications)
+  and render your own components.
+
+```tsx
+<InboxNotification
+  inboxNotification={inboxNotification}
+  kinds={{
+    // Render your custom `$alert` notifications differently
+    $alert: (props) => (
+      <InboxNotification.Custom
+        {...props}
+        title="Alert"
+        aside={<InboxNotification.Icon>⚠️</InboxNotification.Icon>}
+      >
+        Custom notification!
+      </InboxNotification.Custom>
+    ),
+  }}
+/>
+```
+
+### Text editor and AI Copilots
+
+[Text editor](/docs/ready-made-features/text-editor) components such as toolbars
+and floating composers follow the same styling system, and since the editor
+itself is Tiptap, BlockNote, or Lexical, you keep the full customization options
+of your editor. AI Copilots components can be restyled and extended too—learn
+more under
+[AI Copilots styling and customization](/docs/collaboration-features/ai-copilots/styling-and-customization).

--- a/guides/pages/what-should-be-a-room.mdx
+++ b/guides/pages/what-should-be-a-room.mdx
@@ -1,0 +1,108 @@
+---
+meta:
+  title: "What should be a room?"
+  description:
+    "Learn how to map your product to Liveblocks rooms, with examples and best
+    practices for room granularity, room IDs, and permissions."
+---
+
+A [room](/docs/concepts#Rooms) is the space where people and AI agents
+collaborate—everything room-based in Liveblocks, such as presence, realtime
+storage, and comment threads, happens inside one. Deciding what maps to a room
+is one of the first decisions you’ll make, and getting it right early makes
+everything that follows simpler.
+
+## Each artifact is a room
+
+A good rule of thumb is that each shareable artifact in your product should be
+its own room. If two people open the same page and expect to see each other’s
+activity, they should be connected to the same room.
+
+| Your product                   | What a room maps to                     |
+| ------------------------------ | --------------------------------------- |
+| Canvas or whiteboard product   | Each canvas is a room                   |
+| Dashboard or analytics product | Each dashboard is a room                |
+| Text editor                    | Each document is a room                 |
+| Spreadsheet product            | Each spreadsheet is a room              |
+| Video or design review tool    | Each file under review is a room        |
+| Form builder                   | Each form is a room                     |
+| Project management tool        | Each project, board, or issue is a room |
+
+Avoid creating one large room for your whole app, or one per team—smaller rooms
+keep documents fast, make permissions easier to reason about, and mean users
+only receive updates for the document they’re looking at. Rooms also have
+[limits](/docs/pricing/limits), such as storage size and simultaneous
+connections, that are designed around document-sized spaces.
+
+## Rooms are inexpensive
+
+Rooms cost nothing to create, so it’s normal for a product to have thousands or
+millions of them—one for every document your users have ever created. A room can
+be created explicitly from your back end with
+[`liveblocks.createRoom`](/docs/api-reference/liveblocks-node#post-rooms), or
+automatically the first time a user enters it, for example with
+[`RoomProvider`](/docs/api-reference/liveblocks-react#RoomProvider) in React.
+
+Users can also be connected to more than one room at a time—for example, a page
+that shows live previews of several documents can connect to each document’s
+room simultaneously.
+
+## Choosing room IDs
+
+A room ID is any unique string, so the simplest approach is to reuse the same ID
+your database already uses for the document.
+
+```tsx
+// The document ID from your database is the room ID
+<RoomProvider id={document.id}>{/* ... */}</RoomProvider>
+```
+
+Using a naming pattern such as `organization-id:document-id` also makes it
+easier to
+[grant access to groups of rooms](/docs/authentication/access-token#room-permissions)
+with wildcards. If your app already has rooms and you’d like to adopt a naming
+pattern, read
+[how to rename room IDs and successfully migrate users](/docs/guides/how-to-rename-room-ids-and-successfully-migrate-users).
+
+## Rooms don’t need to be multiplayer from day one
+
+A room with a single user inside behaves exactly like any other document—you can
+start every document as a room, and collaboration features such as multiplayer
+editing, comments, and notifications become available the moment a second person
+(or AI agent) joins. There’s no need to build a separate “collaboration mode”.
+
+## Set permissions on the room
+
+When using [ID token authentication](/docs/authentication#id-token), the room is
+the source of truth for who can enter it. Permissions can be set at three
+levels—default, groups, and users—which is enough to build invite dialogs,
+private documents, and organization-wide access.
+
+```ts
+const room = await liveblocks.createRoom("my-document-id", {
+  // Private by default
+  defaultAccesses: [],
+
+  // The "engineering" group can edit
+  groupsAccesses: {
+    engineering: ["*:write"],
+  },
+
+  // This user can view
+  usersAccesses: {
+    "olivier@example.com": ["*:read"],
+  },
+});
+```
+
+Learn more about [permissions](/docs/authentication/permissions).
+
+## Room-based vs project-based features
+
+Most Liveblocks features live inside a room: presence, realtime storage, Yjs
+documents, and comment threads are all room-based, and require users to be
+connected to the room. Inbox
+[notifications](/docs/ready-made-features/notifications) are the exception—
+they’re project-based, so users receive them across all rooms they have access
+to, without needing to be connected to those rooms. This is what makes a
+cross-document notification inbox possible.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

A batch of additive docs improvements addressing several long-standing gaps. No restructuring—existing pages were only extended, and three new guides were added.

**Concepts / Rooms**
- New guide: **What should be a room?** (`/docs/guides/what-should-be-a-room`) — a "product → room" mapping table (canvas → room, dashboard → room, etc.), room ID naming, granularity, starting single-player, permissions, and room-based vs project-based features. Added a `rooms` topic to `guides/categories.json`. The [Rooms](/docs/concepts) section on the Concepts page keeps a short rule-of-thumb paragraph and links to the guide.

**Comments**
- New feature page: **Attachments and reactions** (`/docs/collaboration-features/comments/attachments-and-reactions`), covering how attachments work, enabling them in custom `onComposerSubmit` behavior, disabling via `showAttachments`, limits (10 per comment, plan-based file size), presigned download URLs, emoji reactions, `showReactions`, custom reactions with `useAddReaction`, and Frimousse. Previously this was only documented in the 2.8 upgrade guide and API reference. Registered in `routes.json`, added a hub card, and cross-linked from the Concepts and Default components pages.

**Notifications**
- `email-notifications.mdx`: made clear the webhook pattern applies to all four channels (with links to the Slack/Teams/Web Push get-started guides), and rewrote the "Notification settings" section to cover **project-level settings** (dashboard) and **user-level settings** (`useNotificationSettings` + server APIs) as two distinct levels.
- `concepts.mdx`: expanded "Data flow" into a 5-step **Notification flow** (inbox notification → in-app inbox → unread check after webhook interval → project + user settings evaluated per channel → `"notification"` webhook → your delivery). Kept the existing diagram.

**Authentication**
- New **Token lifetime** section on `/docs/authentication` (expiry, automatic client refresh, don't-cache warning) and a **Revoking access** subsection explaining the ID token vs access token revocation timing difference. Matching note added to the access token page's limitations.

**New guides** (registered in `guides/guides.json`)
- *What should be a room?* — see above.
- *How to migrate from access tokens to ID tokens* — mapping `session.allow` patterns to room accesses, a pagination script with `getRooms`/`updateRoom`, endpoint switch, and verification steps.
- *What can you customize in Liveblocks?* — the customization ladder (props → CSS variables/class names → overrides → primitives → hooks), a per-feature availability table, and a direct answer to "Can I customize notifications?".

#### ⚠️ Please verify one fact

The token lifetime sections state tokens are **"currently valid for one hour"**. This matches the dev server (`jwt-lite.ts`) and test fixtures, but the production TTL is set by the backend and isn't verifiable from this repo—please confirm or adjust before merging.

#### Redirects

None needed: no existing page URLs changed, and the live site's wildcard redirect from `/docs/ready-made-features/:path*` to `/docs/collaboration-features/:path*` already covers the new Comments page (verified against production).

#### How to test it

All changes are MDX/JSON only. `routes.json`, `guides.json`, and `categories.json` parse as valid JSON, all files are Prettier-formatted with the repo config, and every internal link/anchor was checked against the existing headings and custom `[#id]` anchors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1559bb0a-7b9b-416d-a371-4f4f116a359e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1559bb0a-7b9b-416d-a371-4f4f116a359e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

