### PR TITLE
docs(agents): add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,63 @@ changes to them directly here — prefer editing the source in the backend repo.
 
 - `packages/liveblocks-server`
 - `tools/liveblocks-cli`
+
+# Cursor Cloud specific instructions
+
+## When you do NOT need to build/run anything
+
+Many tasks require no build, dev server, or running app. Editing `docs/`,
+`examples/`, `tutorial/`, `guides/`, and `starter-kits/` (all outside the pnpm
+workspace and depending on _published_ packages) does not require building the
+local packages or starting a dev server. Skip that setup for those tasks.
+
+## Toolchain
+
+- Node `>=24` is required and enforced (`engineStrict: true`). The environment
+  installs Node 24 via `nvm` and pins it in `~/.bashrc`; the default
+  `/exec-daemon/node` is an older Node that fails `pnpm install`. If a shell
+  shows the wrong version, run `nvm use 24.14.1`.
+- `pnpm` comes from `corepack` (pinned via `packageManager`).
+- `bun` is installed (on `PATH` via `~/.bashrc`). It is required by the local
+  Liveblocks dev server and by `@liveblocks/react`'s `lint:package`
+  (`scripts/check-exports.ts`).
+- Standard build/test/lint commands are documented above (use `pnpm exec turbo`).
+
+## Local Liveblocks dev server (backend for tests and e2e apps)
+
+There is no Liveblocks backend in this repo; everything talks to a Liveblocks
+server. Prefer the local dev server (per the guidance above) over cloud keys.
+It is provided by the `liveblocks` CLI and runs on Bun — no Docker needed:
+
+    pnpm dlx liveblocks dev --port 1153          # persistent server
+    pnpm dlx liveblocks dev -P -c '<command>'    # one-off server for a command (random port)
+
+Health check: `curl localhost:1153/health` → `200`. It accepts the local keys
+`pk_localdev` (public) and `sk_localdev` (secret). The package `test` scripts
+already wrap Vitest with `liveblocks dev` (e.g. `@liveblocks/core`), so
+`*.devserver.test.ts` suites get a fresh server automatically. `*.mockserver.test.ts`
+suites need no server at all.
+
+Note: the `*.devserver.test.ts` suites read `LIVEBLOCKS_DEV_SERVER_PORT` (the
+`-P` flag injects it); don't hardcode a port when running them yourself.
+
+## Running an e2e app
+
+Each `e2e/` app reads env from its own `.env.local` (git-ignored). For the local
+dev server use:
+
+    LIVEBLOCKS_SECRET_KEY=sk_localdev
+    NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev
+    NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153
+
+Ports (`pnpm run dev`): next-sandbox `3007`, next-ai-kitchen-sink `3008`,
+next-react-flow-kitchen-sink `3008` (conflicts with ai-kitchen-sink — don't run
+both), next-feeds `3009`. `node-sandbox` has no dev server (Vitest only).
+
+Both public-key pages (`/auth/pubkey`) and access-token pages (`/presence`,
+`/api/auth/access-token` → `session.FULL_ACCESS` → `*:write` scope) work against
+the CLI dev server. (An older published `ghcr.io/liveblocks/dev-server:latest`
+Docker image rejected `*:write` with HTTP 422; the CLI server does not.)
+
+The e2e apps' _production_ `next build` collects page data and fails without a
+reachable server/keys; that's expected — use `pnpm run dev` for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this monorepo in Cursor Cloud, and captures durable, non-obvious setup/run guidance in `AGENTS.md` (symlinked to `CLAUDE.md`) under `## Cursor Cloud specific instructions`.

No product code was modified — only `AGENTS.md`.

## What was set up

- Node `24.14.1` via `nvm` (repo requires `>=24`, `engineStrict: true`; the default `/exec-daemon/node` is too old and fails `pnpm install`). Pinned in `~/.bashrc`.
- `pnpm@10.33.0` via `corepack`.
- `bun` (required by the `liveblocks dev` server and by `@liveblocks/react`'s `lint:package`).
- `pnpm install` (27 workspace projects) and `pnpm exec turbo run build` (all 19 SDK packages built).
- Local Liveblocks dev server via the `liveblocks` CLI on Bun (no Docker): `pnpm dlx liveblocks dev --port 1153`, keys `pk_localdev` / `sk_localdev`.

## Verified

| Check | Command | Result |
| --- | --- | --- |
| Build | `pnpm exec turbo run build` | 19/19 packages built |
| Lint | `pnpm exec turbo run lint --filter=@liveblocks/core` | pass |
| Unit tests | `vitest run` core `*.mockserver.test.ts` (CRDTs) | 23/23 pass |
| Dev-server tests | `liveblocks dev -P -c 'vitest run LiveList.devserver.test.ts'` | 31 pass, 6 skipped |
| Type tests | `pnpm exec turbo run test:types --filter=@liveblocks/client` | 12/12, no type errors |
| App (dev) | `pnpm run dev` in `e2e/next-sandbox` (port 3007) | running |
| Hello-world | Two tabs join room `e2e-hello` via `/presence`; realtime presence syncs bidirectionally through the local dev server | working |

## Note vs the previous setup attempt

The CLI dev server (v1.6.2) accepts the current source's `*:write` scope (`session.FULL_ACCESS`) — the `/api/auth/access-token` flow returns HTTP 200. This avoids the version-skew caveat seen with the published `ghcr.io/liveblocks/dev-server:latest` Docker image (which rejected `*:write` with 422). Using the CLI server means no Docker is required.

## Demo

Realtime multiplayer presence between two tabs (via the local dev server):

[liveblocks_realtime_presence_sync.mp4](https://cursor.com/agents/bc-5975eeb8-1138-4fdd-8cea-a8dd24d7ddf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fliveblocks_realtime_presence_sync.mp4)

Tab 1 (user=1) sees user 2's presence sync in `Their presence`:

[User 1 tab: Their presence foo:3, Others count 1](https://cursor.com/agents/bc-5975eeb8-1138-4fdd-8cea-a8dd24d7ddf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpresence_synced_tab1.webp)

Tab 2 (user=2) sees user 1's presence sync in `Their presence`:

[User 2 tab: Their presence foo:2, Others count 1](https://cursor.com/agents/bc-5975eeb8-1138-4fdd-8cea-a8dd24d7ddf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpresence_synced_tab2.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5975eeb8-1138-4fdd-8cea-a8dd24d7ddf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5975eeb8-1138-4fdd-8cea-a8dd24d7ddf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

