### PR TITLE
Switch example `dev:local` scripts to `--persist`

### DIFF
--- a/examples/nextjs-3d-builder/package.json
+++ b/examples/nextjs-3d-builder/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-connection-status/README.md
+++ b/examples/nextjs-connection-status/README.md
@@ -68,7 +68,7 @@ You can optionally run this example locally using the
 - Run `npm run dev:local` and go to
   [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `pk_localdev`.
 
 </details>

--- a/examples/nextjs-connection-status/package.json
+++ b/examples/nextjs-connection-status/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-dashboard/README.md
+++ b/examples/nextjs-dashboard/README.md
@@ -68,7 +68,7 @@ You can optionally run this example locally using the
 - Run `npm run dev:local` and go to
   [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `pk_localdev`.
 
 </details>

--- a/examples/nextjs-dashboard/package.json
+++ b/examples/nextjs-dashboard/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-form/README.md
+++ b/examples/nextjs-form/README.md
@@ -62,9 +62,9 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server, configures the example with
-`http://localhost:1153` and `sk_localdev`, and runs Next.js. Storage is reset
-when the command exits.
+This starts a local server, configures the example with
+`http://localhost:1153` and `sk_localdev`, and runs Next.js. Its data is kept
+in `.liveblocks/` between runs.
 
 </details>
 

--- a/examples/nextjs-form/package.json
+++ b/examples/nextjs-form/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-avatars-advanced/README.md
+++ b/examples/nextjs-live-avatars-advanced/README.md
@@ -63,7 +63,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-live-avatars-advanced/package.json
+++ b/examples/nextjs-live-avatars-advanced/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-avatars/README.md
+++ b/examples/nextjs-live-avatars/README.md
@@ -62,7 +62,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-live-avatars/package.json
+++ b/examples/nextjs-live-avatars/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-advanced/README.md
+++ b/examples/nextjs-live-cursors-advanced/README.md
@@ -63,7 +63,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-live-cursors-advanced/package.json
+++ b/examples/nextjs-live-cursors-advanced/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-chat/README.md
+++ b/examples/nextjs-live-cursors-chat/README.md
@@ -62,7 +62,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `pk_localdev`.
 
 </details>

--- a/examples/nextjs-live-cursors-chat/package.json
+++ b/examples/nextjs-live-cursors-chat/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors-scroll/README.md
+++ b/examples/nextjs-live-cursors-scroll/README.md
@@ -62,7 +62,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `pk_localdev`.
 
 </details>

--- a/examples/nextjs-live-cursors-scroll/package.json
+++ b/examples/nextjs-live-cursors-scroll/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-live-cursors/README.md
+++ b/examples/nextjs-live-cursors/README.md
@@ -62,7 +62,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-live-cursors/package.json
+++ b/examples/nextjs-live-cursors/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-live-form-selection/README.md
+++ b/examples/nextjs-live-form-selection/README.md
@@ -62,7 +62,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `pk_localdev`.
 
 </details>

--- a/examples/nextjs-live-form-selection/package.json
+++ b/examples/nextjs-live-form-selection/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-nextauth-google-avatars/README.md
+++ b/examples/nextjs-nextauth-google-avatars/README.md
@@ -37,5 +37,5 @@ After setting up the example, run:
 npm run dev:local
 ```
 
-This starts a fresh local server and configures the Liveblocks client with
+This starts a local server and configures the Liveblocks client with
 `http://localhost:1153` and `sk_localdev`.

--- a/examples/nextjs-nextauth-google-avatars/package.json
+++ b/examples/nextjs-nextauth-google-avatars/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-react-flow/package.json
+++ b/examples/nextjs-react-flow/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-tldraw-whiteboard-storage/package.json
+++ b/examples/nextjs-tldraw-whiteboard-storage/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-tldraw-whiteboard-yjs/package.json
+++ b/examples/nextjs-tldraw-whiteboard-yjs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-todo-list/package.json
+++ b/examples/nextjs-todo-list/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/examples/nextjs-whiteboard-advanced/package.json
+++ b/examples/nextjs-whiteboard-advanced/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-whiteboard/package.json
+++ b/examples/nextjs-whiteboard/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=pk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start"
   },

--- a/examples/nextjs-yjs-codemirror/README.md
+++ b/examples/nextjs-yjs-codemirror/README.md
@@ -70,7 +70,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-yjs-codemirror/package.json
+++ b/examples/nextjs-yjs-codemirror/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-monaco/README.md
+++ b/examples/nextjs-yjs-monaco/README.md
@@ -76,7 +76,7 @@ You can optionally run this example locally using the
 - Run `npm run dev:local` and go to
   [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-yjs-monaco/package.json
+++ b/examples/nextjs-yjs-monaco/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-quill/README.md
+++ b/examples/nextjs-yjs-quill/README.md
@@ -75,7 +75,7 @@ You can optionally run this example locally using the
 - Run `npm run dev:local` and go to
   [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-yjs-quill/package.json
+++ b/examples/nextjs-yjs-quill/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-slate/README.md
+++ b/examples/nextjs-yjs-slate/README.md
@@ -66,7 +66,7 @@ You can optionally run this example locally using the
 - Install the example as detailed above
 - Run `npm run dev:local` and go to [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-yjs-slate/package.json
+++ b/examples/nextjs-yjs-slate/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/nextjs-yjs-superdoc/README.md
+++ b/examples/nextjs-yjs-superdoc/README.md
@@ -75,7 +75,7 @@ You can optionally run this example locally using the
 - Run `npm run dev:local` and go to
   [http://localhost:3000](http://localhost:3000)
 
-This starts a fresh local server and configures the example with
+This starts a local server and configures the example with
 `http://localhost:1153` and `sk_localdev`.
 
 </details>

--- a/examples/nextjs-yjs-superdoc/package.json
+++ b/examples/nextjs-yjs-superdoc/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+    "dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
This PR simplifies the `dev:local` scripts added in #3657, now that the CLI supplies the connection details itself (I just released 1.9.0):

```diff
-"dev:local": "npx liveblocks dev --cmd 'NEXT_PUBLIC_LIVEBLOCKS_BASE_URL=http://localhost:1153 LIVEBLOCKS_SECRET_KEY=sk_localdev next dev'",
+"dev:local": "npx liveblocks dev --persist --cmd 'next dev'",
```

I've also added `--persist` so an example's data survives restarts of the server, as one would expect.

