### PR TITLE
Release 3.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## vNEXT (not yet released)
 
+## v3.24.1
+
 ### `@liveblocks/react`
 
 - Add new hook `useMutableStorage()` to get direct access to the mutable Storage
   root. See
   [docs](https://liveblocks.io/docs/api-reference/liveblocks-react#useMutableStorage).
+- Fix thread resolved/unresolved status being reverted under some conditions.
+  (Thanks @VihaanAgarwal for the contribution!)
 
 ## v3.24.0
 

--- a/packages/liveblocks-react/src/__tests__/umbrella-store/patchThread.test.ts
+++ b/packages/liveblocks-react/src/__tests__/umbrella-store/patchThread.test.ts
@@ -1,99 +1,81 @@
-import { kInternal } from "@liveblocks/core";
+import { createClient } from "@liveblocks/client";
 import { describe, expect, test } from "vitest";
 
 import { UmbrellaStore } from "../../umbrella-store";
 import { createComment, createThread } from "./_dummies";
 
-function makeSyncSource() {
-  return {
-    setSyncStatus: () => {},
-    destroy: () => {},
-  };
-}
-
-const NO_CLIENT = {
-  [kInternal]: {
-    as() {
-      return NO_CLIENT;
-    },
-    createSyncSource: makeSyncSource,
-  },
-} as any;
-
 describe("patchThread", () => {
-  test("a settled resolve survives a concurrent stale server refetch", () => {
-    const store = new UmbrellaStore(NO_CLIENT);
-
-    const thread = createThread({
-      id: "th_1",
-      roomId: "room_1",
-      createdAt: new Date("2024-01-01T00:00:00Z"),
-      updatedAt: new Date("2024-01-01T00:00:00Z"),
-      resolved: false,
-      comments: [
-        createComment({
-          threadId: "th_1",
-          roomId: "room_1",
-          createdAt: new Date("2024-01-01T00:00:00Z"),
-        }),
-      ],
-    });
+  test("should keep a settled resolve after a stale refetch", () => {
+    const store = createStore();
+    const thread = makeThread(false);
     store.updateThreadifications([thread], [], []);
 
-    // User resolves the thread; the REST call succeeds and the optimistic
-    // update is replaced by the real thing
-    const resolvedAt = new Date("2024-01-01T00:01:00Z");
+    const settledAt = new Date("2024-01-01T00:01:00Z");
     const optimisticId = store.optimisticUpdates.add({
       type: "mark-thread-as-resolved",
       threadId: thread.id,
-      updatedAt: resolvedAt,
+      updatedAt: settledAt,
     });
-    store.patchThread(thread.id, optimisticId, { resolved: true }, resolvedAt);
+    store.patchThread(thread.id, optimisticId, { resolved: true }, settledAt);
 
-    expect(store.outputs.threads.get().get(thread.id)?.resolved).toBe(true);
+    expect(store.outputs.threads.get().get(thread.id)).toMatchObject({
+      resolved: true,
+      updatedAt: settledAt,
+    });
 
-    // A THREAD_UPDATED (408) triggered refetch can still return a stale
-    // snapshot of the thread from before the resolve. It must not clobber
-    // the newer resolved state
+    // A refetch started before the mutation settled can return an older snapshot.
     store.updateThreadifications([thread], [], []);
 
-    expect(store.outputs.threads.get().get(thread.id)?.resolved).toBe(true);
+    expect(store.outputs.threads.get().get(thread.id)).toMatchObject({
+      resolved: true,
+      updatedAt: settledAt,
+    });
   });
 
-  test("a settled unresolve survives a concurrent stale server refetch", () => {
-    const store = new UmbrellaStore(NO_CLIENT);
-
-    const thread = createThread({
-      id: "th_1",
-      roomId: "room_1",
-      createdAt: new Date("2024-01-01T00:00:00Z"),
-      updatedAt: new Date("2024-01-01T00:00:00Z"),
-      resolved: true,
-      comments: [
-        createComment({
-          threadId: "th_1",
-          roomId: "room_1",
-          createdAt: new Date("2024-01-01T00:00:00Z"),
-        }),
-      ],
-    });
+  test("should keep a settled unresolve after a stale refetch", () => {
+    const store = createStore();
+    const thread = makeThread(true);
     store.updateThreadifications([thread], [], []);
 
-    const unresolvedAt = new Date("2024-01-01T00:01:00Z");
+    const settledAt = new Date("2024-01-01T00:01:00Z");
     const optimisticId = store.optimisticUpdates.add({
       type: "mark-thread-as-unresolved",
       threadId: thread.id,
-      updatedAt: unresolvedAt,
+      updatedAt: settledAt,
     });
-    store.patchThread(
-      thread.id,
-      optimisticId,
-      { resolved: false },
-      unresolvedAt
-    );
+    store.patchThread(thread.id, optimisticId, { resolved: false }, settledAt);
 
     store.updateThreadifications([thread], [], []);
 
-    expect(store.outputs.threads.get().get(thread.id)?.resolved).toBe(false);
+    expect(store.outputs.threads.get().get(thread.id)).toMatchObject({
+      resolved: false,
+      updatedAt: settledAt,
+    });
   });
 });
+
+function createStore() {
+  return new UmbrellaStore(
+    createClient({
+      publicApiKey: "pk_xxx",
+    })
+  );
+}
+
+function makeThread(resolved: boolean) {
+  const createdAt = new Date("2024-01-01T00:00:00Z");
+  return createThread({
+    id: "th_1",
+    roomId: "room_1",
+    createdAt,
+    updatedAt: createdAt,
+    resolved,
+    comments: [
+      createComment({
+        threadId: "th_1",
+        roomId: "room_1",
+        createdAt,
+      }),
+    ],
+  });
+}

--- a/packages/liveblocks-react/src/__tests__/useMarkThreadAsResolved.test.tsx
+++ b/packages/liveblocks-react/src/__tests__/useMarkThreadAsResolved.test.tsx
@@ -1,4 +1,4 @@
-import { nanoid, Permission } from "@liveblocks/core";
+import { nanoid, Permission, Promise_withResolvers } from "@liveblocks/core";
 import { act, renderHook } from "@testing-library/react";
 import { HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -27,6 +27,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   MockWebSocket.reset();
   server.resetHandlers();
 });
@@ -34,9 +35,26 @@ afterEach(() => {
 afterAll(() => server.close());
 
 describe("useMarkThreadAsResolved", () => {
-  test("should mark thread as resolved optimistically", async () => {
+  test("should keep a settled resolve after an in-flight stale refetch", async () => {
+    const initialDate = new Date("2024-01-01T00:00:00Z");
+    const requestedAt = new Date("2024-01-01T00:01:00Z");
+    const refetchedAt = new Date("2024-01-01T00:02:00Z");
+    const settledAt = new Date("2024-01-01T00:03:00Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(requestedAt);
+
     const roomId = nanoid();
-    const initialThread = dummyThreadData({ roomId, resolved: false });
+    const initialThread = dummyThreadData({
+      roomId,
+      createdAt: initialDate,
+      updatedAt: initialDate,
+      resolved: false,
+    });
+    const staleThread = {
+      ...initialThread,
+      updatedAt: refetchedAt,
+    };
+    const mutationResponse = Promise_withResolvers<void>();
     let hasCalledMarkThreadAsResolved = false;
 
     server.use(
@@ -54,8 +72,9 @@ describe("useMarkThreadAsResolved", () => {
           },
         });
       }),
-      mockMarkThreadAsResolved({ threadId: initialThread.id }, () => {
+      mockMarkThreadAsResolved({ threadId: initialThread.id }, async () => {
         hasCalledMarkThreadAsResolved = true;
+        await mutationResponse.promise;
 
         return HttpResponse.json(null, { status: 200 });
       })
@@ -63,6 +82,7 @@ describe("useMarkThreadAsResolved", () => {
 
     const {
       room: { RoomProvider, useThreads, useMarkThreadAsResolved },
+      umbrellaStore,
     } = createContextsForTest();
 
     const { result, unmount } = renderHook(
@@ -89,7 +109,20 @@ describe("useMarkThreadAsResolved", () => {
 
     await vi.waitFor(() => expect(hasCalledMarkThreadAsResolved).toEqual(true));
 
+    act(() => umbrellaStore.updateThreadifications([staleThread], [], []));
+
     expect(result.current.threads![0]?.resolved).toBe(true);
+
+    vi.setSystemTime(settledAt);
+    act(() => mutationResponse.resolve());
+
+    await vi.waitFor(() =>
+      expect(umbrellaStore.optimisticUpdates.signal.get()).toHaveLength(0)
+    );
+    expect(result.current.threads?.[0]?.resolved).toBe(true);
+    expect(result.current.threads?.[0]?.updatedAt.getTime()).toBeGreaterThan(
+      refetchedAt.getTime()
+    );
 
     unmount();
   });

--- a/packages/liveblocks-react/src/room.tsx
+++ b/packages/liveblocks-react/src/room.tsx
@@ -2804,7 +2804,7 @@ function useMarkRoomThreadAsResolved(roomId: string) {
               threadId,
               optimisticId,
               { resolved: true },
-              updatedAt
+              new Date()
             );
           },
           (err: Error) =>
@@ -2868,7 +2868,7 @@ function useMarkRoomThreadAsUnresolved(roomId: string) {
               threadId,
               optimisticId,
               { resolved: false },
-              updatedAt
+              new Date()
             );
           },
           (err: Error) =>


### PR DESCRIPTION
Finalizing and releasing https://github.com/liveblocks/liveblocks/pull/3649.

@nvie Despite the new `useMutableStorage` hook I'm choosing a patch bump since the whole release is too small imo for 3.25.