### PR TITLE
Add support for server-side creation of comments attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ images and videos in a room's Storage tree.
 
 - Add `uploadFile()` to upload a file and return a `LiveFile`.
 - Add `getFileUrl()` to get access to a `LiveFile`.
+- Add `uploadAttachment()` to upload comment attachments, combined with
+  `attachmentIds` params in `createThread()`, `createComment()`, and
+  `editComment()`.
 
 ## v3.22.0
 

--- a/docs/pages/api-reference/liveblocks-node.mdx
+++ b/docs/pages/api-reference/liveblocks-node.mdx
@@ -1950,6 +1950,50 @@ await liveblocks.deleteVersion({
 
 ### Attachments
 
+#### Liveblocks.uploadAttachment [#upload-attachment]
+
+Uploads a file to a room and returns a `CommentAttachment` which can be added to
+a comment. The `userId` must match the comment's user ID.
+
+```ts
+const attachment = await liveblocks.uploadAttachment({
+  roomId: "my-room-id",
+  userId: "pierre@example.com",
+  file,
+});
+
+const comment = await liveblocks.createComment({
+  roomId: "my-room-id",
+  threadId: "th_d75sF3...",
+  data: {
+    userId: "pierre@example.com",
+    body,
+    // +++
+    attachmentIds: [attachment.id],
+    // +++
+  },
+});
+```
+
+You can also pass uploaded attachment IDs to `data.comment.attachmentIds` in
+[`createThread`](#post-rooms-roomId-threads), or to `data.attachmentIds` in
+[`editComment`](#post-rooms-roomId-threads-threadId-comments-commentId). When
+editing, pass the ID of every attachment that should remain on the comment; pass
+an empty array to remove them all. A comment can have up to 10 attachments.
+
+Pass an `AbortSignal` in the optional second argument to cancel the upload.
+
+```ts
+const attachment = await liveblocks.uploadAttachment(
+  {
+    roomId: "my-room-id",
+    userId: "pierre@example.com",
+    file,
+  },
+  { signal }
+);
+```
+
 #### Liveblocks.getAttachment [#get-rooms-roomId-attachments-attachmentId]
 
 Returns an attachment's metadata and a presigned download URL. Throws an error
@@ -2146,6 +2190,9 @@ const thread = await liveblocks.createThread({
         tag: "important",
         spam: false,
       },
+
+      // Optional, IDs of uploaded comment attachments
+      attachmentIds: [attachment.id],
 
       // The comment's body, uses the `CommentBody` type
       body: {
@@ -2573,6 +2620,9 @@ const comment = await liveblocks.createComment({
       tag: "important",
       reviewed: false,
     },
+
+    // Optional, IDs of uploaded comment attachments
+    attachmentIds: [attachment.id],
   },
 });
 ```
@@ -2611,7 +2661,6 @@ const editedComment = await liveblocks.editComment({
   commentId: "cm_agH76a...",
 
   data: {
-    userId: "alicia@example.com",
     body: {
       version: 1,
       content: [
@@ -2627,6 +2676,9 @@ const editedComment = await liveblocks.editComment({
       tag: "important",
       spam: false,
     },
+
+    // Optional, IDs of every attachment that should remain on the comment
+    attachmentIds: [attachment.id],
   },
 });
 

--- a/docs/references/v2.openapi.json
+++ b/docs/references/v2.openapi.json
@@ -3532,6 +3532,424 @@
         }
       }
     },
+    "/rooms/{roomId}/attachments/{attachmentId}/upload/{name}": {
+      "put": {
+        "summary": "Upload attachment",
+        "description": "Uploads a file's bytes and returns a draft comment attachment. Pass the returned attachment ID in the comment's attachment IDs when creating or editing a comment. For large files, use the multipart upload operations instead.",
+        "tags": ["Comments"],
+        "operationId": "upload-attachment",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the room",
+              "example": "my-room-id"
+            }
+          },
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^at_[A-Za-z0-9_-]{21}$",
+              "description": "ID for the attachment",
+              "example": "at_abc123456789012345678"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Name of the file",
+              "example": "screenshot.png"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the user uploading the attachment",
+              "example": "alice"
+            }
+          },
+          {
+            "name": "fileSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Expected file size in bytes",
+              "example": 12345
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. Returns the uploaded draft attachment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentAttachment"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "description": "An attachment with this ID already exists."
+          },
+          "413": {
+            "description": "The attachment exceeds the project's per-file upload limit."
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        }
+      }
+    },
+    "/rooms/{roomId}/attachments/{attachmentId}/multipart/{name}": {
+      "post": {
+        "summary": "Create attachment multipart upload",
+        "description": "Starts a multipart upload for a draft comment attachment.",
+        "tags": ["Comments"],
+        "operationId": "create-attachment-multipart-upload",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the room",
+              "example": "my-room-id"
+            }
+          },
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^at_[A-Za-z0-9_-]{21}$",
+              "description": "ID for the attachment",
+              "example": "at_abc123456789012345678"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Name of the file",
+              "example": "recording.mp4"
+            }
+          },
+          {
+            "name": "fileSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Expected file size in bytes",
+              "example": 10485760
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. Returns identifiers for the multipart upload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentMultipartUpload"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "description": "An attachment with this ID already exists."
+          },
+          "413": {
+            "description": "The attachment exceeds the project's per-file upload limit."
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        }
+      }
+    },
+    "/rooms/{roomId}/attachments/{attachmentId}/multipart/{uploadId}/{partNumber}": {
+      "put": {
+        "summary": "Upload attachment multipart part",
+        "description": "Uploads one part of an attachment multipart upload.",
+        "tags": ["Comments"],
+        "operationId": "upload-attachment-multipart-part",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the room",
+              "example": "my-room-id"
+            }
+          },
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^at_[A-Za-z0-9_-]{21}$",
+              "description": "ID of the attachment",
+              "example": "at_abc123456789012345678"
+            }
+          },
+          {
+            "name": "uploadId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID returned when the multipart upload was created"
+            }
+          },
+          {
+            "name": "partNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "One-based part number",
+              "example": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. Returns the uploaded part's number and ETag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentMultipartPart"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "description": "The multipart upload belongs to a different project or room."
+          }
+        }
+      }
+    },
+    "/rooms/{roomId}/attachments/{attachmentId}/multipart/{uploadId}/complete": {
+      "post": {
+        "summary": "Complete attachment multipart upload",
+        "description": "Completes a multipart upload and returns a draft comment attachment. Pass the returned attachment ID in the comment's attachment IDs when creating or editing a comment.",
+        "tags": ["Comments"],
+        "operationId": "complete-attachment-multipart-upload",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the room",
+              "example": "my-room-id"
+            }
+          },
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^at_[A-Za-z0-9_-]{21}$",
+              "description": "ID of the attachment",
+              "example": "at_abc123456789012345678"
+            }
+          },
+          {
+            "name": "uploadId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID returned when the multipart upload was created"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the user uploading the attachment",
+              "example": "alice"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteAttachmentMultipartUploadRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. Returns the uploaded draft attachment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentAttachment"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "description": "The multipart upload belongs to a different project or room."
+          },
+          "413": {
+            "description": "The completed attachment exceeds the project's per-file upload limit."
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        }
+      }
+    },
+    "/rooms/{roomId}/attachments/{attachmentId}/multipart/{uploadId}": {
+      "delete": {
+        "summary": "Abort attachment multipart upload",
+        "description": "Aborts a multipart upload and discards its uploaded parts.",
+        "tags": ["Comments"],
+        "operationId": "abort-attachment-multipart-upload",
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the room",
+              "example": "my-room-id"
+            }
+          },
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^at_[A-Za-z0-9_-]{21}$",
+              "description": "ID of the attachment",
+              "example": "at_abc123456789012345678"
+            }
+          },
+          {
+            "name": "uploadId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID returned when the multipart upload was created"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success. The multipart upload was aborted."
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "description": "The multipart upload belongs to a different project or room."
+          }
+        }
+      }
+    },
     "/rooms/{roomId}/threads/{threadId}/comments/{commentId}/metadata": {
       "post": {
         "summary": "Edit comment metadata",
@@ -9558,6 +9976,50 @@
           "name": "screenshot.png",
           "size": 12345
         }
+      },
+      "AttachmentMultipartUpload": {
+        "type": "object",
+        "title": "AttachmentMultipartUpload",
+        "properties": {
+          "attachmentId": {
+            "type": "string",
+            "pattern": "^at_[A-Za-z0-9_-]{21}$"
+          },
+          "uploadId": {
+            "type": "string"
+          }
+        },
+        "required": ["attachmentId", "uploadId"],
+        "additionalProperties": false
+      },
+      "AttachmentMultipartPart": {
+        "type": "object",
+        "title": "AttachmentMultipartPart",
+        "properties": {
+          "partNumber": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "etag": {
+            "type": "string"
+          }
+        },
+        "required": ["partNumber", "etag"],
+        "additionalProperties": false
+      },
+      "CompleteAttachmentMultipartUploadRequestBody": {
+        "type": "object",
+        "title": "CompleteAttachmentMultipartUploadRequestBody",
+        "properties": {
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentMultipartPart"
+            }
+          }
+        },
+        "required": ["parts"],
+        "additionalProperties": false
       },
       "AttachmentWithUrl": {
         "type": "object",

--- a/packages/liveblocks-node/src/__tests__/client.test.ts
+++ b/packages/liveblocks-node/src/__tests__/client.test.ts
@@ -897,6 +897,35 @@ describe("client", () => {
       expect(res).toEqual(comment);
     });
 
+    test("should pass attachment IDs when editing a comment", async () => {
+      server.use(
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads/:threadId/comments/:commentId`,
+          async ({ request }) => {
+            expect(await request.json()).toEqual({
+              body: { version: 1, content: [] },
+              attachmentIds: ["at_abc123"],
+            });
+            return HttpResponse.json(comment);
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      await expect(
+        client.editComment({
+          roomId: "room1",
+          threadId: "thread1",
+          commentId: "comment1",
+          data: {
+            body: { version: 1, content: [] },
+            attachmentIds: ["at_abc123"],
+          },
+        })
+      ).resolves.toEqual(comment);
+    });
+
     test("should throw a LiveblocksError when editComment receives an error response", async () => {
       const error = {
         error: "RESOURCE_NOT_FOUND",
@@ -980,6 +1009,39 @@ describe("client", () => {
       });
 
       expect(res).toEqual(thread);
+    });
+
+    test("should pass attachment IDs when creating a thread", async () => {
+      server.use(
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads`,
+          async ({ request }) => {
+            expect(await request.json()).toEqual({
+              comment: {
+                userId: "user1",
+                body: { version: 1, content: [] },
+                attachmentIds: ["at_abc123"],
+              },
+            });
+            return HttpResponse.json(thread);
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      await expect(
+        client.createThread({
+          roomId: "room1",
+          data: {
+            comment: {
+              userId: "user1",
+              body: { version: 1, content: [] },
+              attachmentIds: ["at_abc123"],
+            },
+          },
+        })
+      ).resolves.toEqual(thread);
     });
 
     test("should throw a LiveblocksError when createThread receives an error response", async () => {
@@ -1335,6 +1397,207 @@ describe("client", () => {
           expect(err.name).toBe("LiveblocksError");
         }
       }
+    });
+  });
+
+  describe("upload attachment", () => {
+    test("should upload an attachment through single upload", async () => {
+      const fileName = "document 100%.pdf";
+      const file = new File(["hello"], fileName, {
+        type: "application/pdf",
+      });
+
+      server.use(
+        http.put(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/attachments/:attachmentId/upload/:name`,
+          async ({ request, params }) => {
+            const attachmentId = String(params.attachmentId);
+            const url = new URL(request.url);
+
+            expect(params.roomId).toBe("room1");
+            expect(attachmentId).toMatch(/^at_/);
+            expect(params.name).toBe(fileName);
+            expect(url.searchParams.get("fileSize")).toBe("5");
+            expect(url.searchParams.get("userId")).toBe("user1");
+            expect(await request.text()).toBe("hello");
+
+            return HttpResponse.json({
+              type: "attachment",
+              id: attachmentId,
+              name: fileName,
+              size: 5,
+              mimeType: "application/pdf",
+            });
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      const attachment = await client.uploadAttachment({
+        roomId: "room1",
+        userId: "user1",
+        file,
+      });
+
+      expect(attachment.id).toMatch(/^at_/);
+      expect(attachment).toEqual({
+        type: "attachment",
+        id: attachment.id,
+        name: fileName,
+        size: 5,
+        mimeType: "application/pdf",
+      });
+    });
+
+    test("should retry a single upload with the same attachment ID", async () => {
+      vi.useFakeTimers();
+
+      const fileName = "document.pdf";
+      const file = new File(["hello"], fileName, {
+        type: "application/pdf",
+      });
+      let firstAttachmentId: string | undefined;
+      let uploadCount = 0;
+
+      server.use(
+        http.put(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/attachments/:attachmentId/upload/:name`,
+          async ({ request, params }) => {
+            const attachmentId = String(params.attachmentId);
+            const url = new URL(request.url);
+            uploadCount++;
+
+            expect(params.roomId).toBe("room1");
+            expect(params.name).toBe(fileName);
+            expect(url.searchParams.get("fileSize")).toBe("5");
+            expect(url.searchParams.get("userId")).toBe("user1");
+            expect(await request.text()).toBe("hello");
+
+            if (uploadCount === 1) {
+              firstAttachmentId = attachmentId;
+              return HttpResponse.error();
+            }
+
+            expect(attachmentId).toBe(firstAttachmentId);
+            return HttpResponse.json({
+              type: "attachment",
+              id: attachmentId,
+              name: fileName,
+              size: 5,
+              mimeType: "application/pdf",
+            });
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      try {
+        const upload$ = client.uploadAttachment({
+          roomId: "room1",
+          userId: "user1",
+          file,
+        });
+        await vi.waitFor(() => expect(uploadCount).toBe(1));
+        await vi.advanceTimersByTimeAsync(2_000);
+
+        await expect(upload$).resolves.toEqual({
+          type: "attachment",
+          id: firstAttachmentId,
+          name: fileName,
+          size: 5,
+          mimeType: "application/pdf",
+        });
+        expect(uploadCount).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("should upload an attachment through multipart upload", async () => {
+      const fileName = "video 100%.mp4";
+      const fileSize = 5 * 1024 * 1024 + 1;
+      const file = new File([new Uint8Array(fileSize)], fileName, {
+        type: "video/mp4",
+      });
+      const uploadedPartNumbers: number[] = [];
+
+      server.use(
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/attachments/:attachmentId/multipart/:name`,
+          ({ request, params }) => {
+            const url = new URL(request.url);
+
+            expect(params.roomId).toBe("room1");
+            expect(String(params.attachmentId)).toMatch(/^at_/);
+            expect(params.name).toBe(fileName);
+            expect(url.searchParams.get("fileSize")).toBe(String(fileSize));
+            expect(url.searchParams.get("userId")).toBeNull();
+
+            return HttpResponse.json({ uploadId: "upload_abc123" });
+          }
+        ),
+        http.put(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/attachments/:attachmentId/multipart/:uploadId/:partNumber`,
+          async ({ request, params }) => {
+            const partNumber = Number(params.partNumber);
+
+            expect(params.roomId).toBe("room1");
+            expect(String(params.attachmentId)).toMatch(/^at_/);
+            expect(params.uploadId).toBe("upload_abc123");
+            expect((await request.arrayBuffer()).byteLength).toBe(
+              partNumber === 1 ? 5 * 1024 * 1024 : 1
+            );
+
+            uploadedPartNumbers.push(partNumber);
+            return HttpResponse.json({
+              partNumber,
+              etag: `etag-${partNumber}`,
+            });
+          }
+        ),
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/attachments/:attachmentId/multipart/:uploadId/complete`,
+          async ({ request, params }) => {
+            const url = new URL(request.url);
+
+            expect(url.searchParams.get("userId")).toBe("user1");
+            expect(await request.json()).toEqual({
+              parts: [
+                { partNumber: 1, etag: "etag-1" },
+                { partNumber: 2, etag: "etag-2" },
+              ],
+            });
+
+            return HttpResponse.json({
+              type: "attachment",
+              id: String(params.attachmentId),
+              name: fileName,
+              size: fileSize,
+              mimeType: "video/mp4",
+            });
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      const attachment = await client.uploadAttachment({
+        roomId: "room1",
+        userId: "user1",
+        file,
+      });
+
+      expect(attachment.id).toMatch(/^at_/);
+      expect(attachment).toEqual({
+        type: "attachment",
+        id: attachment.id,
+        name: fileName,
+        size: fileSize,
+        mimeType: "video/mp4",
+      });
+      expect(uploadedPartNumbers.sort()).toEqual([1, 2]);
     });
   });
 
@@ -2239,6 +2502,36 @@ describe("client", () => {
       });
 
       expect(res).toEqual(comment);
+    });
+
+    test("should pass attachment IDs when creating a comment", async () => {
+      server.use(
+        http.post(
+          `${DEFAULT_BASE_URL}/v2/rooms/:roomId/threads/:threadId/comments`,
+          async ({ request }) => {
+            expect(await request.json()).toEqual({
+              userId: "user1",
+              body: { version: 1, content: [] },
+              attachmentIds: ["at_abc123"],
+            });
+            return HttpResponse.json(comment);
+          }
+        )
+      );
+
+      const client = new Liveblocks({ secret: "sk_xxx" });
+
+      await expect(
+        client.createComment({
+          roomId: "room1",
+          threadId: "thread1",
+          data: {
+            userId: "user1",
+            body: { version: 1, content: [] },
+            attachmentIds: ["at_abc123"],
+          },
+        })
+      ).resolves.toEqual(comment);
     });
 
     test("should return the created comment with metadata when createComment receives metadata", async () => {

--- a/packages/liveblocks-node/src/client.ts
+++ b/packages/liveblocks-node/src/client.ts
@@ -9,6 +9,7 @@ import type {
   BaseUserMeta,
   ClientMsg,
   ClientWireOp,
+  CommentAttachment,
   CommentBody,
   CommentData,
   CommentDataPlain,
@@ -75,6 +76,7 @@ import {
   convertToSubscriptionData,
   convertToThreadData,
   convertToUserSubscriptionData,
+  createCommentAttachmentId,
   createManagedPool,
   createNotificationSettings,
   createStorageFileId,
@@ -170,41 +172,42 @@ export type StorageFileUrl = {
 
 export type StorageFileWithUrl = LiveFileData & StorageFileUrl;
 
-const STORAGE_FILE_PART_SIZE = 5 * 1024 * 1024; // 5 MB
-const STORAGE_FILE_RETRY_ATTEMPTS = 10;
-const STORAGE_FILE_RETRY_DELAYS = [
+const ROOM_FILE_PART_SIZE = 5 * 1024 * 1024; // 5 MB
+const ROOM_FILE_RETRY_ATTEMPTS = 10;
+const ROOM_FILE_RETRY_DELAYS = [
   2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000,
 ];
 
-type StorageFilePart = {
+type RoomFilePart = {
   partNumber: number;
   part: Blob;
 };
 
-type UploadedStorageFilePart = {
+type UploadedRoomFilePart = {
   partNumber: number;
   etag: string;
 };
 
-type StorageFileMultipartUpload = {
+type RoomFileMultipartUpload = {
   uploadId: string;
 };
 
-type UploadStorageFileOptions<TResult> = {
+type UploadRoomFileOptions<TResult> = {
   file: File;
   signal?: AbortSignal;
   abortErrorMessage: string;
+  retryMultipartCompletion: boolean;
   uploadSingle: () => Promise<TResult>;
-  createMultipartUpload: () => Promise<StorageFileMultipartUpload>;
+  createMultipartUpload: () => Promise<RoomFileMultipartUpload>;
   uploadMultipartPart: (
     uploadId: string,
     partNumber: number,
     part: Blob,
     signal: AbortSignal
-  ) => Promise<UploadedStorageFilePart>;
+  ) => Promise<UploadedRoomFilePart>;
   completeMultipartUpload: (
     uploadId: string,
-    parts: UploadedStorageFilePart[]
+    parts: UploadedRoomFilePart[]
   ) => Promise<TResult>;
   abortMultipartUpload: (uploadId: string) => Promise<void>;
 };
@@ -220,6 +223,7 @@ export type CreateThreadOptions<
       userId: string;
       createdAt?: Date;
       body: CommentBody;
+      attachmentIds?: string[];
     } & PartialUnless<CM, { metadata: CM }>; // Comment metadata (data.comment.metadata)
   } & PartialUnless<TM, { metadata: TM }>; // Thread metadata (data.metadata)
 };
@@ -231,6 +235,7 @@ export type CreateCommentOptions<CM extends BaseMetadata> = {
     userId: string;
     createdAt?: Date;
     body: CommentBody;
+    attachmentIds?: string[];
   } & PartialUnless<CM, { metadata: CM }>;
 };
 
@@ -767,16 +772,17 @@ export type RequestOptions = {
   signal?: AbortSignal;
 };
 
-async function uploadStorageFile<TResult>({
+async function uploadRoomFile<TResult>({
   file,
   signal,
   abortErrorMessage,
+  retryMultipartCompletion,
   uploadSingle,
   createMultipartUpload,
   uploadMultipartPart,
   completeMultipartUpload,
   abortMultipartUpload,
-}: UploadStorageFileOptions<TResult>): Promise<TResult> {
+}: UploadRoomFileOptions<TResult>): Promise<TResult> {
   const abortError = createAbortError(abortErrorMessage);
 
   if (signal?.aborted) {
@@ -793,21 +799,21 @@ async function uploadStorageFile<TResult>({
     );
   };
 
-  if (file.size <= STORAGE_FILE_PART_SIZE) {
+  if (file.size <= ROOM_FILE_PART_SIZE) {
     return autoRetry(
       uploadSingle,
-      STORAGE_FILE_RETRY_ATTEMPTS,
-      STORAGE_FILE_RETRY_DELAYS,
+      ROOM_FILE_RETRY_ATTEMPTS,
+      ROOM_FILE_RETRY_DELAYS,
       handleRetryError
     );
   }
 
   let uploadId: string | undefined;
-  const uploadedParts: UploadedStorageFilePart[] = [];
+  const uploadedParts: UploadedRoomFilePart[] = [];
   const multipartUpload = await autoRetry(
     createMultipartUpload,
-    STORAGE_FILE_RETRY_ATTEMPTS,
-    STORAGE_FILE_RETRY_DELAYS,
+    ROOM_FILE_RETRY_ATTEMPTS,
+    ROOM_FILE_RETRY_DELAYS,
     handleRetryError
   );
   const partUploadController = new AbortController();
@@ -829,11 +835,11 @@ async function uploadStorageFile<TResult>({
       throw abortError;
     }
 
-    const batches = chunk(splitStorageFileIntoParts(file), 5);
+    const batches = chunk(splitRoomFileIntoParts(file), 5);
 
     for (const parts of batches) {
       const firstPartUploadFailure: { value?: { error: unknown } } = {};
-      const partUploads$: Promise<UploadedStorageFilePart>[] = [];
+      const partUploads$: Promise<UploadedRoomFilePart>[] = [];
 
       for (const { part, partNumber } of parts) {
         partUploads$.push(
@@ -845,8 +851,8 @@ async function uploadStorageFile<TResult>({
                 part,
                 partUploadSignal
               ),
-            STORAGE_FILE_RETRY_ATTEMPTS,
-            STORAGE_FILE_RETRY_DELAYS,
+            ROOM_FILE_RETRY_ATTEMPTS,
+            ROOM_FILE_RETRY_DELAYS,
             (error: unknown) => {
               if (signal?.aborted) {
                 throw abortError;
@@ -884,12 +890,14 @@ async function uploadStorageFile<TResult>({
     const sortedParts = uploadedParts.sort(
       (a, b) => a.partNumber - b.partNumber
     );
-    return autoRetry(
-      () => completeMultipartUpload(multipartUpload.uploadId, sortedParts),
-      STORAGE_FILE_RETRY_ATTEMPTS,
-      STORAGE_FILE_RETRY_DELAYS,
-      handleRetryError
-    );
+    return retryMultipartCompletion
+      ? autoRetry(
+          () => completeMultipartUpload(multipartUpload.uploadId, sortedParts),
+          ROOM_FILE_RETRY_ATTEMPTS,
+          ROOM_FILE_RETRY_DELAYS,
+          handleRetryError
+        )
+      : completeMultipartUpload(uploadId, sortedParts);
   } catch (err) {
     if (uploadId) {
       try {
@@ -905,12 +913,12 @@ async function uploadStorageFile<TResult>({
   }
 }
 
-function splitStorageFileIntoParts(file: File): StorageFilePart[] {
-  const parts: StorageFilePart[] = [];
+function splitRoomFileIntoParts(file: File): RoomFilePart[] {
+  const parts: RoomFilePart[] = [];
   let start = 0;
 
   while (start < file.size) {
-    const end = Math.min(start + STORAGE_FILE_PART_SIZE, file.size);
+    const end = Math.min(start + ROOM_FILE_PART_SIZE, file.size);
 
     parts.push({
       partNumber: parts.length + 1,
@@ -2216,6 +2224,7 @@ export class Liveblocks {
    * @param params.data.userId The user ID of the user who is set to create the comment.
    * @param params.data.createdAt (optional) The date the comment is set to be created.
    * @param params.data.body The body of the comment.
+   * @param params.data.attachmentIds (optional) The attachment IDs to add to the comment.
    * @param params.data.metadata (optional) The metadata for the comment.
    * @param options.signal (optional) An abort signal to cancel the request.
    * @returns The created comment.
@@ -2246,6 +2255,7 @@ export class Liveblocks {
    * @param params.threadId The thread ID to edit the comment in.
    * @param params.commentId The comment ID to edit.
    * @param params.data.body The body of the comment.
+   * @param params.data.attachmentIds (optional) The IDs of every attachment that should remain on the comment.
    * @param params.data.metadata (optional) The metadata for the comment. Value must be a string, boolean or number. Use null to delete a key.
    * @param params.data.editedAt (optional) The date the comment was edited.
    * @param options.signal (optional) An abort signal to cancel the request.
@@ -2258,6 +2268,7 @@ export class Liveblocks {
       commentId: string;
       data: {
         body: CommentBody;
+        attachmentIds?: string[];
         metadata?: Patchable<CM>;
         editedAt?: Date;
       };
@@ -2271,6 +2282,7 @@ export class Liveblocks {
       {
         body: data.body,
         editedAt: data.editedAt?.toISOString(),
+        attachmentIds: data.attachmentIds,
         metadata: data.metadata,
       },
       options
@@ -2330,6 +2342,74 @@ export class Liveblocks {
     return (await res.json()) as AttachmentWithUrl;
   }
 
+  /**
+   * Uploads an attachment that can be added to a comment.
+   *
+   * @param params.roomId The room ID to upload the attachment to.
+   * @param params.userId The user ID of the user uploading the attachment.
+   * @param params.file The file to upload.
+   * @param options.signal (optional) An abort signal to cancel the upload.
+   * @returns The uploaded attachment.
+   */
+  public async uploadAttachment(
+    params: { roomId: string; userId: string; file: File },
+    options?: RequestOptions
+  ): Promise<CommentAttachment> {
+    const { roomId, userId, file } = params;
+    const attachmentId = createCommentAttachmentId();
+
+    return await uploadRoomFile({
+      file,
+      signal: options?.signal,
+      abortErrorMessage: `Upload of attachment ${attachmentId} was aborted.`,
+      retryMultipartCompletion: false,
+      uploadSingle: async () => {
+        const res = await this.#putBlob(
+          url`/v2/rooms/${roomId}/attachments/${attachmentId}/upload/${file.name}`,
+          file,
+          { fileSize: file.size, userId },
+          options
+        );
+        return await this.#readJsonResponse<CommentAttachment>(res);
+      },
+      createMultipartUpload: async () => {
+        const res = await this.#post(
+          url`/v2/rooms/${roomId}/attachments/${attachmentId}/multipart/${file.name}`,
+          undefined,
+          options,
+          { fileSize: file.size }
+        );
+        return await this.#readJsonResponse<RoomFileMultipartUpload>(res);
+      },
+      uploadMultipartPart: async (uploadId, partNumber, part, signal) => {
+        const res = await this.#putBlob(
+          url`/v2/rooms/${roomId}/attachments/${attachmentId}/multipart/${uploadId}/${String(partNumber)}`,
+          part,
+          undefined,
+          { signal }
+        );
+        return await this.#readJsonResponse<UploadedRoomFilePart>(res);
+      },
+      completeMultipartUpload: async (uploadId, parts) => {
+        const res = await this.#post(
+          url`/v2/rooms/${roomId}/attachments/${attachmentId}/multipart/${uploadId}/complete`,
+          { parts },
+          options,
+          { userId }
+        );
+        return await this.#readJsonResponse<CommentAttachment>(res);
+      },
+      abortMultipartUpload: async (uploadId) => {
+        const res = await this.#delete(
+          url`/v2/rooms/${roomId}/attachments/${attachmentId}/multipart/${uploadId}`
+        );
+        if (!res.ok) {
+          throw await LiveblocksError.from(res);
+        }
+      },
+    });
+  }
+
   public async uploadFile(
     params: { roomId: string; file: File },
     options?: RequestOptions
@@ -2337,10 +2417,11 @@ export class Liveblocks {
     const { roomId, file } = params;
     const fileId = createStorageFileId();
 
-    const fileData = await uploadStorageFile({
+    const fileData = await uploadRoomFile({
       file,
       signal: options?.signal,
       abortErrorMessage: `Upload of file ${fileId} was aborted.`,
+      retryMultipartCompletion: true,
       uploadSingle: async () => {
         const res = await this.#putBlob(
           url`/v2/rooms/${roomId}/storage/files/${fileId}/upload/${file.name}`,
@@ -2357,7 +2438,7 @@ export class Liveblocks {
           options,
           { fileSize: file.size }
         );
-        return await this.#readJsonResponse<StorageFileMultipartUpload>(res);
+        return await this.#readJsonResponse<RoomFileMultipartUpload>(res);
       },
       uploadMultipartPart: async (uploadId, partNumber, part, signal) => {
         const res = await this.#putBlob(
@@ -2366,7 +2447,7 @@ export class Liveblocks {
           undefined,
           { signal }
         );
-        return await this.#readJsonResponse<UploadedStorageFilePart>(res);
+        return await this.#readJsonResponse<UploadedRoomFilePart>(res);
       },
       completeMultipartUpload: async (uploadId, parts) => {
         const res = await this.#post(
@@ -2416,6 +2497,7 @@ export class Liveblocks {
    * @param params.thread.comment.userId The user ID of the user who created the comment.
    * @param params.thread.comment.createdAt (optional) The date the comment was created.
    * @param params.thread.comment.body The body of the comment.
+   * @param params.thread.comment.attachmentIds (optional) The attachment IDs to add to the comment.
    * @param params.thread.comment.metadata (optional) The metadata for the comment.
    * @param options.signal (optional) An abort signal to cancel the request.
    * @returns The created thread. The thread will be created with the specified comment as its first comment.

--- a/packages/liveblocks-node/src/index.ts
+++ b/packages/liveblocks-node/src/index.ts
@@ -76,6 +76,7 @@ export {
 } from "./webhooks";
 export type { RoomAccesses, RoomPermissions } from "@liveblocks/core";
 export type {
+  CommentAttachment,
   CommentBody,
   CommentBodyBlockElement,
   CommentBodyElement,

--- a/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
+++ b/packages/liveblocks-node/test-d/no-augmentation.test-d.ts
@@ -1,4 +1,8 @@
-import { Liveblocks, type LiveFile } from "@liveblocks/node";
+import {
+  type CommentAttachment,
+  Liveblocks,
+  type LiveFile,
+} from "@liveblocks/node";
 import { describe, expectTypeOf, test } from "vitest";
 import type {
   CommentReaction,
@@ -132,6 +136,16 @@ describe("Liveblocks client without Liveblocks augmentation", () => {
     expectTypeOf(liveFile).toEqualTypeOf<LiveFile>();
   });
 
+  test("should return a CommentAttachment from uploadAttachment()", async () => {
+    const attachment = await client.uploadAttachment({
+      roomId: "my-room",
+      userId: "user-123",
+      file: new File(["hello"], "hello.txt", { type: "text/plain" }),
+    });
+
+    expectTypeOf(attachment).toEqualTypeOf<CommentAttachment>();
+  });
+
   test("should return correct comment shape from getComment()", async () => {
     const comment = await client.getComment({
       roomId: "my-room",
@@ -172,6 +186,7 @@ describe("Liveblocks client without Liveblocks augmentation", () => {
         comment: {
           userId: "user-123",
           body: { version: 1, content: [] },
+          attachmentIds: ["at_xxx"],
         },
       },
     });
@@ -315,6 +330,7 @@ describe("Liveblocks client without Liveblocks augmentation", () => {
       data: {
         userId,
         body: { version: 1, content: [] },
+        attachmentIds: ["at_xxx"],
       },
     });
 
@@ -324,6 +340,16 @@ describe("Liveblocks client without Liveblocks augmentation", () => {
     expectTypeOf(comment.metadata.foo).toEqualTypeOf<
       string | number | boolean | undefined
     >();
+
+    await client.editComment({
+      roomId,
+      threadId,
+      commentId: comment.id,
+      data: {
+        body: { version: 1, content: [] },
+        attachmentIds: comment.attachments.map((attachment) => attachment.id),
+      },
+    });
 
     const commentWithMetadata = await client.createComment({
       roomId,

--- a/packages/liveblocks-python/README.md
+++ b/packages/liveblocks-python/README.md
@@ -1327,6 +1327,145 @@ print(result)
 
 ---
 
+#### `upload_attachment`
+
+Uploads a file's bytes and returns a draft comment attachment. Pass the returned attachment ID in the comment's attachment IDs when creating or editing a comment. For large files, use the multipart upload operations instead.
+
+**Example**
+```python
+result = client.upload_attachment(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    name="screenshot.png",
+    user_id="alice",
+    body=...,
+    # file_size=12345,
+)
+print(result)
+```
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `str` | Yes | ID of the room |
+| `attachment_id` | `str` | Yes | ID for the attachment |
+| `name` | `str` | Yes | Name of the file |
+| `user_id` | `str` | Yes | ID of the user uploading the attachment |
+| `file_size` | `int \| Unset` | No | Expected file size in bytes |
+| `body` | `File` | Yes | Request body (application/octet-stream) |
+
+
+---
+
+#### `create_attachment_multipart_upload`
+
+Starts a multipart upload for a draft comment attachment.
+
+**Example**
+```python
+result = client.create_attachment_multipart_upload(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    name="recording.mp4",
+    # file_size=10485760,
+)
+print(result)
+```
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `str` | Yes | ID of the room |
+| `attachment_id` | `str` | Yes | ID for the attachment |
+| `name` | `str` | Yes | Name of the file |
+| `file_size` | `int \| Unset` | No | Expected file size in bytes |
+
+
+---
+
+#### `upload_attachment_multipart_part`
+
+Uploads one part of an attachment multipart upload.
+
+**Example**
+```python
+result = client.upload_attachment_multipart_part(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    upload_id="...",
+    part_number=1,
+    body=...,
+)
+print(result)
+```
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `str` | Yes | ID of the room |
+| `attachment_id` | `str` | Yes | ID of the attachment |
+| `upload_id` | `str` | Yes | ID returned when the multipart upload was created |
+| `part_number` | `int` | Yes | One-based part number |
+| `body` | `File` | Yes | Request body (application/octet-stream) |
+
+
+---
+
+#### `complete_attachment_multipart_upload`
+
+Completes a multipart upload and returns a draft comment attachment. Pass the returned attachment ID in the comment's attachment IDs when creating or editing a comment.
+
+**Example**
+```python
+from liveblocks.models import CompleteAttachmentMultipartUploadRequestBody
+
+result = client.complete_attachment_multipart_upload(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    upload_id="...",
+    user_id="alice",
+    body=CompleteAttachmentMultipartUploadRequestBody(
+        parts=[],
+    ),
+)
+print(result)
+```
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `str` | Yes | ID of the room |
+| `attachment_id` | `str` | Yes | ID of the attachment |
+| `upload_id` | `str` | Yes | ID returned when the multipart upload was created |
+| `user_id` | `str` | Yes | ID of the user uploading the attachment |
+| `body` | `CompleteAttachmentMultipartUploadRequestBody` | Yes | Request body (application/json) |
+
+
+---
+
+#### `abort_attachment_multipart_upload`
+
+Aborts a multipart upload and discards its uploaded parts.
+
+**Example**
+```python
+client.abort_attachment_multipart_upload(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    upload_id="...",
+)
+```
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `str` | Yes | ID of the room |
+| `attachment_id` | `str` | Yes | ID of the attachment |
+| `upload_id` | `str` | Yes | ID returned when the multipart upload was created |
+
+
+---
+
 #### `edit_comment_metadata`
 
 This endpoint edits the metadata of a comment. The metadata is a JSON object that can be used to store any information you want about the comment, in `string`, `number`, or `boolean` form. Set a property to `null` to remove it. Corresponds to [`liveblocks.editCommentMetadata`](https://liveblocks.io/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId-metadata).

--- a/packages/liveblocks-python/README.mdx
+++ b/packages/liveblocks-python/README.mdx
@@ -1837,6 +1837,259 @@ print(result)
 </PropertiesList>
 
 
+### upload_attachment
+
+Uploads a file's bytes and returns a draft comment attachment. Pass the returned attachment ID in the comment's attachment IDs when creating or editing a comment. For large files, use the multipart upload operations instead.
+
+```python
+result = client.upload_attachment(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    name="screenshot.png",
+    user_id="alice",
+    body=...,
+    # file_size=12345,
+)
+print(result)
+```
+
+<PropertiesList title="Parameters">
+  <PropertiesListItem
+    name="room_id"
+    type="str"
+  >
+    ID of the room
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="attachment_id"
+    type="str"
+  >
+    ID for the attachment
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="name"
+    type="str"
+  >
+    Name of the file
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="user_id"
+    type="str"
+  >
+    ID of the user uploading the attachment
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="file_size"
+    type="int | Unset"
+  >
+    Expected file size in bytes
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="body"
+    type="File"
+  >
+    Request body (application/octet-stream).
+
+  </PropertiesListItem>
+</PropertiesList>
+
+
+### create_attachment_multipart_upload
+
+Starts a multipart upload for a draft comment attachment.
+
+```python
+result = client.create_attachment_multipart_upload(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    name="recording.mp4",
+    # file_size=10485760,
+)
+print(result)
+```
+
+<PropertiesList title="Parameters">
+  <PropertiesListItem
+    name="room_id"
+    type="str"
+  >
+    ID of the room
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="attachment_id"
+    type="str"
+  >
+    ID for the attachment
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="name"
+    type="str"
+  >
+    Name of the file
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="file_size"
+    type="int | Unset"
+  >
+    Expected file size in bytes
+  </PropertiesListItem>
+</PropertiesList>
+
+
+### upload_attachment_multipart_part
+
+Uploads one part of an attachment multipart upload.
+
+```python
+result = client.upload_attachment_multipart_part(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    upload_id="...",
+    part_number=1,
+    body=...,
+)
+print(result)
+```
+
+<PropertiesList title="Parameters">
+  <PropertiesListItem
+    name="room_id"
+    type="str"
+  >
+    ID of the room
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="attachment_id"
+    type="str"
+  >
+    ID of the attachment
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="upload_id"
+    type="str"
+  >
+    ID returned when the multipart upload was created
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="part_number"
+    type="int"
+  >
+    One-based part number
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="body"
+    type="File"
+  >
+    Request body (application/octet-stream).
+
+  </PropertiesListItem>
+</PropertiesList>
+
+
+### complete_attachment_multipart_upload
+
+Completes a multipart upload and returns a draft comment attachment. Pass the returned attachment ID in the comment's attachment IDs when creating or editing a comment.
+
+```python
+from liveblocks.models import CompleteAttachmentMultipartUploadRequestBody
+
+result = client.complete_attachment_multipart_upload(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    upload_id="...",
+    user_id="alice",
+    body=CompleteAttachmentMultipartUploadRequestBody(
+        parts=[],
+    ),
+)
+print(result)
+```
+
+<PropertiesList title="Parameters">
+  <PropertiesListItem
+    name="room_id"
+    type="str"
+  >
+    ID of the room
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="attachment_id"
+    type="str"
+  >
+    ID of the attachment
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="upload_id"
+    type="str"
+  >
+    ID returned when the multipart upload was created
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="user_id"
+    type="str"
+  >
+    ID of the user uploading the attachment
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="body"
+    type="CompleteAttachmentMultipartUploadRequestBody"
+  >
+    Request body (application/json).
+
+  </PropertiesListItem>
+</PropertiesList>
+
+
+### abort_attachment_multipart_upload
+
+Aborts a multipart upload and discards its uploaded parts.
+
+```python
+client.abort_attachment_multipart_upload(
+    room_id="my-room-id",
+    attachment_id="at_abc123456789012345678",
+    upload_id="...",
+)
+```
+
+<PropertiesList title="Parameters">
+  <PropertiesListItem
+    name="room_id"
+    type="str"
+  >
+    ID of the room
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="attachment_id"
+    type="str"
+  >
+    ID of the attachment
+
+  </PropertiesListItem>
+  <PropertiesListItem
+    name="upload_id"
+    type="str"
+  >
+    ID returned when the multipart upload was created
+
+  </PropertiesListItem>
+</PropertiesList>
+
+
 ### edit_comment_metadata
 
 This endpoint edits the metadata of a comment. The metadata is a JSON object that can be used to store any information you want about the comment, in `string`, `number`, or `boolean` form. Set a property to `null` to remove it. Corresponds to [`liveblocks.editCommentMetadata`](https://liveblocks.io/docs/api-reference/liveblocks-node#post-rooms-roomId-threads-threadId-comments-commentId-metadata).

--- a/packages/liveblocks-python/liveblocks/api/comments/abort_attachment_multipart_upload.py
+++ b/packages/liveblocks-python/liveblocks/api/comments/abort_attachment_multipart_upload.py
@@ -1,0 +1,70 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+
+
+def _get_kwargs(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v2/rooms/{room_id}/attachments/{attachment_id}/multipart/{upload_id}".format(
+            room_id=quote(str(room_id), safe=""),
+            attachment_id=quote(str(attachment_id), safe=""),
+            upload_id=quote(str(upload_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, response: httpx.Response) -> None:
+    if response.status_code == 204:
+        return None
+
+    raise errors.LiveblocksError.from_response(response)
+
+
+def _sync(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    *,
+    client: httpx.Client,
+) -> None:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        upload_id=upload_id,
+    )
+
+    response = client.request(
+        **kwargs,
+    )
+    return _parse_response(response=response)
+
+
+async def _asyncio(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    *,
+    client: httpx.AsyncClient,
+) -> None:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        upload_id=upload_id,
+    )
+
+    response = await client.request(
+        **kwargs,
+    )
+
+    return _parse_response(response=response)

--- a/packages/liveblocks-python/liveblocks/api/comments/complete_attachment_multipart_upload.py
+++ b/packages/liveblocks-python/liveblocks/api/comments/complete_attachment_multipart_upload.py
@@ -1,0 +1,99 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...models.comment_attachment import CommentAttachment
+from ...models.complete_attachment_multipart_upload_request_body import CompleteAttachmentMultipartUploadRequestBody
+from ...types import UNSET
+
+
+def _get_kwargs(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    *,
+    body: CompleteAttachmentMultipartUploadRequestBody,
+    user_id: str,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["userId"] = user_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v2/rooms/{room_id}/attachments/{attachment_id}/multipart/{upload_id}/complete".format(
+            room_id=quote(str(room_id), safe=""),
+            attachment_id=quote(str(attachment_id), safe=""),
+            upload_id=quote(str(upload_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, response: httpx.Response) -> CommentAttachment:
+    if response.status_code == 200:
+        response_200 = CommentAttachment.from_dict(response.json())
+
+        return response_200
+
+    raise errors.LiveblocksError.from_response(response)
+
+
+def _sync(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    *,
+    client: httpx.Client,
+    body: CompleteAttachmentMultipartUploadRequestBody,
+    user_id: str,
+) -> CommentAttachment:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        upload_id=upload_id,
+        body=body,
+        user_id=user_id,
+    )
+
+    response = client.request(
+        **kwargs,
+    )
+    return _parse_response(response=response)
+
+
+async def _asyncio(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    *,
+    client: httpx.AsyncClient,
+    body: CompleteAttachmentMultipartUploadRequestBody,
+    user_id: str,
+) -> CommentAttachment:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        upload_id=upload_id,
+        body=body,
+        user_id=user_id,
+    )
+
+    response = await client.request(
+        **kwargs,
+    )
+
+    return _parse_response(response=response)

--- a/packages/liveblocks-python/liveblocks/api/comments/create_attachment_multipart_upload.py
+++ b/packages/liveblocks-python/liveblocks/api/comments/create_attachment_multipart_upload.py
@@ -1,0 +1,87 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...models.attachment_multipart_upload import AttachmentMultipartUpload
+from ...types import UNSET, Unset
+
+
+def _get_kwargs(
+    room_id: str,
+    attachment_id: str,
+    name: str,
+    *,
+    file_size: int | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    params["fileSize"] = file_size
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v2/rooms/{room_id}/attachments/{attachment_id}/multipart/{name}".format(
+            room_id=quote(str(room_id), safe=""),
+            attachment_id=quote(str(attachment_id), safe=""),
+            name=quote(str(name), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, response: httpx.Response) -> AttachmentMultipartUpload:
+    if response.status_code == 200:
+        response_200 = AttachmentMultipartUpload.from_dict(response.json())
+
+        return response_200
+
+    raise errors.LiveblocksError.from_response(response)
+
+
+def _sync(
+    room_id: str,
+    attachment_id: str,
+    name: str,
+    *,
+    client: httpx.Client,
+    file_size: int | Unset = UNSET,
+) -> AttachmentMultipartUpload:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        name=name,
+        file_size=file_size,
+    )
+
+    response = client.request(
+        **kwargs,
+    )
+    return _parse_response(response=response)
+
+
+async def _asyncio(
+    room_id: str,
+    attachment_id: str,
+    name: str,
+    *,
+    client: httpx.AsyncClient,
+    file_size: int | Unset = UNSET,
+) -> AttachmentMultipartUpload:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        name=name,
+        file_size=file_size,
+    )
+
+    response = await client.request(
+        **kwargs,
+    )
+
+    return _parse_response(response=response)

--- a/packages/liveblocks-python/liveblocks/api/comments/upload_attachment.py
+++ b/packages/liveblocks-python/liveblocks/api/comments/upload_attachment.py
@@ -1,0 +1,108 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...models.comment_attachment import CommentAttachment
+from ...types import UNSET, File, Unset
+
+
+def _get_kwargs(
+    room_id: str,
+    attachment_id: str,
+    name: str,
+    *,
+    body: File,
+    user_id: str,
+    file_size: int | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["userId"] = user_id
+
+    params["fileSize"] = file_size
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v2/rooms/{room_id}/attachments/{attachment_id}/upload/{name}".format(
+            room_id=quote(str(room_id), safe=""),
+            attachment_id=quote(str(attachment_id), safe=""),
+            name=quote(str(name), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["content"] = body.payload
+
+    headers["Content-Type"] = "application/octet-stream"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, response: httpx.Response) -> CommentAttachment:
+    if response.status_code == 200:
+        response_200 = CommentAttachment.from_dict(response.json())
+
+        return response_200
+
+    raise errors.LiveblocksError.from_response(response)
+
+
+def _sync(
+    room_id: str,
+    attachment_id: str,
+    name: str,
+    *,
+    client: httpx.Client,
+    body: File,
+    user_id: str,
+    file_size: int | Unset = UNSET,
+) -> CommentAttachment:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        name=name,
+        body=body,
+        user_id=user_id,
+        file_size=file_size,
+    )
+
+    response = client.request(
+        **kwargs,
+    )
+    return _parse_response(response=response)
+
+
+async def _asyncio(
+    room_id: str,
+    attachment_id: str,
+    name: str,
+    *,
+    client: httpx.AsyncClient,
+    body: File,
+    user_id: str,
+    file_size: int | Unset = UNSET,
+) -> CommentAttachment:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        name=name,
+        body=body,
+        user_id=user_id,
+        file_size=file_size,
+    )
+
+    if isinstance(body, File):
+        kwargs["content"] = body._iter_bytes()
+
+    response = await client.request(
+        **kwargs,
+    )
+
+    return _parse_response(response=response)

--- a/packages/liveblocks-python/liveblocks/api/comments/upload_attachment_multipart_part.py
+++ b/packages/liveblocks-python/liveblocks/api/comments/upload_attachment_multipart_part.py
@@ -1,0 +1,95 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...models.attachment_multipart_part import AttachmentMultipartPart
+from ...types import File
+
+
+def _get_kwargs(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    part_number: int,
+    *,
+    body: File,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v2/rooms/{room_id}/attachments/{attachment_id}/multipart/{upload_id}/{part_number}".format(
+            room_id=quote(str(room_id), safe=""),
+            attachment_id=quote(str(attachment_id), safe=""),
+            upload_id=quote(str(upload_id), safe=""),
+            part_number=quote(str(part_number), safe=""),
+        ),
+    }
+
+    _kwargs["content"] = body.payload
+
+    headers["Content-Type"] = "application/octet-stream"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, response: httpx.Response) -> AttachmentMultipartPart:
+    if response.status_code == 200:
+        response_200 = AttachmentMultipartPart.from_dict(response.json())
+
+        return response_200
+
+    raise errors.LiveblocksError.from_response(response)
+
+
+def _sync(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    part_number: int,
+    *,
+    client: httpx.Client,
+    body: File,
+) -> AttachmentMultipartPart:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        upload_id=upload_id,
+        part_number=part_number,
+        body=body,
+    )
+
+    response = client.request(
+        **kwargs,
+    )
+    return _parse_response(response=response)
+
+
+async def _asyncio(
+    room_id: str,
+    attachment_id: str,
+    upload_id: str,
+    part_number: int,
+    *,
+    client: httpx.AsyncClient,
+    body: File,
+) -> AttachmentMultipartPart:
+    kwargs = _get_kwargs(
+        room_id=room_id,
+        attachment_id=attachment_id,
+        upload_id=upload_id,
+        part_number=part_number,
+        body=body,
+    )
+
+    if isinstance(body, File):
+        kwargs["content"] = body._iter_bytes()
+
+    response = await client.request(
+        **kwargs,
+    )
+
+    return _parse_response(response=response)

--- a/packages/liveblocks-python/liveblocks/client.py
+++ b/packages/liveblocks-python/liveblocks/client.py
@@ -16,12 +16,16 @@ if TYPE_CHECKING:
     from .models.ai_copilot_google import AiCopilotGoogle
     from .models.ai_copilot_open_ai import AiCopilotOpenAi
     from .models.ai_copilot_open_ai_compatible import AiCopilotOpenAiCompatible
+    from .models.attachment_multipart_part import AttachmentMultipartPart
+    from .models.attachment_multipart_upload import AttachmentMultipartUpload
     from .models.attachment_with_url import AttachmentWithUrl
     from .models.authorize_user_request_body import AuthorizeUserRequestBody
     from .models.authorize_user_response import AuthorizeUserResponse
     from .models.comment import Comment
+    from .models.comment_attachment import CommentAttachment
     from .models.comment_metadata import CommentMetadata
     from .models.comment_reaction import CommentReaction
+    from .models.complete_attachment_multipart_upload_request_body import CompleteAttachmentMultipartUploadRequestBody
     from .models.complete_storage_file_multipart_upload_request_body import (
         CompleteStorageFileMultipartUploadRequestBody,
     )
@@ -1915,6 +1919,197 @@ class Liveblocks:
         return get_attachment._sync(
             room_id=room_id,
             attachment_id=attachment_id,
+            client=self._client,
+        )
+
+    def upload_attachment(
+        self,
+        room_id: str,
+        attachment_id: str,
+        name: str,
+        *,
+        body: File,
+        user_id: str,
+        file_size: int | Unset = UNSET,
+    ) -> CommentAttachment:
+        """Upload attachment
+
+         Uploads a file's bytes and returns a draft comment attachment. Pass the returned attachment ID in
+        the comment's attachment IDs when creating or editing a comment. For large files, use the multipart
+        upload operations instead.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID for the attachment Example: at_abc123456789012345678.
+            name (str): Name of the file Example: screenshot.png.
+            user_id (str): ID of the user uploading the attachment Example: alice.
+            file_size (int | Unset): Expected file size in bytes Example: 12345.
+            body (File):
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            CommentAttachment
+        """
+
+        from .api.comments import upload_attachment
+
+        return upload_attachment._sync(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            name=name,
+            body=body,
+            user_id=user_id,
+            file_size=file_size,
+            client=self._client,
+        )
+
+    def create_attachment_multipart_upload(
+        self,
+        room_id: str,
+        attachment_id: str,
+        name: str,
+        *,
+        file_size: int | Unset = UNSET,
+    ) -> AttachmentMultipartUpload:
+        """Create attachment multipart upload
+
+         Starts a multipart upload for a draft comment attachment.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID for the attachment Example: at_abc123456789012345678.
+            name (str): Name of the file Example: recording.mp4.
+            file_size (int | Unset): Expected file size in bytes Example: 10485760.
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            AttachmentMultipartUpload
+        """
+
+        from .api.comments import create_attachment_multipart_upload
+
+        return create_attachment_multipart_upload._sync(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            name=name,
+            file_size=file_size,
+            client=self._client,
+        )
+
+    def upload_attachment_multipart_part(
+        self,
+        room_id: str,
+        attachment_id: str,
+        upload_id: str,
+        part_number: int,
+        *,
+        body: File,
+    ) -> AttachmentMultipartPart:
+        """Upload attachment multipart part
+
+         Uploads one part of an attachment multipart upload.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID of the attachment Example: at_abc123456789012345678.
+            upload_id (str): ID returned when the multipart upload was created
+            part_number (int): One-based part number Example: 1.
+            body (File):
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            AttachmentMultipartPart
+        """
+
+        from .api.comments import upload_attachment_multipart_part
+
+        return upload_attachment_multipart_part._sync(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            upload_id=upload_id,
+            part_number=part_number,
+            body=body,
+            client=self._client,
+        )
+
+    def complete_attachment_multipart_upload(
+        self,
+        room_id: str,
+        attachment_id: str,
+        upload_id: str,
+        *,
+        body: CompleteAttachmentMultipartUploadRequestBody,
+        user_id: str,
+    ) -> CommentAttachment:
+        """Complete attachment multipart upload
+
+         Completes a multipart upload and returns a draft comment attachment. Pass the returned attachment ID
+        in the comment's attachment IDs when creating or editing a comment.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID of the attachment Example: at_abc123456789012345678.
+            upload_id (str): ID returned when the multipart upload was created
+            user_id (str): ID of the user uploading the attachment Example: alice.
+            body (CompleteAttachmentMultipartUploadRequestBody):
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            CommentAttachment
+        """
+
+        from .api.comments import complete_attachment_multipart_upload
+
+        return complete_attachment_multipart_upload._sync(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            upload_id=upload_id,
+            body=body,
+            user_id=user_id,
+            client=self._client,
+        )
+
+    def abort_attachment_multipart_upload(
+        self,
+        room_id: str,
+        attachment_id: str,
+        upload_id: str,
+    ) -> None:
+        """Abort attachment multipart upload
+
+         Aborts a multipart upload and discards its uploaded parts.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID of the attachment Example: at_abc123456789012345678.
+            upload_id (str): ID returned when the multipart upload was created
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            None
+        """
+
+        from .api.comments import abort_attachment_multipart_upload
+
+        return abort_attachment_multipart_upload._sync(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            upload_id=upload_id,
             client=self._client,
         )
 
@@ -5302,6 +5497,197 @@ class AsyncLiveblocks:
         return await get_attachment._asyncio(
             room_id=room_id,
             attachment_id=attachment_id,
+            client=self._client,
+        )
+
+    async def upload_attachment(
+        self,
+        room_id: str,
+        attachment_id: str,
+        name: str,
+        *,
+        body: File,
+        user_id: str,
+        file_size: int | Unset = UNSET,
+    ) -> CommentAttachment:
+        """Upload attachment
+
+         Uploads a file's bytes and returns a draft comment attachment. Pass the returned attachment ID in
+        the comment's attachment IDs when creating or editing a comment. For large files, use the multipart
+        upload operations instead.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID for the attachment Example: at_abc123456789012345678.
+            name (str): Name of the file Example: screenshot.png.
+            user_id (str): ID of the user uploading the attachment Example: alice.
+            file_size (int | Unset): Expected file size in bytes Example: 12345.
+            body (File):
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            CommentAttachment
+        """
+
+        from .api.comments import upload_attachment
+
+        return await upload_attachment._asyncio(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            name=name,
+            body=body,
+            user_id=user_id,
+            file_size=file_size,
+            client=self._client,
+        )
+
+    async def create_attachment_multipart_upload(
+        self,
+        room_id: str,
+        attachment_id: str,
+        name: str,
+        *,
+        file_size: int | Unset = UNSET,
+    ) -> AttachmentMultipartUpload:
+        """Create attachment multipart upload
+
+         Starts a multipart upload for a draft comment attachment.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID for the attachment Example: at_abc123456789012345678.
+            name (str): Name of the file Example: recording.mp4.
+            file_size (int | Unset): Expected file size in bytes Example: 10485760.
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            AttachmentMultipartUpload
+        """
+
+        from .api.comments import create_attachment_multipart_upload
+
+        return await create_attachment_multipart_upload._asyncio(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            name=name,
+            file_size=file_size,
+            client=self._client,
+        )
+
+    async def upload_attachment_multipart_part(
+        self,
+        room_id: str,
+        attachment_id: str,
+        upload_id: str,
+        part_number: int,
+        *,
+        body: File,
+    ) -> AttachmentMultipartPart:
+        """Upload attachment multipart part
+
+         Uploads one part of an attachment multipart upload.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID of the attachment Example: at_abc123456789012345678.
+            upload_id (str): ID returned when the multipart upload was created
+            part_number (int): One-based part number Example: 1.
+            body (File):
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            AttachmentMultipartPart
+        """
+
+        from .api.comments import upload_attachment_multipart_part
+
+        return await upload_attachment_multipart_part._asyncio(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            upload_id=upload_id,
+            part_number=part_number,
+            body=body,
+            client=self._client,
+        )
+
+    async def complete_attachment_multipart_upload(
+        self,
+        room_id: str,
+        attachment_id: str,
+        upload_id: str,
+        *,
+        body: CompleteAttachmentMultipartUploadRequestBody,
+        user_id: str,
+    ) -> CommentAttachment:
+        """Complete attachment multipart upload
+
+         Completes a multipart upload and returns a draft comment attachment. Pass the returned attachment ID
+        in the comment's attachment IDs when creating or editing a comment.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID of the attachment Example: at_abc123456789012345678.
+            upload_id (str): ID returned when the multipart upload was created
+            user_id (str): ID of the user uploading the attachment Example: alice.
+            body (CompleteAttachmentMultipartUploadRequestBody):
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            CommentAttachment
+        """
+
+        from .api.comments import complete_attachment_multipart_upload
+
+        return await complete_attachment_multipart_upload._asyncio(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            upload_id=upload_id,
+            body=body,
+            user_id=user_id,
+            client=self._client,
+        )
+
+    async def abort_attachment_multipart_upload(
+        self,
+        room_id: str,
+        attachment_id: str,
+        upload_id: str,
+    ) -> None:
+        """Abort attachment multipart upload
+
+         Aborts a multipart upload and discards its uploaded parts.
+
+        Args:
+            room_id (str): ID of the room Example: my-room-id.
+            attachment_id (str): ID of the attachment Example: at_abc123456789012345678.
+            upload_id (str): ID returned when the multipart upload was created
+
+        Raises:
+            errors.LiveblocksError: If the server returns a response with non-2xx status code.
+            httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+        Returns:
+            None
+        """
+
+        from .api.comments import abort_attachment_multipart_upload
+
+        return await abort_attachment_multipart_upload._asyncio(
+            room_id=room_id,
+            attachment_id=attachment_id,
+            upload_id=upload_id,
             client=self._client,
         )
 

--- a/packages/liveblocks-python/liveblocks/models/__init__.py
+++ b/packages/liveblocks-python/liveblocks/models/__init__.py
@@ -24,6 +24,8 @@ from .anthropic_provider_options_anthropic_anthropic_thinking_enabled import (
 from .anthropic_provider_options_anthropic_anthropic_web_search import (
     AnthropicProviderOptionsAnthropicAnthropicWebSearch,
 )
+from .attachment_multipart_part import AttachmentMultipartPart
+from .attachment_multipart_upload import AttachmentMultipartUpload
 from .attachment_with_url import AttachmentWithUrl
 from .authorization import Authorization
 from .authorize_user_request_body import AuthorizeUserRequestBody
@@ -36,6 +38,7 @@ from .comment_body import CommentBody
 from .comment_body_content_item import CommentBodyContentItem
 from .comment_metadata import CommentMetadata
 from .comment_reaction import CommentReaction
+from .complete_attachment_multipart_upload_request_body import CompleteAttachmentMultipartUploadRequestBody
 from .complete_storage_file_multipart_upload_request_body import CompleteStorageFileMultipartUploadRequestBody
 from .copy_json_patch_operation import CopyJsonPatchOperation
 from .create_ai_copilot_options_anthropic import CreateAiCopilotOptionsAnthropic
@@ -203,6 +206,8 @@ __all__ = (
     "AnthropicProviderOptionsAnthropicAnthropicThinkingDisabled",
     "AnthropicProviderOptionsAnthropicAnthropicThinkingEnabled",
     "AnthropicProviderOptionsAnthropicAnthropicWebSearch",
+    "AttachmentMultipartPart",
+    "AttachmentMultipartUpload",
     "AttachmentWithUrl",
     "Authorization",
     "AuthorizeUserRequestBody",
@@ -215,6 +220,7 @@ __all__ = (
     "CommentBodyContentItem",
     "CommentMetadata",
     "CommentReaction",
+    "CompleteAttachmentMultipartUploadRequestBody",
     "CompleteStorageFileMultipartUploadRequestBody",
     "CopyJsonPatchOperation",
     "CreateAiCopilotOptionsAnthropic",

--- a/packages/liveblocks-python/liveblocks/models/attachment_multipart_part.py
+++ b/packages/liveblocks-python/liveblocks/models/attachment_multipart_part.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self
+
+from attrs import define as _attrs_define
+
+
+@_attrs_define
+class AttachmentMultipartPart:
+    """
+    Attributes:
+        part_number (int):
+        etag (str):
+    """
+
+    part_number: int
+    etag: str
+
+    def to_dict(self) -> dict[str, Any]:
+        part_number = self.part_number
+
+        etag = self.etag
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "partNumber": part_number,
+                "etag": etag,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        part_number = d.pop("partNumber")
+
+        etag = d.pop("etag")
+
+        attachment_multipart_part = cls(
+            part_number=part_number,
+            etag=etag,
+        )
+
+        return attachment_multipart_part

--- a/packages/liveblocks-python/liveblocks/models/attachment_multipart_upload.py
+++ b/packages/liveblocks-python/liveblocks/models/attachment_multipart_upload.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Self
+
+from attrs import define as _attrs_define
+
+
+@_attrs_define
+class AttachmentMultipartUpload:
+    """
+    Attributes:
+        attachment_id (str):
+        upload_id (str):
+    """
+
+    attachment_id: str
+    upload_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        attachment_id = self.attachment_id
+
+        upload_id = self.upload_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "attachmentId": attachment_id,
+                "uploadId": upload_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        d = dict(src_dict)
+        attachment_id = d.pop("attachmentId")
+
+        upload_id = d.pop("uploadId")
+
+        attachment_multipart_upload = cls(
+            attachment_id=attachment_id,
+            upload_id=upload_id,
+        )
+
+        return attachment_multipart_upload

--- a/packages/liveblocks-python/liveblocks/models/complete_attachment_multipart_upload_request_body.py
+++ b/packages/liveblocks-python/liveblocks/models/complete_attachment_multipart_upload_request_body.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Self
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.attachment_multipart_part import AttachmentMultipartPart
+
+
+@_attrs_define
+class CompleteAttachmentMultipartUploadRequestBody:
+    """
+    Attributes:
+        parts (list[AttachmentMultipartPart]):
+    """
+
+    parts: list[AttachmentMultipartPart]
+
+    def to_dict(self) -> dict[str, Any]:
+        parts = []
+        for parts_item_data in self.parts:
+            parts_item = parts_item_data.to_dict()
+            parts.append(parts_item)
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "parts": parts,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self:
+        from ..models.attachment_multipart_part import AttachmentMultipartPart
+
+        d = dict(src_dict)
+        parts = []
+        _parts = d.pop("parts")
+        for parts_item_data in _parts:
+            parts_item = AttachmentMultipartPart.from_dict(parts_item_data)
+
+            parts.append(parts_item)
+
+        complete_attachment_multipart_upload_request_body = cls(
+            parts=parts,
+        )
+
+        return complete_attachment_multipart_upload_request_body


### PR DESCRIPTION
This PR (alongside https://github.com/liveblocks/liveblocks-backend/pull/1819) adds support for creating (and attaching) comments attachments to `@liveblocks/node` and the Python SDK.