### PR TITLE
Stop the tldraw examples from going out of sync

### DIFF
--- a/docs/pages/get-started/nextjs-tldraw.mdx
+++ b/docs/pages/get-started/nextjs-tldraw.mdx
@@ -202,9 +202,38 @@ collaboration to your Next.js and Tldraw app using hooks from
         TLInstancePresence,
         TLPageId,
         TLRecord,
+        TLStore,
         TLStoreEventInfo,
         TLStoreWithStatus,
       } from "tldraw";
+
+      const skippedRecordIds = new Set<TLRecord["id"]>();
+
+      // Put records from Storage into tldraw, falling back to one record at a
+      // time if the batch is rejected. tldraw throws on a record it can't read,
+      // for instance one written by a client running a different version of
+      // tldraw, and one unreadable record would otherwise take the rest of the
+      // batch with it.
+      function putRecords(
+        store: TLStore,
+        records: TLRecord[],
+        phase?: "initialize"
+      ) {
+        try {
+          store.put(records, phase);
+        } catch {
+          for (const record of records) {
+            try {
+              store.put([record], phase);
+            } catch (error) {
+              if (!skippedRecordIds.has(record.id)) {
+                skippedRecordIds.add(record.id);
+                console.warn(`Skipping record ${record.id} from Storage`, error);
+              }
+            }
+          }
+        }
+      }
 
       export function useStorageStore({
         shapeUtils = [],
@@ -245,7 +274,8 @@ collaboration to your Next.js and Tldraw app using hooks from
 
             // Initialize tldraw with records from Storage
             store.clear();
-            store.put(
+            putRecords(
+              store,
               [
                 DocumentRecordType.create({
                   id: "document:document" as TLDocument["id"],
@@ -352,7 +382,7 @@ collaboration to your Next.js and Tldraw app using hooks from
                       store.remove(toRemove);
                     }
                     if (toPut.length) {
-                      store.put(toPut);
+                      putRecords(store, toPut);
                     }
                   });
                 },
@@ -445,7 +475,7 @@ collaboration to your Next.js and Tldraw app using hooks from
                     store.remove(toRemove);
                   }
                   if (toPut.length) {
-                    store.put(toPut);
+                    putRecords(store, toPut);
                   }
                 });
               })

