### PR TITLE
Create the Yjs provider from `useLiveblocksExtension`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## vNEXT (not yet released)
 
+### `@liveblocks/react-tiptap`
+
+- `useLiveblocksExtension` now creates the Yjs provider itself, instead of
+  waiting until an editor is constructed. `useIsEditorReady` can therefore be
+  used to defer creating your editor until the content has loaded, rather than
+  only to hide it.
+
 ## v3.23.1
 
 ### `@liveblocks/react-ui`

--- a/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
+++ b/packages/liveblocks-react-tiptap/src/LiveblocksExtension.ts
@@ -176,6 +176,10 @@ export const useLiveblocksExtension = (
   );
   const editor = useRef<Editor | null>(null);
   const room = useRoom();
+  const provider = getYjsProviderForRoom(room, {
+    enablePermanentUserData: !!options.ai || options.enablePermanentUserData,
+    offlineSupport_experimental: options.offlineSupport_experimental,
+  });
 
   // TODO: we don't need these things if comments isn't turned on...
   // TODO: we don't have a reference to the editor here, need to figure this out
@@ -377,11 +381,6 @@ export const useLiveblocksExtension = (
       ];
     },
     addStorage() {
-      const provider = getYjsProviderForRoom(room, {
-        enablePermanentUserData:
-          !!options.ai || options.enablePermanentUserData,
-        offlineSupport_experimental: options.offlineSupport_experimental,
-      });
       return {
         doc: provider.getYDoc(),
         provider,


### PR DESCRIPTION
At Resend, we use Liveblocks for the broadcast editor. However, we have seen some issues related to the first load of the editor (TipTap + Liveblocks), such as an empty screen/document while loading, duplicated content, and complete content drop. 

Digging into this issue, we believe that TipTap, or most likely ProseMirror, run two transactions: 
1) when mounted with empty content; 
2) after the Liveblocks storage is connected. 

This first transaction is very problematic because we have a couple of extension that adds content in **empty documents**, which ends up wiping out the previous (still to be loaded) document.

For now, we introduced a Yjs gate over the editor, and then the `editor` object is only created when the content is available on the page ensuring that the first ProseMirror transaction runs with the proper content. 

----

_Here are more details after an agent exploration:_ 

Problem: `useIsEditorReady` cannot be used to defer editor creation. The Yjs provider is created by the extension's `addStorage`, which Tiptap only runs when an Editor is constructed. A component that waits for readiness before creating its editor therefore starves itself: no editor means no `addStorage`, no provider, and readiness that never arrives. The hook only reported anything once the editor already existed -- by which point it was bound to the empty pre-sync document, which is what deferring creation is meant to avoid.

Solution: create the provider in the hook body instead. `getYjsProviderForRoom` is memoized per room, so `addStorage` still receives the same instance, and the call already ran during render inside Tiptap's editor construction. This moves a side effect rather than adding one.

Repro: Open a broadcast/template editor on a throttled connection. The Tiptap editor is created immediately, bound to an empty local Yjs doc; the server content pops in only after first sync. During that window the doc is readable as empty — an autosave then persists emptiness over the DB copy, and any local write (e.g. auto-wrapping) merges junk with the arriving content.

Why this PR fixes it: The fix is to not create the editor until the room's first sync answers — but useIsEditorReady couldn't express that: the Yjs provider was only constructed inside the extension's addStorage(), i.e. after an editor exists, so before any editor the hook returned false forever (chicken-and-egg). Moving provider creation into useLiveblocksExtension starts sync immediately; useIsEditorReady now flips on first sync with no editor mounted, so apps can defer editor creation until the doc already holds its content — the empty window never exists.
