### PR TITLE
Fix release script flag parsing

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -28,7 +28,7 @@ COMMIT_MESSAGE="Bump to "
 FORCE_FLAG=""
 WORKSPACES_UPDATE_FLAG=""
 UPDATE_CHANGELOG="false"
-while getopts V:p:m:fwch flag; do
+while getopts V:pm:fwch flag; do
     case "$flag" in
         V) VERSION=$OPTARG;;
         p) PUSH_COMMIT="true";;


### PR DESCRIPTION
This PR fixes `release.sh` treating `-p` as an option that requires an argument, which caused `-p -m` to interpret the commit message as a package directory.