### PR TITLE
feat(examples): add OrcaRouter as an optional AI provider for the React Flow example

### DIFF
--- a/docs/pages/get-started/nextjs-ai-react-flow.mdx
+++ b/docs/pages/get-started/nextjs-ai-react-flow.mdx
@@ -73,6 +73,33 @@ See the finished result in the [Collaborative Flowchart AI](/examples/collaborat
       OPENAI_API_KEY="sk-..."
       ```
 
+      <Banner title="Use OrcaRouter instead of OpenAI" type="info">
+
+This example also works with
+[OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway
+that routes to models from many providers through a single endpoint. It
+also runs gateway-level, zero-trust security for AI agents on the same
+endpoint — screening every prompt/response and governing every tool
+call on a default-deny basis, with no application code changes.
+
+To use it, install the compatible provider and set the OrcaRouter key
+instead of the OpenAI key:
+
+```bash
+npm install @ai-sdk/openai-compatible
+```
+
+```env file=".env.local"
+LIVEBLOCKS_SECRET_KEY="{{SECRET_KEY}}"
+ORCAROUTER_API_KEY="sk-orca-..."
+```
+
+The agent picks the OpenAI-compatible gateway automatically when
+`ORCAROUTER_API_KEY` is set. You can override the endpoint and model
+with `ORCAROUTER_BASE_URL` and `ORCAROUTER_MODEL`.
+
+      </Banner>
+
     </StepContent>
 
   </Step>

--- a/examples/nextjs-react-flow-ai/.env.example
+++ b/examples/nextjs-react-flow-ai/.env.example
@@ -1,8 +1,16 @@
 # https://liveblocks.io/dashboard/apikeys
 LIVEBLOCKS_SECRET_KEY=
 
+# Either the OpenAI provider (default)…
 # https://platform.openai.com/settings/organization/api-keys
 OPENAI_API_KEY=
+
+# …or OrcaRouter (https://www.orcarouter.ai). When ORCAROUTER_API_KEY is set,
+# the AI agent uses OrcaRouter's OpenAI-compatible gateway instead of OpenAI.
+# https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
+# ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+# ORCAROUTER_MODEL=orcarouter/auto
 
 # https://liveblocks.io/dashboard/webhooks (enable commentCreated)
 LIVEBLOCKS_WEBHOOK_SECRET_KEY=

--- a/examples/nextjs-react-flow-ai/README.md
+++ b/examples/nextjs-react-flow-ai/README.md
@@ -24,7 +24,9 @@
 This example shows how to build a collaborative flowchart with an AI agent,
 powered by [Liveblocks](https://liveblocks.io),
 [React Flow](https://reactflow.dev/), [Next.js](https://nextjs.org/), the
-[Vercel AI SDK](https://sdk.vercel.ai/), and [OpenAI](https://openai.com).
+[Vercel AI SDK](https://sdk.vercel.ai/), and [OpenAI](https://openai.com). It
+also works with [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible
+gateway, by setting the `ORCAROUTER_API_KEY` environment variable.
 
 You can place blocks, connect them, edit labels, undo and redo, add pinned
 comments on the canvas, and ask the AI to edit the diagram in real-time for
@@ -66,6 +68,25 @@ You need your own OpenAI API key to run the AI agent.
   [OpenAI Dashboard](https://platform.openai.com/api-keys)
 - Add your OpenAI API key to `.env.local` as the `OPENAI_API_KEY` environment
   variable
+
+### Setting up OrcaRouter (optional)
+
+Instead of OpenAI, the AI agent can run through
+[OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway that
+routes to models from many providers through a single endpoint. It also runs
+gateway-level, zero-trust security for AI agents on the same endpoint —
+screening every prompt/response and governing every tool call on a default-deny
+basis, with no application code changes.
+
+- Create an account on [OrcaRouter](https://www.orcarouter.ai)
+- Create a new API key from your OrcaRouter dashboard
+- Add your OrcaRouter API key to `.env.local` as the `ORCAROUTER_API_KEY`
+  environment variable
+
+When `ORCAROUTER_API_KEY` is set, the AI agent uses OrcaRouter's
+OpenAI-compatible gateway with the `orcarouter/auto` model by default. You can
+override the endpoint and model with `ORCAROUTER_BASE_URL` and
+`ORCAROUTER_MODEL`.
 
 ### Manual setup
 

--- a/examples/nextjs-react-flow-ai/app/flowchart/agent/agent.ts
+++ b/examples/nextjs-react-flow-ai/app/flowchart/agent/agent.ts
@@ -1,3 +1,4 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { openai } from "@ai-sdk/openai";
 import { Liveblocks } from "@liveblocks/node";
 import { mutateFlow } from "@liveblocks/react-flow/node";
@@ -38,6 +39,22 @@ const DEFAULT_BOUNDS_RADIUS = 200;
 const POSITION_ANIMATION_MIN_STEPS = 7;
 const POSITION_ANIMATION_MAX_STEPS = 14;
 const POSITION_ANIMATION_STEP_DISTANCE = 40;
+
+const ORCAROUTER_BASE_URL =
+  process.env.ORCAROUTER_BASE_URL ?? "https://api.orcarouter.ai/v1";
+const ORCAROUTER_MODEL = process.env.ORCAROUTER_MODEL ?? "orcarouter/auto";
+
+const orcarouter = createOpenAICompatible({
+  name: "orcarouter",
+  baseURL: ORCAROUTER_BASE_URL,
+  apiKey: process.env.ORCAROUTER_API_KEY,
+});
+
+function getChatModel() {
+  return process.env.ORCAROUTER_API_KEY
+    ? orcarouter.chatModel(ORCAROUTER_MODEL)
+    : openai("gpt-5.4-nano");
+}
 
 const liveblocks = new Liveblocks({
   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
@@ -151,7 +168,7 @@ export async function runFlowchartAgent(
         void options?.onProgress?.("Editing flowchart…");
 
         const result = await generateText({
-          model: openai("gpt-5.4-nano"),
+          model: getChatModel(),
           system: dedent`
           You edit a live collaborative React Flow flowchart.
 
@@ -181,7 +198,13 @@ export async function runFlowchartAgent(
             ${prompt}
           </user-message>
         `,
-          providerOptions: { openai: { reasoningEffort: "low" } },
+          providerOptions: process.env.ORCAROUTER_API_KEY
+            ? {
+                orcarouter: { reasoningEffort: "low" },
+              }
+            : {
+                openai: { reasoningEffort: "low" },
+              },
           tools: {
             addNode: tool({
               description: "Create one block node.",

--- a/examples/nextjs-react-flow-ai/app/flowchart/agent/input-agent.ts
+++ b/examples/nextjs-react-flow-ai/app/flowchart/agent/input-agent.ts
@@ -8,7 +8,10 @@ export async function submitFlowchartAgentAction(
   _: FlowchartAgentActionState,
   formData: FormData
 ): Promise<FlowchartAgentActionState> {
-  if (!process.env.LIVEBLOCKS_SECRET_KEY || !process.env.OPENAI_API_KEY) {
+  if (
+    !process.env.LIVEBLOCKS_SECRET_KEY ||
+    (!process.env.OPENAI_API_KEY && !process.env.ORCAROUTER_API_KEY)
+  ) {
     return null;
   }
 

--- a/examples/nextjs-react-flow-ai/package-lock.json
+++ b/examples/nextjs-react-flow-ai/package-lock.json
@@ -8,6 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.48",
+        "@ai-sdk/openai-compatible": "^2.0.37",
         "@dnd-kit/core": "^6.3.1",
         "@liveblocks/client": "^3.23.0",
         "@liveblocks/node": "^3.23.0",
@@ -51,6 +52,21 @@
       "version": "3.0.49",
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.49.tgz",
       "integrity": "sha512-U2f0pCyNn/jQH3wjgxr8o9VvCkuDFTtXbIhbFFtgXqCzMbed6rBnvzQcAMEK0/Pa44byL9zfcvCOFOflvkRA8w==",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.37.tgz",
+      "integrity": "sha512-+POSFVcgiu47BK64dhsI6OpcDC0/VAE2ZSaXdXGNNhpC/ava++uSRJYks0k2bpfY0wwCTgpAWZsXn/dG2Yppiw==",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.21"

--- a/examples/nextjs-react-flow-ai/package.json
+++ b/examples/nextjs-react-flow-ai/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.48",
+    "@ai-sdk/openai-compatible": "^2.0.37",
     "@dnd-kit/core": "^6.3.1",
     "@liveblocks/client": "^3.23.0",
     "@liveblocks/node": "^3.23.0",


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as an optional AI provider for the
`nextjs-react-flow-ai` example. OrcaRouter is an OpenAI-compatible gateway that
routes to models from many providers through a single endpoint
(`https://api.orcarouter.ai/v1`).

When `ORCAROUTER_API_KEY` is set, the AI agent uses the OrcaRouter gateway via
`@ai-sdk/openai-compatible` (`orcarouter/auto` model by default). You can
override the endpoint and model with `ORCAROUTER_BASE_URL` and
`ORCAROUTER_MODEL`. Without the key, the example behaves exactly as before
(OpenAI `gpt-5.4-nano`).

It also runs gateway-level, zero-trust security for AI agents on the same
endpoint — screening every prompt/response and governing every tool call on a
default-deny basis, with no application code changes.

## Changes

- **`examples/nextjs-react-flow-ai`**: add `@ai-sdk/openai-compatible`
  dependency, a `getChatModel()` helper that picks OrcaRouter when
  `ORCAROUTER_API_KEY` is present, and conditional `providerOptions`. Update
  `input-agent.ts` to accept either key, `.env.example`, and the README
  (new "Setting up OrcaRouter" section).
- **`docs/pages/get-started/nextjs-ai-react-flow.mdx`**: document the optional
  OrcaRouter setup in the quickstart.

## Testing

- `tsc --noEmit` clean.
- `next build` full production build passes.
- Live test with a real OrcaRouter key through the production wiring
  (`createOpenAICompatible({ name: "orcarouter", baseURL, apiKey })` +
  `chatModel("orcarouter/auto")` + tool call) returned `ORCA-OK`,
  `finishReason: stop`.

Disclosure: I'm an engineer on the OrcaRouter team.
