### PR TITLE
Add flag to skip installs when upgrading examples

### DIFF
--- a/scripts/for-all-examples.sh
+++ b/scripts/for-all-examples.sh
@@ -16,11 +16,12 @@ err () {
 }
 
 usage () {
-    err "usage: for-all-examples.sh [-qfh] [-c <shell-cmd>] <cmd> [<arg1> [<arg2> ...]]"
+    err "usage: for-all-examples.sh [-pqfh] [-c <shell-cmd>] <cmd> [<arg1> [<arg2> ...]]"
     err
     err "Runs the given script inside all of our examples directories."
     err
     err "Options:"
+    err "-p    Run up to 8 commands in parallel and buffer their output"
     err "-q    Don't print the current directory"
     err "-f    Continue, even after an error occurs"
     err "-c    Run command with \`sh -c\` instead"
@@ -28,11 +29,13 @@ usage () {
 }
 
 cmd=
+parallel=0
 quiet=0
 force=0
-while getopts qc:fh flag; do
+while getopts pqc:fh flag; do
     case "$flag" in
         c) cmd="$OPTARG" ; ;;
+        p) parallel=1 ; ;;
         q) quiet=1 ; ;;
         f) force=1 ; ;;
         *) usage; exit 2;;
@@ -40,7 +43,10 @@ while getopts qc:fh flag; do
 done
 shift $(($OPTIND - 1))
 
-for dir in $(find examples starter-kits -maxdepth 1 -type d | grep -Ee /); do
+run_in_dir () {
+    dir="$1"
+    shift
+
     if [ $quiet -eq 0 ]; then
         err
         err "==> In $dir"
@@ -62,4 +68,55 @@ for dir in $(find examples starter-kits -maxdepth 1 -type d | grep -Ee /); do
             set -e
         fi
     ) )
+}
+
+if [ $parallel -eq 0 ]; then
+    for dir in $(find examples starter-kits -maxdepth 1 -type d | grep -Ee /); do
+        run_in_dir "$dir" "$@"
+    done
+    exit
+fi
+
+output_dir="$(mktemp -d)"
+trap 'rm -r "$output_dir"' 0
+trap 'exit 1' 1 2 15
+
+jobs=
+active_jobs=0
+output_index=0
+
+flush_jobs () {
+    failed=0
+
+    for job in $jobs; do
+        pid="${job%%:*}"
+        output_file="${job#*:}"
+
+        if ! wait "$pid"; then
+            failed=1
+        fi
+
+        cat "$output_file"
+        rm "$output_file"
+    done
+
+    jobs=
+    active_jobs=0
+    return "$failed"
+}
+
+for dir in $(find examples starter-kits -maxdepth 1 -type d | grep -Ee /); do
+    output_file="$output_dir/$output_index"
+    run_in_dir "$dir" "$@" > "$output_file" 2>&1 &
+    jobs="$jobs $!:$output_file"
+    active_jobs=$((active_jobs + 1))
+    output_index=$((output_index + 1))
+
+    if [ $active_jobs -eq 8 ]; then
+        flush_jobs
+    fi
 done
+
+if [ $active_jobs -gt 0 ]; then
+    flush_jobs
+fi

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -36,4 +36,4 @@ shift $(($OPTIND - 1))
 
 VERSION="${1:-latest}"
 
-scripts/for-all-examples.sh -c "pnpm dlx liveblocks@latest upgrade $upgrade_options $VERSION" -f
+scripts/for-all-examples.sh -p -c "pnpm dlx liveblocks@latest upgrade $upgrade_options $VERSION" -f

--- a/scripts/upgrade-examples.sh
+++ b/scripts/upgrade-examples.sh
@@ -15,17 +15,20 @@ err () {
 }
 
 usage () {
-    err "usage: upgrade-examples.sh [<version>]"
+    err "usage: upgrade-examples.sh [-s] [<version>]"
     err
     err "Upgrades all the example projects by bumping the Liveblocks dependencies"
     err "to the given version. If not provided, uses the latest version."
     err
     err "Options:"
+    err "-s    Skip installing dependencies"
     err "-h    Show this help"
 }
 
-while getopts h flag; do
+upgrade_options=
+while getopts sh flag; do
     case "$flag" in
+        s) upgrade_options="--skip-install" ; ;;
         *) usage; exit 2;;
     esac
 done
@@ -33,4 +36,4 @@ shift $(($OPTIND - 1))
 
 VERSION="${1:-latest}"
 
-scripts/for-all-examples.sh -c "pnpm dlx liveblocks@latest upgrade $VERSION" -f
+scripts/for-all-examples.sh -c "pnpm dlx liveblocks@latest upgrade $upgrade_options $VERSION" -f


### PR DESCRIPTION
We now have many examples so I added a flag to the `upgrade-examples.sh` script to skip installing everything (all examples’ dependencies currently reach 31 GB), it uses a new flag in the Liveblocks CLI's `upgrade` command done in https://github.com/liveblocks/liveblocks-backend/pull/1822. While I was there I also added parallelization.

