### PR TITLE
CHANGELOG — WEEK 30

### DIFF
--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -49,6 +49,11 @@ images and videos in a room's Storage tree.
   URLs, and handle multipart uploads.
 - Add methods to upload comment attachments, including multipart uploads.
 
+## Examples
+
+- Updated the
+  [Collaborative Whiteboard](https://liveblocks.io/examples/collaborative-whiteboard-advanced/nextjs-whiteboard-advanced) and [tldraw Whiteboard](https://liveblocks.io/examples/tldraw-whiteboard/nextjs-tldraw-whiteboard-storage) examples to support images using `LiveFile` in Liveblocks Storage.
+
 ## Contributors
 
 ofoucherot, marcbouchenoire

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -18,6 +18,10 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 -->
 
+# Week 30 (2026-07-24)
+
+## Contributors
+
 # Week 29 (2026-07-17)
 
 ## Examples

--- a/CHANGELOG_PUBLIC.md
+++ b/CHANGELOG_PUBLIC.md
@@ -20,7 +20,38 @@ list and feel free to give them credit at the end of a line, e.g.:
 
 # Week 30 (2026-07-24)
 
+## v3.23.0
+
+This release introduces `LiveFile`: a new data structure to store files such as
+images and videos in a room's Storage tree.
+
+### `@liveblocks/client`
+
+- Add `room.uploadFile()` to upload a file and return a `LiveFile`.
+- Add `room.getFileUrl()` to get access to a `LiveFile`.
+
+### `@liveblocks/react`
+
+- Add `useUploadFile()` to upload a file and return a `LiveFile`.
+- Add `useFileUrl()` to get access to a `LiveFile`.
+
+### `@liveblocks/node`
+
+- Add `uploadFile()` to upload a file and return a `LiveFile`.
+- Add `getFileUrl()` to get access to a `LiveFile`.
+- Add `uploadAttachment()` to upload comment attachments, combined with
+  `attachmentIds` params in `createThread()`, `createComment()`, and
+  `editComment()`.
+
+### Python SDK
+
+- Add methods to upload Storage files for `LiveFile`, retrieve their download
+  URLs, and handle multipart uploads.
+- Add methods to upload comment attachments, including multipart uploads.
+
 ## Contributors
+
+ofoucherot, marcbouchenoire
 
 # Week 29 (2026-07-17)
 


### PR DESCRIPTION
### **[Add your changes](https://github.com/liveblocks/liveblocks/edit/CHANGELOG-WEEK-28-2026/CHANGELOG_PUBLIC.md)**
Click above to edit the file, and add your new changes. Will be published on **Friday, 24th of July.**

## Example

```md
# Week 19 (2024-05-12)

## v1.1.1

### `@liveblocks/react`
- Added a new hook for fetching threads from notifications.
- Fixed a problem with thread caching. Thank you [@random_dev](https://github.com/random_dev)!

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

### Full example

<details><summary>Toggle</summary>

<p></p>

```md
# Week 1 (2024-06-12)

## v1.1.1

### `@liveblocks/react`
- Fixed a bug.  Thank you [@random_dev](https://github.com/random_dev)!

### `@liveblocks/react-comments`
- Added a new component.

## v1.1.0

### `@liveblocks/node`
- Fix "process is undefined" issue in Vite builds. This issue was already fixed for `@liveblocks/core`, but not for `@liveblocks/node` yet.

## Infrastructure
- REST API allows for longer room IDs, up to 128 characters.
- Webhooks retry more quickly.

## Documentation
- New guide on [using your Y.Doc on the server](https://liveblocks.io/docs/guides/how-to-use-your-ydoc-on-the-server).

## Examples
- Added mobile support for [Canvas Comments example](https://liveblocks.io/examples/canvas-comments/nextjs-comments-canvas).
- Next.js Starter Kit now has a new room type.

## Dashboard
- Improved onboarding flow.
- New inline quickstart guide.

## Website
- New blog post: [Liveblocks 1.12: Advanced filtering and custom notifications](https://liveblocks.io/blog/liveblocks-1-12-advanced-filtering-and-custom-notifications).
- Added a new changelog section.

## Contributors
pierrelevaillant, guillaumesalles, stevenfabre, random_dev
```

</details>

### Custom hero banner 



<details><summary>Toggle</summary>

<p></p>

To replace the banner and OG image for the current entry, add your image to the `/assets` folder, then place it in markdown directly after the `#` title. The image should be `1200 x 630` and the URL should start with `/assets`.

```md
# Week 1 (2024-06-12)

![banner](/assets/changelog/week-1.png)

## Documentation
- Updated API reference for React.

## Contributors
ctnicholas
```

</details>

## How is it published?

The website deploys what it sees in `CHANGELOG_PUBLIC.md` on `main`. When this PR is merged, the next deployment will show the new entries.