### PR TITLE
docs(agents): add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,74 @@ changes to them directly here — prefer editing the source in the backend repo.
 
 - `packages/liveblocks-server`
 - `tools/liveblocks-cli`
+
+# Cursor Cloud specific instructions
+
+## When you do NOT need to build/run anything
+
+Many tasks require no build, dev server, or running app. In particular, editing
+`docs/`, `examples/`, `tutorial/`, `guides/`, and `starter-kits/` (all of which
+live outside the pnpm workspace and depend on _published_ packages) does not
+require building the local packages or starting the dev server. Skip that setup
+for those tasks.
+
+## Toolchain
+
+- Node `>=24` is required and enforced (`engineStrict: true`). The environment
+  installs Node 24 via `nvm` and pins it in `~/.bashrc`; the default
+  `/exec-daemon/node` is an older Node that would fail `pnpm install`. If a
+  shell shows the wrong Node version, run `nvm use 24.14.1`.
+- `pnpm` comes from `corepack` (pinned to `pnpm@10.33.0` via `packageManager`).
+- Standard build/test/lint commands are documented above (use `pnpm exec turbo`).
+
+## Local Liveblocks dev server (backend for e2e apps)
+
+The `e2e/` Next.js apps need a Liveblocks backend. Prefer the local dev server
+over cloud keys. It runs as a Docker container (matching CI):
+
+    docker run -d --name liveblocks-dev -p 1153:1153 ghcr.io/liveblocks/dev-server
+
+Health check: `curl localhost:1153/health` → `200`. It accepts only the local
+keys `pk_localdev` (public) and `sk_localdev` (secret). Docker is preinstalled;
+if the daemon is not running, start it with `sudo dockerd` (configured with
+`fuse-overlayfs` + iptables-legacy for docker-in-docker).
+
+Note the port split: the published image listens on `1153`, but the
+`*.devserver.test.ts` unit tests default to `1154`
+(`process.env.LIVEBLOCKS_DEV_SERVER_PORT`). Point those tests at a running
+server with e.g. `LIVEBLOCKS_DEV_SERVER_PORT=1153`.
+
+### Important version-skew caveat
+
+The published `ghcr.io/liveblocks/dev-server:latest` image lags the source in
+this repo. It only understands the legacy permission scopes (`room:write`,
+`room:read`, `comments:write`, `feeds:write`, `room:presence:write`,
+`comments:read`) and rejects the newer base scope `*:write` (which the current
+`@liveblocks/node` `session.FULL_ACCESS` emits) with HTTP 422. Consequences:
+
+- next-sandbox pages that authenticate via `/api/auth/access-token` or
+  `/api/auth/id-token` (i.e. `session.FULL_ACCESS` → `*:write`) fail to connect
+  against the `latest` image. The public-key pages (e.g.
+  `/auth/pubkey?room=...`) work, because permissions are assigned server-side.
+- Some `*.devserver.test.ts` storage-sync tests may fail against `latest`. The
+  `*.mockserver.test.ts` suites are the authoritative unit tests and pass
+  independently of the dev server.
+
+To fully exercise `*:write`-based flows you need a dev-server image built from a
+matching version (from the backend repo), not `latest`.
+
+## Running an e2e app
+
+Each `e2e/` app reads env from its own `.env.local` (git-ignored). For the local
+dev server use:
+
+    LIVEBLOCKS_SECRET_KEY=sk_localdev
+    NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev
+    NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153
+
+Ports (`pnpm run dev`): next-sandbox `3007`, next-ai-kitchen-sink `3008`,
+next-react-flow-kitchen-sink `3008` (conflicts with ai-kitchen-sink — don't run
+both), next-feeds `3009`. `node-sandbox` has no dev server (Vitest only).
+
+The e2e apps' _production_ `next build` collects page data and will fail without
+valid keys; that's expected — run them with `pnpm run dev` for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this monorepo in Cursor Cloud, and captures durable, non-obvious setup/run guidance in `AGENTS.md` (symlinked to `CLAUDE.md`) under `## Cursor Cloud specific instructions`.

No product code was modified — only `AGENTS.md`.

## What was set up

- Node `24.14.1` via `nvm` (repo requires `>=24`, `engineStrict: true`; the default `/exec-daemon/node` is too old and fails `pnpm install`). Pinned in `~/.bashrc`.
- `pnpm@10.33.0` via `corepack`.
- `pnpm install` (27 workspace projects) and `pnpm exec turbo run build` (all 19 SDK packages built).
- Local Liveblocks dev server via Docker: `ghcr.io/liveblocks/dev-server` on port `1153` (matches CI).

## Verified

| Check | Command | Result |
| --- | --- | --- |
| Build | `pnpm exec turbo run build` | 19/19 packages built |
| Lint | `pnpm exec turbo run lint --filter=@liveblocks/client` | pass |
| Unit tests | `pnpm exec vitest run src/crdts/__tests__/LiveList.mockserver.test.ts` | 18/18 pass |
| App (dev) | `pnpm run dev` in `e2e/next-sandbox` (port 3007) | running |
| Hello-world | Two browser tabs join the same room via `pk_localdev`; realtime presence syncs (`others` populated) through the dev server | working |

## Notable caveat documented

The published `dev-server:latest` image lags the repo source: it only accepts legacy permission scopes and rejects the new `*:write` (`session.FULL_ACCESS`) with HTTP 422. So next-sandbox pages using `/api/auth/access-token` fail against `latest`, while public-key pages (`/auth/pubkey`) work. The `*.mockserver.test.ts` suites are the authoritative unit tests. Details in `AGENTS.md`.

## Demo

Realtime multiplayer presence between two tabs (via the local dev server):

[liveblocks_multiplayer_presence_demo.mp4](https://cursor.com/agents/bc-dcadb852-eea3-4475-ae98-697fdc7c2f2f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fliveblocks_multiplayer_presence_demo.mp4)

[First tab shows others\[\] populated after second tab joins](https://cursor.com/agents/bc-dcadb852-eea3-4475-ae98-697fdc7c2f2f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpresence_others_synced.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadb852-eea3-4475-ae98-697fdc7c2f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadb852-eea3-4475-ae98-697fdc7c2f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

