### PR TITLE
Improve version history components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## vNEXT (not yet released)
 
+## v3.23.1
+
+### `@liveblocks/react-ui`
+
+- Improve version history components for versions without authors, which can
+  occur with server-only changes. Add `HISTORY_VERSION_SUMMARY_AUTHORS_LIST` and
+  update `HISTORY_VERSION_PREVIEW_AUTHORS_LIST` overrides to reflect this.
+
 ## v3.23.0
 
 This release introduces `LiveFile`: a new data structure to store files such as
@@ -768,7 +776,8 @@ metadata to individual comments in the same way as thread metadata.
 This release introduces group mentions (e.g. `@engineering`) across all packages
 and first-class support for tenants. Learn more about
 [group mentions](https://liveblocks.io/docs/ready-made-features/comments/users-and-mentions)
-and [tenants](https://liveblocks.io/docs/authentication/organizations) in the docs.
+and [tenants](https://liveblocks.io/docs/authentication/organizations) in the
+docs.
 
 ### `@liveblocks/client`
 

--- a/docs/pages/api-reference/liveblocks-react-blocknote.mdx
+++ b/docs/pages/api-reference/liveblocks-react-blocknote.mdx
@@ -742,6 +742,11 @@ and logic for restoring. To render a list of versions, see
 Learn how to set this up in our
 [version history guide](/docs/guides/how-to-add-version-history-to-your-app).
 
+A version can have no authors when it contains only server-side changes. In that
+case, `HistoryVersionPreview` displays “Unattributed edits”. You can customize
+this text with
+[`HISTORY_VERSION_PREVIEW_AUTHORS_LIST`](/docs/api-reference/liveblocks-react-ui#Overrides-History-version-preview).
+
 #### Usage [#HistoryVersionPreview-usage]
 
 ```tsx

--- a/docs/pages/api-reference/liveblocks-react-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-react-lexical.mdx
@@ -1702,6 +1702,11 @@ render a list of versions, see
 Learn how to set this up in our
 [version history guide](/docs/guides/how-to-add-version-history-to-your-app).
 
+A version can have no authors when it contains only server-side changes. In that
+case, `HistoryVersionPreview` displays “Unattributed edits”. You can customize
+this text with
+[`HISTORY_VERSION_PREVIEW_AUTHORS_LIST`](/docs/api-reference/liveblocks-react-ui#Overrides-History-version-preview).
+
 #### Usage
 
 ```tsx

--- a/docs/pages/api-reference/liveblocks-react-tiptap.mdx
+++ b/docs/pages/api-reference/liveblocks-react-tiptap.mdx
@@ -1650,6 +1650,11 @@ logic for restoring. To render a list of versions, see
 Learn how to set this up in our
 [version history guide](/docs/guides/how-to-add-version-history-to-your-app).
 
+A version can have no authors when it contains only server-side changes. In that
+case, `HistoryVersionPreview` displays “Unattributed edits”. You can customize
+this text with
+[`HISTORY_VERSION_PREVIEW_AUTHORS_LIST`](/docs/api-reference/liveblocks-react-ui#Overrides-History-version-preview).
+
 #### Usage [#HistoryVersionPreview-usage]
 
 ```tsx

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -4261,6 +4261,11 @@ up in our
 
 Displays a version summary which includes the author and date.
 
+A version can have no authors when it contains only server-side changes. In that
+case, `HistoryVersionSummary` displays “Unattributed”. You can customize this
+text with
+[`HISTORY_VERSION_SUMMARY_AUTHORS_LIST`](/docs/api-reference/liveblocks-react-ui#Overrides-History-version-summary).
+
 ```tsx
 <HistoryVersionSummary
   onClick={() => {

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -4271,7 +4271,7 @@ Displays a version summary which includes the author and date.
 />
 ```
 
-##### Props [#HistoryVersionSummary-props]
+#### Props [#HistoryVersionSummary-props]
 
 <PropertiesList>
   <PropertiesListItem name="onClick" type="() => void">
@@ -4285,7 +4285,7 @@ Displays a version summary which includes the author and date.
   </PropertiesListItem>
 </PropertiesList>
 
-#### HistoryVersionSummaryList
+### HistoryVersionSummaryList
 
 Displays a list of version summaries for a document’s history including authors
 and dates.
@@ -4305,7 +4305,7 @@ and dates.
 </HistoryVersionSummaryList>
 ```
 
-##### Props [#HistoryVersionSummaryList-props]
+#### Props [#HistoryVersionSummaryList-props]
 
 <PropertiesList>
   <PropertiesListItem name="children" type="ReactNode">

--- a/docs/pages/api-reference/liveblocks-react-ui.mdx
+++ b/docs/pages/api-reference/liveblocks-react-ui.mdx
@@ -4723,19 +4723,28 @@ and
 | `INBOX_NOTIFICATION_THREAD_MENTION`       | Thread mention text | `"X mentioned you in Y"` |
 | `INBOX_NOTIFICATION_TEXT_MENTION`         | Text mention text   | `"X mentioned you in Y"` |
 
+##### History version summary [#Overrides-History-version-summary]
+
+History version summary overrides can be set on
+[`LiveblocksUiConfig`](/docs/api-reference/liveblocks-react-ui#LiveblocksUiConfig).
+The authors list is `undefined` when the version has no authors.
+
+| Name                                   | Description       | Default value             |
+| -------------------------------------- | ----------------- | ------------------------- |
+| `HISTORY_VERSION_SUMMARY_AUTHORS_LIST` | Authors list text | `"X"` or `"Unattributed"` |
+
 ##### History version preview [#Overrides-History-version-preview]
 
-History version preview overrides can be set on both
-[`HistoryVersionSummary`](/docs/api-reference/liveblocks-react-ui#HistoryVersionSummary)
-and
+History version preview overrides can be set on
 [`LiveblocksUiConfig`](/docs/api-reference/liveblocks-react-ui#LiveblocksUiConfig).
+The authors list is `undefined` when the version has no authors.
 
-| Name                                   | Description          | Default value           |
-| -------------------------------------- | -------------------- | ----------------------- |
-| `HISTORY_VERSION_PREVIEW_AUTHORS_LIST` | Authors list text    | `"Edits from X"`        |
-| `HISTORY_VERSION_PREVIEW_RESTORE`      | Restore button label | `"Restore"`             |
-| `HISTORY_VERSION_PREVIEW_EMPTY`        | Empty state text     | `"No content."`         |
-| `HISTORY_VERSION_PREVIEW_ERROR`        | Error message        | `"There was an error…"` |
+| Name                                   | Description          | Default value                              |
+| -------------------------------------- | -------------------- | ------------------------------------------ |
+| `HISTORY_VERSION_PREVIEW_AUTHORS_LIST` | Authors list text    | `"Edits from X"` or `"Unattributed edits"` |
+| `HISTORY_VERSION_PREVIEW_RESTORE`      | Restore button label | `"Restore"`                                |
+| `HISTORY_VERSION_PREVIEW_EMPTY`        | Empty state text     | `"No content."`                            |
+| `HISTORY_VERSION_PREVIEW_ERROR`        | Error message        | `"There was an error…"`                    |
 
 ##### AI composer [#Overrides-AI-composer]
 

--- a/packages/liveblocks-react-lexical/src/version-history/history-version-preview.tsx
+++ b/packages/liveblocks-react-lexical/src/version-history/history-version-preview.tsx
@@ -200,14 +200,16 @@ export const HistoryVersionPreview = forwardRef<
       <div className="lb-history-version-preview-footer">
         <span className="lb-history-version-preview-authors">
           {$.HISTORY_VERSION_PREVIEW_AUTHORS_LIST(
-            <List
-              values={version.authors.map((author) => (
-                <User key={author.id} userId={author.id} replaceSelf />
-              ))}
-              formatRemaining={$.LIST_REMAINING_USERS}
-              truncate={AUTHORS_TRUNCATE}
-              locale={$.locale}
-            />
+            version.authors.length > 0 ? (
+              <List
+                values={version.authors.map((author) => (
+                  <User key={author.id} userId={author.id} replaceSelf />
+                ))}
+                formatRemaining={$.LIST_REMAINING_USERS}
+                truncate={AUTHORS_TRUNCATE}
+                locale={$.locale}
+              />
+            ) : undefined
           )}
         </span>
         <div className="lb-history-version-preview-actions">

--- a/packages/liveblocks-react-tiptap/src/version-history/HistoryVersionPreview.tsx
+++ b/packages/liveblocks-react-tiptap/src/version-history/HistoryVersionPreview.tsx
@@ -91,14 +91,16 @@ export const HistoryVersionPreview = forwardRef<
         <div className="lb-history-version-preview-footer">
           <span className="lb-history-version-preview-authors">
             {$.HISTORY_VERSION_PREVIEW_AUTHORS_LIST(
-              <List
-                values={version.authors.map((author) => (
-                  <User key={author.id} userId={author.id} replaceSelf />
-                ))}
-                formatRemaining={$.LIST_REMAINING_USERS}
-                truncate={AUTHORS_TRUNCATE}
-                locale={$.locale}
-              />
+              version.authors.length > 0 ? (
+                <List
+                  values={version.authors.map((author) => (
+                    <User key={author.id} userId={author.id} replaceSelf />
+                  ))}
+                  formatRemaining={$.LIST_REMAINING_USERS}
+                  truncate={AUTHORS_TRUNCATE}
+                  locale={$.locale}
+                />
+              ) : undefined
             )}
           </span>
           <div className="lb-history-version-preview-actions">

--- a/packages/liveblocks-react-ui/src/components/HistoryVersionSummary.tsx
+++ b/packages/liveblocks-react-ui/src/components/HistoryVersionSummary.tsx
@@ -42,14 +42,18 @@ export const HistoryVersionSummary = forwardRef<
         className="lb-date lb-history-version-summary-date"
       />
       <span className="lb-history-version-summary-authors">
-        <List
-          values={version.authors.map((author) => (
-            <User key={author.id} userId={author.id} replaceSelf />
-          ))}
-          formatRemaining={$.LIST_REMAINING_USERS}
-          truncate={AUTHORS_TRUNCATE}
-          locale={$.locale}
-        />
+        {$.HISTORY_VERSION_SUMMARY_AUTHORS_LIST(
+          version.authors.length > 0 ? (
+            <List
+              values={version.authors.map((author) => (
+                <User key={author.id} userId={author.id} replaceSelf />
+              ))}
+              formatRemaining={$.LIST_REMAINING_USERS}
+              truncate={AUTHORS_TRUNCATE}
+              locale={$.locale}
+            />
+          ) : undefined
+        )}
       </span>
     </button>
   );

--- a/packages/liveblocks-react-ui/src/overrides.tsx
+++ b/packages/liveblocks-react-ui/src/overrides.tsx
@@ -126,8 +126,16 @@ export interface InboxNotificationOverrides {
   ) => ReactNode;
 }
 
+export interface HistoryVersionSummaryOverrides {
+  HISTORY_VERSION_SUMMARY_AUTHORS_LIST: (
+    list: ReactNode | undefined
+  ) => ReactNode;
+}
+
 export interface HistoryVersionPreviewOverrides {
-  HISTORY_VERSION_PREVIEW_AUTHORS_LIST: (list: ReactNode) => ReactNode;
+  HISTORY_VERSION_PREVIEW_AUTHORS_LIST: (
+    list: ReactNode | undefined
+  ) => ReactNode;
   HISTORY_VERSION_PREVIEW_RESTORE: string;
   HISTORY_VERSION_PREVIEW_EMPTY: ReactNode;
   HISTORY_VERSION_PREVIEW_ERROR: (error: Error) => ReactNode;
@@ -139,6 +147,7 @@ export type Overrides = LocalizationOverrides &
   CommentOverrides &
   ThreadOverrides &
   InboxNotificationOverrides &
+  HistoryVersionSummaryOverrides &
   HistoryVersionPreviewOverrides &
   AiComposerOverrides &
   AiChatMessageOverrides &
@@ -243,9 +252,10 @@ export const defaultOverrides: Overrides = {
       {user} mentioned you{room ? <> in {room}</> : null}
     </>
   ),
-  HISTORY_VERSION_PREVIEW_AUTHORS_LIST: (list: ReactNode) => (
-    <>Edits from {list}</>
-  ),
+  HISTORY_VERSION_SUMMARY_AUTHORS_LIST: (list: ReactNode | undefined) =>
+    list === undefined ? "Unattributed" : list,
+  HISTORY_VERSION_PREVIEW_AUTHORS_LIST: (list: ReactNode | undefined) =>
+    list === undefined ? "Unattributed edits" : <>Edits from {list}</>,
   HISTORY_VERSION_PREVIEW_RESTORE: "Restore",
   HISTORY_VERSION_PREVIEW_EMPTY: "No content.",
   HISTORY_VERSION_PREVIEW_ERROR: () =>

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2373,6 +2373,7 @@
   min-inline-size: 0;
   padding: var(--lb-spacing);
   background: var(--lb-dynamic-background);
+  text-align: start;
   transition-property: background;
 
   &:where(

--- a/packages/liveblocks-react-ui/src/styles/index.css
+++ b/packages/liveblocks-react-ui/src/styles/index.css
@@ -2373,6 +2373,7 @@
   min-inline-size: 0;
   padding: var(--lb-spacing);
   background: var(--lb-dynamic-background);
+  outline: none;
   text-align: start;
   transition-property: background;
 


### PR DESCRIPTION
This PR fixes and slightly improve version history components:

- `HistoryVersionSummary` is now always start-aligned (left or right depending on LTR or RTL)
- `HistoryVersionSummary` and `HistoryVersionPreview` now show “Unattributed” and “Unattributed edits” when a version doesn't have authors, and the docs have been updated to explain this and teach how to customize it via overrides
