### PR TITLE
Add `useMutableStorage()` and deprecate `useStorageRoot()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## vNEXT (not yet released)
 
+### `@liveblocks/react`
+
+- Add new hook `useMutableStorage()` to get direct access to the mutable Storage
+  root. See
+  [docs](https://liveblocks.io/docs/api-reference/liveblocks-react#useMutableStorage).
+
 ## v3.24.0
 
 This release introduces `LiveText` (beta), a collaborative rich-text data

--- a/docs/pages/api-reference/liveblocks-codemirror.mdx
+++ b/docs/pages/api-reference/liveblocks-codemirror.mdx
@@ -81,35 +81,26 @@ export default function App() {
 }
 ```
 
-Attach the plugins after Storage has loaded. Create the editor with the
-`LiveText` content and both plugins in the initial extensions:
+Use
+[`useMutableStorage`](/docs/api-reference/liveblocks-react#useMutableStorage) to
+get the `LiveText` once Storage has loaded, then create the editor with its
+content and both plugins in the initial extensions:
 
 ```tsx file="Editor.tsx"
 "use client";
 
-import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { useEffect, useRef } from "react";
 import { EditorView } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
-import type { LiveText, Room } from "@liveblocks/client";
 import {
   createLiveblocksPresencePlugin,
   createLiveblocksSyncPlugin,
 } from "@liveblocks/codemirror";
-import { useRoom } from "@liveblocks/react/suspense";
+import { useMutableStorage, useRoom } from "@liveblocks/react/suspense";
 
 export function Editor() {
   const room = useRoom();
-  const root = useRoot(room);
-
-  if (root == null) {
-    return <div>Loading…</div>;
-  }
-
-  return <EditorInner text={root.get("document")} />;
-}
-
-function EditorInner({ text }: { text: LiveText }) {
-  const room = useRoom();
+  const text = useMutableStorage().get("document");
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -134,13 +125,6 @@ function EditorInner({ text }: { text: LiveText }) {
   }, [room, text]);
 
   return <div ref={containerRef} className="editor" />;
-}
-
-function useRoot(room: Room) {
-  const subscribe = room.events.storageDidLoad.subscribeOnce;
-  const getSnapshot = room.getStorageOrNull;
-  const getServerSnapshot = useCallback(() => null, []);
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 ```
 

--- a/docs/pages/api-reference/liveblocks-lexical.mdx
+++ b/docs/pages/api-reference/liveblocks-lexical.mdx
@@ -111,7 +111,9 @@ export default function App() {
 }
 ```
 
-Wait for Storage to load, then nest
+Use
+[`useMutableStorage`](/docs/api-reference/liveblocks-react#useMutableStorage) to
+get the document root once Storage has loaded, then nest
 [`LiveblocksCollaborationPlugin`](#LiveblocksCollaborationPlugin) inside
 [`LexicalComposer`](https://lexical.dev/docs/react/plugins). Optionally add
 [`RemoteCursorsPlugin`](#RemoteCursorsPlugin) as a child to show remote carets:
@@ -119,7 +121,6 @@ Wait for Storage to load, then nest
 ```tsx file="Editor.tsx"
 "use client";
 
-import { useCallback, useSyncExternalStore } from "react";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
@@ -128,19 +129,11 @@ import {
   LiveblocksCollaborationPlugin,
   RemoteCursorsPlugin,
 } from "@liveblocks/lexical";
-import type { Room } from "@liveblocks/client";
-import { useRoom } from "@liveblocks/react/suspense";
+import { useMutableStorage } from "@liveblocks/react/suspense";
 import "@liveblocks/lexical/styles.css";
 
 export function Editor() {
-  const room = useRoom();
-  const root = useRoot(room);
-
-  if (root === null) {
-    return <div>Loading…</div>;
-  }
-
-  const document = root.get("document");
+  const document = useMutableStorage().get("document");
 
   return (
     <LexicalComposer
@@ -162,13 +155,6 @@ export function Editor() {
       </div>
     </LexicalComposer>
   );
-}
-
-function useRoot(room: Room) {
-  const subscribe = room.events.storageDidLoad.subscribeOnce;
-  const getSnapshot = room.getStorageOrNull;
-  const getServerSnapshot = useCallback(() => null, []);
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 ```
 
@@ -199,7 +185,7 @@ import { LiveblocksCollaborationPlugin } from "@liveblocks/lexical";
 <PropertiesList title="Props">
   <PropertiesListItem name="root" type="LiveRootNode" required>
     The Storage root document for the editor. Typically
-    `root.get("document")` after Storage has loaded.
+    `useMutableStorage().get("document")`.
   </PropertiesListItem>
   <PropertiesListItem name="children" type="ReactNode">
     Optional children. Place [`RemoteCursorsPlugin`](#RemoteCursorsPlugin) here

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -3971,6 +3971,67 @@ const myTodos = useStorage(
   </PropertiesListItem>
 </PropertiesList>
 
+### useMutableStorage [@badge=RoomProvider]
+
+Returns the current room's _mutable_ Storage root. Always a LiveObject.
+
+```tsx
+import { useMutableStorage } from "@liveblocks/react/suspense";
+
+function Editor() {
+  const root = useMutableStorage();
+  const liveText = root.get("document");
+
+  // …pass `liveText` to your editor binding
+}
+```
+
+Unlike [`useStorage`][], this hook is **not reactive**. Your component rerenders
+only once, when Storage has finished loading, and never again when the contents
+of the tree change. That’s the point: the `LiveText` you hand to an editor stays
+referentially stable, so your editor isn’t torn down on every keystroke.
+
+```tsx
+// Rerenders on every keystroke
+const text = useStorage((root) => root.document);
+
+// Rerenders only once, after Storage has loaded
+const liveText = useMutableStorage().get("document");
+```
+
+<Banner title="You are responsible for batching">
+
+If you make changes to Storage via `useMutableStorage`, you’re also responsible
+for batching mutations when you make them. This is unlike
+[`useMutation`](/docs/api-reference/liveblocks-react#useMutation), which
+automatically does that for you. You should always wrap related changes in
+[`Room.batch`](/docs/api-reference/liveblocks-client#Room.batch) yourself, so
+they’re sent as one update and undoable as a single step.
+
+```tsx
+const room = useRoom();
+const root = useMutableStorage();
+
+room.batch(() => {
+  root.get("settings").set("theme", "dark");
+  root.get("settings").set("fontSize", 14);
+});
+```
+
+</Banner>
+
+The non-Suspense version returns `null` while Storage is still loading. The
+[Suspense version][] suspends instead, and always returns the root.
+
+<PropertiesListEmpty title="Arguments">_None_</PropertiesListEmpty>
+
+<PropertiesList title="Returns">
+  <PropertiesListItem name="root" type="LiveObject<TStorage> | null">
+    The mutable Storage root. Returns `null` while Storage is still loading (in
+    the non-Suspense version).
+  </PropertiesListItem>
+</PropertiesList>
+
 ### useUploadFile [@badge=RoomProvider]
 
 Returns a function that uploads a file to the current room. The function

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -3937,14 +3937,14 @@ needs. This will avoid unnecessary rerenders that happen with overselection.
 In order to select one item from a LiveMap within the storage tree with the
 `useStorage` method, you can use the example below:
 
-```ts
+```tsx showLineNumbers={false}
 const key = "errands";
 const myTodos = useStorage((root) => root.todoMap.get(key));
 ```
 
 In order to query a LiveMap, and filter for specific values:
 
-```ts
+```tsx showLineNumbers={false}
 const myTodos = useStorage(
   root => Array.from(root.todoMap.values()).filter(...),
   shallow,
@@ -3975,7 +3975,7 @@ const myTodos = useStorage(
 
 Returns the current room's _mutable_ Storage root. Always a LiveObject.
 
-```tsx
+```tsx showLineNumbers={false}
 import { useMutableStorage } from "@liveblocks/react/suspense";
 
 function Editor() {
@@ -3991,7 +3991,7 @@ only once, when Storage has finished loading, and never again when the contents
 of the tree change. That’s the point: the `LiveText` you hand to an editor stays
 referentially stable, so your editor isn’t torn down on every keystroke.
 
-```tsx
+```tsx showLineNumbers={false}
 // Rerenders on every keystroke
 const text = useStorage((root) => root.document);
 
@@ -4008,7 +4008,7 @@ automatically does that for you. You should always wrap related changes in
 [`Room.batch`](/docs/api-reference/liveblocks-client#Room.batch) yourself, so
 they’re sent as one update and undoable as a single step.
 
-```tsx
+```tsx showLineNumbers={false}
 const room = useRoom();
 const root = useMutableStorage();
 

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -3973,7 +3973,8 @@ const myTodos = useStorage(
 
 ### useMutableStorage [@badge=RoomProvider]
 
-Returns the current room's _mutable_ Storage root. Always a [`LiveObject`](/docs/api-reference/liveblocks-client#LiveObject).
+Returns the current room's _mutable_ Storage root. Always a
+[`LiveObject`](/docs/api-reference/liveblocks-client#LiveObject).
 
 ```tsx showLineNumbers={false}
 import { useMutableStorage } from "@liveblocks/react/suspense";

--- a/docs/pages/api-reference/liveblocks-react.mdx
+++ b/docs/pages/api-reference/liveblocks-react.mdx
@@ -3973,7 +3973,7 @@ const myTodos = useStorage(
 
 ### useMutableStorage [@badge=RoomProvider]
 
-Returns the current room's _mutable_ Storage root. Always a LiveObject.
+Returns the current room's _mutable_ Storage root. Always a [`LiveObject`](/docs/api-reference/liveblocks-client#LiveObject).
 
 ```tsx showLineNumbers={false}
 import { useMutableStorage } from "@liveblocks/react/suspense";
@@ -3982,7 +3982,8 @@ function Editor() {
   const root = useMutableStorage();
   const liveText = root.get("document");
 
-  // …pass `liveText` to your editor binding
+  // Pass `liveText` to your editor binding
+  // ...
 }
 ```
 

--- a/docs/pages/get-started/nextjs-codemirror.mdx
+++ b/docs/pages/get-started/nextjs-codemirror.mdx
@@ -158,29 +158,18 @@ collaboration to your Next.js application using the APIs from the
     ```tsx file="app/Editor.tsx"
     "use client";
 
-    import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+    import { useEffect, useRef } from "react";
     import { EditorView } from "@codemirror/view";
     import { EditorState } from "@codemirror/state";
-    import type { LiveText, Room } from "@liveblocks/client";
     import {
       createLiveblocksPresencePlugin,
       createLiveblocksSyncPlugin,
     } from "@liveblocks/codemirror";
-    import { useRoom } from "@liveblocks/react/suspense";
+    import { useMutableStorage, useRoom } from "@liveblocks/react/suspense";
 
     export function Editor() {
       const room = useRoom();
-      const root = useRoot(room);
-
-      if (root == null) {
-        return <div>Loading…</div>;
-      }
-
-      return <EditorInner text={root.get("document")} />;
-    }
-
-    function EditorInner({ text }: { text: LiveText }) {
-      const room = useRoom();
+      const text = useMutableStorage().get("document");
       const containerRef = useRef<HTMLDivElement>(null);
 
       useEffect(() => {
@@ -205,13 +194,6 @@ collaboration to your Next.js application using the APIs from the
       }, [room, text]);
 
       return <div ref={containerRef} className="editor" />;
-    }
-
-    function useRoot(room: Room) {
-      const subscribe = room.events.storageDidLoad.subscribeOnce;
-      const getSnapshot = room.getStorageOrNull;
-      const getServerSnapshot = useCallback(() => null, []);
-      return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
     }
     ```
 

--- a/docs/pages/get-started/nextjs-lexical-storage.mdx
+++ b/docs/pages/get-started/nextjs-lexical-storage.mdx
@@ -188,7 +188,6 @@ instead.
     ```tsx file="app/Editor.tsx"
     "use client";
 
-    import { useCallback, useSyncExternalStore } from "react";
     import { LexicalComposer } from "@lexical/react/LexicalComposer";
     import { ContentEditable } from "@lexical/react/LexicalContentEditable";
     import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
@@ -197,19 +196,11 @@ instead.
       LiveblocksCollaborationPlugin,
       RemoteCursorsPlugin,
     } from "@liveblocks/lexical";
-    import type { Room } from "@liveblocks/client";
-    import { useRoom } from "@liveblocks/react/suspense";
+    import { useMutableStorage } from "@liveblocks/react/suspense";
     import "@liveblocks/lexical/styles.css";
 
     export function Editor() {
-      const room = useRoom();
-      const root = useRoot(room);
-
-      if (root === null) {
-        return <div>Loading…</div>;
-      }
-
-      const document = root.get("document");
+      const document = useMutableStorage().get("document");
 
       return (
         <LexicalComposer
@@ -231,13 +222,6 @@ instead.
           </div>
         </LexicalComposer>
       );
-    }
-
-    function useRoot(room: Room) {
-      const subscribe = room.events.storageDidLoad.subscribeOnce;
-      const getSnapshot = room.getStorageOrNull;
-      const getServerSnapshot = useCallback(() => null, []);
-      return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
     }
     ```
 

--- a/docs/pages/get-started/react-codemirror.mdx
+++ b/docs/pages/get-started/react-codemirror.mdx
@@ -161,29 +161,18 @@ collaboration to your React application using the APIs from the
       ```tsx file="Editor.tsx"
       "use client";
 
-      import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+      import { useEffect, useRef } from "react";
       import { EditorView } from "@codemirror/view";
       import { EditorState } from "@codemirror/state";
-      import type { LiveText, Room } from "@liveblocks/client";
       import {
         createLiveblocksPresencePlugin,
         createLiveblocksSyncPlugin,
       } from "@liveblocks/codemirror";
-      import { useRoom } from "@liveblocks/react/suspense";
+      import { useMutableStorage, useRoom } from "@liveblocks/react/suspense";
 
       export function Editor() {
         const room = useRoom();
-        const root = useRoot(room);
-
-        if (root == null) {
-          return <div>Loading…</div>;
-        }
-
-        return <EditorInner text={root.get("document")} />;
-      }
-
-      function EditorInner({ text }: { text: LiveText }) {
-        const room = useRoom();
+        const text = useMutableStorage().get("document");
         const containerRef = useRef<HTMLDivElement>(null);
 
         useEffect(() => {
@@ -208,13 +197,6 @@ collaboration to your React application using the APIs from the
         }, [room, text]);
 
         return <div ref={containerRef} className="editor" />;
-      }
-
-      function useRoot(room: Room) {
-        const subscribe = room.events.storageDidLoad.subscribeOnce;
-        const getSnapshot = room.getStorageOrNull;
-        const getServerSnapshot = useCallback(() => null, []);
-        return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
       }
       ```
 

--- a/docs/pages/get-started/react-lexical-storage.mdx
+++ b/docs/pages/get-started/react-lexical-storage.mdx
@@ -212,7 +212,6 @@ instead.
       ```tsx file="Editor.tsx"
       "use client";
 
-      import { useCallback, useSyncExternalStore } from "react";
       import { LexicalComposer } from "@lexical/react/LexicalComposer";
       import { ContentEditable } from "@lexical/react/LexicalContentEditable";
       import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
@@ -221,19 +220,11 @@ instead.
         LiveblocksCollaborationPlugin,
         RemoteCursorsPlugin,
       } from "@liveblocks/lexical";
-      import type { Room } from "@liveblocks/client";
-      import { useRoom } from "@liveblocks/react/suspense";
+      import { useMutableStorage } from "@liveblocks/react/suspense";
       import "@liveblocks/lexical/styles.css";
 
       export function Editor() {
-        const room = useRoom();
-        const root = useRoot(room);
-
-        if (root === null) {
-          return <div>Loading…</div>;
-        }
-
-        const document = root.get("document");
+        const document = useMutableStorage().get("document");
 
         return (
           <LexicalComposer
@@ -255,13 +246,6 @@ instead.
             </div>
           </LexicalComposer>
         );
-      }
-
-      function useRoot(room: Room) {
-        const subscribe = room.events.storageDidLoad.subscribeOnce;
-        const getSnapshot = room.getStorageOrNull;
-        const getServerSnapshot = useCallback(() => null, []);
-        return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
       }
       ```
 

--- a/e2e/next-codemirror-liveblocks/app/rooms/[roomId]/page.tsx
+++ b/e2e/next-codemirror-liveblocks/app/rooms/[roomId]/page.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import { ClientSideSuspense, RoomProvider, useRoom } from "@liveblocks/react";
+import {
+  ClientSideSuspense,
+  RoomProvider,
+  useMutableStorage,
+  useRoom,
+} from "@liveblocks/react/suspense";
 import {
   createLiveblocksPresencePlugin,
   createLiveblocksSyncPlugin,
 } from "@liveblocks/codemirror";
-import {
-  use,
-  useCallback,
-  useEffect,
-  useRef,
-  useSyncExternalStore,
-} from "react";
+import { use, useEffect, useRef } from "react";
 import { EditorState } from "@codemirror/state";
-import { Room } from "@liveblocks/client";
 import { LiveText } from "@liveblocks/core";
 import { EditorView } from "@codemirror/view";
 
@@ -41,16 +39,7 @@ export default function RoomPage({
 
 function Editor() {
   const room = useRoom();
-  const root = useRoot(room);
-  if (root == null) {
-    return <div>Loading room data…</div>;
-  }
-
-  return <EditorInner text={root.get("document")} />;
-}
-
-function EditorInner({ text }: { text: LiveText }) {
-  const room = useRoom();
+  const text = useMutableStorage().get("document");
   const container = useRef<HTMLDivElement>(null);
   const view = useRef<EditorView | null>(null);
 
@@ -80,13 +69,4 @@ function EditorInner({ text }: { text: LiveText }) {
       <div ref={container} className="h-full [&_.cm-editor]:h-full" />
     </div>
   );
-}
-
-function useRoot(room: Room) {
-  const subscribe = room.events.storageDidLoad.subscribeOnce;
-  const getSnapshot = room.getStorageOrNull;
-  const getServerSnapshot = useCallback(() => {
-    return null;
-  }, []);
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/e2e/next-lexical-liveblocks/app/rooms/[roomId]/page.tsx
+++ b/e2e/next-lexical-liveblocks/app/rooms/[roomId]/page.tsx
@@ -28,18 +28,22 @@ import { TablePlugin } from "@lexical/react/LexicalTablePlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 import { $insertNodeToNearestRoot } from "@lexical/utils";
-import { LiveList, LiveObject, LiveText, type Room } from "@liveblocks/client";
+import { LiveList, LiveObject, LiveText } from "@liveblocks/client";
 import {
   LiveblocksCollaborationPlugin,
   RemoteCursorsPlugin,
 } from "@liveblocks/lexical";
-import { ClientSideSuspense, RoomProvider, useRoom } from "@liveblocks/react";
+import {
+  ClientSideSuspense,
+  RoomProvider,
+  useMutableStorage,
+} from "@liveblocks/react/suspense";
 import {
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_EDITOR,
 } from "lexical";
-import { use, useCallback, useEffect, useSyncExternalStore } from "react";
+import { use, useEffect } from "react";
 
 import { ImageNode } from "./nodes/ImageNode";
 import { MentionNode } from "./nodes/MentionNode";
@@ -102,17 +106,7 @@ export default function RoomPage({
 }
 
 function Editor() {
-  const room = useRoom();
-  const root = useRoot(room);
-  if (root === null) {
-    return (
-      <div className="p-4 text-neutral-500 dark:text-neutral-400">
-        Loading room data…
-      </div>
-    );
-  }
-
-  const document = root.get("document");
+  const document = useMutableStorage().get("document");
 
   return (
     <LexicalComposer
@@ -185,15 +179,6 @@ function HorizontalRulePlugin() {
   }, [editor]);
 
   return null;
-}
-
-function useRoot(room: Room) {
-  const subscribe = room.events.storageDidLoad.subscribeOnce;
-  const getSnapshot = room.getStorageOrNull;
-  const getServerSnapshot = useCallback(() => {
-    return null;
-  }, []);
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 const THEME = {

--- a/packages/liveblocks-react/scripts/check-exports.ts
+++ b/packages/liveblocks-react/scripts/check-exports.ts
@@ -21,6 +21,7 @@ const ALLOW_DIFFERENT_JSDOCS = [
   "useInboxNotifications",
   "useRoomInfo",
   "useSelf",
+  "useMutableStorage",
   "useThreads",
   "useFeeds",
   "useFeedMessages",

--- a/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
+++ b/packages/liveblocks-react/src/__tests__/_liveblocks.config.ts
@@ -24,12 +24,15 @@ const client = createClient({
   },
 });
 
+const roomContext = createRoomContext<Presence, Storage>(client);
+
 export const {
   RoomProvider,
   useCanRedo,
   useCanUndo,
   useHistory,
   useIsInsideRoom,
+  useMutableStorage,
   useMutation,
   useMyPresence,
   useOthers,
@@ -37,4 +40,6 @@ export const {
   useStorage,
   useUndo,
   useThreads,
-} = createRoomContext<Presence, Storage>(client);
+} = roomContext;
+
+export const { suspense } = roomContext;

--- a/packages/liveblocks-react/src/__tests__/useMutableStorage.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMutableStorage.test.tsx
@@ -1,0 +1,115 @@
+import { LiveList, LiveObject } from "@liveblocks/client";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { Suspense } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+import {
+  RoomProvider,
+  suspense,
+  useMutableStorage,
+  useMutation,
+} from "./_liveblocks.config";
+import MockWebSocket, { websocketSimulator } from "./_MockWebSocket";
+import { act, renderHook, screen } from "./_utils";
+
+// Access token with perms: { "*": ["room:write"] }
+const exampleToken =
+  "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NjQ1NjY0MTAsImV4cCI6MTY2NDU3MDAxMCwicGlkIjoiNjA1YTRmZDMxYTM2ZDVlYTdhMmUwOGYxIiwidWlkIjoidXNlcjEiLCJwZXJtcyI6eyIqIjpbInJvb206d3JpdGUiXX0sImsiOiJhY2MifQ.OwLJdtVzMmIwIGO4gVWEJSng3DaUFsljpFXKE0Jcl1OTSHKCpDqJDkHMkkhgHmpUbBPMMdf8QmYa-4h4tMAikxzZL_tFdWQ-5kr92jOFqXPscDQTk0_GCMhv7R6vFj4YjT-msYVNVPI5M0Jlmm9fU5U_s3ZssEYhQl6AYkZT0XErrFYch8WmCVCIQ3bmFuUg5WDtnGJFiQIuCvLr0RyalJh4aILKPZ7ii_u9Q04__rN5kUhIqh2NaXWqFwsITuKaFwn24PJfBz-GJNX5Jk-tlmfJItkPFuBFp3WY8J9r9m59rJF35W_UxMU1tBNYVYRs8c3pjJKdnBiSUDUjNPvxr";
+
+const server = setupServer(
+  http.post("/api/auth", () => HttpResponse.json({ token: exampleToken }))
+);
+
+beforeAll(() => server.listen());
+beforeEach(() => MockWebSocket.reset());
+afterEach(() => {
+  MockWebSocket.reset();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+describe("useMutableStorage (non-Suspense version)", () => {
+  test("returns null before storage has loaded", () => {
+    const { result } = renderHook(() => useMutableStorage());
+    expect(result.current).toBeNull();
+  });
+
+  test("returns the mutable Storage root once storage has loaded", async () => {
+    const { result } = renderHook(() => useMutableStorage());
+
+    const sim = await websocketSimulator();
+    act(() => sim.simulateStorageLoaded());
+
+    const root = result.current;
+    expect(root).toBeInstanceOf(LiveObject);
+    expect(root?.get("obj").get("a")).toBe(0);
+    expect(root?.get("obj").get("nested").toJSON()).toEqual(["foo", "bar"]);
+  });
+
+  test("does not re-render when the contents of Storage change", async () => {
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders++;
+      return useMutableStorage();
+    });
+    const { result: mut } = renderHook(() =>
+      useMutation(({ storage }) => storage.get("obj").set("a", 1), [])
+    );
+
+    const sim = await websocketSimulator();
+    act(() => sim.simulateStorageLoaded());
+
+    const rendersAfterLoading = renders;
+    const rootAfterLoading = result.current;
+
+    act(() => mut.current());
+
+    expect(result.current?.get("obj").get("a")).toBe(1);
+    expect(renders).toBe(rendersAfterLoading);
+    expect(result.current).toBe(rootAfterLoading); // Referentially equal!
+  });
+});
+
+describe("useMutableStorage (Suspense version)", () => {
+  test("suspends until storage has loaded, then returns the root", async () => {
+    const { result } = renderHook(() => suspense.useMutableStorage(), {
+      wrapper: ({ children }) => (
+        <RoomProvider
+          id="room"
+          initialPresence={() => ({ x: 1 })}
+          initialStorage={() => ({
+            obj: new LiveObject({ a: 0, nested: new LiveList(["foo", "bar"]) }),
+          })}
+        >
+          <Suspense fallback={<div>Loading</div>}>
+            <div>Loaded</div>
+            {children}
+          </Suspense>
+        </RoomProvider>
+      ),
+    });
+
+    await vi.waitFor(() =>
+      expect(screen.getByText("Loading")).toBeInTheDocument()
+    );
+
+    const sim = await websocketSimulator();
+    act(() => sim.simulateStorageLoaded());
+
+    await vi.waitFor(() =>
+      expect(screen.getByText("Loaded")).toBeInTheDocument()
+    );
+    expect(result.current).toBeInstanceOf(LiveObject);
+    expect(result.current.get("obj").get("a")).toBe(0);
+  });
+});

--- a/packages/liveblocks-react/src/index.ts
+++ b/packages/liveblocks-react/src/index.ts
@@ -90,6 +90,7 @@ export {
   useOthersConnectionIds,
   useOthersMapped,
   useSelf,
+  useMutableStorage,
   useStorage,
   useThreads,
   useFeeds,

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -1397,7 +1397,6 @@ function useStorageRoot_withRoomContext<S extends LsonObject>(
   return [useMutableStorage_withRoomContext<S>(RoomContext)];
 }
 
-// NOTE: This API exists for backward compatible reasons
 function useStorageRoot<S extends LsonObject>(): [root: LiveObject<S> | null] {
   return useStorageRoot_withRoomContext<S>(GlobalRoomContext);
 }
@@ -5443,8 +5442,11 @@ function _useSelfSuspense(...args: any[]) {
 }
 
 /**
- * Returns the mutable (!) Storage root. This hook exists for
- * backward-compatible reasons.
+ * Returns the mutable (!) Storage root, wrapped in a 1-tuple.
+ *
+ * @deprecated Use {@link useMutableStorage} instead, which returns the root
+ * directly instead of wrapping it in a 1-tuple, and which does not return
+ * `null` in its Suspense version.
  *
  * @example
  * const [root] = useStorageRoot();

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -64,6 +64,7 @@ import {
   HttpError,
   kInternal,
   makePoller,
+  nn,
   ServerMsgCode,
   stableStringify,
 } from "@liveblocks/core";
@@ -1371,7 +1372,7 @@ function useOther<P extends JsonObject, U extends BaseUserMeta, T>(
 /**
  * @internal
  */
-function useMutableStorageRoot_withRoomContext<S extends LsonObject>(
+function useMutableStorage_withRoomContext<S extends LsonObject>(
   RoomContext: Context<OpaqueRoom | null>
 ): LiveObject<S> | null {
   const room = useRoom_withRoomContext<never, S, never, never, never, never>(
@@ -1383,13 +1384,17 @@ function useMutableStorageRoot_withRoomContext<S extends LsonObject>(
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
+function useMutableStorage<S extends LsonObject>(): LiveObject<S> | null {
+  return useMutableStorage_withRoomContext<S>(GlobalRoomContext);
+}
+
 /**
  * @internal
  */
 function useStorageRoot_withRoomContext<S extends LsonObject>(
   RoomContext: Context<OpaqueRoom | null>
 ): [root: LiveObject<S> | null] {
-  return [useMutableStorageRoot_withRoomContext<S>(RoomContext)];
+  return [useMutableStorage_withRoomContext<S>(RoomContext)];
 }
 
 // NOTE: This API exists for backward compatible reasons
@@ -1411,7 +1416,7 @@ function useStorage_withRoomContext<S extends LsonObject, T>(
   const room = useRoom_withRoomContext<never, S, never, never, never, never>(
     RoomContext
   );
-  const rootOrNull = useMutableStorageRoot_withRoomContext<S>(RoomContext);
+  const rootOrNull = useMutableStorage_withRoomContext<S>(RoomContext);
 
   const wrappedSelector = useCallback(
     (rootOrNull: Snapshot): Selection =>
@@ -3752,6 +3757,23 @@ export function useSuspendUntilStorageReady(): void {
 /**
  * @internal
  */
+function useMutableStorageSuspense_withRoomContext<S extends LsonObject>(
+  RoomContext: Context<OpaqueRoom | null>
+): LiveObject<S> {
+  useSuspendUntilStorageReady_withRoomContext(RoomContext);
+  return nn(
+    useMutableStorage_withRoomContext<S>(RoomContext),
+    "Storage should be loaded here"
+  );
+}
+
+function useMutableStorageSuspense<S extends LsonObject>(): LiveObject<S> {
+  return useMutableStorageSuspense_withRoomContext<S>(GlobalRoomContext);
+}
+
+/**
+ * @internal
+ */
 function useStorageSuspense_withRoomContext<S extends LsonObject, T>(
   RoomContext: Context<OpaqueRoom | null>,
   selector: (root: ToJson<S>) => T,
@@ -4240,6 +4262,10 @@ export function createRoomContext<
     return useCanRedo_withRoomContext(BoundRoomContext);
   }
 
+  function useMutableStorage_withBoundRoomContext() {
+    return useMutableStorage_withRoomContext<S>(BoundRoomContext);
+  }
+
   function useStorageRoot_withBoundRoomContext() {
     return useStorageRoot_withRoomContext<S>(BoundRoomContext);
   }
@@ -4248,6 +4274,10 @@ export function createRoomContext<
     ...args: Parameters<typeof useStorage<S, T>>
   ) {
     return useStorage_withRoomContext<S, T>(BoundRoomContext, ...args);
+  }
+
+  function useMutableStorageSuspense_withBoundRoomContext() {
+    return useMutableStorageSuspense_withRoomContext<S>(BoundRoomContext);
   }
 
   function useStorageSuspense_withBoundRoomContext<T>(
@@ -4569,6 +4599,8 @@ export function createRoomContext<
     useCanRedo: useCanRedo_withBoundRoomContext as TRoomBundle["useCanRedo"],
 
     // prettier-ignore
+    useMutableStorage: useMutableStorage_withBoundRoomContext as TRoomBundle["useMutableStorage"],
+    // prettier-ignore
     useStorageRoot: useStorageRoot_withBoundRoomContext as TRoomBundle["useStorageRoot"],
     // prettier-ignore
     useStorage: useStorage_withBoundRoomContext as TRoomBundle["useStorage"],
@@ -4696,6 +4728,8 @@ export function createRoomContext<
       // prettier-ignore
       useCanRedo: useCanRedo_withBoundRoomContext as TRoomBundle["suspense"]["useCanRedo"],
 
+      // prettier-ignore
+      useMutableStorage: useMutableStorageSuspense_withBoundRoomContext as TRoomBundle["suspense"]["useMutableStorage"],
       // prettier-ignore
       useStorageRoot: useStorageRoot_withBoundRoomContext as TRoomBundle["suspense"]["useStorageRoot"],
       // prettier-ignore
@@ -5300,6 +5334,37 @@ const _useStorageSuspense: TypedBundle["suspense"]["useStorage"] =
   useStorageSuspense;
 
 /**
+ * Returns the mutable Storage root, or `null` while Storage is still loading.
+ *
+ * Unlike `useStorage()`, this hook is not reactive: your component will
+ * re-render only once, when Storage has finished loading. It will not
+ * re-render when the contents of the returned tree change. Use it when you
+ * need direct access to a mutable Live structure, for example to hand
+ * a `LiveText` node to a text editor binding.
+ *
+ * @example
+ * const root = useMutableStorage();
+ * const liveText = root?.get("myLiveText");
+ */
+const _useMutableStorage: TypedBundle["useMutableStorage"] = useMutableStorage;
+
+/**
+ * Returns the mutable Storage root, suspending until Storage has finished
+ * loading.
+ *
+ * Unlike `useStorage()`, this hook is not reactive: your component will not
+ * re-render when the contents of the returned tree change. Use it when you
+ * need direct access to a mutable Live structure, for example to hand
+ * a `LiveText` node to a text editor binding.
+ *
+ * @example
+ * const root = useMutableStorage();
+ * const liveText = root.get("myLiveText");
+ */
+const _useMutableStorageSuspense: TypedBundle["suspense"]["useMutableStorage"] =
+  useMutableStorageSuspense;
+
+/**
  * Gets the current user once it is connected to the room.
  *
  * @example
@@ -5453,6 +5518,8 @@ export {
   useMarkThreadAsResolved,
   useMarkThreadAsUnresolved,
   useMentionSuggestionsCache,
+  _useMutableStorage as useMutableStorage,
+  _useMutableStorageSuspense as useMutableStorageSuspense,
   _useMutation as useMutation,
   _useMyPresence as useMyPresence,
   _useOther as useOther,

--- a/packages/liveblocks-react/src/suspense.ts
+++ b/packages/liveblocks-react/src/suspense.ts
@@ -93,6 +93,7 @@ export {
   useOthersConnectionIdsSuspense as useOthersConnectionIds,
   useOthersMappedSuspense as useOthersMapped,
   useSelfSuspense as useSelf,
+  useMutableStorageSuspense as useMutableStorage,
   useStorageSuspense as useStorage,
   useThreadsSuspense as useThreads,
   useAttachmentUrlSuspense as useAttachmentUrl,

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -788,8 +788,11 @@ type RoomContextBundleCommon<
   useCanRedo(): boolean;
 
   /**
-   * Returns the mutable (!) Storage root. This hook exists for
-   * backward-compatible reasons.
+   * Returns the mutable (!) Storage root, wrapped in a 1-tuple.
+   *
+   * @deprecated Use `useMutableStorage()` instead, which returns the root
+   * directly instead of wrapping it in a 1-tuple, and which does not return
+   * `null` in its Suspense version.
    *
    * @example
    * const [root] = useStorageRoot();

--- a/packages/liveblocks-react/src/types/index.ts
+++ b/packages/liveblocks-react/src/types/index.ts
@@ -1190,6 +1190,22 @@ export type RoomContextBundle<
       ): T | null;
 
       /**
+       * Returns the mutable Storage root, or `null` while Storage is still
+       * loading.
+       *
+       * Unlike `useStorage()`, this hook is not reactive: your component will
+       * re-render only once, when Storage has finished loading. It will not
+       * re-render when the contents of the returned tree change. Use it when
+       * you need direct access to a mutable Live structure, for example to
+       * hand a `LiveText` node to a text editor binding.
+       *
+       * @example
+       * const root = useMutableStorage();
+       * const liveText = root?.get("myLiveText");
+       */
+      useMutableStorage(): LiveObject<S> | null;
+
+      /**
        * Gets the current user once it is connected to the room.
        *
        * @example
@@ -1450,6 +1466,22 @@ export type RoomContextBundle<
               selector: (root: ToJson<S>) => T,
               isEqual?: (prev: T, curr: T) => boolean
             ): T;
+
+            /**
+             * Returns the mutable Storage root, suspending until Storage has
+             * finished loading.
+             *
+             * Unlike `useStorage()`, this hook is not reactive: your component
+             * will not re-render when the contents of the returned tree
+             * change. Use it when you need direct access to a mutable Live
+             * structure, for example to hand a `LiveText` node to a text
+             * editor binding.
+             *
+             * @example
+             * const root = useMutableStorage();
+             * const liveText = root.get("myLiveText");
+             */
+            useMutableStorage(): LiveObject<S>;
 
             /**
              * Gets the current user once it is connected to the room.

--- a/packages/liveblocks-react/test-d/factories.test-d.tsx
+++ b/packages/liveblocks-react/test-d/factories.test-d.tsx
@@ -401,6 +401,10 @@ describe("createLiveblocksContext / createRoomContext factories", () => {
       readonly age: number;
     } | null>();
 
+    expectTypeOf(
+      ctx.useMutableStorage()
+    ).toEqualTypeOf<LiveObject<MyStorage> | null>();
+
     expectTypeOf(ctx.useStorageRoot()).toEqualTypeOf<
       [root: LiveObject<MyStorage> | null]
     >();
@@ -417,6 +421,10 @@ describe("createLiveblocksContext / createRoomContext factories", () => {
       readonly name: string;
       readonly age: number;
     }>();
+
+    expectTypeOf(ctx.suspense.useMutableStorage()).toEqualTypeOf<
+      LiveObject<MyStorage>
+    >();
 
     expectTypeOf(ctx.suspense.useStorageRoot()).toEqualTypeOf<
       [root: LiveObject<MyStorage> | null]


### PR DESCRIPTION
This PR adds a new `useMutableStorage()` hook to `@liveblocks/react`, in both a Suspense and a non-Suspense flavor, and deprecates `useStorageRoot()`.

## Why

Getting hold of a mutable Live structure—say, a `LiveText` node to hand to a CodeMirror or Lexical binding—had no first-class API. Everyone (including our own guides and e2e apps) hand-rolled the same `useSyncExternalStore` helper:

```tsx
function useRoot(room: Room) {
  const subscribe = room.events.storageDidLoad.subscribeOnce;
  const getSnapshot = room.getStorageOrNull;
  const getServerSnapshot = useCallback(() => null, []);
  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
}

function MyComponent() {
  const room = useRoom();
  const root = useRoot(room);
  const text = root?.get("myLiveText");

  if (text === null) {
    return <div>Loading...</div>;
  }

  return ...;
}
```

Including this helper makes the following snippet equivalent to the above:

```tsx
function MyComponent() {
  const text = useMutableStorage().get("myLiveText");
}
```


## The API

|                                         | non-Suspense              | Suspense                  |
| --------------------------------------- | ------------------------- | ------------------------- |
| `useMutableStorage()`                   | `LiveObject<S> \| null`   | `LiveObject<S>`           |
| ~~`useStorageRoot()`~~ (now deprecated) | `[LiveObject<S> \| null]` | `[LiveObject<S> \| null]` |
