### PR TITLE
@liveblocks/core: typo in Poller backoff comment (occured → occurred)

### DIFF
--- a/packages/liveblocks-core/src/lib/Poller.ts
+++ b/packages/liveblocks-core/src/lib/Poller.ts
@@ -158,7 +158,7 @@ export function makePoller(
       return {
         target: mayPoll() ? "@enabled" : "@idle",
         effect: () => {
-          // Increase the backoff delay if an error occured
+          // Increase the backoff delay if an error occurred
           context.backoff =
             BACKOFF_DELAYS.find((delay) => delay > context.backoff) ??
             BACKOFF_DELAYS[BACKOFF_DELAYS.length - 1];


### PR DESCRIPTION
This PR fixes the documentation issue reported in #3679: corrects `occured` to `occurred` in `packages/liveblocks-core/src/lib/Poller.ts`.

Fixes #3679

Fixes #3679