### PR TITLE
Prevent a stale thread refetch from reverting a settled resolve

### DIFF
--- a/packages/liveblocks-react/src/__tests__/umbrella-store/patchThread.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/patchThread.test.ts
@@ -1,0 +1,99 @@
+import { kInternal } from "@liveblocks/core";
+import { describe, expect, test } from "vitest";
+
+import { UmbrellaStore } from "../../umbrella-store";
+import { createComment, createThread } from "./_dummies";
+
+function makeSyncSource() {
+  return {
+    setSyncStatus: () => {},
+    destroy: () => {},
+  };
+}
+
+const NO_CLIENT = {
+  [kInternal]: {
+    as() {
+      return NO_CLIENT;
+    },
+    createSyncSource: makeSyncSource,
+  },
+} as any;
+
+describe("patchThread", () => {
+  test("a settled resolve survives a concurrent stale server refetch", () => {
+    const store = new UmbrellaStore(NO_CLIENT);
+
+    const thread = createThread({
+      id: "th_1",
+      roomId: "room_1",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+      resolved: false,
+      comments: [
+        createComment({
+          threadId: "th_1",
+          roomId: "room_1",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+        }),
+      ],
+    });
+    store.updateThreadifications([thread], [], []);
+
+    // User resolves the thread; the REST call succeeds and the optimistic
+    // update is replaced by the real thing
+    const resolvedAt = new Date("2024-01-01T00:01:00Z");
+    const optimisticId = store.optimisticUpdates.add({
+      type: "mark-thread-as-resolved",
+      threadId: thread.id,
+      updatedAt: resolvedAt,
+    });
+    store.patchThread(thread.id, optimisticId, { resolved: true }, resolvedAt);
+
+    expect(store.outputs.threads.get().get(thread.id)?.resolved).toBe(true);
+
+    // A THREAD_UPDATED (408) triggered refetch can still return a stale
+    // snapshot of the thread from before the resolve. It must not clobber
+    // the newer resolved state
+    store.updateThreadifications([thread], [], []);
+
+    expect(store.outputs.threads.get().get(thread.id)?.resolved).toBe(true);
+  });
+
+  test("a settled unresolve survives a concurrent stale server refetch", () => {
+    const store = new UmbrellaStore(NO_CLIENT);
+
+    const thread = createThread({
+      id: "th_1",
+      roomId: "room_1",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+      updatedAt: new Date("2024-01-01T00:00:00Z"),
+      resolved: true,
+      comments: [
+        createComment({
+          threadId: "th_1",
+          roomId: "room_1",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+        }),
+      ],
+    });
+    store.updateThreadifications([thread], [], []);
+
+    const unresolvedAt = new Date("2024-01-01T00:01:00Z");
+    const optimisticId = store.optimisticUpdates.add({
+      type: "mark-thread-as-unresolved",
+      threadId: thread.id,
+      updatedAt: unresolvedAt,
+    });
+    store.patchThread(
+      thread.id,
+      optimisticId,
+      { resolved: false },
+      unresolvedAt
+    );
+
+    store.updateThreadifications([thread], [], []);
+
+    expect(store.outputs.threads.get().get(thread.id)?.resolved).toBe(false);
+  });
+});

--- a/packages/liveblocks-react/src/umbrella-store.ts
+++ b/packages/liveblocks-react/src/umbrella-store.ts
@@ -2113,7 +2113,7 @@ export class UmbrellaStore<TM extends BaseMetadata, CM extends BaseMetadata> {
     return this.#updateThread(
       threadId,
       optimisticId,
-      (thread) => ({ ...thread, ...compactObject(patch) }),
+      (thread) => ({ ...thread, ...compactObject(patch), updatedAt }),
       updatedAt
     );
   }


### PR DESCRIPTION
Fixes #3636

### Problem

Resolving a comment thread can flicker back to unresolved. The sequence:

1. `useMarkThreadAsResolved` adds an optimistic update, the REST call succeeds, and `patchThread` replaces the optimistic update with `resolved: true` on the cached thread. The patch keeps the thread's old `updatedAt`.
2. The server broadcasts a `THREAD_UPDATED` (408) frame, which triggers a refetch in `handleCommentEvent`. If that response is a stale snapshot from before the resolve (same `updatedAt`, `resolved: false`), `ThreadDB.upsertIfNewer` accepts it because the timestamps tie (`>=`), and the cached thread reverts to unresolved.
3. In `@liveblocks/react-tiptap`, the mark reconciliation in `LiveblocksExtension` sees the thread as unresolved again and re-adds the mark, so the thread re-activates in the editor and in `FloatingThreads`. This matches the trace in #3636: the clobbering 408 arrives a few hundred ms after `mark-as-resolved` returns 200.

### Fix

`patchThread` now stamps the patched thread with the mutation's `updatedAt`, the same way the `edit-thread-metadata` optimistic update and `editCommentMetadata` already do. Once the resolve settles, the cached thread carries the resolve timestamp, so a stale refetch from before the resolve fails the `upsertIfNewer` check and can't overwrite it. Genuinely newer server updates still apply as before.

`useMarkThreadAsUnresolved` and `useEditThreadMetadata` go through the same code path, so they get the same protection.

### Tests

Two new tests in `patchThread.test.ts` reproduce the sequence at the store level: seed a thread, settle a resolve (or unresolve), then apply a stale pre-mutation snapshot via `updateThreadifications`. Both fail on main (the thread flips back) and pass with this change. The full `@liveblocks/react` suite passes (315 tests). The two pre-existing `tsc` errors in `src/__tests__/index.test.tsx` reproduce on a clean checkout of main and are unrelated.
