### PR TITLE
fix: correct 'occured' to 'occurred' in Poller backoff comment

### DIFF
--- a/packages/liveblocks-core/src/lib/Poller.ts
+++ b/packages/liveblocks-core/src/lib/Poller.ts
@@ -158,7 +158,7 @@ export function makePoller(
       return {
         target: mayPoll() ? "@enabled" : "@idle",
         effect: () => {
-          // Increase the backoff delay if an error occured
+          // Increase the backoff delay if an error occurred
           context.backoff =
             BACKOFF_DELAYS.find((delay) => delay > context.backoff) ??
             BACKOFF_DELAYS[BACKOFF_DELAYS.length - 1];


### PR DESCRIPTION
## Summary
Fix typo in `packages/liveblocks-core/src/lib/Poller.ts` line 161.

## Before
// Increase the backoff delay if an error occured

## After
// Increase the backoff delay if an error occurred

## Testing
- Single commit, surgical fix
- No code logic change

---
Thanks! Happy to address any feedback.
