### PR TITLE
Replace the `kStorageUpdateSource` symbol with a public/supported `source` field

### DIFF
--- a/e2e/next-codemirror-liveblocks/vitest.config.ts
+++ b/e2e/next-codemirror-liveblocks/vitest.config.ts
@@ -8,8 +8,11 @@ const vitestSetup = path.resolve(
   "../../shared/vitest-config/setup.js"
 );
 
-// Force a single @liveblocks/core instance so kStorageUpdateSource (a Symbol)
-// matches between the mock-server test helpers (core/src) and app imports (@liveblocks/core).
+// The mock WebSocket server lives in @liveblocks/core's src/__tests__/, which
+// is neither exported nor built, so tests can only reach it by relative path.
+// That loads core from source, while the code under test imports the built
+// @liveblocks/core. Two copies means two kInternal Symbols and two sets of CRDT
+// classes, so alias both onto the source copy.
 const liveblocksCore = path.resolve(
   __dirname,
   "../../packages/liveblocks-core/src/index.ts"

--- a/e2e/next-lexical-liveblocks/vitest.config.ts
+++ b/e2e/next-lexical-liveblocks/vitest.config.ts
@@ -8,8 +8,11 @@ const vitestSetup = path.resolve(
   "../../shared/vitest-config/setup.js"
 );
 
-// Force a single @liveblocks/core instance so kStorageUpdateSource (a Symbol)
-// matches between the mock-server test helpers (core/src) and app imports (@liveblocks/core).
+// The mock WebSocket server lives in @liveblocks/core's src/__tests__/, which
+// is neither exported nor built, so tests can only reach it by relative path.
+// That loads core from source, while the code under test imports the built
+// @liveblocks/core. Two copies means two kInternal Symbols and two sets of CRDT
+// classes, so alias both onto the source copy.
 const liveblocksCore = path.resolve(
   __dirname,
   "../../packages/liveblocks-core/src/index.ts"

--- a/packages/liveblocks-codemirror/src/__tests__/sync-plugin.test.ts
+++ b/packages/liveblocks-codemirror/src/__tests__/sync-plugin.test.ts
@@ -1576,7 +1576,7 @@ describe("createLiveblocksSyncPlugin", () => {
                 continue;
               }
               const source = update.source;
-              if (source?.origin !== "local" || source.via !== "undo") {
+              if (source.origin !== "local" || source.via !== "undo") {
                 continue;
               }
 

--- a/packages/liveblocks-codemirror/src/__tests__/sync-plugin.test.ts
+++ b/packages/liveblocks-codemirror/src/__tests__/sync-plugin.test.ts
@@ -7,12 +7,7 @@ import {
 import { EditorView } from "@codemirror/view";
 import type { LiveObject, Room } from "@liveblocks/client";
 import type { LiveText } from "@liveblocks/core";
-import {
-  CrdtType,
-  kInternal,
-  kStorageUpdateSource,
-  OpCode,
-} from "@liveblocks/core";
+import { CrdtType, kInternal, OpCode } from "@liveblocks/core";
 import { describe, expect, onTestFinished, test, vi } from "vitest";
 
 import {
@@ -1580,7 +1575,7 @@ describe("createLiveblocksSyncPlugin", () => {
               if (update.type !== "LiveText" || update.node !== liveText) {
                 continue;
               }
-              const source = update[kStorageUpdateSource];
+              const source = update.source;
               if (
                 source?.origin !== "local" ||
                 source.via !== "history" ||

--- a/packages/liveblocks-codemirror/src/__tests__/sync-plugin.test.ts
+++ b/packages/liveblocks-codemirror/src/__tests__/sync-plugin.test.ts
@@ -1576,11 +1576,7 @@ describe("createLiveblocksSyncPlugin", () => {
                 continue;
               }
               const source = update.source;
-              if (
-                source?.origin !== "local" ||
-                source.via !== "history" ||
-                source.action !== "undo"
-              ) {
+              if (source?.origin !== "local" || source.via !== "undo") {
                 continue;
               }
 

--- a/packages/liveblocks-codemirror/src/sync-plugin.ts
+++ b/packages/liveblocks-codemirror/src/sync-plugin.ts
@@ -46,7 +46,7 @@ export function createLiveblocksSyncPlugin(
                 }
 
                 const source = update.source;
-                if (source?.origin === "local" && source.via === "edit") {
+                if (source.origin === "local" && source.via === "edit") {
                   continue;
                 }
 
@@ -83,7 +83,7 @@ export function createLiveblocksSyncPlugin(
 
                 let selection: EditorSelection | undefined;
                 if (
-                  source?.origin === "local" &&
+                  source.origin === "local" &&
                   (source.via === "undo" || source.via === "redo")
                 ) {
                   const id =

--- a/packages/liveblocks-codemirror/src/sync-plugin.ts
+++ b/packages/liveblocks-codemirror/src/sync-plugin.ts
@@ -4,13 +4,10 @@ import {
   Transaction,
   type Extension,
 } from "@codemirror/state";
-import { EditorView, ViewPlugin, ViewUpdate, keymap } from "@codemirror/view";
-import type { Room } from "@liveblocks/client";
-import {
-  kInternal,
-  kStorageUpdateSource,
-  type LiveText,
-} from "@liveblocks/core";
+import type { EditorView, ViewUpdate } from "@codemirror/view";
+import { ViewPlugin, keymap } from "@codemirror/view";
+import { kInternal } from "@liveblocks/core";
+import type { LiveText, Room } from "@liveblocks/client";
 
 import { clamp } from "./utils";
 
@@ -48,7 +45,7 @@ export function createLiveblocksSyncPlugin(
                   continue;
                 }
 
-                const source = update[kStorageUpdateSource];
+                const source = update.source;
                 if (source?.origin === "local" && source.via === "mutation") {
                   continue;
                 }

--- a/packages/liveblocks-codemirror/src/sync-plugin.ts
+++ b/packages/liveblocks-codemirror/src/sync-plugin.ts
@@ -46,7 +46,7 @@ export function createLiveblocksSyncPlugin(
                 }
 
                 const source = update.source;
-                if (source?.origin === "local" && source.via === "mutation") {
+                if (source?.origin === "local" && source.via === "edit") {
                   continue;
                 }
 

--- a/packages/liveblocks-codemirror/src/sync-plugin.ts
+++ b/packages/liveblocks-codemirror/src/sync-plugin.ts
@@ -82,9 +82,12 @@ export function createLiveblocksSyncPlugin(
                 if (changes.empty) continue;
 
                 let selection: EditorSelection | undefined;
-                if (source?.origin === "local" && source.via === "history") {
+                if (
+                  source?.origin === "local" &&
+                  (source.via === "undo" || source.via === "redo")
+                ) {
                   const id =
-                    source.action === "undo"
+                    source.via === "undo"
                       ? room[kInternal].redoStack.at(-1)?.id
                       : room[kInternal].undoStack.at(-1)?.id;
                   const meta =
@@ -92,7 +95,7 @@ export function createLiveblocksSyncPlugin(
                       ? undefined
                       : this.selectionByHistoryId.get(id);
                   if (meta !== undefined) {
-                    if (source.action === "undo") {
+                    if (source.via === "undo") {
                       if (meta.before.anchor !== meta.before.head) {
                         selection = EditorSelection.single(
                           clamp(meta.before.anchor, {

--- a/packages/liveblocks-codemirror/vitest.config.ts
+++ b/packages/liveblocks-codemirror/vitest.config.ts
@@ -8,8 +8,11 @@ const vitestSetup = path.resolve(
   "../../shared/vitest-config/setup.js"
 );
 
-// Force a single @liveblocks/core instance so kStorageUpdateSource (a Symbol)
-// matches between the mock-server test helpers (core/src) and package imports.
+// The mock WebSocket server lives in @liveblocks/core's src/__tests__/, which
+// is neither exported nor built, so tests can only reach it by relative path.
+// That loads core from source, while the code under test imports the built
+// @liveblocks/core. Two copies means two kInternal Symbols and two sets of CRDT
+// classes, so alias both onto the source copy.
 const liveblocksCore = path.resolve(
   __dirname,
   "../liveblocks-core/src/index.ts"

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -757,7 +757,7 @@ describe("room (dev server)", () => {
       expect(sources).toEqual([{ origin: "remote" }]);
     });
 
-    test("undo produces history-tagged storage updates", async () => {
+    test("undo produces undo-tagged storage updates", async () => {
       const { room, root } = await prepareIsolatedStorageTest<{ a: number }>({
         liveblocksType: "LiveObject",
         data: { a: 0 },
@@ -776,9 +776,7 @@ describe("room (dev server)", () => {
       sources.length = 0;
       room.history.undo();
 
-      expect(sources).toEqual([
-        { origin: "local", via: "history", action: "undo" },
-      ]);
+      expect(sources).toEqual([{ origin: "local", via: "undo" }]);
     });
   });
 });

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -14,7 +14,6 @@ import type {
   StorageUpdate,
   StorageUpdateSource,
 } from "../crdts/StorageUpdates";
-import { kStorageUpdateSource } from "../internal";
 import { nn } from "../lib/assert";
 import { prepareIsolatedStorageTest, prepareStorageTest } from "./_devserver";
 import type { JsonStorageUpdate } from "./_updatesUtils";
@@ -649,7 +648,7 @@ describe("room (dev server)", () => {
 
   describe("storage update source", () => {
     function readSources(updates: StorageUpdate[]): StorageUpdateSource[] {
-      return updates.map((update) => update[kStorageUpdateSource]!);
+      return updates.map((update) => update.source!);
     }
 
     test("local LiveObject mutations are tagged local", async () => {
@@ -691,9 +690,9 @@ describe("room (dev server)", () => {
               continue;
             }
             updates.push({
-              source: update[kStorageUpdateSource]!,
+              source: update.source!,
               changeHasSource: update.updates.some(
-                (change) => kStorageUpdateSource in change
+                (change) => "source" in change
               ),
             });
           }

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -666,7 +666,7 @@ describe("room (dev server)", () => {
 
       root.set("a", 1);
 
-      expect(sources).toEqual([{ origin: "local", via: "mutation" }]);
+      expect(sources).toEqual([{ origin: "local", via: "edit" }]);
     });
 
     test("local LiveText mutations are tagged local on the envelope only", async () => {
@@ -703,7 +703,7 @@ describe("room (dev server)", () => {
 
       expect(updates).toEqual([
         {
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
           changeHasSource: false,
         },
       ]);
@@ -771,7 +771,7 @@ describe("room (dev server)", () => {
       );
 
       root.set("a", 1);
-      expect(sources).toEqual([{ origin: "local", via: "mutation" }]);
+      expect(sources).toEqual([{ origin: "local", via: "edit" }]);
 
       sources.length = 0;
       room.history.undo();

--- a/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.devserver.test.ts
@@ -10,10 +10,7 @@ import { describe, expect, onTestFinished, test, vi } from "vitest";
 import { LiveList } from "../crdts/LiveList";
 import { LiveObject } from "../crdts/LiveObject";
 import type { LiveText } from "../crdts/LiveText";
-import type {
-  StorageUpdate,
-  StorageUpdateSource,
-} from "../crdts/StorageUpdates";
+import type { StorageUpdate, UpdateSource } from "../crdts/StorageUpdates";
 import { nn } from "../lib/assert";
 import { prepareIsolatedStorageTest, prepareStorageTest } from "./_devserver";
 import type { JsonStorageUpdate } from "./_updatesUtils";
@@ -647,8 +644,8 @@ describe("room (dev server)", () => {
   });
 
   describe("storage update source", () => {
-    function readSources(updates: StorageUpdate[]): StorageUpdateSource[] {
-      return updates.map((update) => update.source!);
+    function readSources(updates: StorageUpdate[]): UpdateSource[] {
+      return updates.map((update) => update.source);
     }
 
     test("local LiveObject mutations are tagged local", async () => {
@@ -657,7 +654,7 @@ describe("room (dev server)", () => {
         data: { a: 0 },
       });
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         room.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -680,7 +677,7 @@ describe("room (dev server)", () => {
       });
 
       const updates: Array<{
-        source: StorageUpdateSource;
+        source: UpdateSource;
         changeHasSource: boolean;
       }> = [];
       onTestFinished(
@@ -690,7 +687,7 @@ describe("room (dev server)", () => {
               continue;
             }
             updates.push({
-              source: update.source!,
+              source: update.source,
               changeHasSource: update.updates.some(
                 (change) => "source" in change
               ),
@@ -715,7 +712,7 @@ describe("room (dev server)", () => {
         data: { a: 0 },
       });
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         roomB.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -741,7 +738,7 @@ describe("room (dev server)", () => {
         },
       });
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         roomB.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -763,7 +760,7 @@ describe("room (dev server)", () => {
         data: { a: 0 },
       });
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         room.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -777,6 +774,41 @@ describe("room (dev server)", () => {
       room.history.undo();
 
       expect(sources).toEqual([{ origin: "local", via: "undo" }]);
+    });
+
+    test("the internal optimistic flag never reaches subscribers", async () => {
+      const { storageA, roomA, storageB, roomB } = await prepareStorageTest<{
+        a: number;
+      }>({
+        liveblocksType: "LiveObject",
+        data: { a: 0 },
+      });
+
+      const sources: UpdateSource[] = [];
+      onTestFinished(
+        roomA.events.storageBatch.subscribe((updates) => {
+          sources.push(...readSources(updates));
+        })
+      );
+      onTestFinished(
+        roomB.events.storageBatch.subscribe((updates) => {
+          sources.push(...readSources(updates));
+        })
+      );
+
+      // A local mutation is optimistic internally; its ack is not; an undo
+      // replays an unacknowledged op; and B sees all of it as remote.
+      storageA.root.set("a", 1);
+      roomA.history.undo();
+      storageB.root.set("a", 9);
+
+      await vi.waitFor(() => {
+        expect(sources.length).toBeGreaterThan(3);
+      });
+
+      for (const source of sources) {
+        expect(source).not.toHaveProperty("optimistic");
+      }
     });
   });
 });

--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -29,7 +29,7 @@ import type {
   StorageUpdate,
   StorageUpdateSource,
 } from "../crdts/StorageUpdates";
-import { kInternal, kStorageUpdateSource } from "../internal";
+import { kInternal } from "../internal";
 import { makeEventSource } from "../lib/EventSource";
 import * as console from "../lib/fancy-console";
 import type { Json, JsonObject } from "../lib/Json";
@@ -2831,7 +2831,7 @@ describe("room", () => {
 
   describe("storage update source", () => {
     function readSources(updates: StorageUpdate[]): StorageUpdateSource[] {
-      return updates.map((update) => update[kStorageUpdateSource]!);
+      return updates.map((update) => update.source!);
     }
 
     test("local mutations are tagged local", async () => {

--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -25,10 +25,7 @@ import { LiveMap } from "../crdts/LiveMap";
 import { LiveObject } from "../crdts/LiveObject";
 import type { LiveText } from "../crdts/LiveText";
 import type { LsonObject } from "../crdts/Lson";
-import type {
-  StorageUpdate,
-  StorageUpdateSource,
-} from "../crdts/StorageUpdates";
+import type { StorageUpdate, UpdateSource } from "../crdts/StorageUpdates";
 import { kInternal } from "../internal";
 import { makeEventSource } from "../lib/EventSource";
 import * as console from "../lib/fancy-console";
@@ -2830,8 +2827,8 @@ describe("room", () => {
   });
 
   describe("storage update source", () => {
-    function readSources(updates: StorageUpdate[]): StorageUpdateSource[] {
-      return updates.map((update) => update.source!);
+    function readSources(updates: StorageUpdate[]): UpdateSource[] {
+      return updates.map((update) => update.source);
     }
 
     test("local mutations are tagged local", async () => {
@@ -2841,7 +2838,7 @@ describe("room", () => {
         { a: 0 }
       );
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         room.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -2861,7 +2858,7 @@ describe("room", () => {
           { a: 0 }
         );
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         room.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -2886,7 +2883,7 @@ describe("room", () => {
         0
       );
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         refRoom.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));
@@ -2905,7 +2902,7 @@ describe("room", () => {
         { a: 0 }
       );
 
-      const sources: StorageUpdateSource[] = [];
+      const sources: UpdateSource[] = [];
       onTestFinished(
         room.events.storageBatch.subscribe((updates) => {
           sources.push(...readSources(updates));

--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -2850,7 +2850,7 @@ describe("room", () => {
 
       root.set("a", 1);
 
-      expect(sources).toEqual([{ origin: "local", via: "mutation" }]);
+      expect(sources).toEqual([{ origin: "local", via: "edit" }]);
     });
 
     test("remote ops without opId are tagged remote", async () => {
@@ -2913,7 +2913,7 @@ describe("room", () => {
       );
 
       root.set("a", 1);
-      expect(sources).toEqual([{ origin: "local", via: "mutation" }]);
+      expect(sources).toEqual([{ origin: "local", via: "edit" }]);
 
       sources.length = 0;
       room.history.undo();

--- a/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
+++ b/packages/liveblocks-core/src/__tests__/room.mockserver.test.ts
@@ -2898,7 +2898,7 @@ describe("room", () => {
       expect(sources).toEqual([{ origin: "remote" }]);
     });
 
-    test("undo and redo produce history-tagged storage updates with action", async () => {
+    test("undo and redo produce undo/redo-tagged storage updates", async () => {
       const { room, root } = await prepareIsolatedStorageTest<{ a: number }>(
         [createSerializedRoot({ a: 0 })],
         0,
@@ -2918,16 +2918,12 @@ describe("room", () => {
       sources.length = 0;
       room.history.undo();
 
-      expect(sources).toEqual([
-        { origin: "local", via: "history", action: "undo" },
-      ]);
+      expect(sources).toEqual([{ origin: "local", via: "undo" }]);
 
       sources.length = 0;
       room.history.redo();
 
-      expect(sources).toEqual([
-        { origin: "local", via: "history", action: "redo" },
-      ]);
+      expect(sources).toEqual([{ origin: "local", via: "redo" }]);
     });
   });
 

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -355,7 +355,7 @@ export abstract class AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, _isLocal: boolean): ApplyResult {
+  _apply(op: Op, _source: OpSource): ApplyResult {
     switch (op.type) {
       case OpCode.DELETE_CRDT: {
         if (this.parent.type === "HasParent") {

--- a/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
+++ b/packages/liveblocks-core/src/crdts/AbstractCrdt.ts
@@ -13,7 +13,8 @@ import { OpCode } from "../protocol/Op";
 import type { SerializedCrdt } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { LiveNode, Lson } from "./Lson";
-import type { StorageUpdate } from "./StorageUpdates";
+import type { OpSource, StorageUpdate, UpdateSource } from "./StorageUpdates";
+import { toUpdateSource } from "./StorageUpdates";
 import type { ReadonlyUnacknowledgedOps } from "./UnacknowledgedOps";
 import { UnacknowledgedOps } from "./UnacknowledgedOps";
 
@@ -168,36 +169,6 @@ export function createManagedPool(
 
     unacknowledgedOps,
   };
-}
-
-/**
- * When applying an op to a CRDT, we need to know where it came from to apply
- * it correctly.
- */
-export enum OpSource {
-  /**
-   * Optimistic update applied locally (from an undo, redo, or reconnect). Not
-   * yet acknowledged by the server. Will be sent to server and needs to be
-   * tracked for conflict resolution.
-   */
-  LOCAL,
-
-  /**
-   * Op received from server, originated from another client. Apply it, unless
-   * there's a pending local op for the same key (local ops take precedence
-   * until acknowledged).
-   *
-   * Note that a "fix Op" sent by the server in response to a local mutation
-   * that caused a conflict will also be classified as a THEIRS-like mutation.
-   * (As if another client resolved the conflict.)
-   */
-  THEIRS,
-
-  /**
-   * Op received from server, originated from THIS client. Server echoed it
-   * back to confirm.
-   */
-  OURS,
 }
 
 // TODO Temporary helper to help convert from AbstractCrdt -> LiveNode, only
@@ -355,11 +326,14 @@ export abstract class AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, _source: OpSource): ApplyResult {
+  _apply(op: Op, source: OpSource): ApplyResult {
     switch (op.type) {
       case OpCode.DELETE_CRDT: {
         if (this.parent.type === "HasParent") {
-          return this.parent.node._detachChild(crdtAsLiveNode(this));
+          return this.parent.node._detachChild(
+            crdtAsLiveNode(this),
+            toUpdateSource(source)
+          );
         }
 
         return { modified: false };
@@ -437,7 +411,7 @@ export abstract class AbstractCrdt {
   }
 
   /** @internal */
-  abstract _detachChild(crdt: LiveNode): ApplyResult;
+  abstract _detachChild(crdt: LiveNode, source: UpdateSource): ApplyResult;
 
   /**
    * Serializes this CRDT and all its children into a list of creation ops

--- a/packages/liveblocks-core/src/crdts/LiveFile.ts
+++ b/packages/liveblocks-core/src/crdts/LiveFile.ts
@@ -12,7 +12,7 @@ import type {
 import { CrdtType } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
-import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
+import type { ApplyResult, ManagedPool, OpSource } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
 
 export type { LiveFileData } from "../protocol/StorageNode";
@@ -108,8 +108,8 @@ export class LiveFile extends AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, isLocal: boolean): ApplyResult {
-    return super._apply(op, isLocal);
+  _apply(op: Op, source: OpSource): ApplyResult {
+    return super._apply(op, source);
   }
 
   /** @internal */

--- a/packages/liveblocks-core/src/crdts/LiveFile.ts
+++ b/packages/liveblocks-core/src/crdts/LiveFile.ts
@@ -12,8 +12,9 @@ import type {
 import { CrdtType } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
-import type { ApplyResult, ManagedPool, OpSource } from "./AbstractCrdt";
+import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
+import type { OpSource } from "./StorageUpdates";
 
 export type { LiveFileData } from "../protocol/StorageNode";
 

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -957,8 +957,8 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, isLocal: boolean): ApplyResult {
-    return super._apply(op, isLocal);
+  _apply(op: Op, source: OpSource): ApplyResult {
+    return super._apply(op, source);
   }
 
   /** @internal */

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -215,7 +215,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  #applySetRemote(op: CreateOp): ApplyResult {
+  #applyRemoteSet(op: CreateOp): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -641,7 +641,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  #applyInsertUndoRedo(op: CreateOp, source: UpdateSource): ApplyResult {
+  #applyLocalInsert(op: CreateOp, source: UpdateSource): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
@@ -674,7 +674,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     };
   }
 
-  #applySetUndoRedo(op: CreateOp, source: UpdateSource): ApplyResult {
+  #applyLocalSet(op: CreateOp, source: UpdateSource): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
@@ -743,11 +743,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
     if (op.intent === "set") {
       if (opSource.origin === "remote") {
-        result = this.#applySetRemote(op);
+        result = this.#applyRemoteSet(op);
       } else if (!opSource.optimistic) {
         result = this.#applySetAck(op, source);
       } else {
-        result = this.#applySetUndoRedo(op, source);
+        result = this.#applyLocalSet(op, source);
       }
     } else {
       if (opSource.origin === "remote") {
@@ -755,7 +755,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       } else if (!opSource.optimistic) {
         result = this.#applyInsertAck(op, source);
       } else {
-        result = this.#applyInsertUndoRedo(op, source);
+        result = this.#applyLocalInsert(op, source);
       }
     }
 
@@ -802,7 +802,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return { modified: false };
   }
 
-  #applySetChildKeyRemote(newKey: Pos, child: LiveNode): ApplyResult {
+  #applyRemoteSetChildKey(newKey: Pos, child: LiveNode): ApplyResult {
     if (this.#implicitlyDeletedItems.has(child)) {
       this.#implicitlyDeletedItems.delete(child);
 
@@ -950,7 +950,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
   }
 
-  #applySetChildKeyUndoRedo(
+  #applyLocalSetChildKey(
     newKey: Pos,
     child: LiveNode,
     source: UpdateSource
@@ -1000,11 +1000,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   _setChildKey(newKey: Pos, child: LiveNode, opSource: OpSource): ApplyResult {
     const source = toUpdateSource(opSource);
     if (opSource.origin === "remote") {
-      return this.#applySetChildKeyRemote(newKey, child);
+      return this.#applyRemoteSetChildKey(newKey, child);
     } else if (!opSource.optimistic) {
       return this.#applySetChildKeyAck(newKey, child, source);
     } else {
-      return this.#applySetChildKeyUndoRedo(newKey, child, source);
+      return this.#applyLocalSetChildKey(newKey, child, source);
     }
   }
 

--- a/packages/liveblocks-core/src/crdts/LiveList.ts
+++ b/packages/liveblocks-core/src/crdts/LiveList.ts
@@ -11,7 +11,7 @@ import { CrdtType } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
 import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
-import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
 import {
   creationOpToLiveNode,
   deserialize,
@@ -20,6 +20,8 @@ import {
 } from "./liveblocks-helpers";
 import { LiveRegister } from "./LiveRegister";
 import type { LiveNode, Lson, ToJson } from "./Lson";
+import type { OpSource, UpdateSource } from "./StorageUpdates";
+import { LOCAL_EDIT, REMOTE, toUpdateSource } from "./StorageUpdates";
 
 export type LiveListUpdateDelta =
   | { type: "insert"; index: number; item: Lson }
@@ -35,6 +37,7 @@ export type LiveListUpdates<TItem extends Lson> = {
   type: "LiveList";
   node: LiveList<TItem>;
   updates: LiveListUpdateDelta[];
+  source: UpdateSource;
 };
 
 function childNodeLt(a: LiveNode, b: LiveNode): boolean {
@@ -240,9 +243,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         this.#items.add(child);
 
         return {
-          modified: makeUpdate(this, [
-            setDelta(indexOfItemWithSamePosition, child),
-          ]),
+          modified: makeUpdate(
+            this,
+            [setDelta(indexOfItemWithSamePosition, child)],
+            REMOTE
+          ),
           reverse: [],
         };
       } else {
@@ -263,7 +268,8 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         // Even if we implicitly delete the item at the set position
         // We still need to delete the item that was orginaly deleted by the set
         const deleteDelta = this.#detachItemAssociatedToSetOperation(
-          op.deletedId
+          op.deletedId,
+          REMOTE
         );
 
         if (deleteDelta) {
@@ -271,7 +277,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         }
 
         return {
-          modified: makeUpdate(this, delta),
+          modified: makeUpdate(this, delta, REMOTE),
           reverse: [],
         };
       }
@@ -279,7 +285,8 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       // Item at position to be replaced doesn't exist
       const updates: LiveListUpdateDelta[] = [];
       const deleteDelta = this.#detachItemAssociatedToSetOperation(
-        op.deletedId
+        op.deletedId,
+        REMOTE
       );
       if (deleteDelta) {
         updates.push(deleteDelta);
@@ -291,12 +298,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
       return {
         reverse: [],
-        modified: makeUpdate(this, updates),
+        modified: makeUpdate(this, updates, REMOTE),
       };
     }
   }
 
-  #applySetAck(op: CreateOp): ApplyResult {
+  #applySetAck(op: CreateOp, source: UpdateSource): ApplyResult {
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -304,7 +311,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const delta: LiveListUpdateDelta[] = [];
 
     // Deleted item can be re-inserted by remote undo/redo
-    const deletedDelta = this.#detachItemAssociatedToSetOperation(op.deletedId);
+    const deletedDelta = this.#detachItemAssociatedToSetOperation(
+      op.deletedId,
+      source
+    );
     if (deletedDelta) {
       delta.push(deletedDelta);
     }
@@ -321,7 +331,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     if (unacknowledgedOpId !== undefined && unacknowledgedOpId !== op.opId) {
       return delta.length === 0
         ? { modified: false }
-        : { modified: makeUpdate(this, delta), reverse: [] };
+        : { modified: makeUpdate(this, delta, source), reverse: [] };
     }
 
     const indexOfItemWithSamePosition = this._indexOfPosition(op.parentKey);
@@ -334,7 +344,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       if (existingItem._parentKey === op.parentKey) {
         // ... do nothing
         return {
-          modified: delta.length > 0 ? makeUpdate(this, delta) : false,
+          modified: delta.length > 0 ? makeUpdate(this, delta, source) : false,
           reverse: [],
         };
       }
@@ -356,7 +366,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       }
 
       return {
-        modified: delta.length > 0 ? makeUpdate(this, delta) : false,
+        modified: delta.length > 0 ? makeUpdate(this, delta, source) : false,
         reverse: [],
       };
     } else {
@@ -370,13 +380,17 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
         const recreatedItemIndex = this.#insert(orphan);
         return {
-          modified: makeUpdate(this, [
-            // If there is an item at this position, update is a set, else it's an insert
-            indexOfItemWithSamePosition === -1
-              ? insertDelta(recreatedItemIndex, orphan)
-              : setDelta(recreatedItemIndex, orphan),
-            ...delta,
-          ]),
+          modified: makeUpdate(
+            this,
+            [
+              // If there is an item at this position, update is a set, else it's an insert
+              indexOfItemWithSamePosition === -1
+                ? insertDelta(recreatedItemIndex, orphan)
+                : setDelta(recreatedItemIndex, orphan),
+              ...delta,
+            ],
+            source
+          ),
           reverse: [],
         };
       } else {
@@ -393,13 +407,17 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         );
 
         return {
-          modified: makeUpdate(this, [
-            // If there is an item at this position, update is a set, else it's an insert
-            indexOfItemWithSamePosition === -1
-              ? insertDelta(newIndex, newItem)
-              : setDelta(newIndex, newItem),
-            ...delta,
-          ]),
+          modified: makeUpdate(
+            this,
+            [
+              // If there is an item at this position, update is a set, else it's an insert
+              indexOfItemWithSamePosition === -1
+                ? insertDelta(newIndex, newItem)
+                : setDelta(newIndex, newItem),
+              ...delta,
+            ],
+            source
+          ),
           reverse: [],
         };
       }
@@ -410,7 +428,8 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
    * Returns the update delta of the deletion or null
    */
   #detachItemAssociatedToSetOperation(
-    deletedId?: string
+    deletedId: string | undefined,
+    source: UpdateSource
   ): LiveListUpdateDelta | null {
     if (deletedId === undefined || this._pool === undefined) {
       return null;
@@ -421,7 +440,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       return null;
     }
 
-    const result = this._detachChild(deletedItem);
+    const result = this._detachChild(deletedItem, source);
     if (result.modified === false) {
       return null;
     }
@@ -459,10 +478,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const bumpDeltas = this.#bumpUnackedPushesAbove(key);
 
     return {
-      modified: makeUpdate(this, [
-        insertDelta(newIndex, newItem),
-        ...bumpDeltas,
-      ]),
+      modified: makeUpdate(
+        this,
+        [insertDelta(newIndex, newItem), ...bumpDeltas],
+        REMOTE
+      ),
       reverse: [],
     };
   }
@@ -554,7 +574,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     return deltas;
   }
 
-  #applyInsertAck(op: CreateOp): ApplyResult {
+  #applyInsertAck(op: CreateOp, source: UpdateSource): ApplyResult {
     const existingItem = this.#items.find((item) => item._id === op.id);
     const key = asPos(op.parentKey);
 
@@ -583,9 +603,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         }
 
         return {
-          modified: makeUpdate(this, [
-            moveDelta(oldPositionIndex, newIndex, existingItem),
-          ]),
+          modified: makeUpdate(
+            this,
+            [moveDelta(oldPositionIndex, newIndex, existingItem)],
+            source
+          ),
           reverse: [],
         };
       }
@@ -601,7 +623,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         const newIndex = this._indexOfPosition(key);
 
         return {
-          modified: makeUpdate(this, [insertDelta(newIndex, orphan)]),
+          modified: makeUpdate(this, [insertDelta(newIndex, orphan)], source),
           reverse: [],
         };
       } else {
@@ -612,14 +634,14 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         const { newItem, newIndex } = this.#createAttachItemAndSort(op, key);
 
         return {
-          modified: makeUpdate(this, [insertDelta(newIndex, newItem)]),
+          modified: makeUpdate(this, [insertDelta(newIndex, newItem)], source),
           reverse: [],
         };
       }
     }
   }
 
-  #applyInsertUndoRedo(op: CreateOp): ApplyResult {
+  #applyInsertUndoRedo(op: CreateOp, source: UpdateSource): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
@@ -647,12 +669,12 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     const newIndex = this._indexOfPosition(newKey);
 
     return {
-      modified: makeUpdate(this, [insertDelta(newIndex, child)]),
+      modified: makeUpdate(this, [insertDelta(newIndex, child)], source),
       reverse: [{ type: OpCode.DELETE_CRDT, id }],
     };
   }
 
-  #applySetUndoRedo(op: CreateOp): ApplyResult {
+  #applySetUndoRedo(op: CreateOp, source: UpdateSource): ApplyResult {
     const { id, parentKey: key } = op;
     const child = creationOpToLiveNode(op);
 
@@ -684,33 +706,35 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
       const delta = [setDelta(indexOfItemWithSameKey, child)];
       const deletedDelta = this.#detachItemAssociatedToSetOperation(
-        op.deletedId
+        op.deletedId,
+        source
       );
       if (deletedDelta) {
         delta.push(deletedDelta);
       }
 
       return {
-        modified: makeUpdate(this, delta),
+        modified: makeUpdate(this, delta, source),
         reverse,
       };
     } else {
       this.#insert(child);
 
       // TODO: Use delta
-      this.#detachItemAssociatedToSetOperation(op.deletedId);
+      this.#detachItemAssociatedToSetOperation(op.deletedId, source);
 
       const newIndex = this._indexOfPosition(newKey);
 
       return {
         reverse: [{ type: OpCode.DELETE_CRDT, id }],
-        modified: makeUpdate(this, [insertDelta(newIndex, child)]),
+        modified: makeUpdate(this, [insertDelta(newIndex, child)], source),
       };
     }
   }
 
   /** @internal */
-  _attachChild(op: CreateOp, source: OpSource): ApplyResult {
+  _attachChild(op: CreateOp, opSource: OpSource): ApplyResult {
+    const source = toUpdateSource(opSource);
     if (this._pool === undefined) {
       throw new Error("Can't attach child if managed pool is not present");
     }
@@ -718,20 +742,20 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     let result: ApplyResult;
 
     if (op.intent === "set") {
-      if (source === OpSource.THEIRS) {
+      if (opSource.origin === "remote") {
         result = this.#applySetRemote(op);
-      } else if (source === OpSource.OURS) {
-        result = this.#applySetAck(op);
+      } else if (!opSource.optimistic) {
+        result = this.#applySetAck(op, source);
       } else {
-        result = this.#applySetUndoRedo(op);
+        result = this.#applySetUndoRedo(op, source);
       }
     } else {
-      if (source === OpSource.THEIRS) {
+      if (opSource.origin === "remote") {
         result = this.#applyRemoteInsert(op);
-      } else if (source === OpSource.OURS) {
-        result = this.#applyInsertAck(op);
+      } else if (!opSource.optimistic) {
+        result = this.#applyInsertAck(op, source);
       } else {
-        result = this.#applyInsertUndoRedo(op);
+        result = this.#applyInsertUndoRedo(op, source);
       }
     }
 
@@ -744,7 +768,8 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
   /** @internal */
   _detachChild(
-    child: LiveNode
+    child: LiveNode,
+    source: UpdateSource
   ): { reverse: Op[]; modified: LiveListUpdates<TItem> } | { modified: false } {
     if (child) {
       const parentKey = nn(child._parentKey);
@@ -765,7 +790,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       child._detach();
 
       return {
-        modified: makeUpdate(this, [deleteDelta(indexToDelete, previousNode)]),
+        modified: makeUpdate(
+          this,
+          [deleteDelta(indexToDelete, previousNode)],
+          source
+        ),
         reverse,
       };
     }
@@ -782,7 +811,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
       // TODO: Shift existing item?
       return {
-        modified: makeUpdate(this, [insertDelta(newIndex, child)]),
+        modified: makeUpdate(this, [insertDelta(newIndex, child)], REMOTE),
         reverse: [],
       };
     }
@@ -811,7 +840,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       }
 
       return {
-        modified: makeUpdate(this, [moveDelta(previousIndex, newIndex, child)]),
+        modified: makeUpdate(
+          this,
+          [moveDelta(previousIndex, newIndex, child)],
+          REMOTE
+        ),
         reverse: [],
       };
     } else {
@@ -831,13 +864,21 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       }
 
       return {
-        modified: makeUpdate(this, [moveDelta(previousIndex, newIndex, child)]),
+        modified: makeUpdate(
+          this,
+          [moveDelta(previousIndex, newIndex, child)],
+          REMOTE
+        ),
         reverse: [],
       };
     }
   }
 
-  #applySetChildKeyAck(newKey: Pos, child: LiveNode): ApplyResult {
+  #applySetChildKeyAck(
+    newKey: Pos,
+    child: LiveNode,
+    source: UpdateSource
+  ): ApplyResult {
     const previousKey = nn(child._parentKey);
 
     if (this.#implicitlyDeletedItems.has(child)) {
@@ -860,7 +901,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       child._setParentLink(this, newKey);
       const newIndex = this.#insert(child);
       return {
-        modified: makeUpdate(this, [insertDelta(newIndex, child)]),
+        modified: makeUpdate(this, [insertDelta(newIndex, child)], source),
         reverse: [],
       };
     } else {
@@ -898,16 +939,22 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         };
       } else {
         return {
-          modified: makeUpdate(this, [
-            moveDelta(previousIndex, newIndex, child),
-          ]),
+          modified: makeUpdate(
+            this,
+            [moveDelta(previousIndex, newIndex, child)],
+            source
+          ),
           reverse: [],
         };
       }
     }
   }
 
-  #applySetChildKeyUndoRedo(newKey: Pos, child: LiveNode): ApplyResult {
+  #applySetChildKeyUndoRedo(
+    newKey: Pos,
+    child: LiveNode,
+    source: UpdateSource
+  ): ApplyResult {
     const previousKey = nn(child._parentKey);
 
     const previousIndex = this.#items.findIndex((item) => item === child);
@@ -934,7 +981,11 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
     }
 
     return {
-      modified: makeUpdate(this, [moveDelta(previousIndex, newIndex, child)]),
+      modified: makeUpdate(
+        this,
+        [moveDelta(previousIndex, newIndex, child)],
+        source
+      ),
       reverse: [
         {
           type: OpCode.SET_PARENT_KEY,
@@ -946,13 +997,14 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
   }
 
   /** @internal */
-  _setChildKey(newKey: Pos, child: LiveNode, source: OpSource): ApplyResult {
-    if (source === OpSource.THEIRS) {
+  _setChildKey(newKey: Pos, child: LiveNode, opSource: OpSource): ApplyResult {
+    const source = toUpdateSource(opSource);
+    if (opSource.origin === "remote") {
       return this.#applySetChildKeyRemote(newKey, child);
-    } else if (source === OpSource.OURS) {
-      return this.#applySetChildKeyAck(newKey, child);
+    } else if (!opSource.optimistic) {
+      return this.#applySetChildKeyAck(newKey, child, source);
     } else {
-      return this.#applySetChildKeyUndoRedo(newKey, child);
+      return this.#applySetChildKeyUndoRedo(newKey, child, source);
     }
   }
 
@@ -1031,7 +1083,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         intent === "push" ? addIntentToRootOp(ops, "push") : ops,
         [{ type: OpCode.DELETE_CRDT, id }],
         new Map<string, LiveListUpdates<TItem>>([
-          [this._id, makeUpdate(this, [insertDelta(index, value)])],
+          [this._id, makeUpdate(this, [insertDelta(index, value)], LOCAL_EDIT)],
         ])
       );
     }
@@ -1087,7 +1139,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
     if (this._pool && this._id) {
       const storageUpdates = new Map<string, LiveListUpdates<TItem>>([
-        [this._id, makeUpdate(this, [moveDelta(index, targetIndex, item)])],
+        [
+          this._id,
+          makeUpdate(this, [moveDelta(index, targetIndex, item)], LOCAL_EDIT),
+        ],
       ]);
 
       this._pool.dispatch(
@@ -1136,7 +1191,7 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
         const storageUpdates = new Map<string, LiveListUpdates<TItem>>();
         storageUpdates.set(
           nn(this._id),
-          makeUpdate(this, [deleteDelta(index, item)])
+          makeUpdate(this, [deleteDelta(index, item)], LOCAL_EDIT)
         );
 
         this._pool.dispatch(
@@ -1185,7 +1240,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       this.invalidate();
 
       const storageUpdates = new Map<string, LiveListUpdates<TItem>>();
-      storageUpdates.set(nn(this._id), makeUpdate(this, updateDelta));
+      storageUpdates.set(
+        nn(this._id),
+        makeUpdate(this, updateDelta, LOCAL_EDIT)
+      );
 
       this._pool.dispatch(ops, reverseOps, storageUpdates);
     } else {
@@ -1224,7 +1282,10 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
       value._attach(id, this._pool);
 
       const storageUpdates = new Map<string, LiveListUpdates<TItem>>();
-      storageUpdates.set(this._id, makeUpdate(this, [setDelta(index, value)]));
+      storageUpdates.set(
+        this._id,
+        makeUpdate(this, [setDelta(index, value)], LOCAL_EDIT)
+      );
 
       const ops = addIntentToRootOp(
         value._toOpsWithOpId(this._id, position, this._pool),
@@ -1436,12 +1497,14 @@ export class LiveList<TItem extends Lson> extends AbstractCrdt {
 
 function makeUpdate<TItem extends Lson>(
   liveList: LiveList<TItem>,
-  deltaUpdates: LiveListUpdateDelta[]
+  deltaUpdates: LiveListUpdateDelta[],
+  source: UpdateSource
 ): LiveListUpdates<TItem> {
   return {
     node: liveList,
     type: "LiveList",
     updates: deltaUpdates,
+    source,
   };
 }
 

--- a/packages/liveblocks-core/src/crdts/LiveMap.ts
+++ b/packages/liveblocks-core/src/crdts/LiveMap.ts
@@ -8,7 +8,7 @@ import { CrdtType } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
 import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
-import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
 import {
   creationOpToLiveNode,
   deserialize,
@@ -17,6 +17,8 @@ import {
   lsonToLiveNode,
 } from "./liveblocks-helpers";
 import type { LiveNode, Lson, ToJson } from "./Lson";
+import type { OpSource, UpdateSource } from "./StorageUpdates";
+import { LOCAL_EDIT, toUpdateSource } from "./StorageUpdates";
 import type { UpdateDelta } from "./UpdateDelta";
 
 /**
@@ -30,6 +32,7 @@ export type LiveMapUpdates<TKey extends string, TValue extends Lson> = {
   //               ^^^^^^
   //               FIXME: `string` is not specific enough here. See if we can
   //               improve this type to match TKey!
+  source: UpdateSource;
 };
 
 /**
@@ -139,7 +142,12 @@ export class LiveMap<
       return { modified: false };
     }
 
-    if (source === OpSource.OURS) {
+    if (source.origin === "remote") {
+      // If a remote operation set an item,
+      // delete the unacknowledgedSet associated to the key
+      // to make sure any future ack can override it
+      this.#unacknowledgedSet.delete(key);
+    } else if (!source.optimistic) {
       const lastUpdateOpId = this.#unacknowledgedSet.get(key);
       if (lastUpdateOpId === opId) {
         // Acknowlegment from local operation
@@ -149,11 +157,6 @@ export class LiveMap<
         // Another local set has overriden the value, so we do nothing
         return { modified: false };
       }
-    } else if (source === OpSource.THEIRS) {
-      // If a remote operation set an item,
-      // delete the unacknowledgedSet associated to the key
-      // to make sure any future ack can override it
-      this.#unacknowledgedSet.delete(key);
     }
 
     const previousValue = this.#map.get(key);
@@ -176,6 +179,7 @@ export class LiveMap<
         node: this,
         type: "LiveMap",
         updates: { [key]: { type: "update" } },
+        source: toUpdateSource(source),
       },
       reverse,
     };
@@ -191,7 +195,7 @@ export class LiveMap<
   }
 
   /** @internal */
-  _detachChild(child: LiveNode): ApplyResult {
+  _detachChild(child: LiveNode, source: UpdateSource): ApplyResult {
     const id = nn(this._id);
     const parentKey = nn(child._parentKey);
     const reverse = child._toOps(id, parentKey);
@@ -214,6 +218,7 @@ export class LiveMap<
           deletedItem: liveNodeToLson(child),
         },
       },
+      source,
     };
 
     return { modified: storageUpdate, reverse };
@@ -275,6 +280,7 @@ export class LiveMap<
         node: this,
         type: "LiveMap",
         updates: { [key]: { type: "update" } },
+        source: LOCAL_EDIT,
       });
 
       const ops = item._toOpsWithOpId(this._id, key, this._pool);
@@ -335,6 +341,7 @@ export class LiveMap<
             deletedItem: liveNodeToLson(item),
           },
         },
+        source: LOCAL_EDIT,
       });
       this._pool.dispatch(
         [

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -27,7 +27,7 @@ import type * as DevTools from "../types/DevToolsTreeNode";
 import type { KnownKeys } from "../types/KnownKeys";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
 import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
-import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
 import {
   creationOpToLson,
   deserializeToLson,
@@ -37,6 +37,8 @@ import {
 } from "./liveblocks-helpers";
 import type { SyncConfig } from "./reconcile";
 import { reconcileLiveObject } from "./reconcile";
+import type { OpSource, UpdateSource } from "./StorageUpdates";
+import { LOCAL_EDIT, toUpdateSource } from "./StorageUpdates";
 import type { UpdateDelta } from "./UpdateDelta";
 
 /**
@@ -70,6 +72,7 @@ export type LiveObjectUpdates<TData extends LsonObject> = {
   type: "LiveObject";
   node: LiveObject<TData>;
   updates: LiveObjectUpdateDelta<TData>;
+  source: UpdateSource;
 };
 
 /**
@@ -258,7 +261,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       return { modified: false };
     }
 
-    if (source === OpSource.LOCAL) {
+    if (source.origin === "local" && source.optimistic) {
       // Track locally-generated opId to preserve optimistic update
       this.#unackedOpsByKey.set(key, nn(opId));
     } else if (this.#unackedOpsByKey.get(key) === undefined) {
@@ -305,12 +308,13 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
         node: this,
         type: "LiveObject",
         updates: { [key]: { type: "update" } },
+        source: toUpdateSource(source),
       },
     };
   }
 
   /** @internal */
-  _detachChild(child: LiveNode): ApplyResult {
+  _detachChild(child: LiveNode, source: UpdateSource): ApplyResult {
     if (child) {
       const id = nn(this._id);
       const parentKey = nn(child._parentKey);
@@ -332,6 +336,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
         updates: {
           [parentKey]: { type: "delete", deletedItem },
         } as { [K in keyof O]: UpdateDelta },
+        source,
       };
 
       return { modified: storageUpdate, reverse };
@@ -420,7 +425,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
         continue;
       }
 
-      if (source === OpSource.LOCAL) {
+      if (source.origin === "local" && source.optimistic) {
         // Track locally-generated opId to preserve optimistic update
         this.#unackedOpsByKey.set(key, nn(op.opId));
       } else if (this.#unackedOpsByKey.get(key) === undefined) {
@@ -458,6 +463,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
             node: this,
             type: "LiveObject",
             updates: updateDelta,
+            source: toUpdateSource(source),
           },
           reverse,
         }
@@ -476,7 +482,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     // If a local operation exists on the same key and we receive a remote
     // one prevent flickering by not applying delete op.
     if (
-      source !== OpSource.LOCAL &&
+      !(source.origin === "local" && source.optimistic) &&
       this.#unackedOpsByKey.get(key) !== undefined
     ) {
       return { modified: false };
@@ -507,6 +513,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
         updates: {
           [op.key]: { type: "delete", deletedItem: oldValue satisfies Lson },
         },
+        source: toUpdateSource(source),
       },
       reverse,
     };
@@ -568,6 +575,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
           ...existing?.updates,
           [key]: { type: "update" } satisfies UpdateDelta,
         } as { [K in keyof O]: UpdateDelta },
+        source: LOCAL_EDIT,
       });
 
       this._pool.dispatch(ops, reverse, storageUpdates);
@@ -622,6 +630,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
               deletedItem: oldValue,
             } satisfies UpdateDelta,
           } as { [K in keyof O]: UpdateDelta },
+          source: LOCAL_EDIT,
         });
         return [[], [], storageUpdates];
       }
@@ -680,6 +689,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       } as {
         [K in keyof O]: UpdateDelta;
       },
+      source: LOCAL_EDIT,
     });
 
     return [ops, reverse, storageUpdates];
@@ -857,6 +867,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       node: this,
       type: "LiveObject",
       updates: updateDelta,
+      source: LOCAL_EDIT,
     });
     this._pool.dispatch(ops, reverseOps, storageUpdates);
   }

--- a/packages/liveblocks-core/src/crdts/LiveObject.ts
+++ b/packages/liveblocks-core/src/crdts/LiveObject.ts
@@ -352,14 +352,14 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, isLocal: boolean): ApplyResult {
+  _apply(op: Op, source: OpSource): ApplyResult {
     if (op.type === OpCode.UPDATE_OBJECT) {
-      return this.#applyUpdate(op, isLocal);
+      return this.#applyUpdate(op, source);
     } else if (op.type === OpCode.DELETE_OBJECT_KEY) {
-      return this.#applyDeleteObjectKey(op, isLocal);
+      return this.#applyDeleteObjectKey(op, source);
     }
 
-    return super._apply(op, isLocal);
+    return super._apply(op, source);
   }
 
   /** @internal */
@@ -389,7 +389,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
     }
   }
 
-  #applyUpdate(op: UpdateObjectOp, isLocal: boolean): ApplyResult {
+  #applyUpdate(op: UpdateObjectOp, source: OpSource): ApplyResult {
     let isModified = false;
     const id = nn(this._id);
     const reverse: Op[] = [];
@@ -420,7 +420,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
         continue;
       }
 
-      if (isLocal) {
+      if (source === OpSource.LOCAL) {
         // Track locally-generated opId to preserve optimistic update
         this.#unackedOpsByKey.set(key, nn(op.opId));
       } else if (this.#unackedOpsByKey.get(key) === undefined) {
@@ -464,7 +464,7 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
       : { modified: false };
   }
 
-  #applyDeleteObjectKey(op: DeleteObjectKeyOp, isLocal: boolean): ApplyResult {
+  #applyDeleteObjectKey(op: DeleteObjectKeyOp, source: OpSource): ApplyResult {
     const key = op.key;
 
     // If property does not exist, exit without notifying
@@ -475,7 +475,10 @@ export class LiveObject<O extends LsonObject> extends AbstractCrdt {
 
     // If a local operation exists on the same key and we receive a remote
     // one prevent flickering by not applying delete op.
-    if (!isLocal && this.#unackedOpsByKey.get(key) !== undefined) {
+    if (
+      source !== OpSource.LOCAL &&
+      this.#unackedOpsByKey.get(key) !== undefined
+    ) {
       return { modified: false };
     }
 

--- a/packages/liveblocks-core/src/crdts/LiveRegister.ts
+++ b/packages/liveblocks-core/src/crdts/LiveRegister.ts
@@ -12,7 +12,7 @@ import type {
 import { CrdtType } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
-import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
+import type { ApplyResult, ManagedPool, OpSource } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
 
 /**
@@ -85,8 +85,8 @@ export class LiveRegister<TValue extends Json> extends AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, isLocal: boolean): ApplyResult {
-    return super._apply(op, isLocal);
+  _apply(op: Op, source: OpSource): ApplyResult {
+    return super._apply(op, source);
   }
 
   /** @internal */

--- a/packages/liveblocks-core/src/crdts/LiveRegister.ts
+++ b/packages/liveblocks-core/src/crdts/LiveRegister.ts
@@ -12,8 +12,9 @@ import type {
 import { CrdtType } from "../protocol/StorageNode";
 import type * as DevTools from "../types/DevToolsTreeNode";
 import type { ParentToChildNodeMap } from "../types/NodeMap";
-import type { ApplyResult, ManagedPool, OpSource } from "./AbstractCrdt";
+import type { ApplyResult, ManagedPool } from "./AbstractCrdt";
 import { AbstractCrdt } from "./AbstractCrdt";
+import type { OpSource } from "./StorageUpdates";
 
 /**
  * INTERNAL

--- a/packages/liveblocks-core/src/crdts/LiveText.ts
+++ b/packages/liveblocks-core/src/crdts/LiveText.ts
@@ -23,7 +23,7 @@ import type {
   ManagedPool,
   PrivateLiveNodeApi,
 } from "./AbstractCrdt";
-import { AbstractCrdt, OpSource } from "./AbstractCrdt";
+import { AbstractCrdt } from "./AbstractCrdt";
 import {
   applyDelete,
   applyFormat,
@@ -42,7 +42,8 @@ import {
   transformTextOperationsX,
 } from "./liveTextOps";
 import type { LiveNode } from "./Lson";
-import type { StorageUpdate } from "./StorageUpdates";
+import type { OpSource, StorageUpdate, UpdateSource } from "./StorageUpdates";
+import { LOCAL_EDIT, toUpdateSource } from "./StorageUpdates";
 
 export type LiveTextAttributes = TextAttributes;
 export type LiveTextAttributesPatch = JsonObject;
@@ -81,6 +82,7 @@ export type LiveTextUpdates = {
   node: LiveText;
   version: number;
   updates: LiveTextChange[];
+  source: UpdateSource;
 };
 
 /**
@@ -289,12 +291,12 @@ export class LiveText extends AbstractCrdt {
       return super._apply(op, source);
     }
 
-    if (source === OpSource.LOCAL) {
-      return this.#applyLocal(op);
+    if (source.origin === "local" && source.optimistic) {
+      return this.#applyLocal(op, toUpdateSource(source));
     }
 
     if (op.opId !== undefined && op.opId === this.#inFlightOpId) {
-      return this.#applyAck(op);
+      return this.#applyAck(op, toUpdateSource(source));
     }
 
     if (
@@ -306,7 +308,7 @@ export class LiveText extends AbstractCrdt {
       return { modified: false };
     }
 
-    return this.#applyRemote(op);
+    return this.#applyRemote(op, toUpdateSource(source));
   }
 
   /**
@@ -497,6 +499,7 @@ export class LiveText extends AbstractCrdt {
           node: this,
           version: this.#version,
           updates: changes,
+          source: LOCAL_EDIT,
         },
       ],
     ]);
@@ -532,7 +535,7 @@ export class LiveText extends AbstractCrdt {
    * A local replay of an existing wire op: an undo/redo frame, or an
    * unacknowledged op re-sent after a reconnect.
    */
-  #applyLocal(op: UpdateTextOp): ApplyResult {
+  #applyLocal(op: UpdateTextOp, source: UpdateSource): ApplyResult {
     const mutableOp = op as { baseVersion: number; ops: TextOperation[] };
 
     // Re-sent offline op (reconnect): its content is already applied
@@ -587,12 +590,13 @@ export class LiveText extends AbstractCrdt {
         node: this,
         version: this.#version,
         updates: changes,
+        source,
       },
     };
   }
 
   /** Server acknowledgement of our in-flight op. */
-  #applyAck(op: UpdateTextOp): ApplyResult {
+  #applyAck(op: UpdateTextOp, source: UpdateSource): ApplyResult {
     const ackedVersion =
       op.version ?? Math.max(this.#version, op.baseVersion + 1);
     const predicted = this.#inFlightOps;
@@ -623,6 +627,7 @@ export class LiveText extends AbstractCrdt {
             node: this,
             version: ackedVersion,
             updates: rebuilt.changes,
+            source,
           },
         };
       }
@@ -635,7 +640,7 @@ export class LiveText extends AbstractCrdt {
   }
 
   /** An accepted op from another client (or a server-fabricated fix op). */
-  #applyRemote(op: UpdateTextOp): ApplyResult {
+  #applyRemote(op: UpdateTextOp, source: UpdateSource): ApplyResult {
     const version = op.version ?? this.#version + 1;
 
     // Advance the confirmed state with the authoritative ops as-is.
@@ -674,6 +679,7 @@ export class LiveText extends AbstractCrdt {
         node: this,
         version: this.#version,
         updates: changes,
+        source,
       },
     };
   }
@@ -776,7 +782,8 @@ export class LiveText extends AbstractCrdt {
    */
   _resyncText(
     data: LiveTextData,
-    version: number
+    version: number,
+    source: UpdateSource
   ): LiveTextUpdates | undefined {
     this.#confirmed = dataToSegments(data);
     this.#version = version;
@@ -794,6 +801,7 @@ export class LiveText extends AbstractCrdt {
       node: this,
       version: this.#version,
       updates: rebuilt.changes,
+      source,
     };
   }
 

--- a/packages/liveblocks-core/src/crdts/LiveText.ts
+++ b/packages/liveblocks-core/src/crdts/LiveText.ts
@@ -23,7 +23,7 @@ import type {
   ManagedPool,
   PrivateLiveNodeApi,
 } from "./AbstractCrdt";
-import { AbstractCrdt } from "./AbstractCrdt";
+import { AbstractCrdt, OpSource } from "./AbstractCrdt";
 import {
   applyDelete,
   applyFormat,
@@ -284,12 +284,12 @@ export class LiveText extends AbstractCrdt {
   }
 
   /** @internal */
-  _apply(op: Op, isLocal: boolean): ApplyResult {
+  _apply(op: Op, source: OpSource): ApplyResult {
     if (op.type !== OpCode.UPDATE_TEXT) {
-      return super._apply(op, isLocal);
+      return super._apply(op, source);
     }
 
-    if (isLocal) {
+    if (source === OpSource.LOCAL) {
       return this.#applyLocal(op);
     }
 

--- a/packages/liveblocks-core/src/crdts/StorageUpdates.ts
+++ b/packages/liveblocks-core/src/crdts/StorageUpdates.ts
@@ -3,7 +3,6 @@ import type { LiveMapUpdates } from "../crdts/LiveMap";
 import type { LiveObjectUpdates } from "../crdts/LiveObject";
 import type { LiveTextUpdates } from "../crdts/LiveText";
 import type { Lson, LsonObject } from "../crdts/Lson";
-import type { kStorageUpdateSource } from "../internal";
 
 export type StorageCallback = (updates: StorageUpdate[]) => void;
 
@@ -23,7 +22,7 @@ export type StorageUpdateSource =
  * in-client.
  *
  * Updates delivered through `room.subscribe` may carry
- * `[kStorageUpdateSource]` to distinguish where a mutation came from.
+ * `source` to distinguish where a mutation came from.
  * Undo/redo replays use `via: "history"` with `action: "undo" | "redo"`.
  */
 export type StorageUpdate = (
@@ -32,5 +31,5 @@ export type StorageUpdate = (
   | LiveListUpdate
   | LiveTextUpdate
 ) & {
-  [kStorageUpdateSource]?: StorageUpdateSource;
+  source?: StorageUpdateSource;
 };

--- a/packages/liveblocks-core/src/crdts/StorageUpdates.ts
+++ b/packages/liveblocks-core/src/crdts/StorageUpdates.ts
@@ -11,10 +11,17 @@ export type LiveObjectUpdate = LiveObjectUpdates<LsonObject>;
 export type LiveListUpdate = LiveListUpdates<Lson>;
 export type LiveTextUpdate = LiveTextUpdates;
 
+/**
+ * Where a Storage update came from.
+ *
+ * Updates with `origin: "remote"` were made by another client (or by the
+ * server), and reached this client over the network. Updates with
+ * `origin: "local"` were made by this client, and `via` says how: a regular
+ * edit, or a replay from the undo/redo history.
+ */
 export type StorageUpdateSource =
   | { origin: "remote" }
-  | { origin: "local"; via: "edit" }
-  | { origin: "local"; via: "history"; action: "undo" | "redo" };
+  | { origin: "local"; via: "edit" | "undo" | "redo" };
 
 /**
  * The payload of notifications sent (in-client) when LiveStructures change.
@@ -23,7 +30,7 @@ export type StorageUpdateSource =
  *
  * Updates delivered through `room.subscribe` may carry
  * `source` to distinguish where a mutation came from.
- * Undo/redo replays use `via: "history"` with `action: "undo" | "redo"`.
+ * Undo/redo replays use `via: "undo"` or `via: "redo"`.
  */
 export type StorageUpdate = (
   | LiveMapUpdate

--- a/packages/liveblocks-core/src/crdts/StorageUpdates.ts
+++ b/packages/liveblocks-core/src/crdts/StorageUpdates.ts
@@ -57,12 +57,10 @@ export type UpdateSource =
   | { origin: "remote" }
   | { origin: "local"; via: Via };
 
-export const LOCAL_EDIT = freeze({
-  origin: "local",
-  via: "edit",
-}) satisfies UpdateSource;
-
 export const REMOTE = freeze({ origin: "remote" }) satisfies UpdateSource;
+export const LOCAL_EDIT = freeze({ origin: "local", via: "edit" }) satisfies UpdateSource; // prettier-ignore
+export const LOCAL_UNDO = freeze({ origin: "local", via: "undo" }) satisfies UpdateSource; // prettier-ignore
+export const LOCAL_REDO = freeze({ origin: "local", via: "redo" }) satisfies UpdateSource; // prettier-ignore
 
 /** Narrows an {@link OpSource} down to what subscribers may see. */
 export function toUpdateSource(source: OpSource | UpdateSource): UpdateSource {

--- a/packages/liveblocks-core/src/crdts/StorageUpdates.ts
+++ b/packages/liveblocks-core/src/crdts/StorageUpdates.ts
@@ -3,6 +3,7 @@ import type { LiveMapUpdates } from "../crdts/LiveMap";
 import type { LiveObjectUpdates } from "../crdts/LiveObject";
 import type { LiveTextUpdates } from "../crdts/LiveText";
 import type { Lson, LsonObject } from "../crdts/Lson";
+import { freeze } from "../lib/freeze";
 
 export type StorageCallback = (updates: StorageUpdate[]) => void;
 
@@ -11,32 +12,76 @@ export type LiveObjectUpdate = LiveObjectUpdates<LsonObject>;
 export type LiveListUpdate = LiveListUpdates<Lson>;
 export type LiveTextUpdate = LiveTextUpdates;
 
+export type Via = "edit" | "undo" | "redo";
+
+/**
+ * type OpSource:
+ *   Internal type for the source of an Op. Has an extra `optimistic` field
+ *   that is not exposed publicly.
+ *
+ * type UpdateSource:
+ *   Public type for the source of an Op.
+ *
+ * When applying an op to a CRDT, we need to know where it came from to apply
+ * it correctly. The three cases are:
+ *
+ * - `{ origin: "local", optimistic: true }`: applied locally (an undo, redo, or
+ *   reconnect replay), not yet acknowledged by the server. Will be sent to the
+ *   server and needs to be tracked for conflict resolution.
+ *
+ * - `{ origin: "local", optimistic: false }`: received from the server, but
+ *   originated from THIS client. The server echoed it back to confirm.
+ *
+ * - `{ origin: "remote" }`: received from the server, originated from another
+ *   client. Apply it, unless there's a pending local op for the same key (local
+ *   ops take precedence until acknowledged). Note that a "fix Op" sent by the
+ *   server in response to a local mutation that caused a conflict is also
+ *   classified this way, as if another client resolved the conflict.
+ *
+ * @internal
+ */
+export type OpSource =
+  | { origin: "remote" }
+  | { origin: "local"; via: Via; optimistic: boolean };
+
 /**
  * Where a Storage update came from.
  *
- * Updates with `origin: "remote"` were made by another client (or by the
- * server), and reached this client over the network. Updates with
- * `origin: "local"` were made by this client, and `via` says how: a regular
- * edit, or a replay from the undo/redo history.
+ * Updates with `origin: "remote"` were made by another client, and reached
+ * this client over the network. Updates with `origin: "local"` were made by
+ * this client, and `via` says how: a regular edit, or a replay from the
+ * undo/redo history.
  */
-export type StorageUpdateSource =
+// prettier-ignore
+export type UpdateSource = 
   | { origin: "remote" }
-  | { origin: "local"; via: "edit" | "undo" | "redo" };
+  | { origin: "local"; via: Via };
+
+export const LOCAL_EDIT = freeze({
+  origin: "local",
+  via: "edit",
+}) satisfies UpdateSource;
+
+export const REMOTE = freeze({ origin: "remote" }) satisfies UpdateSource;
+
+/** Narrows an {@link OpSource} down to what subscribers may see. */
+export function toUpdateSource(source: OpSource | UpdateSource): UpdateSource {
+  return source.origin === "remote"
+    ? source
+    : // Removes `optimistic` field, which is not public
+      { origin: "local", via: source.via };
+}
 
 /**
  * The payload of notifications sent (in-client) when LiveStructures change.
  * Messages of this kind are not originating from the network, but are 100%
  * in-client.
  *
- * Updates delivered through `room.subscribe` may carry
- * `source` to distinguish where a mutation came from.
- * Undo/redo replays use `via: "undo"` or `via: "redo"`.
+ * Every update carries a `source`, saying where the change came from. See
+ * {@link UpdateSource}.
  */
-export type StorageUpdate = (
+export type StorageUpdate =
   | LiveMapUpdate
   | LiveObjectUpdate
   | LiveListUpdate
-  | LiveTextUpdate
-) & {
-  source?: StorageUpdateSource;
-};
+  | LiveTextUpdate;

--- a/packages/liveblocks-core/src/crdts/StorageUpdates.ts
+++ b/packages/liveblocks-core/src/crdts/StorageUpdates.ts
@@ -13,7 +13,7 @@ export type LiveTextUpdate = LiveTextUpdates;
 
 export type StorageUpdateSource =
   | { origin: "remote" }
-  | { origin: "local"; via: "mutation" }
+  | { origin: "local"; via: "edit" }
   | { origin: "local"; via: "history"; action: "undo" | "redo" };
 
 /**

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.devserver.test.ts
@@ -807,7 +807,7 @@ describe("LiveList", () => {
             { index: 1, item: "b", type: "insert" },
             { index: 2, item: "c", type: "insert" },
           ],
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.devserver.test.ts
@@ -17,7 +17,7 @@ import {
   listUpdateInsert,
   listUpdateMove,
 } from "../../__tests__/_updatesUtils";
-import { kInternal, kStorageUpdateSource } from "../../internal";
+import { kInternal } from "../../internal";
 import { LiveList } from "../LiveList";
 import { LiveMap } from "../LiveMap";
 import { LiveObject } from "../LiveObject";
@@ -807,7 +807,7 @@ describe("LiveList", () => {
             { index: 1, item: "b", type: "insert" },
             { index: 2, item: "c", type: "insert" },
           ],
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
@@ -606,7 +606,7 @@ describe("LiveList edge cases", () => {
           type: "LiveList",
           node: listItems,
           updates: [{ index: 2, item: "c", type: "insert" }],
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
       expect(listCallback).toHaveBeenCalledTimes(2);

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
@@ -761,13 +761,14 @@ describe("LiveList edge cases", () => {
       const items = root.get("items");
       const secondItem = items.get(1);
 
-      const applyResult = items._detachChild(secondItem!);
+      const applyResult = items._detachChild(secondItem!, { origin: "remote" });
 
       expect(applyResult).toEqual({
         modified: {
           type: "LiveList",
           node: items,
           updates: [{ index: 1, type: "delete", deletedItem: secondItem }],
+          source: { origin: "remote" },
         },
         reverse: [
           {

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveList.mockserver.test.ts
@@ -24,7 +24,7 @@ import {
   waitUntilStatus,
   waitUntilStorageUpdate,
 } from "../../__tests__/_waitUtils";
-import { kInternal, kStorageUpdateSource } from "../../internal";
+import { kInternal } from "../../internal";
 import type { ServerWireOp } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
 import { ServerMsgCode } from "../../protocol/ServerMsg";
@@ -598,7 +598,7 @@ describe("LiveList edge cases", () => {
           type: "LiveList",
           node: listItems,
           updates: [{ index: 1, item: "b", type: "insert" }],
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
       expect(rootDeepCallback).toHaveBeenCalledWith([
@@ -606,7 +606,7 @@ describe("LiveList edge cases", () => {
           type: "LiveList",
           node: listItems,
           updates: [{ index: 2, item: "c", type: "insert" }],
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
       expect(listCallback).toHaveBeenCalledTimes(2);
@@ -675,7 +675,7 @@ describe("LiveList edge cases", () => {
           type: "LiveList",
           node: listItems,
           updates: [{ index: 0, previousIndex: 1, item: "b", type: "move" }],
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
 
@@ -736,7 +736,7 @@ describe("LiveList edge cases", () => {
           type: "LiveList",
           node: listItems,
           updates: [{ index: 1, type: "delete", deletedItem: "b" }],
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
 
@@ -849,7 +849,7 @@ describe("LiveList edge cases", () => {
             node: items,
             type: "LiveList",
             updates: [{ type: "set", index: 0, item: "B" }],
-            [kStorageUpdateSource]: { origin: "remote" },
+            source: { origin: "remote" },
           },
         ]);
       });
@@ -930,7 +930,7 @@ describe("LiveList edge cases", () => {
             node: items,
             type: "LiveList",
             updates: [{ type: "insert", index: 0, item: "B" }],
-            [kStorageUpdateSource]: { origin: "remote" },
+            source: { origin: "remote" },
           },
         ]);
       });
@@ -977,7 +977,7 @@ describe("LiveList edge cases", () => {
             node: items,
             type: "LiveList",
             updates: [{ type: "insert", index: 0, item: "1" }],
-            [kStorageUpdateSource]: { origin: "remote" },
+            source: { origin: "remote" },
           },
         ]);
       });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveMap.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveMap.devserver.test.ts
@@ -637,7 +637,7 @@ describe("LiveMap", () => {
           type: "LiveObject",
           node: mapElement,
           updates: { a: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveMap.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveMap.devserver.test.ts
@@ -11,7 +11,7 @@ import {
   prepareStorageTest,
   replaceStorageAndReconnectDevServer,
 } from "../../__tests__/_devserver";
-import { kInternal, kStorageUpdateSource } from "../../internal";
+import { kInternal } from "../../internal";
 import { LiveList } from "../LiveList";
 import { LiveMap } from "../LiveMap";
 import { LiveObject } from "../LiveObject";
@@ -637,7 +637,7 @@ describe("LiveMap", () => {
           type: "LiveObject",
           node: mapElement,
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveMap.mockserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveMap.mockserver.test.ts
@@ -35,13 +35,14 @@ describe("LiveMap edge cases", () => {
       const map = root.get("map");
       const secondItem = map.get("el2");
 
-      const applyResult = map._detachChild(secondItem!);
+      const applyResult = map._detachChild(secondItem!, { origin: "remote" });
 
       expect(applyResult).toEqual({
         modified: {
           node: map,
           type: "LiveMap",
           updates: { el2: { type: "delete", deletedItem: secondItem } },
+          source: { origin: "remote" },
         },
         reverse: [
           {

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
@@ -24,7 +24,7 @@ import {
   objectUpdate,
   serializeUpdateToJson,
 } from "../../__tests__/_updatesUtils";
-import { kInternal, kStorageUpdateSource } from "../../internal";
+import { kInternal } from "../../internal";
 import { LiveList } from "../LiveList";
 import { LiveObject } from "../LiveObject";
 
@@ -767,7 +767,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: root.get("child"),
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
       expect(callback).toHaveBeenCalledWith([
@@ -775,7 +775,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: root.get("child").get("subchild"),
           updates: { b: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });
@@ -823,7 +823,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: rootA.get("child"),
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
       expect(callback).toHaveBeenCalledWith([
@@ -831,7 +831,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: rootA.get("child").get("subchild"),
           updates: { b: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
     });
@@ -912,7 +912,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: rootA.get("child"),
           updates: { a: { type: "delete", deletedItem: -1 } },
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
       expect(callback).toHaveBeenNthCalledWith(2, [
@@ -920,7 +920,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: rootA.get("child"),
           updates: { b: { type: "delete", deletedItem: -2 } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });
@@ -1052,7 +1052,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: root,
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: {
+          source: {
             origin: "local",
             via: "history",
             action: "undo",

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
@@ -767,7 +767,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: root.get("child"),
           updates: { a: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
       expect(callback).toHaveBeenCalledWith([
@@ -775,7 +775,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: root.get("child").get("subchild"),
           updates: { b: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });
@@ -823,7 +823,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: rootA.get("child"),
           updates: { a: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
       expect(callback).toHaveBeenCalledWith([
@@ -920,7 +920,7 @@ describe("LiveObject", () => {
           type: "LiveObject",
           node: rootA.get("child"),
           updates: { b: { type: "delete", deletedItem: -2 } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.devserver.test.ts
@@ -1054,8 +1054,7 @@ describe("LiveObject", () => {
           updates: { a: { type: "update" } },
           source: {
             origin: "local",
-            via: "history",
-            action: "undo",
+            via: "undo",
           },
         },
       ]);

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveObject.mockserver.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveObject.mockserver.test.ts
@@ -138,13 +138,14 @@ describe("LiveObject edge cases", () => {
       const obj = root.get("obj");
       const secondItem = obj.get("b");
 
-      const applyResult = obj._detachChild(secondItem);
+      const applyResult = obj._detachChild(secondItem, { origin: "remote" });
 
       expect(applyResult).toEqual({
         modified: {
           node: obj,
           type: "LiveObject",
           updates: { b: { type: "delete", deletedItem: secondItem } },
+          source: { origin: "remote" },
         },
         reverse: [
           {

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.concurrency.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.concurrency.test.ts
@@ -16,18 +16,6 @@ import {
   transformTextOperations,
 } from "../liveTextOps";
 
-const THEIRS = { origin: "remote" } as const;
-const OURS = {
-  origin: "local",
-  via: "edit",
-  optimistic: false,
-} as const;
-const LOCAL = {
-  origin: "local",
-  via: "edit",
-  optimistic: true,
-} as const;
-
 const initialNodes: StorageNode[] = [
   createSerializedRoot(),
   [
@@ -145,7 +133,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 5, text: " world" }],
       },
-      OURS
+      { origin: "local", via: "edit", optimistic: false }
     );
 
     const undoOp = undoOps[0];
@@ -154,7 +142,11 @@ describe("LiveText acknowledgement", () => {
     }
 
     const outgoingUndoOp = { ...undoOp, opId: "undo" };
-    text._apply(outgoingUndoOp, LOCAL);
+    text._apply(outgoingUndoOp, {
+      origin: "local",
+      via: "edit",
+      optimistic: true,
+    });
 
     expect(outgoingUndoOp).toMatchObject({
       baseVersion: 1,
@@ -186,7 +178,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "B" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
 
     // The remote insert was accepted first, so it wins the same-index tie.
@@ -203,7 +195,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "insert", index: 1, text: "A" }],
       },
-      OURS
+      { origin: "local", via: "edit", optimistic: false }
     );
 
     expect(text.toString()).toBe("BAHello");
@@ -236,7 +228,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "A" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
 
     expect(text.toString()).toBe("Allo");
@@ -250,7 +242,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "delete", index: 1, length: 2 }],
       },
-      OURS
+      { origin: "local", via: "edit", optimistic: false }
     );
 
     expect(text.toString()).toBe("Allo");
@@ -262,7 +254,11 @@ describe("LiveText acknowledgement", () => {
     }
 
     const outgoingUndoOp = { ...undoOp, opId: "undo" };
-    text._apply(outgoingUndoOp, LOCAL);
+    text._apply(outgoingUndoOp, {
+      origin: "local",
+      via: "edit",
+      optimistic: true,
+    });
 
     expect(outgoingUndoOp).toMatchObject({
       baseVersion: 2,
@@ -307,7 +303,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "A" }],
       },
-      OURS
+      { origin: "local", via: "edit", optimistic: false }
     );
 
     expect(text.toString()).toBe("AHello!");
@@ -329,7 +325,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "!" }],
       },
-      OURS
+      { origin: "local", via: "edit", optimistic: false }
     );
 
     expect(text.toString()).toBe("AHello!");

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.concurrency.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.concurrency.test.ts
@@ -9,12 +9,24 @@ import type { UpdateTextOp } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
 import type { StorageNode } from "../../protocol/StorageNode";
 import { CrdtType } from "../../protocol/StorageNode";
-import { createManagedPool, OpSource } from "../AbstractCrdt";
+import { createManagedPool } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
 import {
   applyTextOperationsToSegments,
   transformTextOperations,
 } from "../liveTextOps";
+
+const THEIRS = { origin: "remote" } as const;
+const OURS = {
+  origin: "local",
+  via: "edit",
+  optimistic: false,
+} as const;
+const LOCAL = {
+  origin: "local",
+  via: "edit",
+  optimistic: true,
+} as const;
 
 const initialNodes: StorageNode[] = [
   createSerializedRoot(),
@@ -133,7 +145,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 5, text: " world" }],
       },
-      OpSource.OURS
+      OURS
     );
 
     const undoOp = undoOps[0];
@@ -142,7 +154,7 @@ describe("LiveText acknowledgement", () => {
     }
 
     const outgoingUndoOp = { ...undoOp, opId: "undo" };
-    text._apply(outgoingUndoOp, OpSource.LOCAL);
+    text._apply(outgoingUndoOp, LOCAL);
 
     expect(outgoingUndoOp).toMatchObject({
       baseVersion: 1,
@@ -174,7 +186,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "B" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
 
     // The remote insert was accepted first, so it wins the same-index tie.
@@ -191,7 +203,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "insert", index: 1, text: "A" }],
       },
-      OpSource.OURS
+      OURS
     );
 
     expect(text.toString()).toBe("BAHello");
@@ -224,7 +236,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "A" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
 
     expect(text.toString()).toBe("Allo");
@@ -238,7 +250,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "delete", index: 1, length: 2 }],
       },
-      OpSource.OURS
+      OURS
     );
 
     expect(text.toString()).toBe("Allo");
@@ -250,7 +262,7 @@ describe("LiveText acknowledgement", () => {
     }
 
     const outgoingUndoOp = { ...undoOp, opId: "undo" };
-    text._apply(outgoingUndoOp, OpSource.LOCAL);
+    text._apply(outgoingUndoOp, LOCAL);
 
     expect(outgoingUndoOp).toMatchObject({
       baseVersion: 2,
@@ -295,7 +307,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "A" }],
       },
-      OpSource.OURS
+      OURS
     );
 
     expect(text.toString()).toBe("AHello!");
@@ -317,7 +329,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "!" }],
       },
-      OpSource.OURS
+      OURS
     );
 
     expect(text.toString()).toBe("AHello!");

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.concurrency.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.concurrency.test.ts
@@ -9,7 +9,7 @@ import type { UpdateTextOp } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
 import type { StorageNode } from "../../protocol/StorageNode";
 import { CrdtType } from "../../protocol/StorageNode";
-import { createManagedPool } from "../AbstractCrdt";
+import { createManagedPool, OpSource } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
 import {
   applyTextOperationsToSegments,
@@ -133,7 +133,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 5, text: " world" }],
       },
-      false
+      OpSource.OURS
     );
 
     const undoOp = undoOps[0];
@@ -142,7 +142,7 @@ describe("LiveText acknowledgement", () => {
     }
 
     const outgoingUndoOp = { ...undoOp, opId: "undo" };
-    text._apply(outgoingUndoOp, true);
+    text._apply(outgoingUndoOp, OpSource.LOCAL);
 
     expect(outgoingUndoOp).toMatchObject({
       baseVersion: 1,
@@ -174,7 +174,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "B" }],
       },
-      false
+      OpSource.THEIRS
     );
 
     // The remote insert was accepted first, so it wins the same-index tie.
@@ -191,7 +191,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "insert", index: 1, text: "A" }],
       },
-      false
+      OpSource.OURS
     );
 
     expect(text.toString()).toBe("BAHello");
@@ -224,7 +224,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "A" }],
       },
-      false
+      OpSource.THEIRS
     );
 
     expect(text.toString()).toBe("Allo");
@@ -238,7 +238,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "delete", index: 1, length: 2 }],
       },
-      false
+      OpSource.OURS
     );
 
     expect(text.toString()).toBe("Allo");
@@ -250,7 +250,7 @@ describe("LiveText acknowledgement", () => {
     }
 
     const outgoingUndoOp = { ...undoOp, opId: "undo" };
-    text._apply(outgoingUndoOp, true);
+    text._apply(outgoingUndoOp, OpSource.LOCAL);
 
     expect(outgoingUndoOp).toMatchObject({
       baseVersion: 2,
@@ -295,7 +295,7 @@ describe("LiveText acknowledgement", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "A" }],
       },
-      false
+      OpSource.OURS
     );
 
     expect(text.toString()).toBe("AHello!");
@@ -317,7 +317,7 @@ describe("LiveText acknowledgement", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "!" }],
       },
-      false
+      OpSource.OURS
     );
 
     expect(text.toString()).toBe("AHello!");

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.convergence.fuzz.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.convergence.fuzz.test.ts
@@ -9,7 +9,7 @@ import type {
   UpdateTextOp,
 } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
-import { createManagedPool, OpSource } from "../AbstractCrdt";
+import { createManagedPool } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
 import {
   applyLiveTextOperations,
@@ -19,6 +19,18 @@ import {
   transformTextOperations,
   transformTextOperationsX,
 } from "../liveTextOps";
+
+const THEIRS = { origin: "remote" } as const;
+const OURS = {
+  origin: "local",
+  via: "edit",
+  optimistic: false,
+} as const;
+const LOCAL = {
+  origin: "local",
+  via: "edit",
+  optimistic: true,
+} as const;
 
 // -----------------------------------------------------------------------------
 // Arbitraries
@@ -607,7 +619,7 @@ class SimClient {
     // Mimic room.applyLocalOps(): assign opIds, apply locally, send.
     for (const op of frame) {
       const wireOp = { ...op, opId: `${this.id}:u${this.#opClock++}` };
-      this.text._apply(wireOp, OpSource.LOCAL);
+      this.text._apply(wireOp, LOCAL);
       this.outbox.push(wireOp);
     }
   }
@@ -618,10 +630,7 @@ class SimClient {
       return;
     }
     // Acks carry our own opId; forwards from other clients don't.
-    this.text._apply(
-      message,
-      message.opId !== undefined ? OpSource.OURS : OpSource.THEIRS
-    );
+    this.text._apply(message, message.opId !== undefined ? OURS : THEIRS);
   }
 }
 

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.convergence.fuzz.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.convergence.fuzz.test.ts
@@ -20,18 +20,6 @@ import {
   transformTextOperationsX,
 } from "../liveTextOps";
 
-const THEIRS = { origin: "remote" } as const;
-const OURS = {
-  origin: "local",
-  via: "edit",
-  optimistic: false,
-} as const;
-const LOCAL = {
-  origin: "local",
-  via: "edit",
-  optimistic: true,
-} as const;
-
 // -----------------------------------------------------------------------------
 // Arbitraries
 // -----------------------------------------------------------------------------
@@ -619,7 +607,11 @@ class SimClient {
     // Mimic room.applyLocalOps(): assign opIds, apply locally, send.
     for (const op of frame) {
       const wireOp = { ...op, opId: `${this.id}:u${this.#opClock++}` };
-      this.text._apply(wireOp, LOCAL);
+      this.text._apply(wireOp, {
+        origin: "local",
+        via: "edit",
+        optimistic: true,
+      });
       this.outbox.push(wireOp);
     }
   }
@@ -630,7 +622,12 @@ class SimClient {
       return;
     }
     // Acks carry our own opId; forwards from other clients don't.
-    this.text._apply(message, message.opId !== undefined ? OURS : THEIRS);
+    this.text._apply(
+      message,
+      message.opId !== undefined
+        ? { origin: "local", via: "edit", optimistic: false }
+        : { origin: "remote" }
+    );
   }
 }
 

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.convergence.fuzz.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.convergence.fuzz.test.ts
@@ -9,7 +9,7 @@ import type {
   UpdateTextOp,
 } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
-import { createManagedPool } from "../AbstractCrdt";
+import { createManagedPool, OpSource } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
 import {
   applyLiveTextOperations,
@@ -607,7 +607,7 @@ class SimClient {
     // Mimic room.applyLocalOps(): assign opIds, apply locally, send.
     for (const op of frame) {
       const wireOp = { ...op, opId: `${this.id}:u${this.#opClock++}` };
-      this.text._apply(wireOp, true);
+      this.text._apply(wireOp, OpSource.LOCAL);
       this.outbox.push(wireOp);
     }
   }
@@ -617,7 +617,11 @@ class SimClient {
     if (message === undefined) {
       return;
     }
-    this.text._apply(message, false);
+    // Acks carry our own opId; forwards from other clients don't.
+    this.text._apply(
+      message,
+      message.opId !== undefined ? OpSource.OURS : OpSource.THEIRS
+    );
   }
 }
 

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.encode.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.encode.test.ts
@@ -4,12 +4,13 @@ import { kInternal } from "../../internal";
 import { nn } from "../../lib/assert";
 import type { UpdateTextOp } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
-import { createManagedPool } from "../AbstractCrdt";
+import { createManagedPool, OpSource } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
 
 /**
  * Helper: build a LiveText attached to a pool that captures the wire ops it
- * dispatches, so tests can fabricate matching acks via `_apply(_, false)`.
+ * dispatches, so tests can fabricate matching acks via
+ * `_apply(_, OpSource.OURS)`.
  */
 function attachedLiveText(initial: string): {
   text: LiveText;
@@ -106,7 +107,7 @@ describe("LiveText[kInternal].encodeIndex", () => {
   test("does not change the reported version on the LiveText node", () => {
     const { text, dispatched } = attachedLiveText("Hello");
     text.insert(5, "!");
-    text._apply(ackOp(dispatched, 1), false);
+    text._apply(ackOp(dispatched, 1), OpSource.OURS);
 
     expect(text.version).toBe(1);
     expect(text[kInternal].encodeIndex(6)).toBe(6);
@@ -139,7 +140,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 5, text: "!" }],
       },
-      false
+      OpSource.THEIRS
     );
     text._apply(
       {
@@ -149,7 +150,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "?" }],
       },
-      false
+      OpSource.THEIRS
     );
     expect(text.version).toBe(2);
     // fromVersion = 5 is in the future → null (covered by the ahead branch).
@@ -175,7 +176,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      false
+      OpSource.THEIRS
     );
     // A peer broadcast at version 0 with index 3 ("Hel|lo"). After our
     // accepted insert of "Z" at 0, the same logical position is at offset 4
@@ -193,7 +194,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      false
+      OpSource.THEIRS
     );
     expect(text.toString()).toBe("ZHello");
 
@@ -210,7 +211,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
     // Acknowledge the in-flight Q insert and verify decoding behaviour is
     // stable across the ack (Q moved from in-flight into #confirmed; the
     // queued ! becomes the next in-flight).
-    text._apply(ackOp(dispatched, 2), false);
+    text._apply(ackOp(dispatched, 2), OpSource.OURS);
     expect(text.version).toBe(2);
     // Now: cross-version (versions 1 and 2): version 1 has insert Z at 0 → 3
     // becomes 4. Version 2 records the local Q ack as empty ops (own ack), so
@@ -221,7 +222,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
   test("own acks are recorded as empty ops and do not shift decoded positions", () => {
     const { text, dispatched } = attachedLiveText("Hello");
     text.insert(0, "A");
-    text._apply(ackOp(dispatched, 1), false);
+    text._apply(ackOp(dispatched, 1), OpSource.OURS);
 
     expect(text.version).toBe(1);
     // A peer at version 0 broadcasts index 3 ("Hel|lo"). On our side, the
@@ -325,7 +326,7 @@ describe("LiveText encode/decode pair", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "1" }],
       },
-      false
+      OpSource.THEIRS
     );
     expect(receiver.toString()).toBe("1ABCDE9");
     // The server delivers the receiver's own ack in server-rebased form:
@@ -340,7 +341,7 @@ describe("LiveText encode/decode pair", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "9" }],
       },
-      false
+      OpSource.OURS
     );
     expect(receiver.toString()).toBe("1ABCDE9");
     expect(receiver.version).toBe(2);
@@ -355,7 +356,7 @@ describe("LiveText encode/decode pair", () => {
     expect(decodedAfterSync).toBe(4);
 
     // Sender acks their own op and applies the receiver's accepted op.
-    sender._apply(ackOp(senderDispatched, 1), false);
+    sender._apply(ackOp(senderDispatched, 1), OpSource.OURS);
     sender._apply(
       {
         type: OpCode.UPDATE_TEXT,
@@ -364,7 +365,7 @@ describe("LiveText encode/decode pair", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "9" }],
       },
-      false
+      OpSource.THEIRS
     );
     expect(sender.toString()).toBe("1ABCDE9");
     expect(sender.version).toBe(2);
@@ -399,7 +400,7 @@ describe("LiveText encode/decode pair", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      false
+      OpSource.THEIRS
     );
     expect(text.version).toBe(1);
     expect(text[kInternal].decodeIndex(3, 1)).toBe(3);

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.encode.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.encode.test.ts
@@ -4,13 +4,20 @@ import { kInternal } from "../../internal";
 import { nn } from "../../lib/assert";
 import type { UpdateTextOp } from "../../protocol/Op";
 import { OpCode } from "../../protocol/Op";
-import { createManagedPool, OpSource } from "../AbstractCrdt";
+import { createManagedPool } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
+
+const THEIRS = { origin: "remote" } as const;
+const OURS = {
+  origin: "local",
+  via: "edit",
+  optimistic: false,
+} as const;
 
 /**
  * Helper: build a LiveText attached to a pool that captures the wire ops it
  * dispatches, so tests can fabricate matching acks via
- * `_apply(_, OpSource.OURS)`.
+ * `_apply(_, OURS)`.
  */
 function attachedLiveText(initial: string): {
   text: LiveText;
@@ -107,7 +114,7 @@ describe("LiveText[kInternal].encodeIndex", () => {
   test("does not change the reported version on the LiveText node", () => {
     const { text, dispatched } = attachedLiveText("Hello");
     text.insert(5, "!");
-    text._apply(ackOp(dispatched, 1), OpSource.OURS);
+    text._apply(ackOp(dispatched, 1), OURS);
 
     expect(text.version).toBe(1);
     expect(text[kInternal].encodeIndex(6)).toBe(6);
@@ -140,7 +147,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 5, text: "!" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     text._apply(
       {
@@ -150,7 +157,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "?" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     expect(text.version).toBe(2);
     // fromVersion = 5 is in the future → null (covered by the ahead branch).
@@ -176,7 +183,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     // A peer broadcast at version 0 with index 3 ("Hel|lo"). After our
     // accepted insert of "Z" at 0, the same logical position is at offset 4
@@ -194,7 +201,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     expect(text.toString()).toBe("ZHello");
 
@@ -211,7 +218,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
     // Acknowledge the in-flight Q insert and verify decoding behaviour is
     // stable across the ack (Q moved from in-flight into #confirmed; the
     // queued ! becomes the next in-flight).
-    text._apply(ackOp(dispatched, 2), OpSource.OURS);
+    text._apply(ackOp(dispatched, 2), OURS);
     expect(text.version).toBe(2);
     // Now: cross-version (versions 1 and 2): version 1 has insert Z at 0 → 3
     // becomes 4. Version 2 records the local Q ack as empty ops (own ack), so
@@ -222,7 +229,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
   test("own acks are recorded as empty ops and do not shift decoded positions", () => {
     const { text, dispatched } = attachedLiveText("Hello");
     text.insert(0, "A");
-    text._apply(ackOp(dispatched, 1), OpSource.OURS);
+    text._apply(ackOp(dispatched, 1), OURS);
 
     expect(text.version).toBe(1);
     // A peer at version 0 broadcasts index 3 ("Hel|lo"). On our side, the
@@ -326,7 +333,7 @@ describe("LiveText encode/decode pair", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "1" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     expect(receiver.toString()).toBe("1ABCDE9");
     // The server delivers the receiver's own ack in server-rebased form:
@@ -341,7 +348,7 @@ describe("LiveText encode/decode pair", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "9" }],
       },
-      OpSource.OURS
+      OURS
     );
     expect(receiver.toString()).toBe("1ABCDE9");
     expect(receiver.version).toBe(2);
@@ -356,7 +363,7 @@ describe("LiveText encode/decode pair", () => {
     expect(decodedAfterSync).toBe(4);
 
     // Sender acks their own op and applies the receiver's accepted op.
-    sender._apply(ackOp(senderDispatched, 1), OpSource.OURS);
+    sender._apply(ackOp(senderDispatched, 1), OURS);
     sender._apply(
       {
         type: OpCode.UPDATE_TEXT,
@@ -365,7 +372,7 @@ describe("LiveText encode/decode pair", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "9" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     expect(sender.toString()).toBe("1ABCDE9");
     expect(sender.version).toBe(2);
@@ -400,7 +407,7 @@ describe("LiveText encode/decode pair", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      OpSource.THEIRS
+      THEIRS
     );
     expect(text.version).toBe(1);
     expect(text[kInternal].decodeIndex(3, 1)).toBe(3);

--- a/packages/liveblocks-core/src/crdts/__tests__/LiveText.encode.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/LiveText.encode.test.ts
@@ -7,17 +7,10 @@ import { OpCode } from "../../protocol/Op";
 import { createManagedPool } from "../AbstractCrdt";
 import { LiveText } from "../LiveText";
 
-const THEIRS = { origin: "remote" } as const;
-const OURS = {
-  origin: "local",
-  via: "edit",
-  optimistic: false,
-} as const;
-
 /**
  * Helper: build a LiveText attached to a pool that captures the wire ops it
  * dispatches, so tests can fabricate matching acks via
- * `_apply(_, OURS)`.
+ * `_apply(_, { origin: "local", via: "edit", optimistic: false })`.
  */
 function attachedLiveText(initial: string): {
   text: LiveText;
@@ -114,7 +107,11 @@ describe("LiveText[kInternal].encodeIndex", () => {
   test("does not change the reported version on the LiveText node", () => {
     const { text, dispatched } = attachedLiveText("Hello");
     text.insert(5, "!");
-    text._apply(ackOp(dispatched, 1), OURS);
+    text._apply(ackOp(dispatched, 1), {
+      origin: "local",
+      via: "edit",
+      optimistic: false,
+    });
 
     expect(text.version).toBe(1);
     expect(text[kInternal].encodeIndex(6)).toBe(6);
@@ -147,7 +144,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 5, text: "!" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     text._apply(
       {
@@ -157,7 +154,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "?" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     expect(text.version).toBe(2);
     // fromVersion = 5 is in the future → null (covered by the ahead branch).
@@ -183,7 +180,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     // A peer broadcast at version 0 with index 3 ("Hel|lo"). After our
     // accepted insert of "Z" at 0, the same logical position is at offset 4
@@ -201,7 +198,7 @@ describe("LiveText[kInternal].decodeIndex", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     expect(text.toString()).toBe("ZHello");
 
@@ -218,7 +215,11 @@ describe("LiveText[kInternal].decodeIndex", () => {
     // Acknowledge the in-flight Q insert and verify decoding behaviour is
     // stable across the ack (Q moved from in-flight into #confirmed; the
     // queued ! becomes the next in-flight).
-    text._apply(ackOp(dispatched, 2), OURS);
+    text._apply(ackOp(dispatched, 2), {
+      origin: "local",
+      via: "edit",
+      optimistic: false,
+    });
     expect(text.version).toBe(2);
     // Now: cross-version (versions 1 and 2): version 1 has insert Z at 0 → 3
     // becomes 4. Version 2 records the local Q ack as empty ops (own ack), so
@@ -229,7 +230,11 @@ describe("LiveText[kInternal].decodeIndex", () => {
   test("own acks are recorded as empty ops and do not shift decoded positions", () => {
     const { text, dispatched } = attachedLiveText("Hello");
     text.insert(0, "A");
-    text._apply(ackOp(dispatched, 1), OURS);
+    text._apply(ackOp(dispatched, 1), {
+      origin: "local",
+      via: "edit",
+      optimistic: false,
+    });
 
     expect(text.version).toBe(1);
     // A peer at version 0 broadcasts index 3 ("Hel|lo"). On our side, the
@@ -333,7 +338,7 @@ describe("LiveText encode/decode pair", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "1" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     expect(receiver.toString()).toBe("1ABCDE9");
     // The server delivers the receiver's own ack in server-rebased form:
@@ -348,7 +353,7 @@ describe("LiveText encode/decode pair", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "9" }],
       },
-      OURS
+      { origin: "local", via: "edit", optimistic: false }
     );
     expect(receiver.toString()).toBe("1ABCDE9");
     expect(receiver.version).toBe(2);
@@ -363,7 +368,11 @@ describe("LiveText encode/decode pair", () => {
     expect(decodedAfterSync).toBe(4);
 
     // Sender acks their own op and applies the receiver's accepted op.
-    sender._apply(ackOp(senderDispatched, 1), OURS);
+    sender._apply(ackOp(senderDispatched, 1), {
+      origin: "local",
+      via: "edit",
+      optimistic: false,
+    });
     sender._apply(
       {
         type: OpCode.UPDATE_TEXT,
@@ -372,7 +381,7 @@ describe("LiveText encode/decode pair", () => {
         version: 2,
         ops: [{ type: "insert", index: 6, text: "9" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     expect(sender.toString()).toBe("1ABCDE9");
     expect(sender.version).toBe(2);
@@ -407,7 +416,7 @@ describe("LiveText encode/decode pair", () => {
         version: 1,
         ops: [{ type: "insert", index: 0, text: "Z" }],
       },
-      THEIRS
+      { origin: "remote" }
     );
     expect(text.version).toBe(1);
     expect(text[kInternal].decodeIndex(3, 1)).toBe(3);

--- a/packages/liveblocks-core/src/crdts/__tests__/doc.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/doc.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 
 import { prepareStorageTest } from "../../__tests__/_devserver";
-import { kStorageUpdateSource } from "../../internal";
 import type { LiveList } from "../LiveList";
 import type { LiveMap } from "../LiveMap";
 import type { LiveObject } from "../LiveObject";
@@ -32,7 +31,7 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });
@@ -63,7 +62,7 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storageA.root,
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
     });
@@ -98,7 +97,7 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storageA.root,
           updates: { a: { type: "update" }, b: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "remote" },
+          source: { origin: "remote" },
         },
       ]);
     });
@@ -140,7 +139,7 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" }, b: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
 
@@ -176,13 +175,13 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
         {
           type: "LiveObject",
           node: root.get("child"),
           updates: { b: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });
@@ -222,25 +221,25 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
         {
           type: "LiveObject",
           node: root.get("childObj"),
           updates: { b: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
         {
           type: "LiveList",
           node: root.get("childList"),
           updates: [{ index: 0, item: "item1", type: "insert" }],
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
         {
           type: "LiveMap",
           node: root.get("childMap"),
           updates: { el1: { type: "update" } },
-          [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "mutation" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/doc.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/doc.test.ts
@@ -31,7 +31,7 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });
@@ -139,7 +139,7 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" }, b: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
 
@@ -175,13 +175,13 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
         {
           type: "LiveObject",
           node: root.get("child"),
           updates: { b: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });
@@ -221,25 +221,25 @@ describe("Storage", () => {
           type: "LiveObject",
           node: storage.root,
           updates: { a: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
         {
           type: "LiveObject",
           node: root.get("childObj"),
           updates: { b: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
         {
           type: "LiveList",
           node: root.get("childList"),
           updates: [{ index: 0, item: "item1", type: "insert" }],
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
         {
           type: "LiveMap",
           node: root.get("childMap"),
           updates: { el1: { type: "update" } },
-          source: { origin: "local", via: "mutation" },
+          source: { origin: "local", via: "edit" },
         },
       ]);
     });

--- a/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 
-import { kStorageUpdateSource } from "../../internal";
 import { mergeStorageUpdates } from "../liveblocks-helpers";
 import { LiveObject } from "../LiveObject";
 import { LiveText } from "../LiveText";
@@ -13,7 +12,7 @@ function liveObjectUpdate(source?: StorageUpdateSource): StorageUpdate {
     updates: { a: { type: "update" } },
   };
   if (source !== undefined) {
-    update[kStorageUpdateSource] = source;
+    update.source = source;
   }
   return update;
 }
@@ -26,7 +25,7 @@ function liveTextUpdate(source?: StorageUpdateSource): StorageUpdate {
     updates: [{ type: "insert", index: 5, text: "!" }],
   };
   if (source !== undefined) {
-    update[kStorageUpdateSource] = source;
+    update.source = source;
   }
   return update;
 }
@@ -37,7 +36,7 @@ describe("mergeStorageUpdates source propagation", () => {
       liveObjectUpdate({ origin: "local", via: "mutation" }),
       liveObjectUpdate({ origin: "local", via: "mutation" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({
+    expect(merged.source).toEqual({
       origin: "local",
       via: "mutation",
     });
@@ -48,7 +47,7 @@ describe("mergeStorageUpdates source propagation", () => {
       liveTextUpdate({ origin: "remote" }),
       liveTextUpdate({ origin: "remote" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({ origin: "remote" });
+    expect(merged.source).toEqual({ origin: "remote" });
   });
 
   test("mixed local and remote -> merged is remote", () => {
@@ -56,7 +55,7 @@ describe("mergeStorageUpdates source propagation", () => {
       liveObjectUpdate({ origin: "local", via: "mutation" }),
       liveObjectUpdate({ origin: "remote" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({ origin: "remote" });
+    expect(merged.source).toEqual({ origin: "remote" });
   });
 
   test("mixed local mutation and history -> merged is history", () => {
@@ -64,7 +63,7 @@ describe("mergeStorageUpdates source propagation", () => {
       liveObjectUpdate({ origin: "local", via: "mutation" }),
       liveObjectUpdate({ origin: "local", via: "history", action: "undo" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({
+    expect(merged.source).toEqual({
       origin: "local",
       via: "history",
       action: "undo",
@@ -76,7 +75,7 @@ describe("mergeStorageUpdates source propagation", () => {
       liveObjectUpdate({ origin: "local", via: "history", action: "undo" }),
       liveObjectUpdate({ origin: "local", via: "history", action: "redo" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({
+    expect(merged.source).toEqual({
       origin: "local",
       via: "history",
       action: "redo",
@@ -88,7 +87,7 @@ describe("mergeStorageUpdates source propagation", () => {
       liveObjectUpdate(),
       liveObjectUpdate({ origin: "local", via: "mutation" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({
+    expect(merged.source).toEqual({
       origin: "local",
       via: "mutation",
     });
@@ -96,7 +95,7 @@ describe("mergeStorageUpdates source propagation", () => {
 
   test("untagged + untagged -> merged stays untagged", () => {
     const merged = mergeStorageUpdates(liveObjectUpdate(), liveObjectUpdate());
-    expect(merged[kStorageUpdateSource]).toBeUndefined();
+    expect(merged.source).toBeUndefined();
   });
 
   test("undefined first preserves second source", () => {
@@ -104,6 +103,6 @@ describe("mergeStorageUpdates source propagation", () => {
       undefined,
       liveTextUpdate({ origin: "remote" })
     );
-    expect(merged[kStorageUpdateSource]).toEqual({ origin: "remote" });
+    expect(merged.source).toEqual({ origin: "remote" });
   });
 });

--- a/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
@@ -33,12 +33,12 @@ function liveTextUpdate(source?: StorageUpdateSource): StorageUpdate {
 describe("mergeStorageUpdates source propagation", () => {
   test("both local mutation -> merged is local mutation", () => {
     const merged = mergeStorageUpdates(
-      liveObjectUpdate({ origin: "local", via: "mutation" }),
-      liveObjectUpdate({ origin: "local", via: "mutation" })
+      liveObjectUpdate({ origin: "local", via: "edit" }),
+      liveObjectUpdate({ origin: "local", via: "edit" })
     );
     expect(merged.source).toEqual({
       origin: "local",
-      via: "mutation",
+      via: "edit",
     });
   });
 
@@ -52,7 +52,7 @@ describe("mergeStorageUpdates source propagation", () => {
 
   test("mixed local and remote -> merged is remote", () => {
     const merged = mergeStorageUpdates(
-      liveObjectUpdate({ origin: "local", via: "mutation" }),
+      liveObjectUpdate({ origin: "local", via: "edit" }),
       liveObjectUpdate({ origin: "remote" })
     );
     expect(merged.source).toEqual({ origin: "remote" });
@@ -60,7 +60,7 @@ describe("mergeStorageUpdates source propagation", () => {
 
   test("mixed local mutation and history -> merged is history", () => {
     const merged = mergeStorageUpdates(
-      liveObjectUpdate({ origin: "local", via: "mutation" }),
+      liveObjectUpdate({ origin: "local", via: "edit" }),
       liveObjectUpdate({ origin: "local", via: "history", action: "undo" })
     );
     expect(merged.source).toEqual({
@@ -85,11 +85,11 @@ describe("mergeStorageUpdates source propagation", () => {
   test("untagged + local mutation -> merged is local mutation", () => {
     const merged = mergeStorageUpdates(
       liveObjectUpdate(),
-      liveObjectUpdate({ origin: "local", via: "mutation" })
+      liveObjectUpdate({ origin: "local", via: "edit" })
     );
     expect(merged.source).toEqual({
       origin: "local",
-      via: "mutation",
+      via: "edit",
     });
   });
 

--- a/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
@@ -58,27 +58,44 @@ describe("mergeStorageUpdates source propagation", () => {
     expect(merged.source).toEqual({ origin: "remote" });
   });
 
-  test("mixed local mutation and history -> merged is history", () => {
+  test("mixed remote and local -> merged is remote", () => {
+    const merged = mergeStorageUpdates(
+      liveObjectUpdate({ origin: "remote" }),
+      liveObjectUpdate({ origin: "local", via: "edit" })
+    );
+    expect(merged.source).toEqual({ origin: "remote" });
+  });
+
+  test("mixed local edit and undo -> merged is undo", () => {
     const merged = mergeStorageUpdates(
       liveObjectUpdate({ origin: "local", via: "edit" }),
-      liveObjectUpdate({ origin: "local", via: "history", action: "undo" })
+      liveObjectUpdate({ origin: "local", via: "undo" })
     );
     expect(merged.source).toEqual({
       origin: "local",
-      via: "history",
-      action: "undo",
+      via: "undo",
     });
   });
 
-  test("mixed history undo and redo -> merged keeps second action", () => {
+  test("mixed undo and local edit -> merged is undo", () => {
     const merged = mergeStorageUpdates(
-      liveObjectUpdate({ origin: "local", via: "history", action: "undo" }),
-      liveObjectUpdate({ origin: "local", via: "history", action: "redo" })
+      liveObjectUpdate({ origin: "local", via: "undo" }),
+      liveObjectUpdate({ origin: "local", via: "edit" })
     );
     expect(merged.source).toEqual({
       origin: "local",
-      via: "history",
-      action: "redo",
+      via: "undo",
+    });
+  });
+
+  test("mixed undo and redo -> merged keeps second one", () => {
+    const merged = mergeStorageUpdates(
+      liveObjectUpdate({ origin: "local", via: "undo" }),
+      liveObjectUpdate({ origin: "local", via: "redo" })
+    );
+    expect(merged.source).toEqual({
+      origin: "local",
+      via: "redo",
     });
   });
 

--- a/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
+++ b/packages/liveblocks-core/src/crdts/__tests__/storageUpdateSource.test.ts
@@ -3,31 +3,26 @@ import { describe, expect, test } from "vitest";
 import { mergeStorageUpdates } from "../liveblocks-helpers";
 import { LiveObject } from "../LiveObject";
 import { LiveText } from "../LiveText";
-import type { StorageUpdate, StorageUpdateSource } from "../StorageUpdates";
+import type { StorageUpdate, UpdateSource } from "../StorageUpdates";
+import { toUpdateSource } from "../StorageUpdates";
 
-function liveObjectUpdate(source?: StorageUpdateSource): StorageUpdate {
-  const update: StorageUpdate = {
+function liveObjectUpdate(source: UpdateSource): StorageUpdate {
+  return {
     type: "LiveObject",
     node: new LiveObject({ a: 1 }),
     updates: { a: { type: "update" } },
+    source,
   };
-  if (source !== undefined) {
-    update.source = source;
-  }
-  return update;
 }
 
-function liveTextUpdate(source?: StorageUpdateSource): StorageUpdate {
-  const update: StorageUpdate = {
+function liveTextUpdate(source: UpdateSource): StorageUpdate {
+  return {
     type: "LiveText",
     node: new LiveText("hello"),
     version: 1,
     updates: [{ type: "insert", index: 5, text: "!" }],
+    source,
   };
-  if (source !== undefined) {
-    update.source = source;
-  }
-  return update;
 }
 
 describe("mergeStorageUpdates source propagation", () => {
@@ -99,27 +94,28 @@ describe("mergeStorageUpdates source propagation", () => {
     });
   });
 
-  test("untagged + local mutation -> merged is local mutation", () => {
-    const merged = mergeStorageUpdates(
-      liveObjectUpdate(),
-      liveObjectUpdate({ origin: "local", via: "edit" })
-    );
-    expect(merged.source).toEqual({
-      origin: "local",
-      via: "edit",
-    });
-  });
-
-  test("untagged + untagged -> merged stays untagged", () => {
-    const merged = mergeStorageUpdates(liveObjectUpdate(), liveObjectUpdate());
-    expect(merged.source).toBeUndefined();
-  });
-
   test("undefined first preserves second source", () => {
     const merged = mergeStorageUpdates(
       undefined,
       liveTextUpdate({ origin: "remote" })
     );
     expect(merged.source).toEqual({ origin: "remote" });
+  });
+});
+
+describe("toUpdateSource", () => {
+  test("drops the internal optimistic flag from local sources", () => {
+    for (const via of ["edit", "undo", "redo"] as const) {
+      for (const optimistic of [true, false]) {
+        expect(toUpdateSource({ origin: "local", via, optimistic })).toEqual({
+          origin: "local",
+          via,
+        });
+      }
+    }
+  });
+
+  test("leaves remote sources alone", () => {
+    expect(toUpdateSource({ origin: "remote" })).toEqual({ origin: "remote" });
   });
 });

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -658,7 +658,7 @@ export function mergeStorageUpdates(
         merged.source = historySource;
       }
     } else {
-      merged.source = { origin: "local", via: "mutation" };
+      merged.source = { origin: "local", via: "edit" };
     }
   }
   return merged;

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -1,4 +1,3 @@
-import { kStorageUpdateSource } from "../internal";
 import { assertNever, nn } from "../lib/assert";
 import type { Json } from "../lib/Json";
 import { stringifyOrLog as stringify } from "../lib/stringify";
@@ -647,19 +646,19 @@ export function mergeStorageUpdates(
     merged = second;
   }
 
-  const sa = first[kStorageUpdateSource];
-  const sb = second[kStorageUpdateSource];
+  const sa = first.source;
+  const sb = second.source;
   if (sa !== undefined || sb !== undefined) {
     if (sa?.origin === "remote" || sb?.origin === "remote") {
-      merged[kStorageUpdateSource] = { origin: "remote" };
+      merged.source = { origin: "remote" };
     } else if (sa?.via === "history" || sb?.via === "history") {
       const historySource =
         sb?.via === "history" ? sb : sa?.via === "history" ? sa : undefined;
       if (historySource?.via === "history") {
-        merged[kStorageUpdateSource] = historySource;
+        merged.source = historySource;
       }
     } else {
-      merged[kStorageUpdateSource] = { origin: "local", via: "mutation" };
+      merged.source = { origin: "local", via: "mutation" };
     }
   }
   return merged;

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -29,7 +29,7 @@ import { LiveRegister } from "./LiveRegister";
 import { LiveText, type LiveTextUpdates } from "./LiveText";
 import type { LiveNode, LiveStructure, Lson, LsonObject } from "./Lson";
 import type { StorageUpdate, UpdateSource } from "./StorageUpdates";
-import { LOCAL_EDIT } from "./StorageUpdates";
+import { LOCAL_EDIT, REMOTE } from "./StorageUpdates";
 
 export function creationOpToLiveNode(op: CreateOp): LiveNode {
   return lsonToLiveNode(creationOpToLson(op));
@@ -632,7 +632,7 @@ function mergeUpdateSources(
   // Any remote change in the mix makes the merged update remote: it no longer
   // describes a change this client made on its own.
   if (first.origin === "remote" || second.origin === "remote") {
-    return { origin: "remote" };
+    return REMOTE;
   }
 
   // Undo/redo replays are more specific than plain edits, so they win. When

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -651,14 +651,15 @@ export function mergeStorageUpdates(
   if (sa !== undefined || sb !== undefined) {
     if (sa?.origin === "remote" || sb?.origin === "remote") {
       merged.source = { origin: "remote" };
-    } else if (sa?.via === "history" || sb?.via === "history") {
-      const historySource =
-        sb?.via === "history" ? sb : sa?.via === "history" ? sa : undefined;
-      if (historySource?.via === "history") {
-        merged.source = historySource;
-      }
     } else {
-      merged.source = { origin: "local", via: "edit" };
+      // Undo/redo replays win over plain edits, most recent one first
+      const historySource =
+        sb !== undefined && sb.via !== "edit"
+          ? sb
+          : sa !== undefined && sa.via !== "edit"
+            ? sa
+            : undefined;
+      merged.source = historySource ?? { origin: "local", via: "edit" };
     }
   }
   return merged;

--- a/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
+++ b/packages/liveblocks-core/src/crdts/liveblocks-helpers.ts
@@ -28,7 +28,8 @@ import { LiveObject, type LiveObjectUpdates } from "./LiveObject";
 import { LiveRegister } from "./LiveRegister";
 import { LiveText, type LiveTextUpdates } from "./LiveText";
 import type { LiveNode, LiveStructure, Lson, LsonObject } from "./Lson";
-import type { StorageUpdate } from "./StorageUpdates";
+import type { StorageUpdate, UpdateSource } from "./StorageUpdates";
+import { LOCAL_EDIT } from "./StorageUpdates";
 
 export function creationOpToLiveNode(op: CreateOp): LiveNode {
   return lsonToLiveNode(creationOpToLson(op));
@@ -624,6 +625,23 @@ function mergeTextStorageUpdates(
   };
 }
 
+function mergeUpdateSources(
+  first: UpdateSource,
+  second: UpdateSource
+): UpdateSource {
+  // Any remote change in the mix makes the merged update remote: it no longer
+  // describes a change this client made on its own.
+  if (first.origin === "remote" || second.origin === "remote") {
+    return { origin: "remote" };
+  }
+
+  // Undo/redo replays are more specific than plain edits, so they win. When
+  // both are replays, the later one describes the merged update best.
+  if (second.via !== "edit") return second;
+  if (first.via !== "edit") return first;
+  return LOCAL_EDIT;
+}
+
 export function mergeStorageUpdates(
   first: StorageUpdate | undefined,
   second: StorageUpdate
@@ -632,35 +650,18 @@ export function mergeStorageUpdates(
     return second;
   }
 
-  let merged: StorageUpdate;
+  const source = mergeUpdateSources(first.source, second.source);
+
   if (first.type === "LiveObject" && second.type === "LiveObject") {
-    merged = mergeObjectStorageUpdates(first, second);
+    return { ...mergeObjectStorageUpdates(first, second), source };
   } else if (first.type === "LiveMap" && second.type === "LiveMap") {
-    merged = mergeMapStorageUpdates(first, second);
+    return { ...mergeMapStorageUpdates(first, second), source };
   } else if (first.type === "LiveList" && second.type === "LiveList") {
-    merged = mergeListStorageUpdates(first, second);
+    return { ...mergeListStorageUpdates(first, second), source };
   } else if (first.type === "LiveText" && second.type === "LiveText") {
-    merged = mergeTextStorageUpdates(first, second);
+    return { ...mergeTextStorageUpdates(first, second), source };
   } else {
     /* Mismatching merge types. Throw an error here? */
-    merged = second;
+    return { ...second, source };
   }
-
-  const sa = first.source;
-  const sb = second.source;
-  if (sa !== undefined || sb !== undefined) {
-    if (sa?.origin === "remote" || sb?.origin === "remote") {
-      merged.source = { origin: "remote" };
-    } else {
-      // Undo/redo replays win over plain edits, most recent one first
-      const historySource =
-        sb !== undefined && sb.via !== "edit"
-          ? sb
-          : sa !== undefined && sa.via !== "edit"
-            ? sa
-            : undefined;
-      merged.source = historySource ?? { origin: "local", via: "edit" };
-    }
-  }
-  return merged;
 }

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -117,7 +117,7 @@ export type {
   LiveObjectUpdate,
   LiveTextUpdate,
   StorageUpdate,
-  StorageUpdateSource,
+  UpdateSource,
 } from "./crdts/StorageUpdates";
 export { toPlainLson } from "./crdts/utils";
 export type {

--- a/packages/liveblocks-core/src/index.ts
+++ b/packages/liveblocks-core/src/index.ts
@@ -135,7 +135,7 @@ export type {
   KDAD,
 } from "./globals/augmentation";
 export type { SyncConfig, SyncMode } from "./immutable";
-export { kInternal, kStorageUpdateSource } from "./internal";
+export { kInternal } from "./internal";
 export { makeAbortController } from "./lib/abortController";
 export { assert, assertNever, nn } from "./lib/assert";
 export type {

--- a/packages/liveblocks-core/src/internal.ts
+++ b/packages/liveblocks-core/src/internal.ts
@@ -16,5 +16,3 @@
  * );
  */
 export const kInternal = Symbol();
-
-export const kStorageUpdateSource = Symbol();

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -33,7 +33,13 @@ import type {
   UpdateSource,
   Via,
 } from "./crdts/StorageUpdates";
-import { toUpdateSource } from "./crdts/StorageUpdates";
+import {
+  LOCAL_EDIT,
+  LOCAL_REDO,
+  LOCAL_UNDO,
+  REMOTE,
+  toUpdateSource,
+} from "./crdts/StorageUpdates";
 import { UnacknowledgedOps } from "./crdts/UnacknowledgedOps";
 import type {
   DCM,
@@ -2076,9 +2082,7 @@ export function createRoom<
           if (node !== undefined && isLiveText(node)) {
             // An authoritative snapshot from the server, so whatever it
             // changes locally is a remote change as far as subscribers go.
-            const update = node._resyncText(crdt.data, crdt.version, {
-              origin: "remote",
-            });
+            const update = node._resyncText(crdt.data, crdt.version, REMOTE);
             if (update !== undefined) {
               result.updates.storageUpdates.set(
                 id,
@@ -2256,10 +2260,7 @@ export function createRoom<
 
   function applyLocalOps(
     frames: readonly Stackframe<P>[],
-    localSource: Extract<UpdateSource, { origin: "local" }> = {
-      origin: "local",
-      via: "edit",
-    }
+    localSource: Extract<UpdateSource, { origin: "local" }> = LOCAL_EDIT
   ): {
     opsToEmit: ClientWireOp[]; // Ops to send over the wire afterwards
     reverse: Stackframe<P>[]; // Reverse ops to add to the undo stack aftwards
@@ -2313,10 +2314,7 @@ export function createRoom<
     pframes: readonly PresenceStackframe<P>[],
     ops: readonly Op[],
     isLocal: boolean,
-    localSource: Extract<UpdateSource, { origin: "local" }> = {
-      origin: "local",
-      via: "edit",
-    }
+    localSource: Extract<UpdateSource, { origin: "local" }> = LOCAL_EDIT
   ): {
     reverse: Stackframe<P>[];
     updates: {
@@ -2374,7 +2372,7 @@ export function createRoom<
       } else {
         // Remotely generated Ops (and fix Ops as a special case of that)
         // don't have opId anymore.
-        source = { origin: "remote" };
+        source = REMOTE;
       }
 
       const applyOpResult = applyOp(op, source);
@@ -3586,10 +3584,7 @@ export function createRoom<
     }
 
     context.pausedHistory = null;
-    const result = applyLocalOps(item.frames, {
-      origin: "local",
-      via: "undo",
-    });
+    const result = applyLocalOps(item.frames, LOCAL_UNDO);
 
     context.redoStack.push({ id: item.id, frames: result.reverse });
     notifyPrivateHistory({ action: "undo", id: item.id });
@@ -3613,10 +3608,7 @@ export function createRoom<
     }
 
     context.pausedHistory = null;
-    const result = applyLocalOps(item.frames, {
-      origin: "local",
-      via: "redo",
-    });
+    const result = applyLocalOps(item.frames, LOCAL_REDO);
 
     context.undoStack.push({ id: item.id, frames: result.reverse });
     notifyPrivateHistory({ action: "redo", id: item.id });

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -2398,7 +2398,7 @@ export function createRoom<
           return { modified: false };
         }
 
-        return node._apply(op, source === OpSource.LOCAL);
+        return node._apply(op, source);
       }
 
       case OpCode.SET_PARENT_KEY: {

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -10,7 +10,7 @@ import type {
   DispatchOptions,
   ManagedPool,
 } from "./crdts/AbstractCrdt";
-import { createManagedPool, OpSource } from "./crdts/AbstractCrdt";
+import { createManagedPool } from "./crdts/AbstractCrdt";
 import {
   cloneLson,
   diffNodeMap,
@@ -27,10 +27,13 @@ import { getLiveFileId } from "./crdts/LiveFile";
 import { LiveObject } from "./crdts/LiveObject";
 import type { LiveStructure, LsonObject } from "./crdts/Lson";
 import type {
+  OpSource,
   StorageCallback,
   StorageUpdate,
-  StorageUpdateSource,
+  UpdateSource,
+  Via,
 } from "./crdts/StorageUpdates";
+import { toUpdateSource } from "./crdts/StorageUpdates";
 import { UnacknowledgedOps } from "./crdts/UnacknowledgedOps";
 import type {
   DCM,
@@ -1873,10 +1876,6 @@ export function createRoom<
     storageUpdates: Map<string, StorageUpdate>,
     options?: DispatchOptions
   ): void {
-    for (const value of storageUpdates.values()) {
-      value.source = { origin: "local", via: "edit" };
-    }
-
     if (context.activeBatch) {
       for (const op of ops) {
         context.activeBatch.ops.push(op);
@@ -2075,7 +2074,11 @@ export function createRoom<
         if (crdt.type === CrdtType.TEXT) {
           const node = context.pool.nodes.get(id);
           if (node !== undefined && isLiveText(node)) {
-            const update = node._resyncText(crdt.data, crdt.version);
+            // An authoritative snapshot from the server, so whatever it
+            // changes locally is a remote change as far as subscribers go.
+            const update = node._resyncText(crdt.data, crdt.version, {
+              origin: "remote",
+            });
             if (update !== undefined) {
               result.updates.storageUpdates.set(
                 id,
@@ -2213,7 +2216,12 @@ export function createRoom<
     }
 
     if (storageUpdates !== undefined && storageUpdates.size > 0) {
-      const updates = Array.from(storageUpdates.values());
+      // This is the only place Storage updates reach subscribers, so it's
+      // where the internal `optimistic` flag gets dropped. See OpSource.
+      const updates = Array.from(storageUpdates.values(), (update) => ({
+        ...update,
+        source: toUpdateSource(update.source),
+      }));
       eventHub.storageBatch.notify(updates);
     }
     notifyStorageStatus();
@@ -2230,12 +2238,28 @@ export function createRoom<
     );
   }
 
+  /**
+   * How each still-unacknowledged op was made, for the ops where that isn't a
+   * plain edit. Lets an ack be reported with the same `via` as the change it
+   * confirms, instead of every ack looking like a fresh edit.
+   */
+  const viaByOpId = new Map<string, Via>();
+
+  function viaOfAckedOp(opId: string): Via {
+    const via = viaByOpId.get(opId);
+    if (via === undefined) {
+      return "edit";
+    }
+    viaByOpId.delete(opId);
+    return via;
+  }
+
   function applyLocalOps(
     frames: readonly Stackframe<P>[],
-    localStorageUpdateSource: Extract<
-      StorageUpdateSource,
-      { origin: "local" }
-    > = { origin: "local", via: "edit" }
+    localSource: Extract<UpdateSource, { origin: "local" }> = {
+      origin: "local",
+      via: "edit",
+    }
   ): {
     opsToEmit: ClientWireOp[]; // Ops to send over the wire afterwards
     reverse: Stackframe<P>[]; // Reverse ops to add to the undo stack aftwards
@@ -2257,11 +2281,20 @@ export function createRoom<
         : (op as ClientWireOp)
     );
 
+    // Remember how these ops came about, so that when the server acks them we
+    // can report the ack the same way. Only history replays are recorded; a
+    // plain edit is what an unrecorded opId means (see viaOfAckedOp).
+    if (localSource.via !== "edit") {
+      for (const op of opsWithOpIds) {
+        viaByOpId.set(op.opId, localSource.via);
+      }
+    }
+
     const { reverse, updates } = applyOps(
       pframes,
       opsWithOpIds,
       /* isLocal */ true,
-      localStorageUpdateSource
+      localSource
     );
     return { opsToEmit: opsWithOpIds, reverse, updates };
   }
@@ -2280,10 +2313,10 @@ export function createRoom<
     pframes: readonly PresenceStackframe<P>[],
     ops: readonly Op[],
     isLocal: boolean,
-    localStorageUpdateSource: Extract<
-      StorageUpdateSource,
-      { origin: "local" }
-    > = { origin: "local", via: "edit" }
+    localSource: Extract<UpdateSource, { origin: "local" }> = {
+      origin: "local",
+      via: "edit",
+    }
   ): {
     reverse: Stackframe<P>[];
     updates: {
@@ -2328,23 +2361,24 @@ export function createRoom<
       let source: OpSource;
 
       if (isLocal) {
-        source = OpSource.LOCAL;
+        source = { ...localSource, optimistic: true };
       } else if (op.opId !== undefined) {
         context.unacknowledgedOps.delete(op.opId);
-        source = OpSource.OURS;
+        // The server echoing back our own op. It describes a change this
+        // client made, now confirmed, so it keeps the `via` it was made with.
+        source = {
+          origin: "local",
+          via: viaOfAckedOp(op.opId),
+          optimistic: false,
+        };
       } else {
         // Remotely generated Ops (and fix Ops as a special case of that)
         // don't have opId anymore.
-        source = OpSource.THEIRS;
+        source = { origin: "remote" };
       }
 
       const applyOpResult = applyOp(op, source);
       if (applyOpResult.modified) {
-        applyOpResult.modified.source =
-          source === OpSource.THEIRS
-            ? { origin: "remote" }
-            : localStorageUpdateSource;
-
         const nodeId = applyOpResult.modified.node._id;
 
         // If the modified node was created in the same batch, we don't want
@@ -2778,6 +2812,7 @@ export function createRoom<
             context.unacknowledgedOps.delete(opId);
             context.buffer.storageOperations =
               context.buffer.storageOperations.filter((op) => op.opId !== opId);
+            viaByOpId.delete(opId);
 
             if (
               rejectedOp !== undefined &&

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -42,7 +42,7 @@ import type {
   DTM,
   DU,
 } from "./globals/augmentation";
-import { kInternal, kStorageUpdateSource } from "./internal";
+import { kInternal } from "./internal";
 import { assertNever, nn } from "./lib/assert";
 import type { BatchStore } from "./lib/batch";
 import { Promise_withResolvers } from "./lib/controlledPromise";
@@ -1874,7 +1874,7 @@ export function createRoom<
     options?: DispatchOptions
   ): void {
     for (const value of storageUpdates.values()) {
-      value[kStorageUpdateSource] = { origin: "local", via: "mutation" };
+      value.source = { origin: "local", via: "mutation" };
     }
 
     if (context.activeBatch) {
@@ -2340,7 +2340,7 @@ export function createRoom<
 
       const applyOpResult = applyOp(op, source);
       if (applyOpResult.modified) {
-        applyOpResult.modified[kStorageUpdateSource] =
+        applyOpResult.modified.source =
           source === OpSource.THEIRS
             ? { origin: "remote" }
             : localStorageUpdateSource;

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -3553,8 +3553,7 @@ export function createRoom<
     context.pausedHistory = null;
     const result = applyLocalOps(item.frames, {
       origin: "local",
-      via: "history",
-      action: "undo",
+      via: "undo",
     });
 
     context.redoStack.push({ id: item.id, frames: result.reverse });
@@ -3581,8 +3580,7 @@ export function createRoom<
     context.pausedHistory = null;
     const result = applyLocalOps(item.frames, {
       origin: "local",
-      via: "history",
-      action: "redo",
+      via: "redo",
     });
 
     context.undoStack.push({ id: item.id, frames: result.reverse });

--- a/packages/liveblocks-core/src/room.ts
+++ b/packages/liveblocks-core/src/room.ts
@@ -1874,7 +1874,7 @@ export function createRoom<
     options?: DispatchOptions
   ): void {
     for (const value of storageUpdates.values()) {
-      value.source = { origin: "local", via: "mutation" };
+      value.source = { origin: "local", via: "edit" };
     }
 
     if (context.activeBatch) {
@@ -2235,7 +2235,7 @@ export function createRoom<
     localStorageUpdateSource: Extract<
       StorageUpdateSource,
       { origin: "local" }
-    > = { origin: "local", via: "mutation" }
+    > = { origin: "local", via: "edit" }
   ): {
     opsToEmit: ClientWireOp[]; // Ops to send over the wire afterwards
     reverse: Stackframe<P>[]; // Reverse ops to add to the undo stack aftwards
@@ -2283,7 +2283,7 @@ export function createRoom<
     localStorageUpdateSource: Extract<
       StorageUpdateSource,
       { origin: "local" }
-    > = { origin: "local", via: "mutation" }
+    > = { origin: "local", via: "edit" }
   ): {
     reverse: Stackframe<P>[];
     updates: {

--- a/packages/liveblocks-lexical/src/__tests__/history.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/history.test.ts
@@ -164,7 +164,7 @@ describe("LiveblocksHistory", () => {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "mutation";
+              return source?.origin === "local" && source.via === "edit";
             })
           ) {
             return;
@@ -577,7 +577,7 @@ describe("LiveblocksHistory", () => {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "mutation";
+              return source?.origin === "local" && source.via === "edit";
             })
           ) {
             return;
@@ -693,7 +693,7 @@ describe("LiveblocksHistory", () => {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "mutation";
+              return source?.origin === "local" && source.via === "edit";
             })
           ) {
             return;

--- a/packages/liveblocks-lexical/src/__tests__/history.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/history.test.ts
@@ -157,7 +157,7 @@ describe("LiveblocksHistory", () => {
         }
       );
 
-      // Storage → Lexical, including local via:"history" (undo/redo).
+      // Storage → Lexical, including local via:"undo"/via:"redo".
       const unsubscribeStorage = room.subscribe(
         document,
         (updates) => {
@@ -172,7 +172,10 @@ describe("LiveblocksHistory", () => {
 
           const isFromHistory = updates.some((update) => {
             const source = update.source;
-            return source?.origin === "local" && source.via === "history";
+            return (
+              source?.origin === "local" &&
+              (source.via === "undo" || source.via === "redo")
+            );
           });
 
           editor.update(
@@ -585,7 +588,10 @@ describe("LiveblocksHistory", () => {
 
           const isFromHistory = updates.some((update) => {
             const source = update.source;
-            return source?.origin === "local" && source.via === "history";
+            return (
+              source?.origin === "local" &&
+              (source.via === "undo" || source.via === "redo")
+            );
           });
 
           editor.update(
@@ -701,7 +707,10 @@ describe("LiveblocksHistory", () => {
 
           const isFromHistory = updates.some((update) => {
             const source = update.source;
-            return source?.origin === "local" && source.via === "history";
+            return (
+              source?.origin === "local" &&
+              (source.via === "undo" || source.via === "redo")
+            );
           });
 
           editor.update(

--- a/packages/liveblocks-lexical/src/__tests__/history.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/history.test.ts
@@ -164,7 +164,7 @@ describe("LiveblocksHistory", () => {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "edit";
+              return source.origin === "local" && source.via === "edit";
             })
           ) {
             return;
@@ -173,7 +173,7 @@ describe("LiveblocksHistory", () => {
           const isFromHistory = updates.some((update) => {
             const source = update.source;
             return (
-              source?.origin === "local" &&
+              source.origin === "local" &&
               (source.via === "undo" || source.via === "redo")
             );
           });
@@ -580,7 +580,7 @@ describe("LiveblocksHistory", () => {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "edit";
+              return source.origin === "local" && source.via === "edit";
             })
           ) {
             return;
@@ -589,7 +589,7 @@ describe("LiveblocksHistory", () => {
           const isFromHistory = updates.some((update) => {
             const source = update.source;
             return (
-              source?.origin === "local" &&
+              source.origin === "local" &&
               (source.via === "undo" || source.via === "redo")
             );
           });
@@ -699,7 +699,7 @@ describe("LiveblocksHistory", () => {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "edit";
+              return source.origin === "local" && source.via === "edit";
             })
           ) {
             return;
@@ -708,7 +708,7 @@ describe("LiveblocksHistory", () => {
           const isFromHistory = updates.some((update) => {
             const source = update.source;
             return (
-              source?.origin === "local" &&
+              source.origin === "local" &&
               (source.via === "undo" || source.via === "redo")
             );
           });

--- a/packages/liveblocks-lexical/src/__tests__/history.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/history.test.ts
@@ -6,7 +6,7 @@ import {
   LiveText,
   type Room,
 } from "@liveblocks/client";
-import { kInternal, kStorageUpdateSource } from "@liveblocks/core";
+import { kInternal } from "@liveblocks/core";
 import {
   $applyNodeReplacement,
   $createParagraphNode,
@@ -163,7 +163,7 @@ describe("LiveblocksHistory", () => {
         (updates) => {
           if (
             updates.every((update) => {
-              const source = update[kStorageUpdateSource];
+              const source = update.source;
               return source?.origin === "local" && source.via === "mutation";
             })
           ) {
@@ -171,7 +171,7 @@ describe("LiveblocksHistory", () => {
           }
 
           const isFromHistory = updates.some((update) => {
-            const source = update[kStorageUpdateSource];
+            const source = update.source;
             return source?.origin === "local" && source.via === "history";
           });
 
@@ -576,7 +576,7 @@ describe("LiveblocksHistory", () => {
         (updates) => {
           if (
             updates.every((update) => {
-              const source = update[kStorageUpdateSource];
+              const source = update.source;
               return source?.origin === "local" && source.via === "mutation";
             })
           ) {
@@ -584,7 +584,7 @@ describe("LiveblocksHistory", () => {
           }
 
           const isFromHistory = updates.some((update) => {
-            const source = update[kStorageUpdateSource];
+            const source = update.source;
             return source?.origin === "local" && source.via === "history";
           });
 
@@ -692,7 +692,7 @@ describe("LiveblocksHistory", () => {
         (updates) => {
           if (
             updates.every((update) => {
-              const source = update[kStorageUpdateSource];
+              const source = update.source;
               return source?.origin === "local" && source.via === "mutation";
             })
           ) {
@@ -700,7 +700,7 @@ describe("LiveblocksHistory", () => {
           }
 
           const isFromHistory = updates.some((update) => {
-            const source = update[kStorageUpdateSource];
+            const source = update.source;
             return source?.origin === "local" && source.via === "history";
           });
 
@@ -2041,7 +2041,9 @@ describe("LiveblocksHistory", () => {
       editor.update(() => {}, { discrete: true });
 
       const content = (
-        (document.get("children").get(0) as LiveElementNode).get("children").get(0)! as LiveTextNode
+        (document.get("children").get(0) as LiveElementNode)
+          .get("children")
+          .get(0)! as LiveTextNode
       ).get("content");
       expect(content.toString()).toBe("Ft");
 
@@ -2118,7 +2120,9 @@ describe("LiveblocksHistory", () => {
       editor.update(() => {}, { discrete: true });
 
       const content = (
-        (document.get("children").get(0) as LiveElementNode).get("children").get(0)! as LiveTextNode
+        (document.get("children").get(0) as LiveElementNode)
+          .get("children")
+          .get(0)! as LiveTextNode
       ).get("content");
 
       vi.advanceTimersByTime(1000);
@@ -2197,7 +2201,9 @@ describe("LiveblocksHistory", () => {
       );
 
       const content = (
-        (document.get("children").get(0) as LiveElementNode).get("children").get(0)! as LiveTextNode
+        (document.get("children").get(0) as LiveElementNode)
+          .get("children")
+          .get(0)! as LiveTextNode
       ).get("content");
       expect(content.toString()).toBe("Ft");
 
@@ -2419,7 +2425,9 @@ describe("LiveblocksHistory", () => {
         decodeAnchor: number | null;
       } | null = null;
       const firstContent = (
-        (document.get("children").get(0) as LiveElementNode).get("children").get(0)! as LiveTextNode
+        (document.get("children").get(0) as LiveElementNode)
+          .get("children")
+          .get(0)! as LiveTextNode
       ).get("content");
 
       const unsub = room[kInternal].history.subscribe((event) => {
@@ -2800,9 +2808,7 @@ describe("LiveblocksHistory", () => {
       const { editor, collaboration, manager } =
         createCollaborationFromDocument(room, document);
 
-      const liveText = (
-        document.get("children").get(0) as LiveElementNode
-      )
+      const liveText = (document.get("children").get(0) as LiveElementNode)
         .get("children")
         .get(0)! as LiveTextNode;
 
@@ -2848,12 +2854,14 @@ describe("LiveblocksHistory", () => {
       expect(staleFocusKey).not.toBeNull();
 
       // Detached keys that createBinding will not scrub (not in forward[]).
-      (
-        manager.binding.reverse as Map<string, typeof liveText>
-      ).set(staleAnchorKey!, liveText);
-      (
-        manager.binding.reverse as Map<string, typeof liveText>
-      ).set(staleFocusKey!, liveText);
+      (manager.binding.reverse as Map<string, typeof liveText>).set(
+        staleAnchorKey!,
+        liveText
+      );
+      (manager.binding.reverse as Map<string, typeof liveText>).set(
+        staleFocusKey!,
+        liveText
+      );
 
       vi.advanceTimersByTime(1000);
 
@@ -3085,7 +3093,9 @@ describe("LiveblocksHistory", () => {
       editor.update(() => {}, { discrete: true });
       collaboration.register();
 
-      const paragraph_liveblocks = document.get("children").get(0) as LiveElementNode;
+      const paragraph_liveblocks = document
+        .get("children")
+        .get(0) as LiveElementNode;
 
       editor.update(
         () => {
@@ -3176,13 +3186,19 @@ describe("LiveblocksHistory", () => {
       );
       vi.advanceTimersByTime(1000);
 
-      expect((document.get("children").get(0) as LiveElementNode).get("children").length).toBe(2);
+      expect(
+        (document.get("children").get(0) as LiveElementNode).get("children")
+          .length
+      ).toBe(2);
 
       editor.dispatchCommand(UNDO_COMMAND, undefined);
       await Promise.resolve();
       await Promise.resolve();
 
-      expect((document.get("children").get(0) as LiveElementNode).get("children").length).toBe(1);
+      expect(
+        (document.get("children").get(0) as LiveElementNode).get("children")
+          .length
+      ).toBe(1);
       expect(
         editor.read(() => {
           const selection = $getSelection();
@@ -3255,9 +3271,9 @@ describe("LiveblocksHistory", () => {
       editor.update(() => {}, { discrete: true });
       collaboration.register();
 
-      const decorator_liveblocks = (document
-        .get("children")
-        .get(0) as LiveElementNode)
+      const decorator_liveblocks = (
+        document.get("children").get(0) as LiveElementNode
+      )
         .get("children")
         .get(0)! as LiveDecoratorNode;
 
@@ -3341,7 +3357,10 @@ describe("LiveblocksHistory", () => {
           }
           const suffix = paragraph
             .getChildren()
-            .find((child) => $isTextNode(child) && child.getTextContent() === " you?");
+            .find(
+              (child) =>
+                $isTextNode(child) && child.getTextContent() === " you?"
+            );
           if (suffix === undefined || !$isTextNode(suffix)) {
             throw new Error("Expected suffix text node");
           }
@@ -3375,11 +3394,7 @@ describe("LiveblocksHistory", () => {
       ).toEqual([
         {
           kind: "text",
-          content: [
-            ["How "],
-            ["are", { bold: true }],
-            [" you?"],
-          ],
+          content: [["How "], ["are", { bold: true }], [" you?"]],
         },
       ]);
 
@@ -3799,7 +3814,9 @@ async function createRoomWithFormattedText(
 
   const document = root.get("document") as LiveRootNode;
   const content = (
-    (document.get("children").get(0) as LiveElementNode).get("children").get(0)! as LiveTextNode
+    (document.get("children").get(0) as LiveElementNode)
+      .get("children")
+      .get(0)! as LiveTextNode
   ).get("content");
 
   return { room, document, content };
@@ -3843,7 +3860,9 @@ async function createRoomWithText(text: string = "Hello") {
 
   const document = root.get("document") as LiveRootNode;
   const content = (
-    (document.get("children").get(0) as LiveElementNode).get("children").get(0)! as LiveTextNode
+    (document.get("children").get(0) as LiveElementNode)
+      .get("children")
+      .get(0)! as LiveTextNode
   ).get("content");
 
   return { room, document, content };

--- a/packages/liveblocks-lexical/src/__tests__/manager.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/manager.test.ts
@@ -5490,8 +5490,7 @@ describe("LiveblocksCollaborationManager", () => {
               ],
               source: {
                 origin: "local",
-                via: "history",
-                action: "redo",
+                via: "redo",
               },
             },
           ]);

--- a/packages/liveblocks-lexical/src/__tests__/manager.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/manager.test.ts
@@ -5445,7 +5445,7 @@ describe("LiveblocksCollaborationManager", () => {
                 text: "Changed",
               },
             ],
-            source: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "edit" },
           },
         ]);
       });
@@ -5591,7 +5591,7 @@ describe("LiveblocksCollaborationManager", () => {
                 item: paragraph_liveblocks,
               },
             ],
-            source: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "edit" },
           },
         ]);
       });
@@ -5781,7 +5781,7 @@ describe("LiveblocksCollaborationManager", () => {
                 deletedItem: deletedParagraph,
               },
             ],
-            source: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "edit" },
           },
         ]);
       });
@@ -6785,7 +6785,7 @@ describe("LiveblocksCollaborationManager", () => {
                 item: movedParagraph,
               },
             ],
-            source: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "edit" },
           },
         ]);
       });
@@ -7025,7 +7025,7 @@ describe("LiveblocksCollaborationManager", () => {
                 item: newParagraph,
               },
             ],
-            source: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "edit" },
           },
         ]);
       });
@@ -7266,7 +7266,7 @@ describe("LiveblocksCollaborationManager", () => {
               type: { type: "update" },
               props: { type: "update" },
             },
-            source: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "edit" },
           },
         ]);
       });

--- a/packages/liveblocks-lexical/src/__tests__/manager.test.ts
+++ b/packages/liveblocks-lexical/src/__tests__/manager.test.ts
@@ -8,7 +8,7 @@ import {
   type Room,
 } from "@liveblocks/client";
 import type { Json, TextAttributes } from "@liveblocks/core";
-import { kInternal, kStorageUpdateSource } from "@liveblocks/core";
+import { kInternal } from "@liveblocks/core";
 import {
   $applyNodeReplacement,
   $createParagraphNode,
@@ -5445,7 +5445,7 @@ describe("LiveblocksCollaborationManager", () => {
                 text: "Changed",
               },
             ],
-            [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "mutation" },
           },
         ]);
       });
@@ -5488,7 +5488,7 @@ describe("LiveblocksCollaborationManager", () => {
                   text: "!",
                 },
               ],
-              [kStorageUpdateSource]: {
+              source: {
                 origin: "local",
                 via: "history",
                 action: "redo",
@@ -5541,7 +5541,7 @@ describe("LiveblocksCollaborationManager", () => {
                   text: "!",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5591,7 +5591,7 @@ describe("LiveblocksCollaborationManager", () => {
                 item: paragraph_liveblocks,
               },
             ],
-            [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "mutation" },
           },
         ]);
       });
@@ -5634,7 +5634,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: paragraph_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5708,7 +5708,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5781,7 +5781,7 @@ describe("LiveblocksCollaborationManager", () => {
                 deletedItem: deletedParagraph,
               },
             ],
-            [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "mutation" },
           },
         ]);
       });
@@ -5817,7 +5817,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedText: "Hello",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5855,7 +5855,7 @@ describe("LiveblocksCollaborationManager", () => {
                   text: "Recovered",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5897,7 +5897,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedText: "Keep",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5935,7 +5935,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -5982,7 +5982,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedText: "Keep",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6013,7 +6013,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6045,7 +6045,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedItem: empty_text,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6091,7 +6091,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedText: "Keep",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6122,7 +6122,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6156,7 +6156,7 @@ describe("LiveblocksCollaborationManager", () => {
                   text: "After",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6220,7 +6220,7 @@ describe("LiveblocksCollaborationManager", () => {
                 { type: "insert", index: 1, item: p2 },
                 { type: "insert", index: 2, item: p3 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6376,7 +6376,7 @@ describe("LiveblocksCollaborationManager", () => {
                   { type: "delete", index: 1, deletedItem: before[1]! },
                   { type: "delete", index: 1, deletedItem: before[2]! },
                 ],
-                [kStorageUpdateSource]: { origin: "remote" },
+                source: { origin: "remote" },
               },
               {
                 type: "LiveText",
@@ -6390,7 +6390,7 @@ describe("LiveblocksCollaborationManager", () => {
                     deletedText: "Alpha",
                   },
                 ],
-                [kStorageUpdateSource]: { origin: "remote" },
+                source: { origin: "remote" },
               },
             ]);
           } else {
@@ -6404,7 +6404,7 @@ describe("LiveblocksCollaborationManager", () => {
                   { type: "delete", index: 0, deletedItem: before[2]! },
                   { type: "insert", index: 0, item: remaining },
                 ],
-                [kStorageUpdateSource]: { origin: "remote" },
+                source: { origin: "remote" },
               },
             ]);
           }
@@ -6497,7 +6497,7 @@ describe("LiveblocksCollaborationManager", () => {
               type: "LiveList",
               node: children_liveblocks,
               updates: [{ type: "delete", index: 1, deletedItem: before[1]! }],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
             {
               type: "LiveText",
@@ -6511,7 +6511,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedText: "Alpha",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6546,7 +6546,7 @@ describe("LiveblocksCollaborationManager", () => {
                   text: "KeepMe",
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6612,7 +6612,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedItem: deletedParagraph,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6683,7 +6683,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6714,7 +6714,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedItem: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6785,7 +6785,7 @@ describe("LiveblocksCollaborationManager", () => {
                 item: movedParagraph,
               },
             ],
-            [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "mutation" },
           },
         ]);
       });
@@ -6863,7 +6863,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: movedParagraph,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6936,7 +6936,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -6971,7 +6971,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7025,7 +7025,7 @@ describe("LiveblocksCollaborationManager", () => {
                 item: newParagraph,
               },
             ],
-            [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "mutation" },
           },
         ]);
       });
@@ -7103,7 +7103,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: newParagraph,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7180,7 +7180,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: linebreak_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7218,7 +7218,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: replacement,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7266,7 +7266,7 @@ describe("LiveblocksCollaborationManager", () => {
               type: { type: "update" },
               props: { type: "update" },
             },
-            [kStorageUpdateSource]: { origin: "local", via: "mutation" },
+            source: { origin: "local", via: "mutation" },
           },
         ]);
       });
@@ -7296,7 +7296,7 @@ describe("LiveblocksCollaborationManager", () => {
                 type: { type: "update" },
                 props: { type: "update" },
               },
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7337,7 +7337,7 @@ describe("LiveblocksCollaborationManager", () => {
                 type: { type: "update" },
                 props: { type: "update" },
               },
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7359,7 +7359,7 @@ describe("LiveblocksCollaborationManager", () => {
               updates: {
                 tag: { type: "update" },
               },
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7409,7 +7409,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: decorator_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7488,7 +7488,7 @@ describe("LiveblocksCollaborationManager", () => {
                   deletedItem: decorator_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7563,7 +7563,7 @@ describe("LiveblocksCollaborationManager", () => {
                     deletedItem: decorator_liveblocks,
                   },
                 ],
-                [kStorageUpdateSource]: { origin: "remote" },
+                source: { origin: "remote" },
               },
             ]);
           },
@@ -7630,7 +7630,7 @@ describe("LiveblocksCollaborationManager", () => {
               updates: {
                 props: { type: "update" },
               },
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7698,7 +7698,7 @@ describe("LiveblocksCollaborationManager", () => {
                 src: { type: "update" },
                 altText: { type: "update" },
               },
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7770,7 +7770,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: decorator_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },
@@ -7844,7 +7844,7 @@ describe("LiveblocksCollaborationManager", () => {
                   item: decorator_liveblocks,
                 },
               ],
-              [kStorageUpdateSource]: { origin: "remote" },
+              source: { origin: "remote" },
             },
           ]);
         },

--- a/packages/liveblocks-lexical/src/collaboration.ts
+++ b/packages/liveblocks-lexical/src/collaboration.ts
@@ -1,5 +1,4 @@
 import type { Room } from "@liveblocks/client";
-import { kStorageUpdateSource } from "@liveblocks/core";
 import { mergeRegister } from "@lexical/utils";
 import {
   $getSelection,
@@ -102,7 +101,7 @@ export class LiveblocksCollaboration {
 
           if (
             updates.every((update) => {
-              const source = update[kStorageUpdateSource];
+              const source = update.source;
               return source?.origin === "local" && source.via === "mutation";
             })
           ) {
@@ -110,7 +109,7 @@ export class LiveblocksCollaboration {
           }
 
           const isFromHistory = updates.some((update) => {
-            const source = update[kStorageUpdateSource];
+            const source = update.source;
             return source?.origin === "local" && source.via === "history";
           });
 

--- a/packages/liveblocks-lexical/src/collaboration.ts
+++ b/packages/liveblocks-lexical/src/collaboration.ts
@@ -102,7 +102,7 @@ export class LiveblocksCollaboration {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "mutation";
+              return source?.origin === "local" && source.via === "edit";
             })
           ) {
             return;

--- a/packages/liveblocks-lexical/src/collaboration.ts
+++ b/packages/liveblocks-lexical/src/collaboration.ts
@@ -110,7 +110,10 @@ export class LiveblocksCollaboration {
 
           const isFromHistory = updates.some((update) => {
             const source = update.source;
-            return source?.origin === "local" && source.via === "history";
+            return (
+              source?.origin === "local" &&
+              (source.via === "undo" || source.via === "redo")
+            );
           });
 
           try {

--- a/packages/liveblocks-lexical/src/collaboration.ts
+++ b/packages/liveblocks-lexical/src/collaboration.ts
@@ -102,7 +102,7 @@ export class LiveblocksCollaboration {
           if (
             updates.every((update) => {
               const source = update.source;
-              return source?.origin === "local" && source.via === "edit";
+              return source.origin === "local" && source.via === "edit";
             })
           ) {
             return;
@@ -111,7 +111,7 @@ export class LiveblocksCollaboration {
           const isFromHistory = updates.some((update) => {
             const source = update.source;
             return (
-              source?.origin === "local" &&
+              source.origin === "local" &&
               (source.via === "undo" || source.via === "redo")
             );
           });

--- a/packages/liveblocks-lexical/src/manager.ts
+++ b/packages/liveblocks-lexical/src/manager.ts
@@ -1501,13 +1501,14 @@ export class LiveblocksCollaborationManager {
 
   public $applyRemoteUpdates(updates: readonly StorageUpdate[]) {
     // Apply peer edits and local undo/redo replays. Skip our own live
-    // mutations — Lexical already reflects those. History updates use
-    // `origin: "local", via: "history"` (see StorageUpdateSource).
+    // mutations: Lexical already reflects those. History updates use
+    // `origin: "local", via: "undo" | "redo"` (see StorageUpdateSource).
     updates = updates.filter((update) => {
       const source = update.source;
       return (
         source?.origin === "remote" ||
-        (source?.origin === "local" && source.via === "history")
+        (source?.origin === "local" &&
+          (source.via === "undo" || source.via === "redo"))
       );
     });
     if (updates.length === 0) {

--- a/packages/liveblocks-lexical/src/manager.ts
+++ b/packages/liveblocks-lexical/src/manager.ts
@@ -9,7 +9,6 @@ import {
 import {
   type JsonObject,
   kInternal,
-  kStorageUpdateSource,
   type PrivateLiveNodeApi,
   type TextAttributes,
 } from "@liveblocks/core";
@@ -1505,7 +1504,7 @@ export class LiveblocksCollaborationManager {
     // mutations — Lexical already reflects those. History updates use
     // `origin: "local", via: "history"` (see StorageUpdateSource).
     updates = updates.filter((update) => {
-      const source = update[kStorageUpdateSource];
+      const source = update.source;
       return (
         source?.origin === "remote" ||
         (source?.origin === "local" && source.via === "history")

--- a/packages/liveblocks-lexical/src/manager.ts
+++ b/packages/liveblocks-lexical/src/manager.ts
@@ -1502,12 +1502,12 @@ export class LiveblocksCollaborationManager {
   public $applyRemoteUpdates(updates: readonly StorageUpdate[]) {
     // Apply peer edits and local undo/redo replays. Skip our own live
     // mutations: Lexical already reflects those. History updates use
-    // `origin: "local", via: "undo" | "redo"` (see StorageUpdateSource).
+    // `origin: "local", via: "undo" | "redo"` (see UpdateSource).
     updates = updates.filter((update) => {
       const source = update.source;
       return (
-        source?.origin === "remote" ||
-        (source?.origin === "local" &&
+        source.origin === "remote" ||
+        (source.origin === "local" &&
           (source.via === "undo" || source.via === "redo"))
       );
     });

--- a/packages/liveblocks-lexical/vitest.config.ts
+++ b/packages/liveblocks-lexical/vitest.config.ts
@@ -8,8 +8,11 @@ const vitestSetup = path.resolve(
   "../../shared/vitest-config/setup.js"
 );
 
-// Force a single @liveblocks/core instance so kStorageUpdateSource (a Symbol)
-// matches between the mock-server test helpers (core/src) and package imports.
+// The mock WebSocket server lives in @liveblocks/core's src/__tests__/, which
+// is neither exported nor built, so tests can only reach it by relative path.
+// That loads core from source, while the code under test imports the built
+// @liveblocks/core. Two copies means two kInternal Symbols and two sets of CRDT
+// classes, so alias both onto the source copy.
 const liveblocksCore = path.resolve(
   __dirname,
   "../liveblocks-core/src/index.ts"

--- a/packages/liveblocks-prosemirror/src/__tests__/collaboration-liveblocks.test.ts
+++ b/packages/liveblocks-prosemirror/src/__tests__/collaboration-liveblocks.test.ts
@@ -911,10 +911,7 @@ describe("collaboration-liveblocks schema", () => {
           text: "!",
         },
       ],
-    };
-    localUpdate.source = {
-      origin: "local",
-      via: "edit",
+      source: { origin: "local", via: "edit" },
     };
 
     notifyStorageUpdate([localUpdate]);

--- a/packages/liveblocks-prosemirror/src/__tests__/collaboration-liveblocks.test.ts
+++ b/packages/liveblocks-prosemirror/src/__tests__/collaboration-liveblocks.test.ts
@@ -914,7 +914,7 @@ describe("collaboration-liveblocks schema", () => {
     };
     localUpdate.source = {
       origin: "local",
-      via: "mutation",
+      via: "edit",
     };
 
     notifyStorageUpdate([localUpdate]);

--- a/packages/liveblocks-prosemirror/src/__tests__/collaboration-liveblocks.test.ts
+++ b/packages/liveblocks-prosemirror/src/__tests__/collaboration-liveblocks.test.ts
@@ -1,6 +1,6 @@
 import type { LsonObject, StorageUpdate } from "@liveblocks/client";
 import { LiveList, LiveMap, LiveObject, LiveText } from "@liveblocks/client";
-import { kInternal, kStorageUpdateSource, OpCode } from "@liveblocks/core";
+import { kInternal, OpCode } from "@liveblocks/core";
 import { Editor, Extension, Mark, Node } from "@tiptap/core";
 import Document from "@tiptap/extension-document";
 import Paragraph from "@tiptap/extension-paragraph";
@@ -912,7 +912,7 @@ describe("collaboration-liveblocks schema", () => {
         },
       ],
     };
-    localUpdate[kStorageUpdateSource] = {
+    localUpdate.source = {
       origin: "local",
       via: "mutation",
     };

--- a/packages/liveblocks-prosemirror/src/plugin.ts
+++ b/packages/liveblocks-prosemirror/src/plugin.ts
@@ -127,8 +127,11 @@ function getHistoryAction(
 ): "undo" | "redo" | undefined {
   for (const update of updates ?? []) {
     const source = update.source;
-    if (source?.origin === "local" && source.via === "history") {
-      return source.action;
+    if (
+      source?.origin === "local" &&
+      (source.via === "undo" || source.via === "redo")
+    ) {
+      return source.via;
     }
   }
 

--- a/packages/liveblocks-prosemirror/src/plugin.ts
+++ b/packages/liveblocks-prosemirror/src/plugin.ts
@@ -128,7 +128,7 @@ function getHistoryAction(
   for (const update of updates ?? []) {
     const source = update.source;
     if (
-      source?.origin === "local" &&
+      source.origin === "local" &&
       (source.via === "undo" || source.via === "redo")
     ) {
       return source.via;
@@ -493,7 +493,7 @@ export function createLiveblocksCollaborationPlugin(
             if (
               updates.every((update) => {
                 const source = update.source;
-                return source?.origin === "local" && source.via === "edit";
+                return source.origin === "local" && source.via === "edit";
               })
             ) {
               return;

--- a/packages/liveblocks-prosemirror/src/plugin.ts
+++ b/packages/liveblocks-prosemirror/src/plugin.ts
@@ -490,7 +490,7 @@ export function createLiveblocksCollaborationPlugin(
             if (
               updates.every((update) => {
                 const source = update.source;
-                return source?.origin === "local" && source.via === "mutation";
+                return source?.origin === "local" && source.via === "edit";
               })
             ) {
               return;

--- a/packages/liveblocks-prosemirror/src/plugin.ts
+++ b/packages/liveblocks-prosemirror/src/plugin.ts
@@ -1,6 +1,6 @@
 import type { LsonObject, StorageUpdate } from "@liveblocks/client";
 import { LiveMap, LiveObject } from "@liveblocks/client";
-import { kInternal, kStorageUpdateSource } from "@liveblocks/core";
+import { kInternal } from "@liveblocks/core";
 import { Slice } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
@@ -126,7 +126,7 @@ function getHistoryAction(
   updates: readonly StorageUpdate[] | undefined
 ): "undo" | "redo" | undefined {
   for (const update of updates ?? []) {
-    const source = update[kStorageUpdateSource];
+    const source = update.source;
     if (source?.origin === "local" && source.via === "history") {
       return source.action;
     }
@@ -489,7 +489,7 @@ export function createLiveblocksCollaborationPlugin(
           (updates) => {
             if (
               updates.every((update) => {
-                const source = update[kStorageUpdateSource];
+                const source = update.source;
                 return source?.origin === "local" && source.via === "mutation";
               })
             ) {

--- a/packages/liveblocks-prosemirror/vitest.config.ts
+++ b/packages/liveblocks-prosemirror/vitest.config.ts
@@ -8,8 +8,11 @@ const vitestSetup = path.resolve(
   "../../shared/vitest-config/setup.js"
 );
 
-// Force one copy of the Liveblocks internals so Symbols and CRDT classes match
-// the source-level mock server used by the history integration tests.
+// The mock WebSocket server lives in @liveblocks/core's src/__tests__/, which
+// is neither exported nor built, so tests can only reach it by relative path.
+// That loads core from source, while the code under test imports the built
+// @liveblocks/core. Two copies means two kInternal Symbols and two sets of CRDT
+// classes, so alias both onto the source copy.
 const liveblocksCore = path.resolve(
   __dirname,
   "../liveblocks-core/src/index.ts"


### PR DESCRIPTION
This PR replaces the internal `kStorageUpdateSource` symbol on Storage updates with a normal, public `source` field (like discussed and agreed [here](https://liveblocks.slack.com/archives/C02PZL7QAAW/p1785237763100729)).

```diff
 export type UpdateSource =
   | { origin: "remote" }
-  | { origin: "local"; via: "mutation" }
-  | { origin: "local"; via: "history"; action: "undo" | "redo" };
+  | { origin: "local"; via: "edit" | "undo" | "redo" };

 export type StorageUpdate = (
   | LiveMapUpdate
   | LiveObjectUpdate
   | LiveListUpdate
   | LiveTextUpdate
 ) & {
-  [kStorageUpdateSource]?: StorageUpdateSource;
+  source: UpdateSource;
 };
```

## ~`source` is still optional~

~I wanted to make it mandatory in the same go, and I got it working, but it's a bigger can of worms than it looks, so I've cut it out of this PR and want to attempt to make the change again. I think making it mandatory is necessary to make it publicly supported. I'm sure it can be done, but it requires a bit more wiring internally than I initially expected.~

~So take two folllowing soon for that part. The current changes in this PR however are all simple and ready to go already! 🙏~

This is now done in https://github.com/liveblocks/liveblocks/compare/liveblocks:e89cf4a...liveblocks:3f773bd.

## Reviewing

Nothing here changes user-facing behaviour. Best reviewed commit-by-commit.
