### PR TITLE
fix(core): correct spelling in Poller backoff comment

### DIFF
--- a/packages/liveblocks-core/src/lib/Poller.ts
+++ b/packages/liveblocks-core/src/lib/Poller.ts
@@ -158,7 +158,7 @@ export function makePoller(
       return {
         target: mayPoll() ? "@enabled" : "@idle",
         effect: () => {
-          // Increase the backoff delay if an error occured
+          // Increase the backoff delay if an error occurred
           context.backoff =
             BACKOFF_DELAYS.find((delay) => delay > context.backoff) ??
             BACKOFF_DELAYS[BACKOFF_DELAYS.length - 1];


### PR DESCRIPTION
Corrects the `occured` typo to `occurred` in the Poller error-path backoff comment. Fixes #3680.