--- a/docs/pages/get-started/nextjs-tldraw.mdx
+++ b/docs/pages/get-started/nextjs-tldraw.mdx
@@ -236,76 +236,27 @@ collaboration to your Next.js and Tldraw app using hooks from
 
         useEffect(() => {
           const unsubs: (() => void)[] = [];
-          let isCancelled = false;
           // State is already initialized to "loading", no need to set it again
 
           async function setup() {
             // Get Liveblocks Storage values
             const { root } = await room.getStorage();
-
-            // The effect was cleaned up while Storage was loading
-            if (isCancelled) {
-              return;
-            }
-
-            const defaultRecords: TLRecord[] = [
-              DocumentRecordType.create({
-                id: "document:document" as TLDocument["id"],
-              }),
-              PageRecordType.create({
-                id: "page:page" as TLPageId,
-                name: "Page 1",
-                index: "a1" as IndexKey,
-              }),
-            ];
-
-            // The `records` map isn't a stable object: when several people open
-            // a brand new room at the same time, they each create one to
-            // populate the room's `initialStorage`, and only one of those maps
-            // wins. Never hold onto the map, always read the current one and
-            // initialize it the first time it's seen, otherwise reads and
-            // writes end up on a map that is no longer part of Storage, and the
-            // whiteboard silently stops syncing.
-            let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
-
-            function getLiveRecords() {
-              const liveRecords = root.get("records");
-
-              if (liveRecords !== knownLiveRecords) {
-                knownLiveRecords = liveRecords;
-
-                room.batch(() => {
-                  // The records tldraw needs to start up, plus everything
-                  // already drawn locally, so that nothing is lost if this map
-                  // replaced another one
-                  const records = [
-                    ...defaultRecords,
-                    ...store
-                      .allRecords()
-                      .filter((record) =>
-                        store.scopedTypes.document.has(record.typeName)
-                      ),
-                  ];
-
-                  records.forEach((record) => {
-                    if (!liveRecords.has(record.id)) {
-                      liveRecords.set(record.id, record);
-                    }
-                  });
-                });
-              }
-
-              return liveRecords;
-            }
-
-            function getRecordsFromStorage(): TLRecord[] {
-              return [...getLiveRecords().values()];
-            }
+            const liveRecords = root.get("records");
 
             // Initialize tldraw with records from Storage
             store.clear();
             store.put(
-              [...defaultRecords, ...getRecordsFromStorage()],
+              [
+                DocumentRecordType.create({
+                  id: "document:document" as TLDocument["id"],
+                }),
+                PageRecordType.create({
+                  id: "page:page" as TLPageId,
+                  name: "Page 1",
+                  index: "a1" as IndexKey,
+                }),
+                ...[...liveRecords.values()],
+              ],
               "initialize"
             );
 
@@ -313,8 +264,6 @@ collaboration to your Next.js and Tldraw app using hooks from
             unsubs.push(
               store.listen(
                 ({ changes }: TLStoreEventInfo) => {
-                  const liveRecords = getLiveRecords();
-
                   room.batch(() => {
                     Object.values(changes.added).forEach((record) => {
                       liveRecords.set(record.id, record);
@@ -333,23 +282,69 @@ collaboration to your Next.js and Tldraw app using hooks from
               )
             );
 
-            // Update tldraw when Storage changes. Subscribing to the root, and
-            // not to the `records` map, keeps working if that map is ever
-            // replaced
+            // Sync tldraw changes with Presence
+            function syncStoreWithPresence({ changes }: TLStoreEventInfo) {
+              room.batch(() => {
+                Object.values(changes.added).forEach((record) => {
+                  room.updatePresence({ [record.id]: record });
+                });
+
+                Object.values(changes.updated).forEach(([_, record]) => {
+                  room.updatePresence({ [record.id]: record });
+                });
+
+                Object.values(changes.removed).forEach((record) => {
+                  room.updatePresence({ [record.id]: null });
+                });
+              });
+            }
+
+            unsubs.push(
+              store.listen(syncStoreWithPresence, {
+                source: "user",
+                scope: "session",
+              })
+            );
+
+            unsubs.push(
+              store.listen(syncStoreWithPresence, {
+                source: "user",
+                scope: "presence",
+              })
+            );
+
+            // Update tldraw when Storage changes
             unsubs.push(
               room.subscribe(
-                root,
-                () => {
-                  const toPut = getRecordsFromStorage();
-                  const recordIds = new Set(toPut.map((record) => record.id));
-                  const toRemove = store
-                    .allRecords()
-                    .filter(
-                      (record) =>
-                        store.scopedTypes.document.has(record.typeName) &&
-                        !recordIds.has(record.id)
-                    )
-                    .map((record) => record.id);
+                liveRecords,
+                (storageChanges) => {
+                  const toRemove: TLRecord["id"][] = [];
+                  const toPut: TLRecord[] = [];
+
+                  for (const update of storageChanges) {
+                    if (update.type !== "LiveMap") {
+                      return;
+                    }
+
+                    for (const [id, { type }] of Object.entries(update.updates)) {
+                      switch (type) {
+                        // Object deleted from Liveblocks, remove from tldraw
+                        case "delete": {
+                          toRemove.push(id as TLRecord["id"]);
+                          break;
+                        }
+
+                        // Object updated on Liveblocks, update tldraw
+                        case "update": {
+                          const curr = update.node.get(id);
+                          if (curr) {
+                            toPut.push(curr as any as TLRecord);
+                          }
+                          break;
+                        }
+                      }
+                    }
+                  }
 
                   // Update tldraw with changes
                   store.mergeRemoteChanges(() => {
@@ -466,7 +461,6 @@ collaboration to your Next.js and Tldraw app using hooks from
           setup();
 
           return () => {
-            isCancelled = true;
             unsubs.forEach((fn) => fn());
             unsubs.length = 0;
           };

--- a/docs/pages/get-started/nextjs-tldraw.mdx
+++ b/docs/pages/get-started/nextjs-tldraw.mdx
@@ -265,28 +265,77 @@ collaboration to your Next.js and Tldraw app using hooks from
 
         useEffect(() => {
           const unsubs: (() => void)[] = [];
+          let isCancelled = false;
           // State is already initialized to "loading", no need to set it again
 
           async function setup() {
             // Get Liveblocks Storage values
             const { root } = await room.getStorage();
-            const liveRecords = root.get("records");
+
+            // The effect was cleaned up while Storage was loading
+            if (isCancelled) {
+              return;
+            }
+
+            const defaultRecords: TLRecord[] = [
+              DocumentRecordType.create({
+                id: "document:document" as TLDocument["id"],
+              }),
+              PageRecordType.create({
+                id: "page:page" as TLPageId,
+                name: "Page 1",
+                index: "a1" as IndexKey,
+              }),
+            ];
+
+            // The `records` map isn't a stable object: when two people open the
+            // same new room at the same time, they each create one to populate
+            // the room's `initialStorage`, and only one of those maps wins.
+            // Never hold onto the map, always read the current one and
+            // initialize it the first time it's seen, otherwise reads and writes
+            // end up on a map that is no longer part of Storage and the
+            // whiteboard silently stops syncing.
+            let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
+
+            function getLiveRecords() {
+              const liveRecords = root.get("records");
+
+              if (liveRecords !== knownLiveRecords) {
+                knownLiveRecords = liveRecords;
+
+                room.batch(() => {
+                  // The records tldraw needs to start up, plus everything
+                  // already drawn locally, so that nothing is lost if this map
+                  // replaced another one
+                  const records = [
+                    ...defaultRecords,
+                    ...store
+                      .allRecords()
+                      .filter((record) =>
+                        store.scopedTypes.document.has(record.typeName)
+                      ),
+                  ];
+
+                  records.forEach((record) => {
+                    if (!liveRecords.has(record.id)) {
+                      liveRecords.set(record.id, record);
+                    }
+                  });
+                });
+              }
+
+              return liveRecords;
+            }
+
+            function getRecordsFromStorage(): TLRecord[] {
+              return [...getLiveRecords().values()];
+            }
 
             // Initialize tldraw with records from Storage
             store.clear();
             putRecords(
               store,
-              [
-                DocumentRecordType.create({
-                  id: "document:document" as TLDocument["id"],
-                }),
-                PageRecordType.create({
-                  id: "page:page" as TLPageId,
-                  name: "Page 1",
-                  index: "a1" as IndexKey,
-                }),
-                ...[...liveRecords.values()],
-              ],
+              [...defaultRecords, ...getRecordsFromStorage()],
               "initialize"
             );
 
@@ -294,6 +343,8 @@ collaboration to your Next.js and Tldraw app using hooks from
             unsubs.push(
               store.listen(
                 ({ changes }: TLStoreEventInfo) => {
+                  const liveRecords = getLiveRecords();
+
                   room.batch(() => {
                     Object.values(changes.added).forEach((record) => {
                       liveRecords.set(record.id, record);
@@ -343,38 +394,23 @@ collaboration to your Next.js and Tldraw app using hooks from
               })
             );
 
-            // Update tldraw when Storage changes
+            // Update tldraw when Storage changes. Subscribing to the root, and
+            // not to the `records` map, keeps working if that map is ever
+            // replaced
             unsubs.push(
               room.subscribe(
-                liveRecords,
-                (storageChanges) => {
-                  const toRemove: TLRecord["id"][] = [];
-                  const toPut: TLRecord[] = [];
-
-                  for (const update of storageChanges) {
-                    if (update.type !== "LiveMap") {
-                      return;
-                    }
-
-                    for (const [id, { type }] of Object.entries(update.updates)) {
-                      switch (type) {
-                        // Object deleted from Liveblocks, remove from tldraw
-                        case "delete": {
-                          toRemove.push(id as TLRecord["id"]);
-                          break;
-                        }
-
-                        // Object updated on Liveblocks, update tldraw
-                        case "update": {
-                          const curr = update.node.get(id);
-                          if (curr) {
-                            toPut.push(curr as any as TLRecord);
-                          }
-                          break;
-                        }
-                      }
-                    }
-                  }
+                root,
+                () => {
+                  const toPut = getRecordsFromStorage();
+                  const recordIds = new Set(toPut.map((record) => record.id));
+                  const toRemove = store
+                    .allRecords()
+                    .filter(
+                      (record) =>
+                        store.scopedTypes.document.has(record.typeName) &&
+                        !recordIds.has(record.id)
+                    )
+                    .map((record) => record.id);
 
                   // Update tldraw with changes
                   store.mergeRemoteChanges(() => {
@@ -491,6 +527,7 @@ collaboration to your Next.js and Tldraw app using hooks from
           setup();
 
           return () => {
+            isCancelled = true;
             unsubs.forEach((fn) => fn());
             unsubs.length = 0;
           };

--- a/docs/pages/get-started/nextjs-tldraw.mdx
+++ b/docs/pages/get-started/nextjs-tldraw.mdx
@@ -236,27 +236,76 @@ collaboration to your Next.js and Tldraw app using hooks from
 
         useEffect(() => {
           const unsubs: (() => void)[] = [];
+          let isCancelled = false;
           // State is already initialized to "loading", no need to set it again
 
           async function setup() {
             // Get Liveblocks Storage values
             const { root } = await room.getStorage();
-            const liveRecords = root.get("records");
+
+            // The effect was cleaned up while Storage was loading
+            if (isCancelled) {
+              return;
+            }
+
+            const defaultRecords: TLRecord[] = [
+              DocumentRecordType.create({
+                id: "document:document" as TLDocument["id"],
+              }),
+              PageRecordType.create({
+                id: "page:page" as TLPageId,
+                name: "Page 1",
+                index: "a1" as IndexKey,
+              }),
+            ];
+
+            // The `records` map isn't a stable object: when several people open
+            // a brand new room at the same time, they each create one to
+            // populate the room's `initialStorage`, and only one of those maps
+            // wins. Never hold onto the map, always read the current one and
+            // initialize it the first time it's seen, otherwise reads and
+            // writes end up on a map that is no longer part of Storage, and the
+            // whiteboard silently stops syncing.
+            let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
+
+            function getLiveRecords() {
+              const liveRecords = root.get("records");
+
+              if (liveRecords !== knownLiveRecords) {
+                knownLiveRecords = liveRecords;
+
+                room.batch(() => {
+                  // The records tldraw needs to start up, plus everything
+                  // already drawn locally, so that nothing is lost if this map
+                  // replaced another one
+                  const records = [
+                    ...defaultRecords,
+                    ...store
+                      .allRecords()
+                      .filter((record) =>
+                        store.scopedTypes.document.has(record.typeName)
+                      ),
+                  ];
+
+                  records.forEach((record) => {
+                    if (!liveRecords.has(record.id)) {
+                      liveRecords.set(record.id, record);
+                    }
+                  });
+                });
+              }
+
+              return liveRecords;
+            }
+
+            function getRecordsFromStorage(): TLRecord[] {
+              return [...getLiveRecords().values()];
+            }
 
             // Initialize tldraw with records from Storage
             store.clear();
             store.put(
-              [
-                DocumentRecordType.create({
-                  id: "document:document" as TLDocument["id"],
-                }),
-                PageRecordType.create({
-                  id: "page:page" as TLPageId,
-                  name: "Page 1",
-                  index: "a1" as IndexKey,
-                }),
-                ...[...liveRecords.values()],
-              ],
+              [...defaultRecords, ...getRecordsFromStorage()],
               "initialize"
             );
 
@@ -264,6 +313,8 @@ collaboration to your Next.js and Tldraw app using hooks from
             unsubs.push(
               store.listen(
                 ({ changes }: TLStoreEventInfo) => {
+                  const liveRecords = getLiveRecords();
+
                   room.batch(() => {
                     Object.values(changes.added).forEach((record) => {
                       liveRecords.set(record.id, record);
@@ -282,69 +333,23 @@ collaboration to your Next.js and Tldraw app using hooks from
               )
             );
 
-            // Sync tldraw changes with Presence
-            function syncStoreWithPresence({ changes }: TLStoreEventInfo) {
-              room.batch(() => {
-                Object.values(changes.added).forEach((record) => {
-                  room.updatePresence({ [record.id]: record });
-                });
-
-                Object.values(changes.updated).forEach(([_, record]) => {
-                  room.updatePresence({ [record.id]: record });
-                });
-
-                Object.values(changes.removed).forEach((record) => {
-                  room.updatePresence({ [record.id]: null });
-                });
-              });
-            }
-
-            unsubs.push(
-              store.listen(syncStoreWithPresence, {
-                source: "user",
-                scope: "session",
-              })
-            );
-
-            unsubs.push(
-              store.listen(syncStoreWithPresence, {
-                source: "user",
-                scope: "presence",
-              })
-            );
-
-            // Update tldraw when Storage changes
+            // Update tldraw when Storage changes. Subscribing to the root, and
+            // not to the `records` map, keeps working if that map is ever
+            // replaced
             unsubs.push(
               room.subscribe(
-                liveRecords,
-                (storageChanges) => {
-                  const toRemove: TLRecord["id"][] = [];
-                  const toPut: TLRecord[] = [];
-
-                  for (const update of storageChanges) {
-                    if (update.type !== "LiveMap") {
-                      return;
-                    }
-
-                    for (const [id, { type }] of Object.entries(update.updates)) {
-                      switch (type) {
-                        // Object deleted from Liveblocks, remove from tldraw
-                        case "delete": {
-                          toRemove.push(id as TLRecord["id"]);
-                          break;
-                        }
-
-                        // Object updated on Liveblocks, update tldraw
-                        case "update": {
-                          const curr = update.node.get(id);
-                          if (curr) {
-                            toPut.push(curr as any as TLRecord);
-                          }
-                          break;
-                        }
-                      }
-                    }
-                  }
+                root,
+                () => {
+                  const toPut = getRecordsFromStorage();
+                  const recordIds = new Set(toPut.map((record) => record.id));
+                  const toRemove = store
+                    .allRecords()
+                    .filter(
+                      (record) =>
+                        store.scopedTypes.document.has(record.typeName) &&
+                        !recordIds.has(record.id)
+                    )
+                    .map((record) => record.id);
 
                   // Update tldraw with changes
                   store.mergeRemoteChanges(() => {
@@ -461,6 +466,7 @@ collaboration to your Next.js and Tldraw app using hooks from
           setup();
 
           return () => {
+            isCancelled = true;
             unsubs.forEach((fn) => fn());
             unsubs.length = 0;
           };

--- a/examples/nextjs-tldraw-whiteboard-storage/package-lock.json
+++ b/examples/nextjs-tldraw-whiteboard-storage/package-lock.json
@@ -18,7 +18,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-error-boundary": "^4.0.13",
-        "tldraw": "^3.0.3"
+        "tldraw": "3.15.5"
       },
       "devDependencies": {
         "@types/react": "^18.3.27",

--- a/examples/nextjs-tldraw-whiteboard-storage/package.json
+++ b/examples/nextjs-tldraw-whiteboard-storage/package.json
@@ -21,7 +21,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.13",
-    "tldraw": "^3.0.3"
+    "tldraw": "3.15.5"
   },
   "devDependencies": {
     "@types/react": "^18.3.27",

--- a/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
@@ -87,45 +87,81 @@ export function useStorageStore({
 
   useEffect(() => {
     const unsubs: (() => void)[] = [];
+    let isCancelled = false;
     setStoreWithStatus({ status: "loading" });
 
     async function setup() {
       // Get Liveblocks Storage values
       const { root } = await room.getStorage();
-      const liveRecords = root.get("records");
-      const defaultRecords = [
-        DocumentRecordType.create({
-          id: "document:document" as TLDocument["id"],
-        }),
-        PageRecordType.create({
-          id: "page:page" as TLPageId,
-          name: "Page 1",
-          index: "a1" as IndexKey,
-        }),
-      ];
 
-      room.batch(() => {
-        for (const [id, liveRecord] of liveRecords.entries()) {
-          if (isLiveblocksRecord(liveRecord)) {
-            continue;
-          }
+      // The effect was cleaned up while Storage was loading
+      if (isCancelled) {
+        return;
+      }
 
-          const record = getTldrawRecord(liveRecord);
-          if (record) {
-            liveRecords.set(id, createLiveblocksRecord(record));
-          }
+      // The `records` map isn't a stable object: when two people open the same
+      // new room at the same time, they each create one to populate the room's
+      // `initialStorage`, and only one of those maps wins. Never hold onto the
+      // map, always read the current one and initialize it the first time it's
+      // seen, otherwise reads and writes end up on a map that is no longer part
+      // of Storage and the whiteboard silently stops syncing.
+      let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
+
+      function getLiveRecords() {
+        const liveRecords = root.get("records");
+
+        if (liveRecords !== knownLiveRecords) {
+          knownLiveRecords = liveRecords;
+          initializeLiveRecords(liveRecords);
         }
 
-        defaultRecords.forEach((record) => {
-          if (!liveRecords.has(record.id)) {
-            liveRecords.set(record.id, createLiveblocksRecord(record));
+        return liveRecords;
+      }
+
+      function initializeLiveRecords(
+        liveRecords: Liveblocks["Storage"]["records"]
+      ) {
+        room.batch(() => {
+          for (const [id, liveRecord] of liveRecords.entries()) {
+            if (isLiveblocksRecord(liveRecord)) {
+              continue;
+            }
+
+            const record = getTldrawRecord(liveRecord);
+            if (record) {
+              liveRecords.set(id, createLiveblocksRecord(record));
+            }
           }
+
+          // The records tldraw needs to start up, plus everything already drawn
+          // locally, so that nothing is lost if this map replaced another one
+          const records: TLRecord[] = [
+            DocumentRecordType.create({
+              id: "document:document" as TLDocument["id"],
+            }),
+            PageRecordType.create({
+              id: "page:page" as TLPageId,
+              name: "Page 1",
+              index: "a1" as IndexKey,
+            }),
+            ...store
+              .allRecords()
+              .filter((record) =>
+                store.scopedTypes.document.has(record.typeName)
+              ),
+          ];
+
+          records.forEach((record) => {
+            if (!liveRecords.has(record.id)) {
+              liveRecords.set(record.id, createLiveblocksRecord(record));
+            }
+          });
         });
-      });
+      }
 
       function getRecordsFromStorage() {
         const records: TLRecord[] = [];
-        for (const liveRecord of liveRecords.values()) {
+        for (const liveRecord of getLiveRecords().values()) {
           const record = getTldrawRecord(liveRecord);
           if (record) {
             records.push(record);
@@ -142,6 +178,8 @@ export function useStorageStore({
       unsubs.push(
         store.listen(
           ({ changes }: TLStoreEventInfo) => {
+            const liveRecords = getLiveRecords();
+
             room.batch(() => {
               Object.values(changes.added).forEach((record) => {
                 liveRecords.set(record.id, createLiveblocksRecord(record));
@@ -200,10 +238,11 @@ export function useStorageStore({
         })
       );
 
-      // Update tldraw when Storage changes
+      // Update tldraw when Storage changes. Subscribing to the root, and not to
+      // the `records` map, keeps working if that map is ever replaced
       unsubs.push(
         room.subscribe(
-          liveRecords,
+          root,
           () => {
             const toPut = getRecordsFromStorage();
             const recordIds = new Set(toPut.map((record) => record.id));
@@ -338,6 +377,7 @@ export function useStorageStore({
     setup();
 
     return () => {
+      isCancelled = true;
       unsubs.forEach((fn) => fn());
       unsubs.length = 0;
     };

--- a/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
@@ -60,81 +60,45 @@ export function useStorageStore({
 
   useEffect(() => {
     const unsubs: (() => void)[] = [];
-    let isCancelled = false;
     setStoreWithStatus({ status: "loading" });
 
     async function setup() {
       // Get Liveblocks Storage values
       const { root } = await room.getStorage();
+      const liveRecords = root.get("records");
+      const defaultRecords = [
+        DocumentRecordType.create({
+          id: "document:document" as TLDocument["id"],
+        }),
+        PageRecordType.create({
+          id: "page:page" as TLPageId,
+          name: "Page 1",
+          index: "a1" as IndexKey,
+        }),
+      ];
 
-      // The effect was cleaned up while Storage was loading
-      if (isCancelled) {
-        return;
-      }
-
-      // The `records` map isn't a stable object: when several people open a
-      // brand new room at the same time, they each create one to populate the
-      // room's `initialStorage`, and only one of those maps wins. Never hold
-      // onto the map, always read the current one and initialize it the first
-      // time it's seen, otherwise reads and writes end up on a map that is no
-      // longer part of Storage, and the whiteboard silently stops syncing.
-      let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
-
-      function getLiveRecords() {
-        const liveRecords = root.get("records");
-
-        if (liveRecords !== knownLiveRecords) {
-          knownLiveRecords = liveRecords;
-          initializeLiveRecords(liveRecords);
-        }
-
-        return liveRecords;
-      }
-
-      function initializeLiveRecords(
-        liveRecords: Liveblocks["Storage"]["records"]
-      ) {
-        room.batch(() => {
-          for (const [id, liveRecord] of liveRecords.entries()) {
-            if (isLiveblocksRecord(liveRecord)) {
-              continue;
-            }
-
-            const record = getTldrawRecord(liveRecord);
-            if (record) {
-              liveRecords.set(id, createLiveblocksRecord(record));
-            }
+      room.batch(() => {
+        for (const [id, liveRecord] of liveRecords.entries()) {
+          if (isLiveblocksRecord(liveRecord)) {
+            continue;
           }
 
-          // The records tldraw needs to start up, plus everything already drawn
-          // locally, so that nothing is lost if this map replaced another one
-          const records: TLRecord[] = [
-            DocumentRecordType.create({
-              id: "document:document" as TLDocument["id"],
-            }),
-            PageRecordType.create({
-              id: "page:page" as TLPageId,
-              name: "Page 1",
-              index: "a1" as IndexKey,
-            }),
-            ...store
-              .allRecords()
-              .filter((record) =>
-                store.scopedTypes.document.has(record.typeName)
-              ),
-          ];
+          const record = getTldrawRecord(liveRecord);
+          if (record) {
+            liveRecords.set(id, createLiveblocksRecord(record));
+          }
+        }
 
-          records.forEach((record) => {
-            if (!liveRecords.has(record.id)) {
-              liveRecords.set(record.id, createLiveblocksRecord(record));
-            }
-          });
+        defaultRecords.forEach((record) => {
+          if (!liveRecords.has(record.id)) {
+            liveRecords.set(record.id, createLiveblocksRecord(record));
+          }
         });
-      }
+      });
 
       function getRecordsFromStorage() {
         const records: TLRecord[] = [];
-        for (const liveRecord of getLiveRecords().values()) {
+        for (const liveRecord of liveRecords.values()) {
           const record = getTldrawRecord(liveRecord);
           if (record) {
             records.push(record);
@@ -151,8 +115,6 @@ export function useStorageStore({
       unsubs.push(
         store.listen(
           ({ changes }: TLStoreEventInfo) => {
-            const liveRecords = getLiveRecords();
-
             room.batch(() => {
               Object.values(changes.added).forEach((record) => {
                 liveRecords.set(record.id, createLiveblocksRecord(record));
@@ -176,11 +138,45 @@ export function useStorageStore({
         )
       );
 
-      // Update tldraw when Storage changes. Subscribing to the root, and not to
-      // the `records` map, keeps working if that map is ever replaced
+      // Sync tldraw changes with Presence
+      function syncStoreWithPresence({ changes }: TLStoreEventInfo) {
+        room.batch(() => {
+          Object.values(changes.added).forEach((record) => {
+            room.updatePresence({
+              [record.id]: getLiveblocksJsonObject(record),
+            });
+          });
+
+          Object.values(changes.updated).forEach(([_, record]) => {
+            room.updatePresence({
+              [record.id]: getLiveblocksJsonObject(record),
+            });
+          });
+
+          Object.values(changes.removed).forEach((record) => {
+            room.updatePresence({ [record.id]: null });
+          });
+        });
+      }
+
+      unsubs.push(
+        store.listen(syncStoreWithPresence, {
+          source: "user",
+          scope: "session",
+        })
+      );
+
+      unsubs.push(
+        store.listen(syncStoreWithPresence, {
+          source: "user",
+          scope: "presence",
+        })
+      );
+
+      // Update tldraw when Storage changes
       unsubs.push(
         room.subscribe(
-          root,
+          liveRecords,
           () => {
             const toPut = getRecordsFromStorage();
             const recordIds = new Set(toPut.map((record) => record.id));
@@ -315,7 +311,6 @@ export function useStorageStore({
     setup();
 
     return () => {
-      isCancelled = true;
       unsubs.forEach((fn) => fn());
       unsubs.length = 0;
     };

--- a/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
@@ -15,6 +15,7 @@ import {
   TLInstancePresence,
   TLPageId,
   TLRecord,
+  TLStore,
   TLStoreEventInfo,
   TLStoreWithStatus,
 } from "tldraw";
@@ -26,6 +27,32 @@ import {
   isLiveblocksRecord,
   reconcileLiveblocksRecord,
 } from "./liveblocksTldrawStorage";
+
+const skippedRecordIds = new Set<TLRecord["id"]>();
+
+/**
+ * Put records from Storage into tldraw, falling back to one record at a time if
+ * the batch is rejected. tldraw throws on a record it can't read, for instance
+ * one written by a client running a different version of tldraw, and this
+ * whiteboard reapplies every record on every change, so without this a single
+ * unreadable record would stop every later change from being applied too.
+ */
+function putRecords(store: TLStore, records: TLRecord[], phase?: "initialize") {
+  try {
+    store.put(records, phase);
+  } catch {
+    for (const record of records) {
+      try {
+        store.put([record], phase);
+      } catch (error) {
+        if (!skippedRecordIds.has(record.id)) {
+          skippedRecordIds.add(record.id);
+          console.warn(`Skipping record ${record.id} from Storage`, error);
+        }
+      }
+    }
+  }
+}
 
 export function useStorageStore({
   assets,
@@ -109,7 +136,7 @@ export function useStorageStore({
 
       // Initialize tldraw with records from Storage
       store.clear();
-      store.put(getRecordsFromStorage(), "initialize");
+      putRecords(store, getRecordsFromStorage(), "initialize");
 
       // Sync tldraw changes with Storage
       unsubs.push(
@@ -195,7 +222,7 @@ export function useStorageStore({
                 store.remove(toRemove);
               }
               if (toPut.length) {
-                store.put(toPut);
+                putRecords(store, toPut);
               }
             });
           },
@@ -295,7 +322,7 @@ export function useStorageStore({
               store.remove(toRemove);
             }
             if (toPut.length) {
-              store.put(toPut);
+              putRecords(store, toPut);
             }
           });
         })

--- a/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-storage/src/components/useStorageStore.ts
@@ -60,45 +60,81 @@ export function useStorageStore({
 
   useEffect(() => {
     const unsubs: (() => void)[] = [];
+    let isCancelled = false;
     setStoreWithStatus({ status: "loading" });
 
     async function setup() {
       // Get Liveblocks Storage values
       const { root } = await room.getStorage();
-      const liveRecords = root.get("records");
-      const defaultRecords = [
-        DocumentRecordType.create({
-          id: "document:document" as TLDocument["id"],
-        }),
-        PageRecordType.create({
-          id: "page:page" as TLPageId,
-          name: "Page 1",
-          index: "a1" as IndexKey,
-        }),
-      ];
 
-      room.batch(() => {
-        for (const [id, liveRecord] of liveRecords.entries()) {
-          if (isLiveblocksRecord(liveRecord)) {
-            continue;
-          }
+      // The effect was cleaned up while Storage was loading
+      if (isCancelled) {
+        return;
+      }
 
-          const record = getTldrawRecord(liveRecord);
-          if (record) {
-            liveRecords.set(id, createLiveblocksRecord(record));
-          }
+      // The `records` map isn't a stable object: when several people open a
+      // brand new room at the same time, they each create one to populate the
+      // room's `initialStorage`, and only one of those maps wins. Never hold
+      // onto the map, always read the current one and initialize it the first
+      // time it's seen, otherwise reads and writes end up on a map that is no
+      // longer part of Storage, and the whiteboard silently stops syncing.
+      let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
+
+      function getLiveRecords() {
+        const liveRecords = root.get("records");
+
+        if (liveRecords !== knownLiveRecords) {
+          knownLiveRecords = liveRecords;
+          initializeLiveRecords(liveRecords);
         }
 
-        defaultRecords.forEach((record) => {
-          if (!liveRecords.has(record.id)) {
-            liveRecords.set(record.id, createLiveblocksRecord(record));
+        return liveRecords;
+      }
+
+      function initializeLiveRecords(
+        liveRecords: Liveblocks["Storage"]["records"]
+      ) {
+        room.batch(() => {
+          for (const [id, liveRecord] of liveRecords.entries()) {
+            if (isLiveblocksRecord(liveRecord)) {
+              continue;
+            }
+
+            const record = getTldrawRecord(liveRecord);
+            if (record) {
+              liveRecords.set(id, createLiveblocksRecord(record));
+            }
           }
+
+          // The records tldraw needs to start up, plus everything already drawn
+          // locally, so that nothing is lost if this map replaced another one
+          const records: TLRecord[] = [
+            DocumentRecordType.create({
+              id: "document:document" as TLDocument["id"],
+            }),
+            PageRecordType.create({
+              id: "page:page" as TLPageId,
+              name: "Page 1",
+              index: "a1" as IndexKey,
+            }),
+            ...store
+              .allRecords()
+              .filter((record) =>
+                store.scopedTypes.document.has(record.typeName)
+              ),
+          ];
+
+          records.forEach((record) => {
+            if (!liveRecords.has(record.id)) {
+              liveRecords.set(record.id, createLiveblocksRecord(record));
+            }
+          });
         });
-      });
+      }
 
       function getRecordsFromStorage() {
         const records: TLRecord[] = [];
-        for (const liveRecord of liveRecords.values()) {
+        for (const liveRecord of getLiveRecords().values()) {
           const record = getTldrawRecord(liveRecord);
           if (record) {
             records.push(record);
@@ -115,6 +151,8 @@ export function useStorageStore({
       unsubs.push(
         store.listen(
           ({ changes }: TLStoreEventInfo) => {
+            const liveRecords = getLiveRecords();
+
             room.batch(() => {
               Object.values(changes.added).forEach((record) => {
                 liveRecords.set(record.id, createLiveblocksRecord(record));
@@ -138,45 +176,11 @@ export function useStorageStore({
         )
       );
 
-      // Sync tldraw changes with Presence
-      function syncStoreWithPresence({ changes }: TLStoreEventInfo) {
-        room.batch(() => {
-          Object.values(changes.added).forEach((record) => {
-            room.updatePresence({
-              [record.id]: getLiveblocksJsonObject(record),
-            });
-          });
-
-          Object.values(changes.updated).forEach(([_, record]) => {
-            room.updatePresence({
-              [record.id]: getLiveblocksJsonObject(record),
-            });
-          });
-
-          Object.values(changes.removed).forEach((record) => {
-            room.updatePresence({ [record.id]: null });
-          });
-        });
-      }
-
-      unsubs.push(
-        store.listen(syncStoreWithPresence, {
-          source: "user",
-          scope: "session",
-        })
-      );
-
-      unsubs.push(
-        store.listen(syncStoreWithPresence, {
-          source: "user",
-          scope: "presence",
-        })
-      );
-
-      // Update tldraw when Storage changes
+      // Update tldraw when Storage changes. Subscribing to the root, and not to
+      // the `records` map, keeps working if that map is ever replaced
       unsubs.push(
         room.subscribe(
-          liveRecords,
+          root,
           () => {
             const toPut = getRecordsFromStorage();
             const recordIds = new Set(toPut.map((record) => record.id));
@@ -311,6 +315,7 @@ export function useStorageStore({
     setup();
 
     return () => {
+      isCancelled = true;
       unsubs.forEach((fn) => fn());
       unsubs.length = 0;
     };

--- a/examples/nextjs-tldraw-whiteboard-yjs/package-lock.json
+++ b/examples/nextjs-tldraw-whiteboard-yjs/package-lock.json
@@ -19,7 +19,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-error-boundary": "^4.0.13",
-        "tldraw": "^3.0.3",
+        "tldraw": "3.15.5",
         "y-utility": "^0.1.4",
         "yjs": "13.6.29"
       },

--- a/examples/nextjs-tldraw-whiteboard-yjs/package.json
+++ b/examples/nextjs-tldraw-whiteboard-yjs/package.json
@@ -22,7 +22,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.13",
-    "tldraw": "^3.0.3",
+    "tldraw": "3.15.5",
     "y-utility": "^0.1.4",
     "yjs": "13.6.29"
   },

--- a/examples/nextjs-tldraw-whiteboard-yjs/src/components/useYjsStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-yjs/src/components/useYjsStore.ts
@@ -65,19 +65,8 @@ export function useYjsStore({
     setStoreWithStatus({ status: "loading" });
 
     const unsubs: (() => void)[] = [];
-    let hasSetUp = false;
 
-    function handleSync(isSynced?: boolean) {
-      // The provider emits `synced` every time the connection changes, with
-      // `false` when it drops. Set everything up only once: Yjs merges the
-      // document again by itself after reconnecting, whereas running this
-      // function twice would wipe tldraw's session records (camera, selection,
-      // other people's cursors…) and add a second set of listeners
-      if (isSynced === false || hasSetUp) {
-        return;
-      }
-      hasSetUp = true;
-
+    function handleSync() {
       // === DOCUMENT ==========================================================
 
       // Initialize tldraw with Yjs doc records, or if Yjs empty,
@@ -140,10 +129,8 @@ export function useYjsStore({
             // Object added or updated on Liveblocks
             case "add":
             case "update": {
-              const record = yStore.get(id);
-              if (record) {
-                toPut.push(record);
-              }
+              const record = yStore.get(id)!;
+              toPut.push(record);
               break;
             }
 
@@ -275,7 +262,7 @@ export function useYjsStore({
     }
 
     if (yProvider.synced) {
-      handleSync(true);
+      handleSync();
     } else {
       yProvider.on("synced", handleSync);
       unsubs.push(() => yProvider.off("synced", handleSync));

--- a/examples/nextjs-tldraw-whiteboard-yjs/src/components/useYjsStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-yjs/src/components/useYjsStore.ts
@@ -14,8 +14,34 @@ import {
   TLAnyShapeUtilConstructor,
   TLInstancePresence,
   TLRecord,
+  TLStore,
   TLStoreWithStatus,
 } from "tldraw";
+
+const skippedRecordIds = new Set<TLRecord["id"]>();
+
+/**
+ * Put records from the Yjs doc into tldraw, falling back to one record at a time
+ * if the batch is rejected. tldraw throws on a record it can't read, for
+ * instance one written by a client running a different version of tldraw, and
+ * one unreadable record would otherwise take the rest of the batch with it.
+ */
+function putRecords(store: TLStore, records: TLRecord[]) {
+  try {
+    store.put(records);
+  } catch {
+    for (const record of records) {
+      try {
+        store.put([record]);
+      } catch (error) {
+        if (!skippedRecordIds.has(record.id)) {
+          skippedRecordIds.add(record.id);
+          console.warn(`Skipping record ${record.id} from Yjs`, error);
+        }
+      }
+    }
+  }
+}
 
 export function useYjsStore({
   shapeUtils = [],
@@ -65,8 +91,19 @@ export function useYjsStore({
     setStoreWithStatus({ status: "loading" });
 
     const unsubs: (() => void)[] = [];
+    let hasSetUp = false;
 
-    function handleSync() {
+    function handleSync(isSynced?: boolean) {
+      // The provider emits `synced` every time the connection changes, with
+      // `false` when it drops. Set everything up only once: Yjs merges the
+      // document again by itself after reconnecting, whereas running this
+      // function twice would wipe tldraw's session records (camera, selection,
+      // other people's cursors…) and add a second set of listeners
+      if (isSynced === false || hasSetUp) {
+        return;
+      }
+      hasSetUp = true;
+
       // === DOCUMENT ==========================================================
 
       // Initialize tldraw with Yjs doc records, or if Yjs empty,
@@ -76,7 +113,7 @@ export function useYjsStore({
         transact(() => {
           store.clear();
           const records = yStore.yarray.toJSON().map(({ val }) => val);
-          store.put(records);
+          putRecords(store, records);
         });
       } else {
         // Create the initial store records and sync to Yjs
@@ -129,8 +166,10 @@ export function useYjsStore({
             // Object added or updated on Liveblocks
             case "add":
             case "update": {
-              const record = yStore.get(id)!;
-              toPut.push(record);
+              const record = yStore.get(id);
+              if (record) {
+                toPut.push(record);
+              }
               break;
             }
 
@@ -148,7 +187,7 @@ export function useYjsStore({
             store.remove(toRemove);
           }
           if (toPut.length) {
-            store.put(toPut);
+            putRecords(store, toPut);
           }
         });
       };
@@ -246,7 +285,7 @@ export function useYjsStore({
             store.remove(toRemove);
           }
           if (toPut.length > 0) {
-            store.put(toPut);
+            putRecords(store, toPut);
           }
         });
       };
@@ -262,7 +301,7 @@ export function useYjsStore({
     }
 
     if (yProvider.synced) {
-      handleSync();
+      handleSync(true);
     } else {
       yProvider.on("synced", handleSync);
       unsubs.push(() => yProvider.off("synced", handleSync));

--- a/examples/nextjs-tldraw-whiteboard-yjs/src/components/useYjsStore.ts
+++ b/examples/nextjs-tldraw-whiteboard-yjs/src/components/useYjsStore.ts
@@ -65,8 +65,19 @@ export function useYjsStore({
     setStoreWithStatus({ status: "loading" });
 
     const unsubs: (() => void)[] = [];
+    let hasSetUp = false;
 
-    function handleSync() {
+    function handleSync(isSynced?: boolean) {
+      // The provider emits `synced` every time the connection changes, with
+      // `false` when it drops. Set everything up only once: Yjs merges the
+      // document again by itself after reconnecting, whereas running this
+      // function twice would wipe tldraw's session records (camera, selection,
+      // other people's cursors…) and add a second set of listeners
+      if (isSynced === false || hasSetUp) {
+        return;
+      }
+      hasSetUp = true;
+
       // === DOCUMENT ==========================================================
 
       // Initialize tldraw with Yjs doc records, or if Yjs empty,
@@ -129,8 +140,10 @@ export function useYjsStore({
             // Object added or updated on Liveblocks
             case "add":
             case "update": {
-              const record = yStore.get(id)!;
-              toPut.push(record);
+              const record = yStore.get(id);
+              if (record) {
+                toPut.push(record);
+              }
               break;
             }
 
@@ -262,7 +275,7 @@ export function useYjsStore({
     }
 
     if (yProvider.synced) {
-      handleSync();
+      handleSync(true);
     } else {
       yProvider.on("synced", handleSync);
       unsubs.push(() => yProvider.off("synced", handleSync));

--- a/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
+++ b/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
@@ -1,5 +1,5 @@
 import { useRoom } from "@liveblocks/react/suspense";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   DocumentRecordType,
   IndexKey,
@@ -35,9 +35,11 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
     status: "loading",
   });
 
+  // Use a ref to ensure it works in callbacks after strict mode double render
+  const liveRecordsRef = useRef<Liveblocks["Storage"]["records"] | null>(null);
+
   useEffect(() => {
     const unsubs: (() => void)[] = [];
-    let isCancelled = false;
     setStoreWithStatus({ status: "loading" });
 
     async function setup() {
@@ -57,77 +59,36 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
 
       // Get Liveblocks Storage values
       const { root } = await room.getStorage();
-
-      // The effect was cleaned up while Storage was loading
-      if (isCancelled) {
-        return;
-      }
-
-      const defaultRecords: TLRecord[] = [
-        DocumentRecordType.create({
-          id: "document:document" as TLDocument["id"],
-        }),
-        PageRecordType.create({
-          id: "page:page" as TLPageId,
-          name: "Page 1",
-          index: "a1" as IndexKey,
-        }),
-      ];
-
-      // The `records` map isn't a stable object: when several people open a
-      // brand new room at the same time, they each create one to populate the
-      // room's `initialStorage`, and only one of those maps wins. Never hold
-      // onto the map, always read the current one and initialize it the first
-      // time it's seen, otherwise reads and writes end up on a map that is no
-      // longer part of Storage, and the canvas silently stops syncing.
-      let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
-
-      function getLiveRecords() {
-        const liveRecords = root.get("records");
-
-        if (liveRecords !== knownLiveRecords) {
-          knownLiveRecords = liveRecords;
-
-          if (canWrite) {
-            room.batch(() => {
-              // The records tldraw needs to start up, plus everything already
-              // drawn locally, so that nothing is lost if this map replaced
-              // another one
-              const records = [
-                ...defaultRecords,
-                ...store
-                  .allRecords()
-                  .filter((record) =>
-                    store.scopedTypes.document.has(record.typeName)
-                  ),
-              ];
-
-              records.forEach((record) => {
-                if (!liveRecords.has(record.id)) {
-                  liveRecords.set(record.id, record);
-                }
-              });
-            });
-          }
-        }
-
-        return liveRecords;
-      }
-
-      function getRecordsFromStorage(): TLRecord[] {
-        return [...getLiveRecords().values()];
-      }
+      const liveRecords = root.get("records");
+      liveRecordsRef.current = liveRecords;
 
       // Initialize tldraw with records from Storage
       store.clear();
-      store.put([...defaultRecords, ...getRecordsFromStorage()], "initialize");
+      store.put(
+        [
+          DocumentRecordType.create({
+            id: "document:document" as TLDocument["id"],
+          }),
+          PageRecordType.create({
+            id: "page:page" as TLPageId,
+            name: "Page 1",
+            index: "a1" as IndexKey,
+          }),
+          ...[...liveRecords.values()],
+        ],
+        "initialize"
+      );
 
       // Sync tldraw changes with Storage
       if (canWrite) {
         unsubs.push(
           store.listen(
             ({ changes }: TLStoreEventInfo) => {
-              const liveRecords = getLiveRecords();
+              const liveRecords = liveRecordsRef.current;
+
+              if (!liveRecords) {
+                return;
+              }
 
               room.batch(() => {
                 Object.values(changes.added).forEach((record) => {
@@ -148,22 +109,69 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
         );
       }
 
-      // Update tldraw when Storage changes. Subscribing to the root, and not to
-      // the `records` map, keeps working if that map is ever replaced
+      // Sync tldraw changes with Presence
+      function syncStoreWithPresence({ changes }: TLStoreEventInfo) {
+        room.batch(() => {
+          Object.values(changes.added).forEach((record) => {
+            room.updatePresence({ [record.id]: record });
+          });
+
+          Object.values(changes.updated).forEach(([_, record]) => {
+            room.updatePresence({ [record.id]: record });
+          });
+
+          Object.values(changes.removed).forEach((record) => {
+            room.updatePresence({ [record.id]: null });
+          });
+        });
+      }
+
+      unsubs.push(
+        store.listen(syncStoreWithPresence, {
+          source: "user",
+          scope: "session",
+        })
+      );
+
+      unsubs.push(
+        store.listen(syncStoreWithPresence, {
+          source: "user",
+          scope: "presence",
+        })
+      );
+
+      // Update tldraw when Storage changes
       unsubs.push(
         room.subscribe(
-          root,
-          () => {
-            const toPut = getRecordsFromStorage();
-            const recordIds = new Set(toPut.map((record) => record.id));
-            const toRemove = store
-              .allRecords()
-              .filter(
-                (record) =>
-                  store.scopedTypes.document.has(record.typeName) &&
-                  !recordIds.has(record.id)
-              )
-              .map((record) => record.id);
+          liveRecords,
+          (storageChanges) => {
+            const toRemove: TLRecord["id"][] = [];
+            const toPut: TLRecord[] = [];
+
+            for (const update of storageChanges) {
+              if (update.type !== "LiveMap") {
+                return;
+              }
+
+              for (const [id, { type }] of Object.entries(update.updates)) {
+                switch (type) {
+                  // Object deleted from Liveblocks, remove from tldraw
+                  case "delete": {
+                    toRemove.push(id as TLRecord["id"]);
+                    break;
+                  }
+
+                  // Object updated on Liveblocks, update tldraw
+                  case "update": {
+                    const curr = update.node.get(id);
+                    if (curr) {
+                      toPut.push(curr as any as TLRecord);
+                    }
+                    break;
+                  }
+                }
+              }
+            }
 
             // Update tldraw with changes
             store.mergeRemoteChanges(() => {
@@ -280,7 +288,6 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
     setup();
 
     return () => {
-      isCancelled = true;
       unsubs.forEach((fn) => fn());
       unsubs.length = 0;
     };

--- a/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
+++ b/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
@@ -10,6 +10,7 @@ import {
   TLInstancePresence,
   TLPageId,
   TLRecord,
+  TLStore,
   TLStoreEventInfo,
   TLStoreWithStatus,
   computed,
@@ -18,6 +19,31 @@ import {
   defaultShapeUtils,
   react,
 } from "tldraw";
+
+const skippedRecordIds = new Set<TLRecord["id"]>();
+
+/**
+ * Put records from Storage into tldraw, falling back to one record at a time if
+ * the batch is rejected. tldraw throws on a record it can't read, for instance
+ * one written by a client running a different version of tldraw, and one
+ * unreadable record would otherwise take the rest of the batch with it.
+ */
+function putRecords(store: TLStore, records: TLRecord[], phase?: "initialize") {
+  try {
+    store.put(records, phase);
+  } catch {
+    for (const record of records) {
+      try {
+        store.put([record], phase);
+      } catch (error) {
+        if (!skippedRecordIds.has(record.id)) {
+          skippedRecordIds.add(record.id);
+          console.warn(`Skipping record ${record.id} from Storage`, error);
+        }
+      }
+    }
+  }
+}
 
 export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
   // Get Liveblocks room
@@ -64,7 +90,8 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
 
       // Initialize tldraw with records from Storage
       store.clear();
-      store.put(
+      putRecords(
+        store,
         [
           DocumentRecordType.create({
             id: "document:document" as TLDocument["id"],
@@ -179,7 +206,7 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
                 store.remove(toRemove);
               }
               if (toPut.length) {
-                store.put(toPut);
+                putRecords(store, toPut);
               }
             });
           },
@@ -272,7 +299,7 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
               store.remove(toRemove);
             }
             if (toPut.length) {
-              store.put(toPut);
+              putRecords(store, toPut);
             }
           });
         })

--- a/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
+++ b/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
@@ -1,5 +1,5 @@
 import { useRoom } from "@liveblocks/react/suspense";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   DocumentRecordType,
   IndexKey,
@@ -35,11 +35,9 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
     status: "loading",
   });
 
-  // Use a ref to ensure it works in callbacks after strict mode double render
-  const liveRecordsRef = useRef<Liveblocks["Storage"]["records"] | null>(null);
-
   useEffect(() => {
     const unsubs: (() => void)[] = [];
+    let isCancelled = false;
     setStoreWithStatus({ status: "loading" });
 
     async function setup() {
@@ -59,36 +57,77 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
 
       // Get Liveblocks Storage values
       const { root } = await room.getStorage();
-      const liveRecords = root.get("records");
-      liveRecordsRef.current = liveRecords;
+
+      // The effect was cleaned up while Storage was loading
+      if (isCancelled) {
+        return;
+      }
+
+      const defaultRecords: TLRecord[] = [
+        DocumentRecordType.create({
+          id: "document:document" as TLDocument["id"],
+        }),
+        PageRecordType.create({
+          id: "page:page" as TLPageId,
+          name: "Page 1",
+          index: "a1" as IndexKey,
+        }),
+      ];
+
+      // The `records` map isn't a stable object: when several people open a
+      // brand new room at the same time, they each create one to populate the
+      // room's `initialStorage`, and only one of those maps wins. Never hold
+      // onto the map, always read the current one and initialize it the first
+      // time it's seen, otherwise reads and writes end up on a map that is no
+      // longer part of Storage, and the canvas silently stops syncing.
+      let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
+
+      function getLiveRecords() {
+        const liveRecords = root.get("records");
+
+        if (liveRecords !== knownLiveRecords) {
+          knownLiveRecords = liveRecords;
+
+          if (canWrite) {
+            room.batch(() => {
+              // The records tldraw needs to start up, plus everything already
+              // drawn locally, so that nothing is lost if this map replaced
+              // another one
+              const records = [
+                ...defaultRecords,
+                ...store
+                  .allRecords()
+                  .filter((record) =>
+                    store.scopedTypes.document.has(record.typeName)
+                  ),
+              ];
+
+              records.forEach((record) => {
+                if (!liveRecords.has(record.id)) {
+                  liveRecords.set(record.id, record);
+                }
+              });
+            });
+          }
+        }
+
+        return liveRecords;
+      }
+
+      function getRecordsFromStorage(): TLRecord[] {
+        return [...getLiveRecords().values()];
+      }
 
       // Initialize tldraw with records from Storage
       store.clear();
-      store.put(
-        [
-          DocumentRecordType.create({
-            id: "document:document" as TLDocument["id"],
-          }),
-          PageRecordType.create({
-            id: "page:page" as TLPageId,
-            name: "Page 1",
-            index: "a1" as IndexKey,
-          }),
-          ...[...liveRecords.values()],
-        ],
-        "initialize"
-      );
+      store.put([...defaultRecords, ...getRecordsFromStorage()], "initialize");
 
       // Sync tldraw changes with Storage
       if (canWrite) {
         unsubs.push(
           store.listen(
             ({ changes }: TLStoreEventInfo) => {
-              const liveRecords = liveRecordsRef.current;
-
-              if (!liveRecords) {
-                return;
-              }
+              const liveRecords = getLiveRecords();
 
               room.batch(() => {
                 Object.values(changes.added).forEach((record) => {
@@ -109,69 +148,22 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
         );
       }
 
-      // Sync tldraw changes with Presence
-      function syncStoreWithPresence({ changes }: TLStoreEventInfo) {
-        room.batch(() => {
-          Object.values(changes.added).forEach((record) => {
-            room.updatePresence({ [record.id]: record });
-          });
-
-          Object.values(changes.updated).forEach(([_, record]) => {
-            room.updatePresence({ [record.id]: record });
-          });
-
-          Object.values(changes.removed).forEach((record) => {
-            room.updatePresence({ [record.id]: null });
-          });
-        });
-      }
-
-      unsubs.push(
-        store.listen(syncStoreWithPresence, {
-          source: "user",
-          scope: "session",
-        })
-      );
-
-      unsubs.push(
-        store.listen(syncStoreWithPresence, {
-          source: "user",
-          scope: "presence",
-        })
-      );
-
-      // Update tldraw when Storage changes
+      // Update tldraw when Storage changes. Subscribing to the root, and not to
+      // the `records` map, keeps working if that map is ever replaced
       unsubs.push(
         room.subscribe(
-          liveRecords,
-          (storageChanges) => {
-            const toRemove: TLRecord["id"][] = [];
-            const toPut: TLRecord[] = [];
-
-            for (const update of storageChanges) {
-              if (update.type !== "LiveMap") {
-                return;
-              }
-
-              for (const [id, { type }] of Object.entries(update.updates)) {
-                switch (type) {
-                  // Object deleted from Liveblocks, remove from tldraw
-                  case "delete": {
-                    toRemove.push(id as TLRecord["id"]);
-                    break;
-                  }
-
-                  // Object updated on Liveblocks, update tldraw
-                  case "update": {
-                    const curr = update.node.get(id);
-                    if (curr) {
-                      toPut.push(curr as any as TLRecord);
-                    }
-                    break;
-                  }
-                }
-              }
-            }
+          root,
+          () => {
+            const toPut = getRecordsFromStorage();
+            const recordIds = new Set(toPut.map((record) => record.id));
+            const toRemove = store
+              .allRecords()
+              .filter(
+                (record) =>
+                  store.scopedTypes.document.has(record.typeName) &&
+                  !recordIds.has(record.id)
+              )
+              .map((record) => record.id);
 
             // Update tldraw with changes
             store.mergeRemoteChanges(() => {
@@ -288,6 +280,7 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
     setup();
 
     return () => {
+      isCancelled = true;
       unsubs.forEach((fn) => fn());
       unsubs.length = 0;
     };

--- a/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
+++ b/starter-kits/nextjs-starter-kit/components/Canvas/useStorageStore.ts
@@ -1,5 +1,5 @@
 import { useRoom } from "@liveblocks/react/suspense";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   DocumentRecordType,
   IndexKey,
@@ -61,11 +61,9 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
     status: "loading",
   });
 
-  // Use a ref to ensure it works in callbacks after strict mode double render
-  const liveRecordsRef = useRef<Liveblocks["Storage"]["records"] | null>(null);
-
   useEffect(() => {
     const unsubs: (() => void)[] = [];
+    let isCancelled = false;
     setStoreWithStatus({ status: "loading" });
 
     async function setup() {
@@ -85,24 +83,72 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
 
       // Get Liveblocks Storage values
       const { root } = await room.getStorage();
-      const liveRecords = root.get("records");
-      liveRecordsRef.current = liveRecords;
+
+      // The effect was cleaned up while Storage was loading
+      if (isCancelled) {
+        return;
+      }
+
+      const defaultRecords: TLRecord[] = [
+        DocumentRecordType.create({
+          id: "document:document" as TLDocument["id"],
+        }),
+        PageRecordType.create({
+          id: "page:page" as TLPageId,
+          name: "Page 1",
+          index: "a1" as IndexKey,
+        }),
+      ];
+
+      // The `records` map isn't a stable object: when two people open the same
+      // new room at the same time, they each create one to populate the room's
+      // `initialStorage`, and only one of those maps wins. Never hold onto the
+      // map, always read the current one and initialize it the first time it's
+      // seen, otherwise reads and writes end up on a map that is no longer part
+      // of Storage and the canvas silently stops syncing.
+      let knownLiveRecords: Liveblocks["Storage"]["records"] | null = null;
+
+      function getLiveRecords() {
+        const liveRecords = root.get("records");
+
+        if (liveRecords !== knownLiveRecords) {
+          knownLiveRecords = liveRecords;
+
+          if (canWrite) {
+            room.batch(() => {
+              // The records tldraw needs to start up, plus everything already
+              // drawn locally, so that nothing is lost if this map replaced
+              // another one
+              const records = [
+                ...defaultRecords,
+                ...store
+                  .allRecords()
+                  .filter((record) =>
+                    store.scopedTypes.document.has(record.typeName)
+                  ),
+              ];
+
+              records.forEach((record) => {
+                if (!liveRecords.has(record.id)) {
+                  liveRecords.set(record.id, record);
+                }
+              });
+            });
+          }
+        }
+
+        return liveRecords;
+      }
+
+      function getRecordsFromStorage(): TLRecord[] {
+        return [...getLiveRecords().values()];
+      }
 
       // Initialize tldraw with records from Storage
       store.clear();
       putRecords(
         store,
-        [
-          DocumentRecordType.create({
-            id: "document:document" as TLDocument["id"],
-          }),
-          PageRecordType.create({
-            id: "page:page" as TLPageId,
-            name: "Page 1",
-            index: "a1" as IndexKey,
-          }),
-          ...[...liveRecords.values()],
-        ],
+        [...defaultRecords, ...getRecordsFromStorage()],
         "initialize"
       );
 
@@ -111,11 +157,7 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
         unsubs.push(
           store.listen(
             ({ changes }: TLStoreEventInfo) => {
-              const liveRecords = liveRecordsRef.current;
-
-              if (!liveRecords) {
-                return;
-              }
+              const liveRecords = getLiveRecords();
 
               room.batch(() => {
                 Object.values(changes.added).forEach((record) => {
@@ -167,38 +209,22 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
         })
       );
 
-      // Update tldraw when Storage changes
+      // Update tldraw when Storage changes. Subscribing to the root, and not to
+      // the `records` map, keeps working if that map is ever replaced
       unsubs.push(
         room.subscribe(
-          liveRecords,
-          (storageChanges) => {
-            const toRemove: TLRecord["id"][] = [];
-            const toPut: TLRecord[] = [];
-
-            for (const update of storageChanges) {
-              if (update.type !== "LiveMap") {
-                return;
-              }
-
-              for (const [id, { type }] of Object.entries(update.updates)) {
-                switch (type) {
-                  // Object deleted from Liveblocks, remove from tldraw
-                  case "delete": {
-                    toRemove.push(id as TLRecord["id"]);
-                    break;
-                  }
-
-                  // Object updated on Liveblocks, update tldraw
-                  case "update": {
-                    const curr = update.node.get(id);
-                    if (curr) {
-                      toPut.push(curr as any as TLRecord);
-                    }
-                    break;
-                  }
-                }
-              }
-            }
+          root,
+          () => {
+            const toPut = getRecordsFromStorage();
+            const recordIds = new Set(toPut.map((record) => record.id));
+            const toRemove = store
+              .allRecords()
+              .filter(
+                (record) =>
+                  store.scopedTypes.document.has(record.typeName) &&
+                  !recordIds.has(record.id)
+              )
+              .map((record) => record.id);
 
             // Update tldraw with changes
             store.mergeRemoteChanges(() => {
@@ -315,6 +341,7 @@ export function useStorageStore(shapeUtils: TLAnyShapeUtilConstructor[] = []) {
     setup();
 
     return () => {
+      isCancelled = true;
       unsubs.forEach((fn) => fn());
       unsubs.length = 0;
     };

--- a/starter-kits/nextjs-starter-kit/package-lock.json
+++ b/starter-kits/nextjs-starter-kit/package-lock.json
@@ -44,7 +44,7 @@
         "react-dom": "^19.2.4",
         "react-textarea-autosize": "^8.5.8",
         "swr": "^2.3.3",
-        "tldraw": "^3.11.0"
+        "tldraw": "3.15.6"
       },
       "devDependencies": {
         "@types/base-64": "^1.0.0",

--- a/starter-kits/nextjs-starter-kit/package.json
+++ b/starter-kits/nextjs-starter-kit/package.json
@@ -48,7 +48,7 @@
     "react-dom": "^19.2.4",
     "react-textarea-autosize": "^8.5.8",
     "swr": "^2.3.3",
-    "tldraw": "^3.11.0"
+    "tldraw": "3.15.6"
   },
   "devDependencies": {
     "@types/base-64": "^1.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Two ways the tldraw examples silently stop syncing, both reproduced against a local dev server and fixed here. No migrations, no handling of existing rooms — the goal is that rooms created from now on always keep syncing.

**A record the local tldraw can't read killed all syncing.** tldraw throws when handed a record its schema doesn't accept — for example a text shape carrying `props.richText`, written by a client on a newer tldraw version, arriving at a client whose validator still requires `props.text`. The Storage example reapplies every record from Storage on every change, so one such record threw on every notification and that client stopped receiving **any** further changes, permanently. The other person kept drawing and nothing arrived; reloading didn't help, because loading the room applies the same records and throws the same way. The examples allowed `"tldraw": "^3.0.3"`, so two installs drifting apart was the normal case, not an edge case.

Remote records are now applied as one batch as before, falling back to one record at a time when the batch is rejected, so an unreadable record is skipped with a warning instead of taking the whole document with it. tldraw is pinned to an exact version in both examples and the starter kit so two installs of the same app can't end up on different schemas.

**A held-onto `records` map.** When two people open the same new room at the same time, both clients create a `records` `LiveMap` to populate `initialStorage` and only one of them ends up in Storage. The hook read the map once and kept it, so the client whose map lost was reading from and writing to a map no longer part of Storage — nothing it drew reached anyone, and nothing reached it, until reload. It now reads the current map on every use, seeds it with the records already in the local store when it changes, and subscribes to the Storage root rather than to the map.

Also in the Yjs example: its setup ran again on every connection change, because the provider emits `synced` on each one (including with `false` when the connection drops). Each run cleared the store — wiping the editor's camera, selection and other people's cursors — and added another set of listeners. Combined with an unreadable record, that left the board wiped after a blip. It now sets up once and lets Yjs merge the document again by itself.

The starter kit canvas and the tldraw quickstart carried the same code, so they got the same fixes.

#### How to test it

Verified headlessly against `liveblocks dev`, driving the real hook sources (bundled with stubbed React hooks) and, for the heavier runs, two real headless `Editor` instances in jsdom.

Two clients of the same example on different tldraw versions, sharing one room:

```
new tldraw: 3.15.6 | old tldraw: 3.0.3
[NEW] wrote a text shape using props.richText

before: !! At shape(type = text).props.text: Expected string, got undefined
        older client's pages now: ["Page 1"]
        older client still receiving changes: false     <-- dead from here on, forever

after:  Skipping record shape:ealbGu6… from Storage ValidationError: At shape(type = text).props.text …
        older client's pages now: ["Page 1","later-page-from-NEW"]
        older client still receiving changes: true      <-- only the unreadable shape is missing
```

Yjs example, an unreadable record followed by a reconnect: before, the client hung and its board was cleared; after, `B still receiving changes: true` and 13 records intact across the blip.

Two people opening a brand new room at once, then one dropping its connection:

```
before: A sees pages: ["Page 1","drawn-by-A-later"]
        B sees pages: ["Page 1","drawn-by-B-later","drawn-by-B-while-A-offline"]
after:  both see ["Page 1","drawn-by-A-later","drawn-by-B-later","drawn-by-B-while-A-offline"]
```

Regression runs with two real editors doing creates, drags, rotations, arrows bound to shapes, groups, duplicates, deletes, page creates/deletes and undo, plus randomised conflicting edits on the same shapes: every round in sync, no errors, for both examples. `tsc --noEmit` passes in both examples and the starter kit, `npm ci` still resolves cleanly against the updated lockfiles, and Prettier is clean.

#### Note

The last commit (holding onto the `records` map) is separable — drop it if you'd rather not change that part.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b22548ce-dda0-4384-b01d-14e0cf71a4f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b22548ce-dda0-4384-b01d-14e0cf71a4f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

