### PR TITLE
Add dev server command to examples

### DIFF
--- a/examples/nextjs-3d-builder/package.json
+++ b/examples/nextjs-3d-builder/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-3d-builder/pages/_app.js
+++ b/examples/nextjs-3d-builder/pages/_app.js
@@ -8,9 +8,10 @@ function App({ Component, pageProps }) {
   const roomId = useExampleRoomdId("nextjs-3d-builder");
 
   return (
-    <LiveblocksProvider
-      publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY}
-    >
+      <LiveblocksProvider
+        publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY}
+        baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+      >
       <RoomProvider id={roomId} initialStorage={{ colors: new LiveObject() }}>
         <Head>
           <title>Liveblocks</title>

--- a/examples/nextjs-connection-status/README.md
+++ b/examples/nextjs-connection-status/README.md
@@ -65,10 +65,11 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider`
-- Replace `publicApiKey` in `LiveblocksProvider` with `"pk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to
+  [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `pk_localdev`.
 
 </details>
 

--- a/examples/nextjs-connection-status/app/Providers.tsx
+++ b/examples/nextjs-connection-status/app/Providers.tsx
@@ -7,6 +7,7 @@ export function Providers({ children }: PropsWithChildren) {
   return (
     <LiveblocksProvider
       publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY as string}
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
       throttle={16}
       // Try changing the lostConnectionTimeout value to increase
       // or reduct the time it takes to reconnect

--- a/examples/nextjs-connection-status/package.json
+++ b/examples/nextjs-connection-status/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-dashboard/README.md
+++ b/examples/nextjs-dashboard/README.md
@@ -65,10 +65,11 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider`
-- Replace `publicApiKey` in `LiveblocksProvider` with `"pk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to
+  [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `pk_localdev`.
 
 </details>
 

--- a/examples/nextjs-dashboard/package.json
+++ b/examples/nextjs-dashboard/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-dashboard/pages/_app.tsx
+++ b/examples/nextjs-dashboard/pages/_app.tsx
@@ -12,6 +12,7 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <LiveblocksProvider
       publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!}
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
     >
       <RoomProvider
         id={roomId}

--- a/examples/nextjs-form/README.md
+++ b/examples/nextjs-form/README.md
@@ -60,11 +60,11 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server, configures the example with
+`http://localhost:1153` and `sk_localdev`, and runs Next.js. Storage is reset
+when the command exits.
 
 </details>
 

--- a/examples/nextjs-form/package.json
+++ b/examples/nextjs-form/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-form/pages/_app.tsx
+++ b/examples/nextjs-form/pages/_app.tsx
@@ -11,7 +11,10 @@ function App({ Component, pageProps }: AppProps) {
   const roomId = useExampleRoomId("liveblocks:examples:nextjs-form");
 
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <RoomProvider
         id={roomId}
         initialPresence={{ focusedId: null }}

--- a/examples/nextjs-form/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-form/pages/api/liveblocks-auth.ts
@@ -9,6 +9,7 @@ import { NAMES } from "../../constants";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -61,11 +61,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-avatars-advanced/package.json
+++ b/examples/nextjs-live-avatars-advanced/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-avatars-advanced/pages/_app.tsx
+++ b/examples/nextjs-live-avatars-advanced/pages/_app.tsx
@@ -5,7 +5,10 @@ import Head from "next/head";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Head>
         <title>Liveblocks</title>
         <meta name="robots" content="noindex" />

--- a/examples/nextjs-live-avatars-advanced/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-live-avatars-advanced/pages/api/liveblocks-auth.ts
@@ -8,6 +8,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {

--- a/examples/nextjs-live-avatars/README.md
+++ b/examples/nextjs-live-avatars/README.md
@@ -60,11 +60,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-avatars/app/Providers.tsx
+++ b/examples/nextjs-live-avatars/app/Providers.tsx
@@ -7,6 +7,7 @@ export function Providers({ children }: PropsWithChildren) {
   return (
     <LiveblocksProvider
       authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
       resolveUsers={async ({ userIds }) => {
         const searchParams = new URLSearchParams(
           userIds.map((userId) => ["userIds", userId])

--- a/examples/nextjs-live-avatars/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-live-avatars/app/api/liveblocks-auth/route.ts
@@ -10,6 +10,7 @@ import { getRandomUser, getUser } from "../../../database";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {

--- a/examples/nextjs-live-avatars/package.json
+++ b/examples/nextjs-live-avatars/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-advanced/README.md
+++ b/examples/nextjs-live-cursors-advanced/README.md
@@ -61,11 +61,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-cursors-advanced/package.json
+++ b/examples/nextjs-live-cursors-advanced/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-advanced/pages/_app.tsx
+++ b/examples/nextjs-live-cursors-advanced/pages/_app.tsx
@@ -5,7 +5,10 @@ import Head from "next/head";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Head>
         <title>Liveblocks</title>
         <meta name="robots" content="noindex" />

--- a/examples/nextjs-live-cursors-advanced/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-live-cursors-advanced/pages/api/liveblocks-auth.ts
@@ -8,6 +8,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {

--- a/examples/nextjs-live-cursors-chat/README.md
+++ b/examples/nextjs-live-cursors-chat/README.md
@@ -60,10 +60,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider`
-- Replace `publicApiKey` in `LiveblocksProvider` with `"pk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `pk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-cursors-chat/package.json
+++ b/examples/nextjs-live-cursors-chat/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-chat/pages/_app.tsx
+++ b/examples/nextjs-live-cursors-chat/pages/_app.tsx
@@ -8,6 +8,7 @@ function App({ Component, pageProps }: AppProps) {
     <LiveblocksProvider
       throttle={16}
       publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!}
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
     >
       <Head>
         <title>Liveblocks</title>

--- a/examples/nextjs-live-cursors-scroll/README.md
+++ b/examples/nextjs-live-cursors-scroll/README.md
@@ -60,10 +60,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider`
-- Replace `publicApiKey` in `LiveblocksProvider` with `"pk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `pk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-cursors-scroll/package.json
+++ b/examples/nextjs-live-cursors-scroll/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-scroll/pages/_app.tsx
+++ b/examples/nextjs-live-cursors-scroll/pages/_app.tsx
@@ -8,6 +8,7 @@ function App({ Component, pageProps }: AppProps) {
     <LiveblocksProvider
       throttle={16}
       publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!}
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
     >
       <Head>
         <title>Liveblocks</title>

--- a/examples/nextjs-live-cursors/README.md
+++ b/examples/nextjs-live-cursors/README.md
@@ -60,10 +60,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider`
-- Replace `publicApiKey` in `LiveblocksProvider` with `"pk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-cursors/app/Providers.tsx
+++ b/examples/nextjs-live-cursors/app/Providers.tsx
@@ -7,6 +7,7 @@ export function Providers({ children }: PropsWithChildren) {
   return (
     <LiveblocksProvider
       authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
       resolveUsers={async ({ userIds }) => {
         const searchParams = new URLSearchParams(
           userIds.map((userId) => ["userIds", userId])

--- a/examples/nextjs-live-cursors/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-live-cursors/app/api/liveblocks-auth/route.ts
@@ -10,6 +10,7 @@ import { getRandomUser, getUser } from "../../../database";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {

--- a/examples/nextjs-live-cursors/package.json
+++ b/examples/nextjs-live-cursors/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-live-form-selection/README.md
+++ b/examples/nextjs-live-form-selection/README.md
@@ -60,10 +60,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider`
-- Replace `publicApiKey` in `LiveblocksProvider` with `"pk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `pk_localdev`.
 
 </details>
 

--- a/examples/nextjs-live-form-selection/package.json
+++ b/examples/nextjs-live-form-selection/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-form-selection/pages/_app.tsx
+++ b/examples/nextjs-live-form-selection/pages/_app.tsx
@@ -7,6 +7,7 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <LiveblocksProvider
       publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!}
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
     >
       <Head>
         <title>Liveblocks</title>

--- a/examples/nextjs-nextauth-google-avatars/README.md
+++ b/examples/nextjs-nextauth-google-avatars/README.md
@@ -28,3 +28,14 @@ This example shows how to build a live avatar stack with [Liveblocks](https://li
 ## Getting started
 
 Clone this repository, and then follow [the tutorial](https://liveblocks.io/blog/how-to-add-google-authentication-to-your-nextjs-liveblocks-app-with-nextauthjs) to add Google authentication.
+
+### Run with the local dev server
+
+After setting up the example, run:
+
+```bash
+npm run dev:local
+```
+
+This starts a fresh local server and configures the Liveblocks client with
+`http://localhost:1153` and `sk_localdev`.

--- a/examples/nextjs-nextauth-google-avatars/package.json
+++ b/examples/nextjs-nextauth-google-avatars/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-nextauth-google-avatars/pages/_app.tsx
+++ b/examples/nextjs-nextauth-google-avatars/pages/_app.tsx
@@ -7,7 +7,10 @@ import { LiveblocksProvider } from "@liveblocks/react";
 
 function App({ Component, pageProps }: AppProps<{ session: Session }>) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Head>
         <title>Liveblocks</title>
         <meta name="robots" content="noindex" />

--- a/examples/nextjs-nextauth-google-avatars/pages/api/liveblocks-auth.ts
+++ b/examples/nextjs-nextauth-google-avatars/pages/api/liveblocks-auth.ts
@@ -10,6 +10,7 @@ import { User } from "../../types";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export default async function auth(req: NextApiRequest, res: NextApiResponse) {
@@ -33,10 +34,7 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
   });
 
   // Use a naming pattern to allow access to rooms with a wildcard
-  liveblocksSession.allow(
-    `liveblocks:examples:*`,
-    ["*:write"]
-  );
+  liveblocksSession.allow(`liveblocks:examples:*`, ["*:write"]);
 
   const { status, body } = await liveblocksSession.authorize();
   res.status(status).end(body);

--- a/examples/nextjs-react-flow/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-react-flow/app/api/liveblocks-auth/route.ts
@@ -7,9 +7,10 @@ import { getRandomUser } from "../database";
  * https://liveblocks.io/docs/authentication
  */
 
-const liveblocks = new Liveblocks({
-  secret: process.env.LIVEBLOCKS_SECRET_KEY!,
-});
+  const liveblocks = new Liveblocks({
+    secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+    baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
+  });
 
 export async function POST(_request: NextRequest) {
   if (!process.env.LIVEBLOCKS_SECRET_KEY) {

--- a/examples/nextjs-react-flow/app/page.tsx
+++ b/examples/nextjs-react-flow/app/page.tsx
@@ -16,6 +16,7 @@ export default function Page() {
     <LiveblocksProvider
       throttle={16}
       authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
       resolveUsers={async ({ userIds }) => {
         const searchParams = new URLSearchParams(
           userIds.map((userId) => ["userIds", userId])

--- a/examples/nextjs-react-flow/package.json
+++ b/examples/nextjs-react-flow/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-tldraw-whiteboard-storage/package.json
+++ b/examples/nextjs-tldraw-whiteboard-storage/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-tldraw-whiteboard-yjs/package.json
+++ b/examples/nextjs-tldraw-whiteboard-yjs/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-tldraw-whiteboard-yjs/src/app/Room.tsx
+++ b/examples/nextjs-tldraw-whiteboard-yjs/src/app/Room.tsx
@@ -13,6 +13,7 @@ export function Room({ children }: { children: ReactNode }) {
 
   return (
     <RoomProvider
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
       id={roomId}
       initialPresence={{ presence: undefined }}
       initialStorage={{ records: new LiveMap() }}

--- a/examples/nextjs-tldraw-whiteboard-yjs/src/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-tldraw-whiteboard-yjs/src/app/api/liveblocks-auth/route.ts
@@ -4,8 +4,8 @@ import { getRandomUser } from "@/database";
 
 // Authenticating your Liveblocks application
 // https://liveblocks.io/docs/authentication
-
 const liveblocks = new Liveblocks({
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
   secret: process.env.LIVEBLOCKS_SECRET_KEY as string,
 });
 

--- a/examples/nextjs-todo-list/package.json
+++ b/examples/nextjs-todo-list/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-whiteboard/package.json
+++ b/examples/nextjs-whiteboard/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-whiteboard/pages/_app.tsx
+++ b/examples/nextjs-whiteboard/pages/_app.tsx
@@ -7,6 +7,7 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <LiveblocksProvider
       publicApiKey={process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY!}
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
     >
       <Head>
         <title>Liveblocks</title>

--- a/examples/nextjs-yjs-codemirror/README.md
+++ b/examples/nextjs-yjs-codemirror/README.md
@@ -68,11 +68,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-yjs-codemirror/package.json
+++ b/examples/nextjs-yjs-codemirror/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-codemirror/src/app/Providers.tsx
+++ b/examples/nextjs-yjs-codemirror/src/app/Providers.tsx
@@ -5,7 +5,10 @@ import { PropsWithChildren, Suspense } from "react";
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Suspense>{children}</Suspense>
     </LiveblocksProvider>
   );

--- a/examples/nextjs-yjs-codemirror/src/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-yjs-codemirror/src/app/api/liveblocks-auth/route.ts
@@ -8,6 +8,7 @@ import { NextRequest } from "next/server";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {

--- a/examples/nextjs-yjs-monaco/README.md
+++ b/examples/nextjs-yjs-monaco/README.md
@@ -73,11 +73,11 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to
+  [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-yjs-monaco/package.json
+++ b/examples/nextjs-yjs-monaco/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-monaco/src/app/Providers.tsx
+++ b/examples/nextjs-yjs-monaco/src/app/Providers.tsx
@@ -5,7 +5,10 @@ import { PropsWithChildren, Suspense } from "react";
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Suspense>{children}</Suspense>
     </LiveblocksProvider>
   );

--- a/examples/nextjs-yjs-monaco/src/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-yjs-monaco/src/app/api/liveblocks-auth/route.ts
@@ -8,6 +8,7 @@ import { NextRequest } from "next/server";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {

--- a/examples/nextjs-yjs-quill/README.md
+++ b/examples/nextjs-yjs-quill/README.md
@@ -72,11 +72,11 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to
+  [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-yjs-quill/package.json
+++ b/examples/nextjs-yjs-quill/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-quill/src/app/Providers.tsx
+++ b/examples/nextjs-yjs-quill/src/app/Providers.tsx
@@ -5,7 +5,10 @@ import { PropsWithChildren, Suspense } from "react";
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Suspense>{children}</Suspense>
     </LiveblocksProvider>
   );

--- a/examples/nextjs-yjs-quill/src/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-yjs-quill/src/app/api/liveblocks-auth/route.ts
@@ -8,6 +8,7 @@ import { NextRequest } from "next/server";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {

--- a/examples/nextjs-yjs-slate/README.md
+++ b/examples/nextjs-yjs-slate/README.md
@@ -64,11 +64,10 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-yjs-slate/package.json
+++ b/examples/nextjs-yjs-slate/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-slate/src/app/Providers.tsx
+++ b/examples/nextjs-yjs-slate/src/app/Providers.tsx
@@ -5,7 +5,10 @@ import { PropsWithChildren, Suspense } from "react";
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
+    <LiveblocksProvider
+      authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
+    >
       <Suspense>{children}</Suspense>
     </LiveblocksProvider>
   );

--- a/examples/nextjs-yjs-slate/src/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-yjs-slate/src/app/api/liveblocks-auth/route.ts
@@ -8,6 +8,7 @@ import { NextRequest } from "next/server";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {

--- a/examples/nextjs-yjs-superdoc/README.md
+++ b/examples/nextjs-yjs-superdoc/README.md
@@ -72,11 +72,11 @@ You can optionally run this example locally using the
 [Liveblocks dev server](https://liveblocks.io/docs/tools/dev-server).
 
 - Install the example as detailed above
-- Run `npx liveblocks dev` to start the server
-- Add `baseUrl: "http://localhost:1153"` option to `LiveblocksProvider` and
-  `new Liveblocks`
-- Replace `secret` in `new Liveblocks` with `"sk_localdev"`
-- Run `npm run dev` and go to [http://localhost:3000](http://localhost:3000)
+- Run `npm run dev:local` and go to
+  [http://localhost:3000](http://localhost:3000)
+
+This starts a fresh local server and configures the example with
+`http://localhost:1153` and `sk_localdev`.
 
 </details>
 

--- a/examples/nextjs-yjs-superdoc/package.json
+++ b/examples/nextjs-yjs-superdoc/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-superdoc/src/app/Providers.tsx
+++ b/examples/nextjs-yjs-superdoc/src/app/Providers.tsx
@@ -8,6 +8,7 @@ export function Providers({ children }: PropsWithChildren) {
   return (
     <LiveblocksProvider
       authEndpoint="/api/liveblocks-auth"
+      baseUrl={process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL}
       // Get users' info from their ID
       resolveUsers={async ({ userIds }) => {
         const searchParams = new URLSearchParams(

--- a/examples/nextjs-yjs-superdoc/src/app/api/liveblocks-auth/route.ts
+++ b/examples/nextjs-yjs-superdoc/src/app/api/liveblocks-auth/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+  baseUrl: process.env.NEXT_PUBLIC_LIVEBLOCKS_BASE_URL,
 });
 
 export async function POST(request: NextRequest) {


### PR DESCRIPTION
Adds dev server command to the 23/86 fully supported Next.js examples. Run this to use the dev server:

```shell
npm run dev:local
```

## Examples

- `nextjs-3d-builder`
- `nextjs-connection-status`
- `nextjs-dashboard`
- `nextjs-form`
- `nextjs-live-avatars`
- `nextjs-live-avatars-advanced`
- `nextjs-live-cursors`
- `nextjs-live-cursors-advanced`
- `nextjs-live-cursors-chat`
- `nextjs-live-cursors-scroll`
- `nextjs-live-form-selection`
- `nextjs-nextauth-google-avatars`
- `nextjs-react-flow`
- `nextjs-tldraw-whiteboard-storage`
- `nextjs-tldraw-whiteboard-yjs`
- `nextjs-todo-list`
- `nextjs-whiteboard`
- `nextjs-whiteboard-advanced`
- `nextjs-yjs-codemirror`
- `nextjs-yjs-monaco`
- `nextjs-yjs-quill`
- `nextjs-yjs-slate`
- `nextjs-yjs-superdoc`